### PR TITLE
feat: add --debug flag to build and serve commands

### DIFF
--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -35,6 +35,7 @@ module Hwaro
           highlight = true
           verbose = false
           profile = false
+          debug = false
 
           OptionParser.parse(args) do |parser|
             parser.banner = "Usage: hwaro build [options]"
@@ -47,6 +48,7 @@ module Hwaro
             parser.on("--skip-highlighting", "Disable syntax highlighting") { highlight = false }
             parser.on("-v", "--verbose", "Show detailed output including generated files") { verbose = true }
             parser.on("--profile", "Show build timing profile for each phase") { profile = true }
+            parser.on("--debug", "Print debug information after build") { debug = true }
             parser.on("-h", "--help", "Show this help") { Logger.info parser.to_s; exit }
           end
 
@@ -59,7 +61,8 @@ module Hwaro
             cache: cache,
             highlight: highlight,
             verbose: verbose,
-            profile: profile
+            profile: profile,
+            debug: debug
           )
         end
       end

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -19,6 +19,7 @@ module Hwaro
           drafts = false
           open_browser = false
           verbose = false
+          debug = false
 
           OptionParser.parse(args) do |parser|
             parser.banner = "Usage: hwaro serve [options]"
@@ -28,6 +29,7 @@ module Hwaro
             parser.on("-d", "--drafts", "Include draft content") { drafts = true }
             parser.on("--open", "Open browser after starting server") { open_browser = true }
             parser.on("-v", "--verbose", "Show detailed output including generated files") { verbose = true }
+            parser.on("--debug", "Print debug information after build") { debug = true }
             parser.on("-h", "--help", "Show this help") { Logger.info parser.to_s; exit }
           end
 
@@ -37,7 +39,8 @@ module Hwaro
             base_url: base_url,
             drafts: drafts,
             open_browser: open_browser,
-            verbose: verbose
+            verbose: verbose,
+            debug: debug
           )
         end
       end

--- a/src/config/options/build_options.cr
+++ b/src/config/options/build_options.cr
@@ -11,6 +11,7 @@ module Hwaro
         property highlight : Bool
         property verbose : Bool
         property profile : Bool
+        property debug : Bool
 
         def initialize(
           @output_dir : String = "public",
@@ -22,6 +23,7 @@ module Hwaro
           @highlight : Bool = true,
           @verbose : Bool = false,
           @profile : Bool = false,
+          @debug : Bool = false,
         )
         end
       end

--- a/src/config/options/serve_options.cr
+++ b/src/config/options/serve_options.cr
@@ -8,6 +8,7 @@ module Hwaro
         property drafts : Bool
         property open_browser : Bool
         property verbose : Bool
+        property debug : Bool
 
         def initialize(
           @host : String = "0.0.0.0",
@@ -16,6 +17,7 @@ module Hwaro
           @drafts : Bool = false,
           @open_browser : Bool = false,
           @verbose : Bool = false,
+          @debug : Bool = false,
         )
         end
 
@@ -27,7 +29,8 @@ module Hwaro
             drafts: @drafts,
             minify: false,
             parallel: true,
-            verbose: @verbose
+            verbose: @verbose,
+            debug: @debug
           )
         end
       end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -36,6 +36,7 @@ require "../../models/section"
 require "../../models/toc"
 require "../../models/site"
 require "../lifecycle"
+require "../../utils/debug_printer"
 
 module Hwaro
   module Core
@@ -75,7 +76,8 @@ module Hwaro
             cache: options.cache,
             highlight: options.highlight,
             verbose: options.verbose,
-            profile: options.profile
+            profile: options.profile,
+            debug: options.debug
           )
         end
 
@@ -89,6 +91,7 @@ module Hwaro
           highlight : Bool = true,
           verbose : Bool = false,
           profile : Bool = false,
+          debug : Bool = false,
         )
           # Load config early to get build hooks
           config = Models::Config.load
@@ -121,7 +124,8 @@ module Hwaro
             cache: cache,
             highlight: highlight,
             verbose: verbose,
-            profile: profile
+            profile: profile,
+            debug: debug
           )
           ctx = Lifecycle::BuildContext.new(options)
           ctx.stats.start_time = Time.instant
@@ -153,6 +157,10 @@ module Hwaro
             unless Utils::CommandRunner.run_post_hooks(post_hooks)
               Logger.warn "Post-build hooks failed, but build was successful."
             end
+          end
+
+          if options.debug
+            Utils::DebugPrinter.print(@site.not_nil!)
           end
         end
 

--- a/src/utils/debug_printer.cr
+++ b/src/utils/debug_printer.cr
@@ -1,0 +1,87 @@
+require "../models/site"
+require "../models/page"
+require "../models/section"
+require "colorize"
+
+module Hwaro
+  module Utils
+    module DebugPrinter
+      class Node
+        property name : String
+        property children : Hash(String, Node)
+        property pages : Array(Models::Page)
+        property section : Models::Section?
+
+        def initialize(@name : String)
+          @children = {} of String => Node
+          @pages = [] of Models::Page
+        end
+      end
+
+      def self.print(site : Models::Site)
+        root = Node.new("root")
+
+        # Build tree from pages
+        site.pages.each do |page|
+          # Determine path parts based on section
+          # If page.section is empty, it's at root
+          parts = page.section.split("/").reject(&.empty?)
+
+          current = root
+          parts.each do |part|
+            current = current.children[part] ||= Node.new(part)
+          end
+
+          current.pages << page
+        end
+
+        # Build tree from sections (to capture sections that might have no pages but exist)
+        site.sections.each do |section|
+           # Section path is e.g. "blog/_index.md" -> dirname "blog"
+           dir = Path[section.path].dirname
+           dir = "" if dir == "."
+
+           parts = dir.split("/").reject(&.empty?)
+
+           current = root
+           parts.each do |part|
+             current = current.children[part] ||= Node.new(part)
+           end
+
+           current.section = section
+        end
+
+        puts "\nSite Structure (Debug):".colorize(:cyan).mode(:bold)
+        print_node(root, "", true)
+        puts ""
+      end
+
+      private def self.print_node(node : Node, prefix : String, is_root : Bool)
+        unless is_root
+          # Determine label
+          label = node.name
+          if section = node.section
+            label += " (Section: #{section.title})"
+            puts "#{prefix}#{label}".colorize(:blue).mode(:bold)
+          else
+            label += " (Dir)"
+            puts "#{prefix}#{label}".colorize(:blue)
+          end
+        end
+
+        indent = is_root ? "" : prefix + "  "
+
+        # Print pages
+        node.pages.sort_by!(&.title).each do |page|
+          puts "#{indent}- #{page.title} (#{page.path})".colorize(:green)
+        end
+
+        # Print children
+        sorted_children = node.children.keys.sort
+        sorted_children.each do |key|
+          print_node(node.children[key], indent, false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a `--debug` flag to both `build` and `serve` commands. When enabled, the site structure (hierarchy of sections and pages) is printed to the console after the build completes.

- Added `Hwaro::Utils::DebugPrinter` to visualize site tree.
- Updated `BuildOptions` and `ServeOptions` to support `debug`.
- Updated `BuildCommand` and `ServeCommand` to parse the flag.
- Updated `Builder` to invoke the printer when flag is set.