### PR TITLE
🧪 Add unit tests for Creator service path logic

### DIFF
--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -44,8 +44,7 @@ module Hwaro
           end
 
           if title.empty?
-            Logger.error "Title cannot be empty."
-            exit(1)
+            raise "Title cannot be empty."
           end
 
           filename = title.downcase.gsub(/[^\p{L}\p{N}]+/, "-").strip("-") + ".md"
@@ -67,8 +66,7 @@ module Hwaro
                   end
 
         if File.exists?(full_path)
-          Logger.error "File already exists: #{full_path}"
-          exit(1)
+          raise "File already exists: #{full_path}"
         end
 
         File.write(full_path, content)
@@ -83,8 +81,7 @@ module Hwaro
             Logger.debug "Using archetype: #{archetype_path}"
             return File.read(archetype_path)
           else
-            Logger.error "Archetype not found: #{archetype_path}"
-            exit(1)
+            raise "Archetype not found: #{archetype_path}"
           end
         end
 


### PR DESCRIPTION
🎯 **What:** add unit tests for Creator service path logic and refactor error handling
📊 **Coverage:** Added tests for:
- Path starting with `content/`
- Default drafting when path is nil but title provided
- Slug generation from directory path
- Error handling for existing files
- Error handling for missing archetypes
✨ **Result:** Improved testability and robustness of the Creator service. Verified with 13 passing examples in `creator_spec.cr` and full suite pass.

---
*PR created automatically by Jules for task [11515414074079633123](https://jules.google.com/task/11515414074079633123) started by @hahwul*