### PR TITLE
🧪 Add unit tests for NewCommand CLI wrapper

### DIFF
--- a/spec/unit/new_command_spec.cr
+++ b/spec/unit/new_command_spec.cr
@@ -1,0 +1,55 @@
+require "../spec_helper"
+require "../../src/cli/commands/new_command"
+
+describe Hwaro::CLI::Commands::NewCommand do
+  describe "#parse_options" do
+    it "parses path argument" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      options = cmd.parse_options(["posts/hello.md"])
+      options.path.should eq("posts/hello.md")
+    end
+
+    it "parses title flag" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      options = cmd.parse_options(["--title", "Hello World"])
+      options.title.should eq("Hello World")
+
+      options = cmd.parse_options(["-t", "My Title"])
+      options.title.should eq("My Title")
+    end
+
+    it "parses archetype flag" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      options = cmd.parse_options(["--archetype", "blog"])
+      options.archetype.should eq("blog")
+
+      options = cmd.parse_options(["-a", "news"])
+      options.archetype.should eq("news")
+    end
+
+    it "parses combinations of flags and arguments" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      options = cmd.parse_options(["posts/new.md", "--title", "New Post", "-a", "blog"])
+
+      options.path.should eq("posts/new.md")
+      options.title.should eq("New Post")
+      options.archetype.should eq("blog")
+    end
+
+    it "handles empty arguments" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      options = cmd.parse_options([] of String)
+
+      options.path.should be_nil
+      options.title.should be_nil
+      options.archetype.should be_nil
+    end
+
+    it "raises on unknown flags" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      expect_raises(OptionParser::InvalidOption) do
+        cmd.parse_options(["--unknown"])
+      end
+    end
+  end
+end

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -36,7 +36,7 @@ module Hwaro
           Services::Creator.new.run(options)
         end
 
-        private def parse_options(args : Array(String)) : Config::Options::NewOptions
+        def parse_options(args : Array(String)) : Config::Options::NewOptions
           path = nil
           title = nil
           archetype = nil


### PR DESCRIPTION
This PR adds unit tests for the `NewCommand` CLI wrapper in `src/cli/commands/new_command.cr`. 

To facilitate testing of the argument parsing logic without invoking the file creation service, the `parse_options` method was changed from `private` to public. 

A new test file `spec/unit/new_command_spec.cr` was created with tests covering:
- Default behavior (empty arguments)
- Positional arguments (path)
- Title flag (`-t`, `--title`)
- Archetype flag (`-a`, `--archetype`)
- Combinations of flags and arguments
- Invalid flags handling

This improves the test coverage and ensures the CLI argument parsing works as expected.

---
*PR created automatically by Jules for task [2715663125428622363](https://jules.google.com/task/2715663125428622363) started by @hahwul*