### PR TITLE
Optimize pages_for_section performance using hash lookups

### DIFF
--- a/spec/unit/transparent_spec.cr
+++ b/spec/unit/transparent_spec.cr
@@ -146,5 +146,38 @@ describe Hwaro::Models::Site do
       pages_ko.size.should eq(1)
       pages_ko.should contain(post_ko)
     end
+
+    describe "with optimized lookup" do
+      it "returns same results as unoptimized path" do
+        config = Hwaro::Models::Config.new
+        site = Hwaro::Models::Site.new(config)
+
+        blog = Hwaro::Models::Section.new("blog/_index.md")
+        blog.section = "blog"
+
+        archive = Hwaro::Models::Section.new("blog/archive/_index.md")
+        archive.section = "blog/archive"
+        archive.transparent = true
+
+        post2 = Hwaro::Models::Page.new("blog/archive/post2.md")
+        post2.section = "blog/archive"
+        post2.title = "Post 2"
+
+        site.sections << blog
+        site.sections << archive
+        site.pages << post2
+
+        # Verify unoptimized
+        pages1 = site.pages_for_section("blog", nil)
+
+        # Verify optimized
+        site.build_lookup_index
+        pages2 = site.pages_for_section("blog", nil)
+
+        pages1.should eq(pages2)
+        pages2.size.should eq(1)
+        pages2.should contain(post2)
+      end
+    end
   end
 end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -255,6 +255,9 @@ module Hwaro
           site.pages = ctx.pages
           site.sections = ctx.sections
 
+          # Build optimized lookup indices
+          site.build_lookup_index
+
           all_pages = ctx.all_pages
 
           # Filter pages for caching


### PR DESCRIPTION
Optimize Site#pages_for_section to use hash-based lookups and memoization, significantly improving build performance for large sites. This replaces the O(N) linear scan per section with O(1) lookups.

---
*PR created automatically by Jules for task [182309313913540959](https://jules.google.com/task/182309313913540959) started by @hahwul*