### PR TITLE
Add unit tests for DebugPrinter

### DIFF
--- a/spec/unit/debug_printer_spec.cr
+++ b/spec/unit/debug_printer_spec.cr
@@ -1,0 +1,84 @@
+require "../spec_helper"
+require "../../src/utils/debug_printer"
+require "../../src/models/site"
+require "../../src/models/page"
+require "../../src/models/section"
+
+describe Hwaro::Utils::DebugPrinter do
+  describe ".print" do
+    it "prints the site structure correctly" do
+      # Setup site
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      # Create sections
+      blog_section = Hwaro::Models::Section.new("blog/_index.md")
+      blog_section.title = "Blog"
+      site.sections << blog_section
+
+      # Create pages
+      page1 = Hwaro::Models::Page.new("index.md")
+      page1.title = "Home"
+      page1.section = ""
+      site.pages << page1
+
+      page2 = Hwaro::Models::Page.new("blog/post-1.md")
+      page2.title = "Post 1"
+      page2.section = "blog"
+      site.pages << page2
+
+      # Create IO to capture output
+      io = IO::Memory.new
+
+      # Call print
+      Hwaro::Utils::DebugPrinter.print(site, io)
+
+      # Verify output
+      output = io.to_s
+      output.should contain("Site Structure (Debug):")
+      output.should contain("Home")
+      output.should contain("index.md")
+      output.should contain("blog")
+      output.should contain("Blog")
+      output.should contain("Post 1")
+      output.should contain("blog/post-1.md")
+    end
+
+    it "handles nested sections" do
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      # Create nested section
+      tech_section = Hwaro::Models::Section.new("blog/tech/_index.md")
+      tech_section.title = "Tech"
+      site.sections << tech_section
+
+      page = Hwaro::Models::Page.new("blog/tech/post.md")
+      page.title = "Tech Post"
+      page.section = "blog/tech"
+      site.pages << page
+
+      io = IO::Memory.new
+      Hwaro::Utils::DebugPrinter.print(site, io)
+
+      output = io.to_s
+      output.should contain("blog")
+      output.should contain("tech")
+      output.should contain("Tech")
+      output.should contain("Tech Post")
+    end
+
+    it "handles empty site" do
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      io = IO::Memory.new
+      Hwaro::Utils::DebugPrinter.print(site, io)
+
+      output = io.to_s
+      output.should contain("Site Structure (Debug):")
+      # Should not contain any page indicators if there are no pages
+      output.should_not contain("- ")
+    end
+  end
+end

--- a/src/utils/debug_printer.cr
+++ b/src/utils/debug_printer.cr
@@ -18,7 +18,7 @@ module Hwaro
         end
       end
 
-      def self.print(site : Models::Site)
+      def self.print(site : Models::Site, io : IO = STDOUT)
         root = Node.new("root")
 
         # Build tree from pages
@@ -51,21 +51,21 @@ module Hwaro
           current.section = section
         end
 
-        puts "\nSite Structure (Debug):".colorize(:cyan).mode(:bold)
-        print_node(root, "", true)
-        puts ""
+        io.puts "\nSite Structure (Debug):".colorize(:cyan).mode(:bold)
+        print_node(root, "", true, io)
+        io.puts ""
       end
 
-      private def self.print_node(node : Node, prefix : String, is_root : Bool)
+      private def self.print_node(node : Node, prefix : String, is_root : Bool, io : IO)
         unless is_root
           # Determine label
           label = node.name
           if section = node.section
             label += " (Section: #{section.title})"
-            puts "#{prefix}#{label}".colorize(:blue).mode(:bold)
+            io.puts "#{prefix}#{label}".colorize(:blue).mode(:bold)
           else
             label += " (Dir)"
-            puts "#{prefix}#{label}".colorize(:blue)
+            io.puts "#{prefix}#{label}".colorize(:blue)
           end
         end
 
@@ -73,13 +73,13 @@ module Hwaro
 
         # Print pages
         node.pages.sort_by!(&.title).each do |page|
-          puts "#{indent}- #{page.title} (#{page.path})".colorize(:green)
+          io.puts "#{indent}- #{page.title} (#{page.path})".colorize(:green)
         end
 
         # Print children
         sorted_children = node.children.keys.sort
         sorted_children.each do |key|
-          print_node(node.children[key], indent, false)
+          print_node(node.children[key], indent, false, io)
         end
       end
     end


### PR DESCRIPTION
This PR adds unit tests for `Hwaro::Utils::DebugPrinter` to ensure it correctly prints the site structure. It involves refactoring the `print` method to accept an `IO` object (dependency injection) to allow capturing output in tests without modifying global stdout. The new tests cover basic structure, nested sections, and empty site cases.

---
*PR created automatically by Jules for task [4951395784170275754](https://jules.google.com/task/4951395784170275754) started by @hahwul*