### PR TITLE
Add transparent section support

### DIFF
--- a/spec/unit/transparent_spec.cr
+++ b/spec/unit/transparent_spec.cr
@@ -1,0 +1,150 @@
+require "../spec_helper"
+
+describe Hwaro::Models::Site do
+  describe "#pages_for_section" do
+    it "returns direct pages for a non-transparent section" do
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      blog = Hwaro::Models::Section.new("blog/_index.md")
+      blog.section = "blog"
+
+      post1 = Hwaro::Models::Page.new("blog/post1.md")
+      post1.section = "blog"
+      post1.title = "Post 1"
+
+      archive = Hwaro::Models::Section.new("blog/archive/_index.md")
+      archive.section = "blog/archive"
+      archive.title = "Archive"
+
+      site.sections << blog
+      site.sections << archive
+      site.pages << post1
+
+      # When listing pages for "blog", we want post1 and archive
+      pages = site.pages_for_section("blog", nil)
+      pages.size.should eq(2)
+      pages.should contain(post1)
+      pages.should contain(archive)
+    end
+
+    it "bubbles up pages from a transparent section" do
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      blog = Hwaro::Models::Section.new("blog/_index.md")
+      blog.section = "blog"
+
+      archive = Hwaro::Models::Section.new("blog/archive/_index.md")
+      archive.section = "blog/archive"
+      archive.transparent = true
+
+      post2 = Hwaro::Models::Page.new("blog/archive/post2.md")
+      post2.section = "blog/archive"
+      post2.title = "Post 2"
+
+      site.sections << blog
+      site.sections << archive
+      site.pages << post2
+
+      # When listing pages for "blog", archive is transparent, so post2 should bubble up
+      pages = site.pages_for_section("blog", nil)
+      pages.size.should eq(1)
+      pages.should contain(post2)
+      pages.should_not contain(archive)
+    end
+
+    it "bubbles up recursively" do
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      blog = Hwaro::Models::Section.new("blog/_index.md")
+      blog.section = "blog"
+
+      archive = Hwaro::Models::Section.new("blog/archive/_index.md")
+      archive.section = "blog/archive"
+      archive.transparent = true
+
+      year2024 = Hwaro::Models::Section.new("blog/archive/2024/_index.md")
+      year2024.section = "blog/archive/2024"
+      year2024.transparent = true
+
+      post3 = Hwaro::Models::Page.new("blog/archive/2024/post3.md")
+      post3.section = "blog/archive/2024"
+      post3.title = "Post 3"
+
+      site.sections << blog
+      site.sections << archive
+      site.sections << year2024
+      site.pages << post3
+
+      # "blog" -> "blog/archive" (transparent) -> "blog/archive/2024" (transparent) -> post3
+      pages = site.pages_for_section("blog", nil)
+      pages.size.should eq(1)
+      pages.should contain(post3)
+      pages.should_not contain(archive)
+      pages.should_not contain(year2024)
+    end
+
+    it "handles root section correctly" do
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      root = Hwaro::Models::Section.new("_index.md")
+      root.section = ""
+
+      blog = Hwaro::Models::Section.new("blog/_index.md")
+      blog.section = "blog"
+      blog.transparent = true
+
+      post1 = Hwaro::Models::Page.new("blog/post1.md")
+      post1.section = "blog"
+      post1.title = "Post 1"
+
+      about = Hwaro::Models::Page.new("about.md")
+      about.section = ""
+      about.title = "About"
+
+      site.sections << root
+      site.sections << blog
+      site.pages << post1
+      site.pages << about
+
+      # Root should contain "about.md" and bubbled up "post1.md"
+      pages = site.pages_for_section("", nil)
+      pages.size.should eq(2)
+      pages.should contain(about)
+      pages.should contain(post1)
+      pages.should_not contain(blog)
+    end
+
+    it "filters by language" do
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      blog_en = Hwaro::Models::Section.new("blog/_index.md")
+      blog_en.section = "blog"
+      blog_en.language = "en"
+
+      post_en = Hwaro::Models::Page.new("blog/post.md")
+      post_en.section = "blog"
+      post_en.language = "en"
+
+      post_ko = Hwaro::Models::Page.new("blog/post.ko.md")
+      post_ko.section = "blog"
+      post_ko.language = "ko"
+
+      site.sections << blog_en
+      site.pages << post_en
+      site.pages << post_ko
+
+      pages_en = site.pages_for_section("blog", "en")
+      pages_en.size.should eq(1)
+      pages_en.should contain(post_en)
+
+      pages_ko = site.pages_for_section("blog", "ko")
+      pages_ko.size.should eq(1)
+      pages_ko.should contain(post_ko)
+    end
+  end
+end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -678,24 +678,10 @@ module Hwaro
           toc_html : String,
           verbose : Bool = false,
         )
