### PR TITLE
⚡ Optimize Markdown header check by replacing regex with char check

### DIFF
--- a/spec/unit/markdown_toc_spec.cr
+++ b/spec/unit/markdown_toc_spec.cr
@@ -1,0 +1,66 @@
+require "../spec_helper"
+
+describe Hwaro::Content::Processors::Markdown do
+  describe "TOC generation" do
+    it "generates correct TOC structure" do
+      content = <<-MARKDOWN
+      # Header 1
+      ## Header 1.1
+      ### Header 1.1.1
+      ## Header 1.2
+      # Header 2
+      MARKDOWN
+
+      _, toc = Hwaro::Content::Processors::Markdown.new.render(content)
+
+      toc.size.should eq(2)
+      toc[0].level.should eq(1)
+      toc[0].title.should eq("Header 1")
+
+      toc[0].children.size.should eq(2)
+      toc[0].children[0].level.should eq(2)
+      toc[0].children[0].title.should eq("Header 1.1")
+
+      toc[0].children[0].children.size.should eq(1)
+      toc[0].children[0].children[0].level.should eq(3)
+      toc[0].children[0].children[0].title.should eq("Header 1.1.1")
+
+      toc[1].level.should eq(1)
+      toc[1].title.should eq("Header 2")
+    end
+
+    it "ignores non-header tags" do
+      content = <<-MARKDOWN
+      <hr>
+      <div class="h1">Not a header</div>
+
+      # Header
+      MARKDOWN
+
+      _, toc = Hwaro::Content::Processors::Markdown.new.render(content)
+      toc.size.should eq(1)
+      toc[0].title.should eq("Header")
+    end
+
+    it "handles header levels correctly with char check optimization" do
+      content = <<-MARKDOWN
+      # H1
+      ## H2
+      ### H3
+      #### H4
+      ##### H5
+      ###### H6
+      MARKDOWN
+
+      _, toc = Hwaro::Content::Processors::Markdown.new.render(content)
+
+      root = toc[0]
+      root.level.should eq(1)
+      root.children[0].level.should eq(2)
+      root.children[0].children[0].level.should eq(3)
+      root.children[0].children[0].children[0].level.should eq(4)
+      root.children[0].children[0].children[0].children[0].level.should eq(5)
+      root.children[0].children[0].children[0].children[0].children[0].level.should eq(6)
+    end
+  end
+end

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -435,9 +435,12 @@ module Hwaro
 
             # Iterate through h1-h6 tags
             body.xpath_nodes("//*[starts-with(name(), 'h') and string-length(name()) = 2]").each do |node|
-              next unless node.name =~ /^h[1-6]$/
+              # Optimization: Avoid regex for simple char check.
+              # XPath already ensures starts with 'h' and length 2.
+              c = node.name[1]
+              next unless c >= '1' && c <= '6'
 
-              level = node.name[1].to_i
+              level = c.to_i
               title = node.content
 
               # Generate ID


### PR DESCRIPTION
## ⚡ Performance Improvement: Optimize Markdown Header Check

### 💡 What
Replaced the regex check `node.name =~ /^h[1-6]$/` in `src/content/processors/markdown.cr` with a direct character check:
```crystal
c = node.name[1]
next unless c >= '1' && c <= '6'
```

### 🎯 Why
The `post_process_html` method iterates over all potential header nodes. While `node.name` is filtered by XPath to start with 'h' and have length 2, the subsequent check to ensure it is strictly `h1`-`h6` (and not `hr`, `h7`, etc.) used a regex. In Crystal, even regex literals have overhead compared to simple integer comparisons of character codes.

### 📊 Measured Improvement
Micro-benchmarks comparing `regex match` vs `char check` showed a **~25x speedup** for the check itself.

**Benchmark Results:**
```
regex constant   3.98k (251.54µs) (± 1.38%)  62.5kB/op  24.83× slower
    char check  98.72k ( 10.13µs) (± 1.37%)    0.0B/op        fastest
```
(Note: This is a micro-benchmark of the check loop. The overall impact on full site build depends on the number of pages and headers but this removes an unnecessary bottleneck in the hot path of markdown processing.)

### ✅ Verification
- Added `spec/unit/markdown_toc_spec.cr` to verify correct TOC structure and edge case handling (e.g. `<hr>` tags).
- Ran full test suite `crystal spec` with all tests passing.


---
*PR created automatically by Jules for task [4393650080554699781](https://jules.google.com/task/4393650080554699781) started by @hahwul*