### PR TITLE
🧹 Refactor Docs scaffold to use external CSS file

### DIFF
--- a/spec/unit/scaffolds_docs_spec.cr
+++ b/spec/unit/scaffolds_docs_spec.cr
@@ -1,0 +1,24 @@
+require "../spec_helper"
+require "../../src/services/scaffolds/docs"
+
+describe Hwaro::Services::Scaffolds::Docs do
+  describe "#static_files" do
+    it "includes css/style.css" do
+      scaffold = Hwaro::Services::Scaffolds::Docs.new
+      files = scaffold.static_files
+      files.has_key?("css/style.css").should be_true
+      files["css/style.css"].should_not be_empty
+    end
+  end
+
+  describe "#styles" do
+    it "returns a link tag" do
+      # Since `styles` is protected, we need to access it via send or similar if we were in Ruby,
+      # but in Crystal we can't easily call protected methods from outside.
+      # However, we can check `header_template` which uses `styles`.
+      scaffold = Hwaro::Services::Scaffolds::Docs.new
+      header = scaffold.template_files["header.html"]
+      header.should contain("<link rel=\"stylesheet\" href=\"{{ base_url }}/css/style.css\">")
+    end
+  end
+end

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -113,79 +113,89 @@ module Hwaro
         # Override styles for docs - modern unified layout
         protected def styles : String
           <<-CSS
-            <style>
-              :root {
-                --primary: #0070f3;
-                --text: #24292f;
-                --text-muted: #57606a;
-                --border: #d0d7de;
-                --bg: #ffffff;
-                --bg-subtle: #f6f8fa;
-                --header-h: 56px;
-                --sidebar-w: 260px;
-              }
-              *, *::before, *::after { box-sizing: border-box; }
-              body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; margin: 0; color: var(--text); background: var(--bg); }
+            <link rel="stylesheet" href="{{ base_url }}/css/style.css">
+          CSS
+        end
 
-              /* Header - fixed top */
-              .docs-header { position: fixed; top: 0; left: 0; right: 0; height: var(--header-h); background: var(--bg); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 1.5rem; z-index: 100; }
-              .docs-header .logo { font-weight: 600; font-size: 1.1rem; color: var(--text); text-decoration: none; margin-right: 2rem; }
-              .docs-header nav { display: flex; gap: 1.5rem; }
-              .docs-header nav a { color: var(--text-muted); text-decoration: none; font-size: 0.9rem; }
-              .docs-header nav a:hover { color: var(--primary); }
+        def static_files : Hash(String, String)
+          {
+            "css/style.css" => css_content,
+          }
+        end
 
-              /* Layout container */
-              .docs-container { display: flex; padding-top: var(--header-h); min-height: 100vh; }
+        private def css_content : String
+          <<-CSS
+          :root {
+            --primary: #0070f3;
+            --text: #24292f;
+            --text-muted: #57606a;
+            --border: #d0d7de;
+            --bg: #ffffff;
+            --bg-subtle: #f6f8fa;
+            --header-h: 56px;
+            --sidebar-w: 260px;
+          }
+          *, *::before, *::after { box-sizing: border-box; }
+          body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; margin: 0; color: var(--text); background: var(--bg); }
 
-              /* Sidebar - fixed */
-              .docs-sidebar { position: fixed; top: var(--header-h); left: 0; width: var(--sidebar-w); height: calc(100vh - var(--header-h)); background: var(--bg-subtle); border-right: 1px solid var(--border); padding: 1.5rem 1rem; overflow-y: auto; }
-              .sidebar-section { margin-bottom: 1.5rem; }
-              .sidebar-title { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; color: var(--text-muted); margin-bottom: 0.5rem; letter-spacing: 0.05em; padding-left: 0.5rem; }
-              .sidebar-links { list-style: none; padding: 0; margin: 0; }
-              .sidebar-links li { margin-bottom: 2px; }
-              .sidebar-links a { display: block; padding: 0.35rem 0.5rem; color: var(--text-muted); text-decoration: none; border-radius: 4px; font-size: 0.875rem; }
-              .sidebar-links a:hover { background: var(--border); color: var(--text); }
-              .sidebar-links a.active { background: var(--primary); color: white; }
+          /* Header - fixed top */
+          .docs-header { position: fixed; top: 0; left: 0; right: 0; height: var(--header-h); background: var(--bg); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 1.5rem; z-index: 100; }
+          .docs-header .logo { font-weight: 600; font-size: 1.1rem; color: var(--text); text-decoration: none; margin-right: 2rem; }
+          .docs-header nav { display: flex; gap: 1.5rem; }
+          .docs-header nav a { color: var(--text-muted); text-decoration: none; font-size: 0.9rem; }
+          .docs-header nav a:hover { color: var(--primary); }
 
