### PR TITLE
Update documentation to include page.assets

### DIFF
--- a/docs/content/templates/data-model.md
+++ b/docs/content/templates/data-model.md
@@ -166,6 +166,7 @@ An individual content file (`.md`).
 | page.word_count | Int | Word count |
 | page.reading_time | Int | Reading time (minutes) |
 | page.summary | String? | Content before <!-- more --> |
+| page.assets | Array<String> | Static files in page bundle |
 
 ### Boolean Flags
 

--- a/docs/content/writing/pages.md
+++ b/docs/content/writing/pages.md
@@ -227,6 +227,18 @@ In your markdown, you can link to these assets using relative paths:
 [Download Data](data.json)
 ```
 
+### Accessing Assets in Templates
+
+You can access the list of colocated assets in your templates using `page.assets`. This returns an array of relative paths to the files.
+
+```jinja
+{% for asset in page.assets %}
+  {% if asset is matching("[.](jpg|png)$") %}
+    <img src="{{ get_url(path=asset) }}" alt="Gallery Image">
+  {% endif %}
+{% endfor %}
+```
+
 ## URL Mapping
 
 | File | URL |


### PR DESCRIPTION
Updated documentation to include missing `page.assets` property.
- Added usage instructions in `docs/content/writing/pages.md`
- Added API reference in `docs/content/templates/data-model.md`

---
*PR created automatically by Jules for task [311948774980361361](https://jules.google.com/task/311948774980361361) started by @hahwul*