### PR TITLE
🧹 Refactor Markdown processor to unify extra value extraction

### DIFF
--- a/spec/unit/processors_spec.cr
+++ b/spec/unit/processors_spec.cr
@@ -590,4 +590,56 @@ describe Hwaro::Processor::Markdown do
       html.should contain("id=\"title\"")
     end
   end
+
+  describe "extra values extraction" do
+    it "extracts extra values from TOML" do
+      content = <<-MARKDOWN
+      +++
+      title = "Test Page"
+      extra_string = "hello"
+      extra_int = 42
+      extra_float = 3.14
+      extra_bool = true
+      extra_array = ["a", "b"]
+      +++
+
+      # Content
+      MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      extra = result[:extra]
+
+      extra["extra_string"].should eq("hello")
+      extra["extra_int"].should eq(42_i64)
+      extra["extra_float"].should eq(3.14)
+      extra["extra_bool"].should eq(true)
+      extra["extra_array"].should eq(["a", "b"])
+    end
+
+    it "extracts extra values from YAML" do
+      content = <<-MARKDOWN
+      ---
+      title: Test Page
+      extra_string: hello
+      extra_int: 42
+      extra_float: 3.14
+      extra_bool: true
+      extra_array:
+        - a
+        - b
+      ---
+
+      # Content
+      MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      extra = result[:extra]
+
+      extra["extra_string"].should eq("hello")
+      extra["extra_int"].should eq(42_i64)
+      extra["extra_float"].should eq(3.14)
+      extra["extra_bool"].should eq(true)
+      extra["extra_array"].should eq(["a", "b"])
+    end
+  end
 end

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -296,7 +296,7 @@ module Hwaro
                     key = key_any.as_s?
                     next unless key
                     next if known_keys.includes?(key)
-                    extra[key] = extract_extra_value_yaml(value)
+                    extra[key] = extract_extra_value(value)
                   end
                 end
 
@@ -349,25 +349,8 @@ module Hwaro
           }
         end
 
-        # Extract extra value from TOML::Any
-        private def extract_extra_value(value : TOML::Any) : String | Bool | Int64 | Float64 | Array(String)
-          if str = value.as_s?
-            str
-          elsif bool = value.as_bool?
-            bool
-          elsif int = value.as_i?
-            int.to_i64
-          elsif float = value.as_f?
-            float
-          elsif arr = value.as_a?
-            arr.compact_map(&.as_s?)
-          else
-            value.to_s
-          end
-        end
-
-        # Extract extra value from YAML::Any
-        private def extract_extra_value_yaml(value : YAML::Any) : String | Bool | Int64 | Float64 | Array(String)
+        # Extract extra value from TOML::Any or YAML::Any
+        private def extract_extra_value(value : TOML::Any | YAML::Any) : String | Bool | Int64 | Float64 | Array(String)
           if str = value.as_s?
             str
           elsif bool = value.as_bool?


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
  Duplicated logic for extracting "extra" values from TOML and YAML frontmatter in `Hwaro::Content::Processors::Markdown`.

💡 **Why:** How this improves maintainability
  Reduces code duplication by leveraging the shared API of `TOML::Any` and `YAML::Any` through a union type. This makes the code cleaner and easier to maintain, as changes to extraction logic only need to be applied in one place.

✅ **Verification:** How you confirmed the change is safe
  - Created new unit tests in `spec/unit/processors_spec.cr` verifying correct extraction of string, int, float, bool, and array types from both TOML and YAML.
  - Ran `crystal spec` to ensure all tests pass (no regressions).
  - Ran `shards build` to verify the binary still compiles correctly.

✨ **Result:** The improvement achieved
  Removed ~20 lines of duplicated code and improved test coverage for frontmatter parsing.

---
*PR created automatically by Jules for task [6115000213304957854](https://jules.google.com/task/6115000213304957854) started by @hahwul*