-              /* Main content */
-              .docs-main { flex: 1; margin-left: var(--sidebar-w); padding: 2rem 3rem; max-width: 800px; }
-              .docs-main h1 { font-size: 1.75rem; margin: 0 0 1.5rem 0; font-weight: 600; }
-              .docs-main h2 { font-size: 1.35rem; margin: 2rem 0 1rem 0; padding-bottom: 0.4rem; border-bottom: 1px solid var(--border); }
-              .docs-main h3 { font-size: 1.1rem; margin: 1.5rem 0 0.75rem 0; }
+          /* Layout container */
+          .docs-container { display: flex; padding-top: var(--header-h); min-height: 100vh; }
 
-              /* Typography */
-              code { background: var(--bg-subtle); padding: 0.15rem 0.35rem; border-radius: 4px; font-size: 0.85em; font-family: ui-monospace, "SFMono-Regular", Consolas, monospace; }
-              pre { background: var(--bg-subtle); padding: 1rem; border-radius: 6px; overflow-x: auto; border: 1px solid var(--border); }
-              pre code { background: none; padding: 0; }
-              a { color: var(--primary); text-decoration: none; }
-              a:hover { text-decoration: underline; }
+          /* Sidebar - fixed */
+          .docs-sidebar { position: fixed; top: var(--header-h); left: 0; width: var(--sidebar-w); height: calc(100vh - var(--header-h)); background: var(--bg-subtle); border-right: 1px solid var(--border); padding: 1.5rem 1rem; overflow-y: auto; }
+          .sidebar-section { margin-bottom: 1.5rem; }
+          .sidebar-title { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; color: var(--text-muted); margin-bottom: 0.5rem; letter-spacing: 0.05em; padding-left: 0.5rem; }
+          .sidebar-links { list-style: none; padding: 0; margin: 0; }
+          .sidebar-links li { margin-bottom: 2px; }
+          .sidebar-links a { display: block; padding: 0.35rem 0.5rem; color: var(--text-muted); text-decoration: none; border-radius: 4px; font-size: 0.875rem; }
+          .sidebar-links a:hover { background: var(--border); color: var(--text); }
+          .sidebar-links a.active { background: var(--primary); color: white; }
 
