### PR TITLE
Add unit tests for Creator service and fix file path bug

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -1,0 +1,172 @@
+require "../spec_helper"
+require "../../src/services/creator"
+
+describe Hwaro::Services::Creator do
+  describe "#run" do
+    it "creates a file from a direct path with inferred title" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          # Create necessary directories
+          FileUtils.mkdir_p("content/drafts")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "my-first-post.md")
+          creator = Hwaro::Services::Creator.new
+
+          creator.run(options)
+
+          expected_path = "content/drafts/my-first-post.md"
+          File.exists?(expected_path).should be_true
+
+          content = File.read(expected_path)
+          content.should contain("title: My First Post")
+          content.should contain("draft: true")
+        end
+      end
+    end
+
+    it "creates a file from a direct path with explicit title" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "custom.md", title: "My Custom Title")
+          creator = Hwaro::Services::Creator.new
+
+          creator.run(options)
+
+          expected_path = "content/drafts/custom.md"
+          File.exists?(expected_path).should be_true
+
+          content = File.read(expected_path)
+          content.should contain("title: My Custom Title")
+        end
+      end
+    end
+
+    it "creates a file in a subdirectory" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/blog")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "blog/post.md", title: "Blog Post")
+          creator = Hwaro::Services::Creator.new
+
+          creator.run(options)
+
+          expected_path = "content/blog/post.md"
+          File.exists?(expected_path).should be_true
+        end
+      end
+    end
+
+    it "creates a file when path is a directory and title is provided" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/blog")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "blog", title: "My Blog Post")
+          creator = Hwaro::Services::Creator.new
+
+          creator.run(options)
+
+          # "My Blog Post" -> "my-blog-post.md"
+          expected_path = "content/blog/my-blog-post.md"
+          File.exists?(expected_path).should be_true
+
+          content = File.read(expected_path)
+          content.should contain("title: My Blog Post")
+        end
+      end
+    end
+
+    it "uses an explicit archetype if provided" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+          FileUtils.mkdir_p("archetypes")
+
+          File.write("archetypes/custom.md", "+++\ntitle = \"{{ title }}\"\ncustom = true\n+++\n\n# Custom Content")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Archetype Test", archetype: "custom")
+          creator = Hwaro::Services::Creator.new
+
+          creator.run(options)
+
+          expected_path = "content/drafts/post.md"
+          File.exists?(expected_path).should be_true
+
+          content = File.read(expected_path)
+          content.should contain("title = \"Archetype Test\"")
+          content.should contain("custom = true")
+          content.should contain("# Custom Content")
+        end
+      end
+    end
+
+    it "uses an implicit archetype based on directory" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/blog")
+          FileUtils.mkdir_p("archetypes")
+
+          # Create archetype for 'blog' section
+          File.write("archetypes/blog.md", "---\ntitle: {{ title }}\ntype: blog\n---\n")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "blog/post.md", title: "Blog Item")
+          creator = Hwaro::Services::Creator.new
+
+          creator.run(options)
+
+          expected_path = "content/blog/post.md"
+          File.exists?(expected_path).should be_true
+
+          content = File.read(expected_path)
+          content.should contain("type: blog")
+        end
+      end
+    end
+
+    it "uses the default archetype if no specific archetype matches" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+          FileUtils.mkdir_p("archetypes")
+
+          File.write("archetypes/default.md", "---\ntitle: {{ title }}\ndefault: true\n---\n")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Default Test")
+          creator = Hwaro::Services::Creator.new
+
+          creator.run(options)
+
+          expected_path = "content/drafts/post.md"
+          File.exists?(expected_path).should be_true
+
+          content = File.read(expected_path)
+          content.should contain("default: true")
+        end
+      end
+    end
+
+    it "falls back to built-in generation if no archetype exists" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+          # No archetypes directory
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Fallback Test")
+          creator = Hwaro::Services::Creator.new
+
+          creator.run(options)
+
+          expected_path = "content/drafts/post.md"
+          File.exists?(expected_path).should be_true
+
+          content = File.read(expected_path)
+          content.should contain("title: Fallback Test")
+          content.should contain("date: ")
+        end
+      end
+    end
+  end
+end

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -28,7 +28,11 @@ module Hwaro
           end
 
           filename = File.basename(path)
-          full_path = path.starts_with?("content/") ? path : File.join("content", path)
+          if base_dir == "content/drafts"
+            full_path = File.join(base_dir, filename)
+          else
+            full_path = path.starts_with?("content/") ? path : File.join("content", path)
+          end
           base_dir = File.dirname(full_path)
         else
           base_dir = path || "content/drafts"


### PR DESCRIPTION
Added `spec/unit/creator_spec.cr` to test `Hwaro::Services::Creator`.
Fixed a bug in `Creator#run` where files without a directory component were created in `content/` instead of `content/drafts/`.
Tests cover happy paths, directory inference, and archetype usage.

---
*PR created automatically by Jules for task [11918435094067519193](https://jules.google.com/task/11918435094067519193) started by @hahwul*