### PR TITLE
Fix empty section.pages in templates due to cache mutation

### DIFF
--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -874,7 +874,7 @@ module Hwaro
           # Get pages in this section using the site utility method
           section_name = Path[section.path].dirname
           section_name = "" if section_name == "."
-          section_pages = site.pages_for_section(section_name, section.language)
+          section_pages = site.pages_for_section(section_name, section.language).dup
 
           section_pages.sort_by! { |p| p.title }
 
@@ -1339,7 +1339,7 @@ module Hwaro
             section_pages = if paginated_pages
                               paginated_pages
                             else
-                              pages = site.pages_for_section(current_section, page.language)
+                              pages = site.pages_for_section(current_section, page.language).dup
                               # Exclude the current page if it was included
                               pages.reject! { |p| p == page }
                               pages.sort_by! { |p| p.title }


### PR DESCRIPTION
Fixes a bug where "In This Section" list was missing in documentation pages due to in-place modification of the cached pages array returned by `site.pages_for_section`. By using `.dup`, we prevent the cache from being emptied by `reject!` calls in the template variable building process.


---
*PR created automatically by Jules for task [9996117677783995227](https://jules.google.com/task/9996117677783995227) started by @hahwul*