-              /* Info boxes */
-              .info-box { padding: 0.75rem 1rem; border-radius: 6px; margin: 1rem 0; border-left: 3px solid; font-size: 0.9rem; }
-              .info-box.note { background: #ddf4ff; border-color: #54aeff; }
-              .info-box.warning { background: #fff8c5; border-color: #d4a72c; }
-              .info-box.tip { background: #dafbe1; border-color: #4ac26b; }
+          /* Main content */
+          .docs-main { flex: 1; margin-left: var(--sidebar-w); padding: 2rem 3rem; max-width: 800px; }
+          .docs-main h1 { font-size: 1.75rem; margin: 0 0 1.5rem 0; font-weight: 600; }
+          .docs-main h2 { font-size: 1.35rem; margin: 2rem 0 1rem 0; padding-bottom: 0.4rem; border-bottom: 1px solid var(--border); }
+          .docs-main h3 { font-size: 1.1rem; margin: 1.5rem 0 0.75rem 0; }
 
-              /* Section list */
-              ul.section-list { list-style: none; padding: 0; }
-              ul.section-list li { margin-bottom: 0.5rem; padding: 0.6rem 0.75rem; background: var(--bg-subtle); border-radius: 6px; border: 1px solid var(--border); }
-              ul.section-list li a { font-weight: 500; }
-              nav.pagination { margin: 1.5rem 0; }
-              nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
-              nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border-radius: 6px; border: 1px solid var(--border); color: var(--text-muted); text-decoration: none; }
-              nav.pagination a:hover { color: var(--primary); border-color: var(--primary); }
-              .pagination-current span { display: inline-block; padding: 0.25rem 0.55rem; border-radius: 6px; border: 1px solid var(--primary); background: color-mix(in srgb, var(--primary) 12%, transparent); }
-              .pagination-disabled span { display: inline-block; padding: 0.25rem 0.55rem; border-radius: 6px; border: 1px solid var(--border); color: var(--text-muted); opacity: 0.6; }
+          /* Typography */
+          code { background: var(--bg-subtle); padding: 0.15rem 0.35rem; border-radius: 4px; font-size: 0.85em; font-family: ui-monospace, "SFMono-Regular", Consolas, monospace; }
+          pre { background: var(--bg-subtle); padding: 1rem; border-radius: 6px; overflow-x: auto; border: 1px solid var(--border); }
+          pre code { background: none; padding: 0; }
+          a { color: var(--primary); text-decoration: none; }
+          a:hover { text-decoration: underline; }
 
-              /* Footer */
-              .docs-footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 0.85rem; }
+          /* Info boxes */
+          .info-box { padding: 0.75rem 1rem; border-radius: 6px; margin: 1rem 0; border-left: 3px solid; font-size: 0.9rem; }
+          .info-box.note { background: #ddf4ff; border-color: #54aeff; }
+          .info-box.warning { background: #fff8c5; border-color: #d4a72c; }
+          .info-box.tip { background: #dafbe1; border-color: #4ac26b; }
 
-              /* Responsive */
-              @media (max-width: 768px) {
-                .docs-sidebar { display: none; }
-                .docs-main { margin-left: 0; padding: 1.5rem 1rem; }
-              }
-            </style>
+          /* Section list */
+          ul.section-list { list-style: none; padding: 0; }
+          ul.section-list li { margin-bottom: 0.5rem; padding: 0.6rem 0.75rem; background: var(--bg-subtle); border-radius: 6px; border: 1px solid var(--border); }
+          ul.section-list li a { font-weight: 500; }
+          nav.pagination { margin: 1.5rem 0; }
+          nav.pagination .pagination-list { list-style: none; padding: 0; margin: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+          nav.pagination a { display: inline-block; padding: 0.25rem 0.55rem; border-radius: 6px; border: 1px solid var(--border); color: var(--text-muted); text-decoration: none; }
+          nav.pagination a:hover { color: var(--primary); border-color: var(--primary); }
+          .pagination-current span { display: inline-block; padding: 0.25rem 0.55rem; border-radius: 6px; border: 1px solid var(--primary); background: color-mix(in srgb, var(--primary) 12%, transparent); }
+          .pagination-disabled span { display: inline-block; padding: 0.25rem 0.55rem; border-radius: 6px; border: 1px solid var(--border); color: var(--text-muted); opacity: 0.6; }
+
+          /* Footer */
+          .docs-footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 0.85rem; }
+
+          /* Responsive */
+          @media (max-width: 768px) {
+            .docs-sidebar { display: none; }
+            .docs-main { margin-left: 0; padding: 1.5rem 1rem; }
+          }
           CSS
         end
 


### PR DESCRIPTION
🎯 **What:** Extracted the hardcoded embedded CSS from `src/services/scaffolds/docs.cr` into a separate `css_content` method and exposed it via `static_files` as `css/style.css`. Updated the `styles` method to return a `<link>` tag pointing to this file.

💡 **Why:** This improves maintainability and readability by separating concerns (styles vs structure) and aligns the `Docs` scaffold implementation with the existing `Blog` scaffold pattern. It avoids embedding large blocks of CSS directly in the Crystal source code.

✅ **Verification:**
- Created `spec/unit/scaffolds_docs_spec.cr` to verify that `static_files` contains `css/style.css` and `styles` returns the correct `<link>` tag.
- Ran `crystal spec spec/unit/scaffolds_docs_spec.cr` and it passed.
- Ran existing `crystal spec spec/unit/scaffolds_spec.cr` and verified no regressions.

✨ **Result:** The `Docs` scaffold now generates a project structure where CSS is served as a static file, consistent with other scaffolds.

---
*PR created automatically by Jules for task [1807352763808503431](https://jules.google.com/task/1807352763808503431) started by @hahwul*