### PR TITLE
Support initializing project from Git repository URL

### DIFF
--- a/spec/unit/base_url_override_spec.cr
+++ b/spec/unit/base_url_override_spec.cr
@@ -16,7 +16,7 @@ describe "base_url override" do
         skip_sample_content: false,
         skip_taxonomies: true,
         multilingual_languages: [] of String,
-        scaffold_type: Hwaro::Config::Options::ScaffoldType::Simple
+        scaffold_type: "simple"
       )
 
       Dir.cd(project_dir) do

--- a/spec/unit/init_command_spec.cr
+++ b/spec/unit/init_command_spec.cr
@@ -13,7 +13,7 @@ describe Hwaro::CLI::Commands::InitCommand do
       options.skip_sample_content.should be_false
       options.skip_taxonomies.should be_false
       options.multilingual_languages.should be_empty
-      options.scaffold.should eq(Hwaro::Config::Options::ScaffoldType::Simple)
+      options.scaffold.should eq("simple")
     end
 
     it "parses path argument" do
@@ -35,13 +35,13 @@ describe Hwaro::CLI::Commands::InitCommand do
       cmd = Hwaro::CLI::Commands::InitCommand.new
 
       options = cmd.parse_options(["--scaffold", "simple"])
-      options.scaffold.should eq(Hwaro::Config::Options::ScaffoldType::Simple)
+      options.scaffold.should eq("simple")
 
       options = cmd.parse_options(["--scaffold", "blog"])
-      options.scaffold.should eq(Hwaro::Config::Options::ScaffoldType::Blog)
+      options.scaffold.should eq("blog")
 
       options = cmd.parse_options(["--scaffold", "docs"])
-      options.scaffold.should eq(Hwaro::Config::Options::ScaffoldType::Docs)
+      options.scaffold.should eq("docs")
     end
 
     it "parses skip flags" do
@@ -84,7 +84,7 @@ describe Hwaro::CLI::Commands::InitCommand do
 
       options.path.should eq("new-site")
       options.force.should be_true
-      options.scaffold.should eq(Hwaro::Config::Options::ScaffoldType::Blog)
+      options.scaffold.should eq("blog")
       options.multilingual_languages.should eq(["en", "es"])
     end
 

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -47,22 +47,13 @@ module Hwaro
           skip_sample_content = false
           skip_taxonomies = false
           multilingual_languages = [] of String
-          scaffold = Config::Options::ScaffoldType::Simple
+          scaffold = "simple"
 
           OptionParser.parse(args) do |parser|
             parser.banner = "Usage: hwaro init [path] [options]"
             parser.on("-f", "--force", "Force creation even if directory is not empty") { force = true }
-            parser.on("--scaffold TYPE", "Scaffold type: simple, blog, docs (default: simple)") do |type|
-              begin
-                scaffold = Config::Options::ScaffoldType.from_string(type)
-              rescue ex : ArgumentError
-                Logger.error ex.message.not_nil!
-                Logger.info "Available scaffolds:"
-                Logger.info "  simple  - Basic pages structure with homepage and about page"
-                Logger.info "  blog    - Blog-focused structure with posts, archives, and taxonomies"
-                Logger.info "  docs    - Documentation-focused structure with organized sections and sidebar"
-                exit(1)
-              end
+            parser.on("--scaffold TYPE", "Scaffold type: simple, blog, docs or URL (default: simple)") do |type|
+              scaffold = type
             end
             parser.on("--skip-agents-md", "Skip creating AGENTS.md file") { skip_agents_md = true }
             parser.on("--skip-sample-content", "Skip creating sample content files") { skip_sample_content = true }

--- a/src/config/options/init_options.cr
+++ b/src/config/options/init_options.cr
@@ -37,7 +37,7 @@ module Hwaro
         property skip_sample_content : Bool
         property skip_taxonomies : Bool
         property multilingual_languages : Array(String)
-        property scaffold : ScaffoldType
+        property scaffold : String
 
         def initialize(
           @path : String = ".",
@@ -46,7 +46,7 @@ module Hwaro
           @skip_sample_content : Bool = false,
           @skip_taxonomies : Bool = false,
           @multilingual_languages : Array(String) = [] of String,
-          @scaffold : ScaffoldType = ScaffoldType::Simple,
+          @scaffold : String = "simple",
         )
         end
 


### PR DESCRIPTION
This PR enables `hwaro init` to accept a Git repository URL as a scaffold argument. When a URL is provided, the repository is cloned, and a new site is initialized using the repository's structure. Specifically, it copies the entire structure but filters out content pages (except `_index.md`) to provide a clean starting point with the correct section hierarchy and configuration.

---
*PR created automatically by Jules for task [8558637398891838835](https://jules.google.com/task/8558637398891838835) started by @hahwul*