### PR TITLE
Add tests for HTML minification and fix regex bug

### DIFF
--- a/spec/unit/processors_html_spec.cr
+++ b/spec/unit/processors_html_spec.cr
@@ -1,0 +1,86 @@
+require "../spec_helper"
+
+# Open the class to expose private method for testing
+class Hwaro::Content::Processors::Html
+  def test_minify_html(html : String) : String
+    minify_html(html)
+  end
+end
+
+describe Hwaro::Content::Processors::Html do
+  describe "minify_html" do
+    it "removes trailing whitespace on lines" do
+      html = "Line 1   \nLine 2\t\t\nLine 3"
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq("Line 1\nLine 2\nLine 3")
+    end
+
+    it "collapses excessive blank lines" do
+      html = "Line 1\n\n\n\nLine 2"
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq("Line 1\n\nLine 2")
+    end
+
+    it "removes standard HTML comments" do
+      html = "Line 1\n<!-- This is a comment -->\nLine 2"
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq("Line 1\n\nLine 2")
+    end
+
+    it "preserves conditional comments" do
+      html = "<!--[if IE]>Conditional<![endif]-->"
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq(html)
+    end
+
+    it "preserves 'more' markers" do
+      html = "Line 1\n<!-- more -->\nLine 2"
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq("Line 1\n<!-- more -->\nLine 2")
+    end
+
+    it "preserves 'more' markers with whitespace" do
+      html = "Line 1\n<!--  more  -->\nLine 2"
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq("Line 1\n<!--  more  -->\nLine 2")
+    end
+
+    it "cleans up pre/code blocks" do
+      html = "<pre>\n  <code>code</code>\n</pre>"
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq("<pre><code>code</code></pre>")
+    end
+
+    it "preserves pre attributes" do
+      html = "<pre class=\"language-ruby\">\n  <code>code</code>\n</pre>"
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq("<pre class=\"language-ruby\"><code>code</code></pre>")
+    end
+
+    it "strips leading/trailing whitespace of the string" do
+      html = "   \nContent\n   "
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq("Content")
+    end
+
+    it "preserves meaningful structure and indentation" do
+      html = <<-HTML
+      <div>
+        <p>Paragraph</p>
+      </div>
+      HTML
+      processor = Hwaro::Content::Processors::Html.new
+      result = processor.test_minify_html(html)
+      result.should eq("<div>\n  <p>Paragraph</p>\n</div>")
+    end
+  end
+end

--- a/src/content/processors/html.cr
+++ b/src/content/processors/html.cr
@@ -54,7 +54,7 @@ module Hwaro
           minified = cleaned.gsub(/<!--(?!\[if|\s*more\s*-->).*?-->/m, "")
 
           # Remove trailing whitespace on each line
-          minified = minified.gsub(/[ \t]+$/, "")
+          minified = minified.gsub(/[ \t]+$/m, "")
 
           # Collapse 3+ consecutive blank lines to 2
           minified = minified.gsub(/\n{3,}/, "\n\n")


### PR DESCRIPTION
Improved testing for `Hwaro::Content::Processors::Html` by adding unit tests for `minify_html`. Fixed a bug where trailing whitespace was not correctly removed from lines.

---
*PR created automatically by Jules for task [16837488801604060379](https://jules.google.com/task/16837488801604060379) started by @hahwul*