### PR TITLE
⚡ Extract regex to constant in Builder for shortcode parsing

### DIFF
--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -1,0 +1,44 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# Reopen Builder to expose the private method for testing
+module Hwaro::Core::Build
+  class Builder
+    def test_parse_shortcode_args_jinja(args_str)
+      parse_shortcode_args_jinja(args_str)
+    end
+  end
+end
+
+describe Hwaro::Core::Build::Builder do
+  describe "#parse_shortcode_args_jinja" do
+    it "parses quoted and unquoted arguments" do
+      builder = Hwaro::Core::Build::Builder.new
+      args = builder.test_parse_shortcode_args_jinja("key1=\"value 1\" key2='value 2' key3=value3")
+
+      args["key1"].should eq("value 1")
+      args["key2"].should eq("value 2")
+      args["key3"].should eq("value3")
+    end
+
+    it "handles empty arguments" do
+      builder = Hwaro::Core::Build::Builder.new
+      args = builder.test_parse_shortcode_args_jinja("")
+      args.should be_empty
+    end
+
+    it "handles nil arguments" do
+      builder = Hwaro::Core::Build::Builder.new
+      args = builder.test_parse_shortcode_args_jinja(nil)
+      args.should be_empty
+    end
+
+    it "parses arguments with whitespace" do
+      builder = Hwaro::Core::Build::Builder.new
+      args = builder.test_parse_shortcode_args_jinja("key1 = \"value1\"  key2=  'value2'")
+
+      args["key1"].should eq("value1")
+      args["key2"].should eq("value2")
+    end
+  end
+end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -52,6 +52,8 @@ module Hwaro
         @profiler : Profiler?
         @crinja_env : Crinja?
 
+        SHORTCODE_ARGS_REGEX = /(\w+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^,\s]+))/
+
         def initialize
           @lifecycle = Lifecycle::Manager.new
         end
@@ -1587,7 +1589,7 @@ module Hwaro
           return args unless args_str
 
           # Match: key="value", key='value', or key=value (unquoted)
-          args_str.scan(/(\w+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^,\s]+))/) do |match|
+          args_str.scan(SHORTCODE_ARGS_REGEX) do |match|
             key = match[1]
             value = match[2]? || match[3]? || match[4]? || ""
             args[key] = value


### PR DESCRIPTION
This PR extracts the regex used for parsing shortcode arguments in `Hwaro::Core::Build::Builder#parse_shortcode_args_jinja` to a constant `SHORTCODE_ARGS_REGEX`.

### Changes
- Defined `SHORTCODE_ARGS_REGEX` in `Hwaro::Core::Build::Builder`.
- Updated `parse_shortcode_args_jinja` to use the constant.
- Added unit tests in `spec/unit/builder_shortcode_spec.cr`.

### Performance
Micro-benchmarks showed that Crystal effectively caches regex literals, so the performance impact is negligible (~1.0x). However, using a constant is better for code clarity and avoids any potential overhead in different compilation contexts.


---
*PR created automatically by Jules for task [6865190366241516597](https://jules.google.com/task/6865190366241516597) started by @hahwul*