### PR TITLE
🧪 Add unit tests for DeployCommand CLI

### DIFF
--- a/spec/unit/deploy_command_spec.cr
+++ b/spec/unit/deploy_command_spec.cr
@@ -1,0 +1,67 @@
+require "../spec_helper"
+require "../../src/cli/commands/deploy_command"
+
+describe Hwaro::CLI::Commands::DeployCommand do
+  describe "#parse_options" do
+    it "returns default options" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      options, list_targets = cmd.parse_options([] of String)
+
+      options.source_dir.should be_nil
+      options.dry_run.should be_nil
+      options.confirm.should be_nil
+      options.force.should be_nil
+      options.max_deletes.should be_nil
+      options.targets.should be_empty
+      list_targets.should be_false
+    end
+
+    it "parses source directory" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      options, _ = cmd.parse_options(["--source", "dist"])
+      options.source_dir.should eq("dist")
+
+      options, _ = cmd.parse_options(["-s", "public"])
+      options.source_dir.should eq("public")
+    end
+
+    it "parses boolean flags" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      options, _ = cmd.parse_options(["--dry-run", "--confirm", "--force"])
+
+      options.dry_run.should be_true
+      options.confirm.should be_true
+      options.force.should be_true
+    end
+
+    it "parses max deletes" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      options, _ = cmd.parse_options(["--max-deletes", "10"])
+      options.max_deletes.should eq(10)
+
+      options, _ = cmd.parse_options(["--max-deletes", "-1"])
+      options.max_deletes.should eq(-1)
+    end
+
+    it "parses list targets" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      _, list_targets = cmd.parse_options(["--list-targets"])
+      list_targets.should be_true
+    end
+
+    it "parses positional arguments as targets" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      options, _ = cmd.parse_options(["production", "staging"])
+      options.targets.should eq(["production", "staging"])
+    end
+
+    it "parses mixed flags and arguments" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      options, _ = cmd.parse_options(["--dry-run", "production", "-s", "dist"])
+
+      options.dry_run.should be_true
+      options.source_dir.should eq("dist")
+      options.targets.should eq(["production"])
+    end
+  end
+end

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -47,7 +47,7 @@ module Hwaro
           exit(1) unless ok
         end
 
-        private def parse_options(args : Array(String)) : {Config::Options::DeployOptions, Bool}
+        def parse_options(args : Array(String)) : {Config::Options::DeployOptions, Bool}
           source_dir = nil.as(String?)
           dry_run = nil.as(Bool?)
           confirm = nil.as(Bool?)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added unit tests for `Hwaro::CLI::Commands::DeployCommand#parse_options` to verify argument parsing logic.

📊 **Coverage:** What scenarios are now tested
- Default values
- Parsing of --source, --dry-run, --confirm, --force, --max-deletes
- Parsing of --list-targets
- Positional arguments
- Mixed flags and arguments

✨ **Result:** The improvement in test coverage
The `DeployCommand` argument parsing logic is now covered by unit tests, ensuring reliability and preventing regressions in CLI behavior.

---
*PR created automatically by Jules for task [16380342838288110812](https://jules.google.com/task/16380342838288110812) started by @hahwul*