-          # Get pages in this section, filtered by language
-          # nil language means default language, so we need to compare carefully
-          section_lang = section.language
-          section_pages = site.all_content.select do |p|
-            next false if p.section != section.section
-            next false if p == section # Exclude the section's own index page
-            # Match language: both nil (default), or same language code
-            p.language == section_lang
-          end
-
-          # Include subsection index pages
-          subsection_prefix = section.path.sub("_index.md", "").sub("content/", "")
-          subsections = site.sections.select do |s|
-            next false if s.section != section.section
-            next false if s.path == section.path
-            s.path.starts_with?("content/#{subsection_prefix}") && s.language == section_lang
-          end
-          section_pages.concat(subsections)
+          # Get pages in this section using the site utility method
+          section_name = Path[section.path].dirname
+          section_name = "" if section_name == "."
+          section_pages = site.pages_for_section(section_name, section.language)
 
           section_pages.sort_by! { |p| p.title }
 
@@ -783,24 +769,12 @@ module Hwaro
         end
 
         private def generate_section_list(current_page : Models::Page, site : Models::Site) : String
-          current_lang = current_page.language
-          section_pages = site.pages.select do |p|
-            next false if p.section != current_page.section
-            next false if p == current_page # Exclude the current page
-            # Match language: both nil (default), or same language code
-            p.language == current_lang
-          end
+          # Use the site utility method to get pages for the current section
+          section_name = current_page.section
+          section_pages = site.pages_for_section(section_name, current_page.language)
 
-          # Include subsection index pages
-          if current_page.is_index
-            subsection_prefix = current_page.path.sub("_index.md", "").sub("content/", "")
-            subsections = site.sections.select do |s|
-              next false if s.section != current_page.section
-              next false if s.path == current_page.path
-              s.path.starts_with?("content/#{subsection_prefix}") && s.language == current_lang
-            end
-            section_pages.concat(subsections)
-          end
+          # Exclude the current page if it was included
+          section_pages.reject! { |p| p == current_page }
 
           section_pages.sort_by! { |p| p.title }
 
@@ -978,19 +952,11 @@ module Hwaro
           end
 
           if !current_section.empty?
-            # Calculate section pages
-            current_lang = page.language
-            current_section_parts = current_section.split("/")
-            section_depth = current_section_parts.size
+            # Use the site utility method to get pages for the current section
+            section_pages = site.pages_for_section(current_section, page.language)
 
-            section_pages = site.all_content.select do |p|
-              next false if p == page # Exclude the current page
-              next false if p.language != current_lang
-              next false if p.section != current_section
-              p_parts = p.path.split("/")
-              # Include direct children or subdirectory index.md files
-              p_parts.size == section_depth + 1 || (p_parts.size > section_depth + 1 && p.is_index && p.path.ends_with?("/index.md"))
-            end
+            # Exclude the current page if it was included
+            section_pages.reject! { |p| p == page }
 
             section_pages.sort_by! { |p| p.title }
 

--- a/src/models/site.cr
+++ b/src/models/site.cr
@@ -29,6 +29,48 @@ module Hwaro
       def all_content : Array(Page)
         (pages + sections.map { |s| s.as(Page) }).sort_by! { |p| p.path }
       end
+
+      def pages_for_section(section_name : String, language : String?, items : Array(Page)? = nil) : Array(Page)
+        result = [] of Page
+        # Normalize section name: remove leading/trailing slashes and handle root
+        normalized_name = section_name.strip.gsub(/^\/|\/$/, "")
+
+        # Initial call: filter by language and collect all content to improve performance
+        content_items = items || all_content.select { |p| p.language == language }
+
+        content_items.each do |p|
+          if p.is_a?(Section)
+            # p.path is relative to content/ (e.g., "blog/_index.md" or "blog/archive/_index.md")
+            p_dirname = Path[p.path].dirname
+            p_dirname = "" if p_dirname == "."
+
+            # Skip the section's own index page
+            next if p_dirname == normalized_name
+
+            # Check if this section is a direct child of the target section
+            parent_dir = Path[p_dirname].parent.to_s
+            parent_dir = "" if parent_dir == "."
+
+            if parent_dir == normalized_name
+              if p.transparent
+                # Recursive bubble up: get pages from this sub-section
+                result.concat(pages_for_section(p_dirname, language, content_items))
+              else
+                # Non-transparent sections are included as Section (Page) objects
+                result << p
+              end
+            end
+          else
+            # Regular Page (not a Section)
+            # p.section is already normalized by the builder (e.g., "blog" or "blog/archive")
+            if p.section == normalized_name
+              result << p
+            end
+          end
+        end
+
+        result
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds support for a `transparent` property in section front matter. When a section is marked as transparent, its pages and sub-sections are automatically bubbled up into the parent section's page listings. This effect is recursive, allowing multi-level bubbling. Transparent sections themselves are excluded from listings, serving only as content containers. Page URLs remain unchanged.

Changes:
- `src/models/site.cr`: Added `pages_for_section` method with recursive bubbling logic.
- `src/core/build/builder.cr`: Refactored `render_section_with_pagination`, `generate_section_list`, and `build_template_variables` to use the new centralized method.
- `spec/unit/transparent_spec.cr`: New unit tests for the feature.

---
*PR created automatically by Jules for task [9784287352686435953](https://jules.google.com/task/9784287352686435953) started by @hahwul*