### PR TITLE
Add missing configuration values (exclude, permalinks) to hwaro init

### DIFF
--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -288,7 +288,8 @@ module Hwaro
           str << "enabled = true\n"
           str << "format = \"fuse_json\"\n"
           str << "fields = [\"title\", \"content\"]\n"
-          str << "filename = \"search.json\"\n\n"
+          str << "filename = \"search.json\"\n"
+          str << "exclude = []              # Exclude paths or patterns from search index\n\n"
 
           str << "# =============================================================================\n"
           str << "# Pagination\n"
@@ -315,7 +316,8 @@ module Hwaro
           str << "enabled = true\n"
           str << "filename = \"sitemap.xml\"\n"
           str << "changefreq = \"weekly\"\n"
-          str << "priority = 0.5\n\n"
+          str << "priority = 0.5\n"
+          str << "exclude = []              # Exclude paths or patterns from sitemap\n\n"
 
           str << "# =============================================================================\n"
           str << "# SEO: Robots.txt\n"
@@ -354,6 +356,16 @@ module Hwaro
           str << "sections = []             # Limit to specific sections, e.g., [\"posts\"]\n\n"
 
           # Optional features
+          str << "# =============================================================================\n"
+          str << "# Permalinks (Optional)\n"
+          str << "# =============================================================================\n"
+          str << "# Override the output path for specific sections or taxonomies.\n"
+          str << "# Placeholders: :year, :month, :day, :title, :slug, :section\n"
+          str << "#\n"
+          str << "# [permalinks]\n"
+          str << "# posts = \"/posts/:year/:month/:slug/\"\n"
+          str << "# tags = \"/topic/:slug/\"\n\n"
+
           str << "# =============================================================================\n"
           str << "# Auto Includes (Optional)\n"
           str << "# =============================================================================\n"

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -362,6 +362,7 @@ module Hwaro
           format = "fuse_json"
           fields = ["title", "content"]
           filename = "search.json"
+          exclude = []              # Exclude paths or patterns from search index
 
           TOML
         end
@@ -379,6 +380,7 @@ module Hwaro
           filename = "sitemap.xml"
           changefreq = "weekly"
           priority = 0.5
+          exclude = []              # Exclude paths or patterns from sitemap
 
           TOML
         end
@@ -460,6 +462,22 @@ module Hwaro
           truncate = 0              # Truncate content to N characters (0 = full content)
           limit = 10                # Maximum number of items in feed
           sections = #{sections_str}   # Limit to specific sections, e.g., ["posts"]
+
+          TOML
+        end
+
+        protected def permalinks_config : String
+          <<-TOML
+
+          # =============================================================================
+          # Permalinks (Optional)
+          # =============================================================================
+          # Override the output path for specific sections or taxonomies.
+          # Placeholders: :year, :month, :day, :title, :slug, :section
+          #
+          # [permalinks]
+          # posts = "/posts/:year/:month/:slug/"
+          # tags = "/topic/:slug/"
 
           TOML
         end

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -80,6 +80,7 @@ module Hwaro
             str << feeds_config(["posts"])
 
             # Optional features (commented out by default)
+            str << permalinks_config
             str << auto_includes_config
             str << markdown_config
             str << build_hooks_config

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -82,6 +82,7 @@ module Hwaro
             str << feeds_config
 
             # Optional features (commented out by default)
+            str << permalinks_config
             str << auto_includes_config
             str << markdown_config
             str << build_hooks_config

--- a/src/services/scaffolds/simple.cr
+++ b/src/services/scaffolds/simple.cr
@@ -70,6 +70,7 @@ module Hwaro
             str << feeds_config
 
             # Optional features (commented out by default)
+            str << permalinks_config
             str << auto_includes_config
             str << markdown_config
             str << build_hooks_config


### PR DESCRIPTION
Updated the default `config.toml` template generated by `hwaro init` to include `exclude` options for search and sitemap, and a commented-out `[permalinks]` section. This ensures users are aware of these configuration options upon project initialization.

---
*PR created automatically by Jules for task [8497591181577010339](https://jules.google.com/task/8497591181577010339) started by @hahwul*