### PR TITLE
docs: reduce code block padding and margin

### DIFF
--- a/docs/static/assets/css/04-content.css
+++ b/docs/static/assets/css/04-content.css
@@ -143,7 +143,7 @@
 
 .code-wrapper {
     position: relative;
-    margin: 1rem 0 1.5rem 0;
+    margin: 0.75rem 0 1rem 0;
 }
 
 .code-wrapper pre {
@@ -203,11 +203,11 @@ code {
 pre {
     font-family: var(--font-mono);
     background: var(--code-bg);
-    padding: 1.25rem;
+    padding: 0.8rem 1.25rem;
     overflow-x: auto;
     border: 1px solid var(--border);
     border-radius: 8px;
-    margin: 1rem 0 1.5rem 0;
+    margin: 0.75rem 0 1rem 0;
     position: relative;
 }
 


### PR DESCRIPTION
Reduces the vertical padding inside code blocks and the margins around them to create a more compact and cleaner look in the documentation.

---
*PR created automatically by Jules for task [8187175891512767108](https://jules.google.com/task/8187175891512767108) started by @hahwul*