### PR TITLE
Add canonical URL and hreflang support

### DIFF
--- a/docs/content/templates/data-model.md
+++ b/docs/content/templates/data-model.md
@@ -330,10 +330,14 @@ pros = ["Fast", "Reliable"]
 | og_tags | OpenGraph meta tags |
 | twitter_tags | Twitter Card meta tags |
 | og_all_tags | Both OG and Twitter tags |
+| canonical_tag | Canonical link tag |
+| hreflang_tags | Hreflang alternate link tags (multilingual) |
 
 ```jinja
 <head>
   {{ og_all_tags | safe }}
+  {{ canonical_tag | safe }}
+  {{ hreflang_tags | safe }}
 </head>
 ```
 

--- a/spec/content/seo/tags_spec.cr
+++ b/spec/content/seo/tags_spec.cr
@@ -1,0 +1,134 @@
+require "../../spec_helper"
+require "../../../src/content/seo/tags"
+require "../../../src/models/config"
+require "../../../src/models/page"
+
+describe Hwaro::Content::Seo::Tags do
+  describe ".canonical_tag" do
+    it "generates canonical tag from base_url and page url" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+
+      tag = Hwaro::Content::Seo::Tags.canonical_tag(page, config)
+      tag.should eq %(<link rel="canonical" href="https://example.com/test/">)
+    end
+
+    it "uses permalink if available" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      page.permalink = "https://custom.com/foo/"
+
+      tag = Hwaro::Content::Seo::Tags.canonical_tag(page, config)
+      tag.should eq %(<link rel="canonical" href="https://custom.com/foo/">)
+    end
+
+    it "handles base_url with trailing slash correctly" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com/"
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+
+      tag = Hwaro::Content::Seo::Tags.canonical_tag(page, config)
+      tag.should eq %(<link rel="canonical" href="https://example.com/test/">)
+    end
+
+    it "handles page url without leading slash correctly" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "test/"
+
+      tag = Hwaro::Content::Seo::Tags.canonical_tag(page, config)
+      tag.should eq %(<link rel="canonical" href="https://example.com/test/">)
+    end
+  end
+
+  describe ".hreflang_tags" do
+    it "returns empty string if not multilingual" do
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+
+      page = Hwaro::Models::Page.new("test.md")
+
+      tags = Hwaro::Content::Seo::Tags.hreflang_tags(page, config)
+      tags.should be_empty
+    end
+
+    it "returns empty string if no translations" do
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      page = Hwaro::Models::Page.new("test.md")
+
+      tags = Hwaro::Content::Seo::Tags.hreflang_tags(page, config)
+      tags.should be_empty
+    end
+
+    it "generates hreflang tags for translations" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.language = "en"
+      page.url = "/test/"
+
+      # Add translation link
+      translation = Hwaro::Models::TranslationLink.new(
+        code: "ko",
+        url: "/ko/test/",
+        title: "Test (KO)",
+        is_current: false
+      )
+      page.translations << translation
+
+      tags = Hwaro::Content::Seo::Tags.hreflang_tags(page, config)
+
+      expected_tags = [
+        %(<link rel="alternate" hreflang="en" href="https://example.com/test/">),
+        %(<link rel="alternate" hreflang="ko" href="https://example.com/ko/test/">)
+      ]
+
+      tags.should eq expected_tags.sort.join("\n")
+    end
+
+    it "handles absolute translation URLs" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.language = "en"
+      page.url = "/test/"
+
+      # Add translation link with absolute URL
+      translation = Hwaro::Models::TranslationLink.new(
+        code: "ko",
+        url: "https://example.com/ko/test/",
+        title: "Test (KO)",
+        is_current: false
+      )
+      page.translations << translation
+
+      tags = Hwaro::Content::Seo::Tags.hreflang_tags(page, config)
+
+      expected_tags = [
+        %(<link rel="alternate" hreflang="en" href="https://example.com/test/">),
+        %(<link rel="alternate" hreflang="ko" href="https://example.com/ko/test/">)
+      ]
+
+      tags.should eq expected_tags.sort.join("\n")
+    end
+  end
+end

--- a/src/content/seo/tags.cr
+++ b/src/content/seo/tags.cr
@@ -1,0 +1,42 @@
+require "../../models/config"
+require "../../models/page"
+
+module Hwaro
+  module Content
+    module Seo
+      module Tags
+        extend self
+
+        def canonical_tag(page : Models::Page, config : Models::Config) : String
+          # Use permalink if available, otherwise construct from base_url + url
+          url = page.permalink || "#{config.base_url.rstrip("/")}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+          %(<link rel="canonical" href="#{url}">)
+        end
+
+        def hreflang_tags(page : Models::Page, config : Models::Config) : String
+          return "" unless config.multilingual?
+          return "" if page.translations.empty?
+
+          tags = [] of String
+
+          # Add current page
+          current_url = page.permalink || "#{config.base_url.rstrip("/")}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+          lang_code = page.language || config.default_language
+          tags << %(<link rel="alternate" hreflang="#{lang_code}" href="#{current_url}">)
+
+          # Add translations
+          page.translations.each do |t|
+            next if t.is_current
+
+            # TranslationLink url is relative, so we need to make it absolute
+            abs_url = t.url.starts_with?("http") ? t.url : "#{config.base_url.rstrip("/")}#{t.url.starts_with?("/") ? t.url : "/#{t.url}"}"
+            tags << %(<link rel="alternate" hreflang="#{t.code}" href="#{abs_url}">)
+          end
+
+          # Sort tags to ensure deterministic output
+          tags.sort.join("\n")
+        end
+      end
+    end
+  end
+end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -20,6 +20,7 @@ require "../../content/seo/feeds"
 require "../../content/seo/sitemap"
 require "../../content/seo/robots"
 require "../../content/seo/llms"
+require "../../content/seo/tags"
 require "../../content/search"
 require "../../content/pagination/paginator"
 require "../../content/pagination/renderer"
@@ -1416,6 +1417,12 @@ module Hwaro
           vars["og_tags"] = Crinja::Value.new(og_tags)
           vars["twitter_tags"] = Crinja::Value.new(twitter_tags)
           vars["og_all_tags"] = Crinja::Value.new(og_all_tags)
+
+          # Canonical and Hreflang tags
+          canonical_tag = Content::Seo::Tags.canonical_tag(page, config)
+          hreflang_tags = Content::Seo::Tags.hreflang_tags(page, config)
+          vars["canonical_tag"] = Crinja::Value.new(canonical_tag)
+          vars["hreflang_tags"] = Crinja::Value.new(hreflang_tags)
 
           # Time-related variables
           now = Time.local


### PR DESCRIPTION
This PR adds support for canonical URLs and hreflang tags to improve SEO for Hwaro sites.

Key changes:
- `src/content/seo/tags.cr`: New module for generating SEO tags.
- `src/core/build/builder.cr`: Integrated the new module to expose `canonical_tag` and `hreflang_tags` variables to templates.
- `docs/content/templates/data-model.md`: Updated documentation to include the new variables.
- `spec/content/seo/tags_spec.cr`: Added unit tests for the new functionality.


---
*PR created automatically by Jules for task [12570238340392252516](https://jules.google.com/task/12570238340392252516) started by @hahwul*