### PR TITLE
Add multilingual feed generation and default_language_only option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,11 +211,52 @@ To add new hooks:
 #### 4. SEO Features
 
 SEO-related features live in `src/content/seo/`:
-- `feeds.cr` - RSS/Atom feed generation
+- `feeds.cr` - RSS/Atom feed generation (including multilingual per-language feeds)
 - `sitemap.cr` - Sitemap XML generation
 - `robots.cr` - Robots.txt generation
 - `llms.cr` - LLM instructions file generator for AI/LLM crawler instructions
 - `tags.cr` - Canonical URL and hreflang tag generation for multilingual sites
+
+**Multilingual Feed Generation:**
+
+When the site is multilingual (`[languages]` configured in `config.toml`), feeds are generated per language:
+
+| Language | Feed Path | Contents |
+|---|---|---|
+| Default (e.g., `en`) | `/rss.xml` | Default language pages only (configurable) |
+| Non-default (e.g., `ko`) | `/ko/rss.xml` | Only Korean pages |
+| Non-default (e.g., `ja`) | `/ja/rss.xml` | Only Japanese pages |
+
+Behavior details:
+- By default the main site feed (`/rss.xml` or `/atom.xml`) includes **only default language pages** (`default_language_only = true`). Set `default_language_only = false` to include all languages in the main feed.
+- Each non-default language with `generate_feed = true` gets its own feed at `/{lang}/rss.xml` (or `atom.xml`)
+- Language feeds respect the same `sections`, `limit`, and `truncate` settings from `[feeds]` config
+- RSS language feeds include a `<language>` tag (e.g., `<language>ko</language>`)
+- Atom language feeds include an `xml:lang` attribute (e.g., `<feed xmlns="..." xml:lang="ko">`)
+- Feed title includes the language name: `"Site Title (한국어)"`
+- Draft pages and section index pages are excluded from language feeds
+- Language feeds are generated independently of the main feed's `enabled` setting — they are produced whenever the site is multilingual and the language has `generate_feed = true`
+
+Main feed language control in `config.toml`:
+```toml
+[feeds]
+enabled = true
+default_language_only = true   # true (default): main feed has default language only
+                               # false: main feed includes all languages
+```
+
+Per-language feed control in `config.toml`:
+```toml
+[languages.ko]
+language_name = "한국어"
+generate_feed = true    # true by default; set to false to skip this language's feed
+
+[languages.ja]
+language_name = "日本語"
+generate_feed = false   # No /ja/rss.xml will be generated
+```
+
+Implementation: `src/content/seo/feeds.cr` — `generate_language_feeds()` private method called from `generate()`. Main feed filtering controlled by `FeedConfig.default_language_only` (`src/models/config.cr`).
 
 #### 5. Search Feature
 
@@ -952,6 +993,7 @@ content/
 **Implementation details:**
 - `src/content/multilingual.cr` - Translation key generation, language detection, translation linking
 - `src/content/seo/tags.cr` - Canonical URLs and hreflang tag generation
+- `src/content/seo/feeds.cr` - Per-language feed generation (`generate_language_feeds()`)
 - `src/models/config.cr` - `LanguageConfig` class, `multilingual?`, `sorted_languages` methods
 - `src/models/page.cr` - `language`, `translations` properties, `TranslationLink` struct
 
@@ -961,6 +1003,24 @@ content/
 - `Multilingual.language_code` - Determines the language code for a page
 - `Seo::Tags.canonical_tag` - Generates `<link rel="canonical">` tag
 - `Seo::Tags.hreflang_tags` - Generates `<link rel="alternate" hreflang="...">` tags
+- `Seo::Feeds.generate_language_feeds` - Generates per-language RSS/Atom feeds
+
+**Per-language feed generation:**
+
+When the site is multilingual, feeds are generated per language automatically:
+
+| Language | Feed Path | Contents |
+|---|---|---|
+| Default (e.g., `en`) | `/rss.xml` | Default language pages only (configurable) |
+| Non-default (e.g., `ko`) | `/ko/rss.xml` | Only Korean pages |
+| Non-default (e.g., `ja`) | `/ja/rss.xml` | Only Japanese pages |
+
+- By default the main site feed includes **only default language pages** (`default_language_only = true`). Set to `false` to include all languages.
+- Each non-default language with `generate_feed = true` gets its own feed at `/{lang}/rss.xml` (or `atom.xml`)
+- Language feeds respect the same `sections`, `limit`, and `truncate` settings from `[feeds]` config
+- RSS feeds include `<language>ko</language>` tag; Atom feeds include `xml:lang="ko"` attribute
+- Feed title includes language name: `"Site Title (한국어)"`
+- Language feeds are generated independently of the main feed's `enabled` setting
 
 **Template variables for multilingual:**
 - `{{ page.language }}` - Current page language code
@@ -998,7 +1058,38 @@ hwaro init mysite  # defaults to simple
 - Common templates (header, footer, page, section, 404, taxonomy)
 - Base CSS styles
 - Navigation template
-- Config sections (plugins, pagination, content files, highlight, OG, search, sitemap, robots, llms, taxonomies, feeds, auto includes, markdown, build hooks, deployment)
+- Config sections (plugins, pagination, content files, highlight, OG, search, sitemap, robots, llms, taxonomies, feeds, auto includes, markdown, build hooks, deployment, permalinks, multilingual)
+
+**Config generation methods in `base.cr`:**
+
+Each config section has a dedicated protected method that scaffolds compose via `config_content()`:
+
+| Method | Config Section |
+|---|---|
+| `base_config` | `title`, `description`, `base_url` |
+| `multilingual_config` | `default_language`, `[languages]` (commented out) |
+| `plugins_config` | `[plugins]` |
+| `content_files_config` | `[content.files]` |
+| `highlight_config` | `[highlight]` |
+| `og_config` | `[og]` |
+| `search_config` | `[search]` |
+| `pagination_config` | `[pagination]` |
+| `taxonomies_config` | `[[taxonomies]]` |
+| `sitemap_config` | `[sitemap]` |
+| `robots_config` | `[robots]` |
+| `llms_config` | `[llms]` |
+| `feeds_config` | `[feeds]` |
+| `permalinks_config` | `[permalinks]` (commented out) |
+| `auto_includes_config` | `[auto_includes]` (commented out) |
+| `markdown_config` | `[markdown]` |
+| `build_hooks_config` | `[build]` hooks (commented out) |
+| `deployment_config` | `[deployment]` (commented out) |
+
+> **IMPORTANT — When adding a new config option:**
+> If the option belongs to an existing section, update the corresponding method in `base.cr`.
+> If it's an entirely new section, add a new protected method and call it from `config_content()` in all three scaffolds (simple, blog, docs).
+> Also update the default configs in `src/services/defaults/config.cr` (`config`, `config_without_taxonomies`, `config_multilingual`).
+> See the [Config Change Checklist](#config-change-checklist) in the Contributing section for the full list.
 
 #### 22. Content Files Publishing
 
@@ -1101,7 +1192,11 @@ Implementation:
 
 ### Configuration
 
-Configuration is managed through TOML files (`config.toml`). The structure is defined in `src/models/config.cr` with support for:
+Configuration is managed through TOML files (`config.toml`). The structure is defined in `src/models/config.cr`.
+
+> **See also:** [Config Change Checklist](#config-change-checklist) in the Contributing section — follow this checklist whenever you add or modify a config option.
+
+Supported configuration areas:
 - Site metadata (title, description, base_url)
 - SEO features (sitemap, robots, llms, feeds)
 - Search configuration
@@ -1118,6 +1213,7 @@ Configuration is managed through TOML files (`config.toml`). The structure is de
 - Deployment targets and options
 - Permalinks (URL path rewriting)
 - Data directory (auxiliary data files)
+- Feed language control (`default_language_only`)
 
 #### Markdown Configuration
 
@@ -1383,6 +1479,39 @@ When contributing:
 4. Consider backward compatibility
 5. Think about extensibility for future features
 6. Keep changes focused and atomic
+7. **When adding or changing config options, follow the [Config Change Checklist](#config-change-checklist) below**
+
+### Config Change Checklist
+
+Whenever a new configuration option is added or an existing one is modified, **all of the following files must be reviewed and updated**. This is easy to overlook — every item in this list is required, not optional.
+
+#### 1. Model & Parsing (required)
+- [ ] `src/models/config.cr` — Add the property to the relevant `*Config` class, set a sensible default in `initialize`, and parse it in the corresponding `load_*` method.
+
+#### 2. Init / Scaffold defaults (required)
+These files generate `config.toml` when users run `hwaro init`. If the new option is not added here, newly created projects will never see it.
+
+- [ ] `src/services/scaffolds/base.cr` — Update the relevant `*_config` protected method (e.g., `feeds_config`, `search_config`). If the option is niche, add it as a comment so users can discover it. If it's a brand-new config section, create a new protected method and wire it into `config_content()` of all three scaffolds.
+- [ ] `src/services/scaffolds/simple.cr` — If a new config method was added in `base.cr`, call it from `config_content()`.
+- [ ] `src/services/scaffolds/blog.cr` — Same as above.
+- [ ] `src/services/scaffolds/docs.cr` — Same as above.
+- [ ] `src/services/defaults/config.cr` — Update **all three** template methods: `config`, `config_without_taxonomies`, and `config_multilingual`.
+
+#### 3. Tests (required)
+- [ ] `spec/unit/config_spec.cr` — Test default value, setting via property, and loading from TOML. Also update the **boolean round-trip** tests if the option is a `Bool`.
+- [ ] Feature-specific spec (e.g., `spec/unit/feeds_spec.cr`) — Test that the feature respects the new option.
+- [ ] `spec/unit/defaults_config_spec.cr` — If the option should appear in default configs, verify it.
+
+#### 4. Documentation (required)
+- [ ] `AGENTS.md` — Update the relevant feature section and the Configuration summary list.
+- [ ] `docs/content/start/config.md` — Add the option to the config reference page.
+- [ ] `docs/content/features/*.md` — Update the relevant feature documentation page.
+
+#### 5. Quick self-check
+- [ ] Run `crystal spec` — all tests pass.
+- [ ] Run `hwaro init /tmp/test-site && cat /tmp/test-site/config.toml` — verify the new option appears (or is commented out) in the generated config.
+
+> **Why is this important?** Users discover configuration options primarily through the generated `config.toml` from `hwaro init`. If a config option only exists in code but not in the init output, it is effectively invisible.
 
 ## Documentation Site
 

--- a/docs/content/features/multilingual.md
+++ b/docs/content/features/multilingual.md
@@ -34,7 +34,7 @@ weight = 3
 | default_language | string | "en" | Default language code |
 | language_name | string | — | Human-readable language name |
 | weight | int | 0 | Sort order (lower = first) |
-| generate_feed | bool | false | Generate RSS feed for this language |
+| generate_feed | bool | true | Generate RSS/Atom feed for this language |
 | build_search_index | bool | false | Include in search index |
 | taxonomies | array | [] | Taxonomies for this language |
 
@@ -253,8 +253,82 @@ This generates the configuration and sample content files for each specified lan
 </html>
 ```
 
+## Per-Language Feeds
+
+When the site is multilingual, Hwaro automatically generates separate RSS/Atom feeds for each language:
+
+| Language | Feed Path | Contents |
+|----------|-----------|----------|
+| Default (e.g., `en`) | `/rss.xml` | Default language pages only (configurable) |
+| Non-default (e.g., `ko`) | `/ko/rss.xml` | Only Korean pages |
+| Non-default (e.g., `ja`) | `/ja/rss.xml` | Only Japanese pages |
+
+By default, the main site feed (`/rss.xml` or `/atom.xml`) includes **only default language pages**. You can change this behavior with the `default_language_only` option. Each non-default language with `generate_feed = true` gets its own feed under its language prefix regardless of this setting.
+
+### Configuration
+
+#### Main Feed Language Control
+
+```toml
+[feeds]
+enabled = true
+default_language_only = true   # true (default): main feed = default language only
+                               # false: main feed includes all languages
+```
+
+#### Per-Language Feed Control
+
+```toml
+[languages.ko]
+language_name = "한국어"
+generate_feed = true    # Generates /ko/rss.xml (default: true)
+
+[languages.ja]
+language_name = "日本語"
+generate_feed = false   # No /ja/rss.xml will be generated
+```
+
+Language feeds share the same `sections`, `limit`, and `truncate` settings from the global `[feeds]` config:
+
+```toml
+[feeds]
+enabled = true
+type = "rss"       # or "atom"
+limit = 20
+truncate = 0
+sections = []      # empty = all sections
+default_language_only = true
+```
+
+### Feed Details
+
+- **RSS feeds** include a `<language>` tag (e.g., `<language>ko</language>`)
+- **Atom feeds** include an `xml:lang` attribute (e.g., `<feed xmlns="..." xml:lang="ko">`)
+- Feed title includes the language name: `"My Site (한국어)"`
+- Self-referencing links point to the correct language path (e.g., `https://example.com/ko/rss.xml`)
+- Draft pages and section index pages are excluded
+- Language feeds are generated independently of the main feed's `enabled` setting
+
+### Template Links
+
+Add language-specific feed links in your templates:
+
+```jinja
+{# Main feed (default language) #}
+<link rel="alternate" type="application/rss+xml"
+      href="{{ base_url }}/rss.xml"
+      title="{{ site.title }}">
+
+{# Language-specific feed #}
+{% if page.language and page.language != "en" %}
+<link rel="alternate" type="application/rss+xml"
+      href="{{ base_url }}/{{ page.language }}/rss.xml"
+      title="{{ site.title }} ({{ page.language }})">
+{% endif %}
+```
+
 ## See Also
 
 - [Configuration](/start/config/) — Full configuration reference
-- [SEO](/features/seo/) — SEO features including canonical and hreflang
+- [SEO](/features/seo/) — SEO features including feeds, canonical and hreflang
 - [Data Model](/templates/data-model/) — Translation link properties

--- a/docs/content/features/seo.md
+++ b/docs/content/features/seo.md
@@ -78,12 +78,51 @@ Generates `/blog/rss.xml`.
 - `/rss.xml` — Site-wide feed
 - `/blog/rss.xml` — Section feed (if enabled)
 
+### Multilingual Feeds
+
+When the site is multilingual, feeds are generated per language automatically:
+
+| Language | Feed Path | Contents |
+|----------|-----------|----------|
+| Default (e.g., `en`) | `/rss.xml` | Default language pages only (configurable) |
+| Non-default (e.g., `ko`) | `/ko/rss.xml` | Only Korean pages |
+| Non-default (e.g., `ja`) | `/ja/rss.xml` | Only Japanese pages |
+
+By default, the main site feed includes **only default language pages** (`default_language_only = true`). Set `default_language_only = false` to include all languages in the main feed. Each non-default language with `generate_feed = true` gets its own separate feed regardless of this setting.
+
+```toml
+[feeds]
+enabled = true
+default_language_only = true   # true (default): main feed = default language only
+                               # false: main feed includes all languages
+```
+
+Per-language feed control:
+
+```toml
+[languages.ko]
+language_name = "한국어"
+generate_feed = true    # Generates /ko/rss.xml (default: true)
+
+[languages.ja]
+language_name = "日本語"
+generate_feed = false   # No /ja/rss.xml will be generated
+```
+
+Language feeds share the same `sections`, `limit`, and `truncate` settings from `[feeds]` config. RSS language feeds include a `<language>` tag, and Atom feeds include an `xml:lang` attribute. The feed title includes the language name (e.g., `"My Site (한국어)"`).
+
 ### Template Links
 
 ```jinja
 <link rel="alternate" type="application/rss+xml" 
       href="{{ base_url }}/rss.xml" 
       title="{{ site.title }}">
+
+{% if page.language and page.language != "en" %}
+<link rel="alternate" type="application/rss+xml"
+      href="{{ base_url }}/{{ page.language }}/rss.xml"
+      title="{{ site.title }} ({{ page.language }})">
+{% endif %}
 ```
 
 ---

--- a/docs/content/start/config.md
+++ b/docs/content/start/config.md
@@ -82,6 +82,7 @@ Rewrite content directory paths to custom URL paths. Useful for site restructuri
 [feeds]
 enabled = true
 limit = 20
+default_language_only = true   # true: main feed = default language only, false: all languages
 ```
 
 ### Sitemap

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -300,6 +300,7 @@ describe Hwaro::Models::Config do
       config.feeds.truncate.should eq(0)
       config.feeds.limit.should eq(10)
       config.feeds.sections.should eq([] of String)
+      config.feeds.default_language_only.should be_true
     end
 
     it "can update feeds settings" do
@@ -309,12 +310,14 @@ describe Hwaro::Models::Config do
       config.feeds.truncate = 200
       config.feeds.limit = 50
       config.feeds.sections = ["blog", "news"]
+      config.feeds.default_language_only = false
 
       config.feeds.enabled.should be_true
       config.feeds.type.should eq("atom")
       config.feeds.truncate.should eq(200)
       config.feeds.limit.should eq(50)
       config.feeds.sections.should eq(["blog", "news"])
+      config.feeds.default_language_only.should be_false
     end
 
     it "loads all feeds settings from TOML" do
@@ -328,6 +331,7 @@ describe Hwaro::Models::Config do
       truncate = 100
       limit = 25
       sections = ["blog", "news"]
+      default_language_only = false
       TOML
 
       config.feeds.enabled.should be_true
@@ -336,6 +340,30 @@ describe Hwaro::Models::Config do
       config.feeds.truncate.should eq(100)
       config.feeds.limit.should eq(25)
       config.feeds.sections.should eq(["blog", "news"])
+      config.feeds.default_language_only.should be_false
+    end
+
+    it "loads default_language_only as true from TOML" do
+      config = load_config(<<-TOML)
+      title = "Test"
+
+      [feeds]
+      enabled = true
+      default_language_only = true
+      TOML
+
+      config.feeds.default_language_only.should be_true
+    end
+
+    it "defaults default_language_only to true when not specified in TOML" do
+      config = load_config(<<-TOML)
+      title = "Test"
+
+      [feeds]
+      enabled = true
+      TOML
+
+      config.feeds.default_language_only.should be_true
     end
 
     it "loads feeds enabled = false from TOML" do
@@ -1202,7 +1230,9 @@ describe Hwaro::Models::Config do
       #   robots.enabled               true  -> false
       #   llms.enabled                 true  -> false
       #   llms.full_enabled            false -> true
-      #   feeds.enabled                false -> true
+      #   feeds.enabled                false -> true (identity: false)
+      #   feeds.default_language_only  true  -> true (identity: true)
+      #   feeds.default_language_only  true  -> false
       #   search.enabled               false -> true
       #   pagination.enabled           false -> true
       #   highlight.enabled            true  -> false
@@ -1230,6 +1260,7 @@ describe Hwaro::Models::Config do
 
       [feeds]
       enabled = true
+      default_language_only = false
 
       [search]
       enabled = true
@@ -1267,6 +1298,7 @@ describe Hwaro::Models::Config do
       config.llms.enabled.should be_false
       config.llms.full_enabled.should be_true
       config.feeds.enabled.should be_true
+      config.feeds.default_language_only.should be_false
       config.search.enabled.should be_true
       config.pagination.enabled.should be_true
       config.highlight.enabled.should be_false
@@ -1300,6 +1332,7 @@ describe Hwaro::Models::Config do
 
       [feeds]
       enabled = false
+      default_language_only = true
 
       [search]
       enabled = false
@@ -1337,6 +1370,7 @@ describe Hwaro::Models::Config do
       config.llms.enabled.should be_true
       config.llms.full_enabled.should be_false
       config.feeds.enabled.should be_false
+      config.feeds.default_language_only.should be_true
       config.search.enabled.should be_false
       config.pagination.enabled.should be_false
       config.highlight.enabled.should be_true

--- a/spec/unit/feeds_spec.cr
+++ b/spec/unit/feeds_spec.cr
@@ -1,6 +1,850 @@
 require "../spec_helper"
 
 describe Hwaro::Content::Seo::Feeds do
+  describe "multilingual feeds" do
+    it "filters main feed to default language pages when default_language_only is true (default)" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.description = "A test site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      en_page = Hwaro::Models::Page.new("posts/hello.md")
+      en_page.title = "Hello World"
+      en_page.url = "/posts/hello/"
+      en_page.language = nil # default language
+      en_page.draft = false
+      en_page.render = true
+      en_page.is_index = false
+      en_page.raw_content = "English content"
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_page, ko_page], config, output_dir)
+
+        # Main feed should only contain default language pages
+        main_feed = File.read(File.join(output_dir, "rss.xml"))
+        main_feed.should contain("Hello World")
+        main_feed.should_not contain("안녕하세요")
+      end
+    end
+
+    it "generates per-language feed for non-default languages" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.description = "A test site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      en_page = Hwaro::Models::Page.new("posts/hello.md")
+      en_page.title = "Hello World"
+      en_page.url = "/posts/hello/"
+      en_page.language = nil
+      en_page.draft = false
+      en_page.render = true
+      en_page.is_index = false
+      en_page.raw_content = "English content"
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_page, ko_page], config, output_dir)
+
+        # Korean feed should exist at /ko/rss.xml
+        ko_feed_path = File.join(output_dir, "ko", "rss.xml")
+        File.exists?(ko_feed_path).should be_true
+
+        ko_feed = File.read(ko_feed_path)
+        ko_feed.should contain("안녕하세요")
+        ko_feed.should_not contain("Hello World")
+      end
+    end
+
+    it "generates atom feed per language when feed type is atom" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "atom"
+      config.feeds.filename = "atom.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([ko_page], config, output_dir)
+
+        ko_feed_path = File.join(output_dir, "ko", "atom.xml")
+        File.exists?(ko_feed_path).should be_true
+
+        ko_feed = File.read(ko_feed_path)
+        ko_feed.should contain("<feed xmlns=\"http://www.w3.org/2005/Atom\" xml:lang=\"ko\">")
+        ko_feed.should contain("안녕하세요")
+      end
+    end
+
+    it "does not generate language feed when generate_feed is false" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+
+      ko_config = Hwaro::Models::LanguageConfig.new("ko")
+      ko_config.generate_feed = false
+      config.languages["ko"] = ko_config
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([ko_page], config, output_dir)
+
+        File.exists?(File.join(output_dir, "ko", "rss.xml")).should be_false
+      end
+    end
+
+    it "generates feeds for multiple non-default languages" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+      config.languages["ja"] = Hwaro::Models::LanguageConfig.new("ja")
+
+      en_page = Hwaro::Models::Page.new("posts/hello.md")
+      en_page.title = "Hello"
+      en_page.url = "/posts/hello/"
+      en_page.language = nil
+      en_page.draft = false
+      en_page.render = true
+      en_page.is_index = false
+      en_page.raw_content = "English"
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어"
+
+      ja_page = Hwaro::Models::Page.new("posts/hello.ja.md")
+      ja_page.title = "こんにちは"
+      ja_page.url = "/ja/posts/hello/"
+      ja_page.language = "ja"
+      ja_page.draft = false
+      ja_page.render = true
+      ja_page.is_index = false
+      ja_page.raw_content = "日本語"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_page, ko_page, ja_page], config, output_dir)
+
+        # Main feed = English only
+        main_feed = File.read(File.join(output_dir, "rss.xml"))
+        main_feed.should contain("Hello")
+        main_feed.should_not contain("안녕하세요")
+        main_feed.should_not contain("こんにちは")
+
+        # Korean feed
+        ko_feed = File.read(File.join(output_dir, "ko", "rss.xml"))
+        ko_feed.should contain("안녕하세요")
+        ko_feed.should_not contain("Hello")
+        ko_feed.should_not contain("こんにちは")
+
+        # Japanese feed
+        ja_feed = File.read(File.join(output_dir, "ja", "rss.xml"))
+        ja_feed.should contain("こんにちは")
+        ja_feed.should_not contain("Hello")
+        ja_feed.should_not contain("안녕하세요")
+      end
+    end
+
+    it "includes language tag in RSS for language-specific feeds" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.description = "A test site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([ko_page], config, output_dir)
+
+        ko_feed = File.read(File.join(output_dir, "ko", "rss.xml"))
+        ko_feed.should contain("<language>ko</language>")
+      end
+    end
+
+    it "does not include language tag in main RSS feed" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      en_page = Hwaro::Models::Page.new("posts/hello.md")
+      en_page.title = "Hello"
+      en_page.url = "/posts/hello/"
+      en_page.language = nil
+      en_page.draft = false
+      en_page.render = true
+      en_page.is_index = false
+      en_page.raw_content = "English"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_page], config, output_dir)
+
+        main_feed = File.read(File.join(output_dir, "rss.xml"))
+        main_feed.should_not contain("<language>")
+      end
+    end
+
+    it "uses language name in feed title" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "My Site"
+      config.default_language = "en"
+
+      ko_config = Hwaro::Models::LanguageConfig.new("ko")
+      ko_config.language_name = "한국어"
+      config.languages["ko"] = ko_config
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([ko_page], config, output_dir)
+
+        ko_feed = File.read(File.join(output_dir, "ko", "rss.xml"))
+        ko_feed.should contain("<title>My Site (한국어)</title>")
+      end
+    end
+
+    it "generates correct self-referencing link for language feeds" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([ko_page], config, output_dir)
+
+        ko_feed = File.read(File.join(output_dir, "ko", "rss.xml"))
+        ko_feed.should contain("atom:link href=\"https://example.com/ko/rss.xml\"")
+      end
+    end
+
+    it "excludes draft pages from language feeds" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      published = Hwaro::Models::Page.new("posts/hello.ko.md")
+      published.title = "Published Korean"
+      published.url = "/ko/posts/hello/"
+      published.language = "ko"
+      published.draft = false
+      published.render = true
+      published.is_index = false
+      published.raw_content = "Published"
+
+      draft = Hwaro::Models::Page.new("posts/draft.ko.md")
+      draft.title = "Draft Korean"
+      draft.url = "/ko/posts/draft/"
+      draft.language = "ko"
+      draft.draft = true
+      draft.render = true
+      draft.is_index = false
+      draft.raw_content = "Draft"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([published, draft], config, output_dir)
+
+        ko_feed = File.read(File.join(output_dir, "ko", "rss.xml"))
+        ko_feed.should contain("Published Korean")
+        ko_feed.should_not contain("Draft Korean")
+      end
+    end
+
+    it "excludes section pages from language feeds" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      section = Hwaro::Models::Section.new("posts/_index.ko.md")
+      section.title = "게시물"
+      section.url = "/ko/posts/"
+      section.section = "posts"
+      section.language = "ko"
+      section.draft = false
+      section.render = true
+      section.is_index = true
+      section.raw_content = ""
+
+      post = Hwaro::Models::Page.new("posts/hello.ko.md")
+      post.title = "안녕하세요"
+      post.url = "/ko/posts/hello/"
+      post.language = "ko"
+      post.draft = false
+      post.render = true
+      post.is_index = false
+      post.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([section.as(Hwaro::Models::Page), post], config, output_dir)
+
+        ko_feed = File.read(File.join(output_dir, "ko", "rss.xml"))
+        ko_feed.should contain("안녕하세요")
+        ko_feed.should_not contain("게시물")
+      end
+    end
+
+    it "applies section filter to language feeds" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.feeds.sections = ["posts"]
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      blog_post = Hwaro::Models::Page.new("posts/hello.ko.md")
+      blog_post.title = "Blog Korean"
+      blog_post.url = "/ko/posts/hello/"
+      blog_post.section = "posts"
+      blog_post.language = "ko"
+      blog_post.draft = false
+      blog_post.render = true
+      blog_post.is_index = false
+      blog_post.raw_content = "Blog content"
+
+      docs_page = Hwaro::Models::Page.new("docs/guide.ko.md")
+      docs_page.title = "Docs Korean"
+      docs_page.url = "/ko/docs/guide/"
+      docs_page.section = "docs"
+      docs_page.language = "ko"
+      docs_page.draft = false
+      docs_page.render = true
+      docs_page.is_index = false
+      docs_page.raw_content = "Docs content"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([blog_post, docs_page], config, output_dir)
+
+        ko_feed = File.read(File.join(output_dir, "ko", "rss.xml"))
+        ko_feed.should contain("Blog Korean")
+        ko_feed.should_not contain("Docs Korean")
+      end
+    end
+
+    it "does not generate language feeds when site is not multilingual" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      # No additional languages configured
+
+      page = Hwaro::Models::Page.new("posts/hello.md")
+      page.title = "Hello"
+      page.url = "/posts/hello/"
+      page.draft = false
+      page.render = true
+      page.is_index = false
+      page.raw_content = "Content"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([page], config, output_dir)
+
+        # Main feed should exist
+        File.exists?(File.join(output_dir, "rss.xml")).should be_true
+
+        # No language subdirectories should be created
+        Dir.exists?(File.join(output_dir, "en")).should be_false
+      end
+    end
+
+    it "does not generate language feeds when main feed is disabled" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = false
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([ko_page], config, output_dir)
+
+        # Language feeds should still be generated even when main feed is disabled,
+        # because the multilingual block runs independently
+        File.exists?(File.join(output_dir, "ko", "rss.xml")).should be_true
+      end
+    end
+
+    it "includes xml:lang attribute in atom feed for language-specific feeds" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "atom"
+      config.feeds.filename = "atom.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ja"] = Hwaro::Models::LanguageConfig.new("ja")
+
+      ja_page = Hwaro::Models::Page.new("posts/hello.ja.md")
+      ja_page.title = "こんにちは"
+      ja_page.url = "/ja/posts/hello/"
+      ja_page.language = "ja"
+      ja_page.draft = false
+      ja_page.render = true
+      ja_page.is_index = false
+      ja_page.raw_content = "日本語コンテンツ"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([ja_page], config, output_dir)
+
+        ja_feed = File.read(File.join(output_dir, "ja", "atom.xml"))
+        ja_feed.should contain("xml:lang=\"ja\"")
+        ja_feed.should contain("こんにちは")
+      end
+    end
+
+    it "does not include xml:lang in main atom feed" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "atom"
+      config.feeds.filename = "atom.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      en_page = Hwaro::Models::Page.new("posts/hello.md")
+      en_page.title = "Hello"
+      en_page.url = "/posts/hello/"
+      en_page.language = nil
+      en_page.draft = false
+      en_page.render = true
+      en_page.is_index = false
+      en_page.raw_content = "English"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_page], config, output_dir)
+
+        main_feed = File.read(File.join(output_dir, "atom.xml"))
+        main_feed.should_not contain("xml:lang=")
+      end
+    end
+
+    it "respects feed limit for language feeds" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.feeds.limit = 2
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      pages = (1..5).map do |i|
+        page = Hwaro::Models::Page.new("posts/post#{i}.ko.md")
+        page.title = "Korean Post #{i}"
+        page.url = "/ko/posts/post#{i}/"
+        page.language = "ko"
+        page.date = Time.utc(2024, i, 1)
+        page.draft = false
+        page.render = true
+        page.is_index = false
+        page.raw_content = "Content #{i}"
+        page
+      end
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate(pages, config, output_dir)
+
+        ko_feed = File.read(File.join(output_dir, "ko", "rss.xml"))
+        ko_feed.scan(/<item>/).size.should eq(2)
+        # Should include the 2 newest (Post 5 and Post 4)
+        ko_feed.should contain("Korean Post 5")
+        ko_feed.should contain("Korean Post 4")
+      end
+    end
+
+    it "treats pages with nil language as default language in multilingual mode" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      # Page with nil language (should be treated as default "en")
+      page_nil = Hwaro::Models::Page.new("posts/hello.md")
+      page_nil.title = "Nil Language Page"
+      page_nil.url = "/posts/hello/"
+      page_nil.language = nil
+      page_nil.draft = false
+      page_nil.render = true
+      page_nil.is_index = false
+      page_nil.raw_content = "Content"
+
+      # Page with explicit default language
+      page_en = Hwaro::Models::Page.new("posts/world.md")
+      page_en.title = "Explicit EN Page"
+      page_en.url = "/posts/world/"
+      page_en.language = "en"
+      page_en.draft = false
+      page_en.render = true
+      page_en.is_index = false
+      page_en.raw_content = "Content"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([page_nil, page_en], config, output_dir)
+
+        main_feed = File.read(File.join(output_dir, "rss.xml"))
+        main_feed.should contain("Nil Language Page")
+        main_feed.should contain("Explicit EN Page")
+      end
+    end
+  end
+
+  describe "default_language_only option" do
+    it "defaults to true" do
+      config = Hwaro::Models::Config.new
+      config.feeds.default_language_only.should be_true
+    end
+
+    it "includes all languages in main feed when default_language_only is false" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.feeds.default_language_only = false
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.description = "A test site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      en_page = Hwaro::Models::Page.new("posts/hello.md")
+      en_page.title = "Hello World"
+      en_page.url = "/posts/hello/"
+      en_page.language = nil
+      en_page.draft = false
+      en_page.render = true
+      en_page.is_index = false
+      en_page.raw_content = "English content"
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_page, ko_page], config, output_dir)
+
+        # Main feed should contain ALL languages
+        main_feed = File.read(File.join(output_dir, "rss.xml"))
+        main_feed.should contain("Hello World")
+        main_feed.should contain("안녕하세요")
+      end
+    end
+
+    it "still generates per-language feeds when default_language_only is false" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.feeds.default_language_only = false
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      en_page = Hwaro::Models::Page.new("posts/hello.md")
+      en_page.title = "Hello World"
+      en_page.url = "/posts/hello/"
+      en_page.language = nil
+      en_page.draft = false
+      en_page.render = true
+      en_page.is_index = false
+      en_page.raw_content = "English content"
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어 콘텐츠"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_page, ko_page], config, output_dir)
+
+        # Per-language feed should still exist
+        ko_feed_path = File.join(output_dir, "ko", "rss.xml")
+        File.exists?(ko_feed_path).should be_true
+
+        ko_feed = File.read(ko_feed_path)
+        ko_feed.should contain("안녕하세요")
+        ko_feed.should_not contain("Hello World")
+      end
+    end
+
+    it "includes all languages in main feed with multiple languages when false" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.feeds.default_language_only = false
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+      config.languages["ja"] = Hwaro::Models::LanguageConfig.new("ja")
+
+      en_page = Hwaro::Models::Page.new("posts/hello.md")
+      en_page.title = "Hello"
+      en_page.url = "/posts/hello/"
+      en_page.language = nil
+      en_page.draft = false
+      en_page.render = true
+      en_page.is_index = false
+      en_page.raw_content = "English"
+
+      ko_page = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_page.title = "안녕하세요"
+      ko_page.url = "/ko/posts/hello/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.render = true
+      ko_page.is_index = false
+      ko_page.raw_content = "한국어"
+
+      ja_page = Hwaro::Models::Page.new("posts/hello.ja.md")
+      ja_page.title = "こんにちは"
+      ja_page.url = "/ja/posts/hello/"
+      ja_page.language = "ja"
+      ja_page.draft = false
+      ja_page.render = true
+      ja_page.is_index = false
+      ja_page.raw_content = "日本語"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_page, ko_page, ja_page], config, output_dir)
+
+        # Main feed should contain all three languages
+        main_feed = File.read(File.join(output_dir, "rss.xml"))
+        main_feed.should contain("Hello")
+        main_feed.should contain("안녕하세요")
+        main_feed.should contain("こんにちは")
+        main_feed.scan(/<item>/).size.should eq(3)
+
+        # Per-language feeds still separate
+        ko_feed = File.read(File.join(output_dir, "ko", "rss.xml"))
+        ko_feed.should contain("안녕하세요")
+        ko_feed.should_not contain("Hello")
+
+        ja_feed = File.read(File.join(output_dir, "ja", "rss.xml"))
+        ja_feed.should contain("こんにちは")
+        ja_feed.should_not contain("Hello")
+      end
+    end
+
+    it "has no effect on non-multilingual sites" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.feeds.default_language_only = true
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      # No additional languages — not multilingual
+
+      page = Hwaro::Models::Page.new("posts/hello.md")
+      page.title = "Hello"
+      page.url = "/posts/hello/"
+      page.draft = false
+      page.render = true
+      page.is_index = false
+      page.raw_content = "Content"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([page], config, output_dir)
+
+        main_feed = File.read(File.join(output_dir, "rss.xml"))
+        main_feed.should contain("Hello")
+      end
+    end
+
+    it "applies section filter together with default_language_only false" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.feeds.default_language_only = false
+      config.feeds.sections = ["posts"]
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      en_post = Hwaro::Models::Page.new("posts/hello.md")
+      en_post.title = "EN Post"
+      en_post.url = "/posts/hello/"
+      en_post.section = "posts"
+      en_post.language = nil
+      en_post.draft = false
+      en_post.render = true
+      en_post.is_index = false
+      en_post.raw_content = "English"
+
+      ko_post = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_post.title = "KO Post"
+      ko_post.url = "/ko/posts/hello/"
+      ko_post.section = "posts"
+      ko_post.language = "ko"
+      ko_post.draft = false
+      ko_post.render = true
+      ko_post.is_index = false
+      ko_post.raw_content = "한국어"
+
+      ko_docs = Hwaro::Models::Page.new("docs/guide.ko.md")
+      ko_docs.title = "KO Docs"
+      ko_docs.url = "/ko/docs/guide/"
+      ko_docs.section = "docs"
+      ko_docs.language = "ko"
+      ko_docs.draft = false
+      ko_docs.render = true
+      ko_docs.is_index = false
+      ko_docs.raw_content = "문서"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_post, ko_post, ko_docs], config, output_dir)
+
+        # Main feed includes both languages but only "posts" section
+        main_feed = File.read(File.join(output_dir, "rss.xml"))
+        main_feed.should contain("EN Post")
+        main_feed.should contain("KO Post")
+        main_feed.should_not contain("KO Docs")
+      end
+    end
+  end
+
   describe ".generate" do
     it "does not generate feeds when disabled" do
       config = Hwaro::Models::Config.new

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -23,6 +23,17 @@ module Hwaro
               }
             end
 
+            # When multilingual and default_language_only is true,
+            # the main feed only contains default language pages.
+            # When false, the main feed includes all languages (original behavior).
+            if config.multilingual? && config.feeds.default_language_only
+              default_lang = config.default_language
+              site_pages.select! { |p|
+                lang = p.language || default_lang
+                lang == default_lang
+              }
+            end
+
             process_feed(site_pages, config, output_dir, config.feeds.filename, config.title, "", verbose)
           end
 
@@ -46,6 +57,53 @@ module Hwaro
               process_feed(section_pages, config, section_output_dir, "", feed_title, page.url, verbose)
             end
           end
+
+          # 3. Generate Language-specific Feeds (for non-default languages)
+          if config.multilingual?
+            generate_language_feeds(pages, config, output_dir, verbose)
+          end
+        end
+
+        # Generate per-language feeds for non-default languages.
+        # Each language with generate_feed=true gets its own feed at /{lang}/rss.xml (or atom.xml).
+        private def self.generate_language_feeds(pages : Array(Models::Page), config : Models::Config, output_dir : String, verbose : Bool = false)
+          default_lang = config.default_language
+
+          config.languages.each do |lang_code, lang_config|
+            # Skip the default language — it's already covered by the main feed
+            next if lang_code == default_lang
+
+            # Respect per-language generate_feed setting
+            next unless lang_config.generate_feed
+
+            # Filter pages for this language
+            lang_pages = pages.reject { |p|
+              p.draft || !p.render || p.is_a?(Models::Section)
+            }.select { |p|
+              p.language == lang_code
+            }
+
+            # Apply section filter if configured on the main feed
+            if !config.feeds.sections.empty?
+              lang_pages.select! { |p|
+                config.feeds.sections.any? { |s| p.section == s || p.section.starts_with?("#{s}/") }
+              }
+            end
+
+            # Build the output directory: output_dir/{lang}/
+            lang_output_dir = File.join(output_dir, lang_code)
+            FileUtils.mkdir_p(lang_output_dir)
+
+            # Build a language-specific feed title
+            lang_name = lang_config.language_name
+            feed_title = "#{config.title} (#{lang_name})"
+
+            # base_path corresponds to the URL prefix for this language feed
+            # e.g., "/ko/" so the self-referencing link becomes base_url/ko/rss.xml
+            base_path = "/#{lang_code}/"
+
+            process_feed(lang_pages, config, lang_output_dir, "", feed_title, base_path, verbose, lang_code)
+          end
         end
 
         def self.process_feed(
@@ -56,6 +114,7 @@ module Hwaro
           feed_title : String,
           base_path : String = "",
           verbose : Bool = false,
+          language : String? = nil,
         )
           # Determine feed type and filename
           feed_type = config.feeds.type.downcase
@@ -80,9 +139,9 @@ module Hwaro
           # Generate feed content
           feed_content = case feed_type
                          when "atom"
-                           generate_atom(pages, config, filename, config.feeds.truncate > 0, feed_title, base_path)
+                           generate_atom(pages, config, filename, config.feeds.truncate > 0, feed_title, base_path, language)
                          else
-                           generate_rss(pages, config, filename, config.feeds.truncate > 0, feed_title, base_path)
+                           generate_rss(pages, config, filename, config.feeds.truncate > 0, feed_title, base_path, language)
                          end
 
           # Write feed file
@@ -98,6 +157,7 @@ module Hwaro
           is_text : Bool,
           feed_title : String,
           base_path : String,
+          language : String? = nil,
         ) : String
           String.build do |str|
             str << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
@@ -106,6 +166,11 @@ module Hwaro
             str << "    <title>#{Utils::TextUtils.escape_xml(feed_title)}</title>\n"
             str << "    <link>#{Utils::TextUtils.escape_xml(config.base_url)}</link>\n"
             str << "    <description>#{Utils::TextUtils.escape_xml(config.description)}</description>\n"
+
+            # Include language tag for language-specific feeds
+            if language
+              str << "    <language>#{Utils::TextUtils.escape_xml(language)}</language>\n"
+            end
 
             # Self-referencing link
             base_url = config.base_url.rstrip('/')
@@ -148,12 +213,20 @@ module Hwaro
           is_text : Bool,
           feed_title : String,
           base_path : String,
+          language : String? = nil,
         ) : String
           now = Time.utc
 
           String.build do |str|
             str << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            str << "<feed xmlns=\"http://www.w3.org/2005/Atom\">\n"
+
+            # Include xml:lang attribute for language-specific feeds
+            if language
+              str << "<feed xmlns=\"http://www.w3.org/2005/Atom\" xml:lang=\"#{Utils::TextUtils.escape_xml(language)}\">\n"
+            else
+              str << "<feed xmlns=\"http://www.w3.org/2005/Atom\">\n"
+            end
+
             str << "  <title>#{Utils::TextUtils.escape_xml(feed_title)}</title>\n"
             str << "  <link href=\"#{Utils::TextUtils.escape_xml(config.base_url)}\" />\n"
 

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -82,6 +82,7 @@ module Hwaro
       property truncate : Int32
       property limit : Int32
       property sections : Array(String)
+      property default_language_only : Bool
 
       def initialize
         @enabled = false
@@ -90,6 +91,7 @@ module Hwaro
         @truncate = 0
         @limit = 10
         @sections = [] of String
+        @default_language_only = true
       end
     end
 
@@ -622,6 +624,7 @@ module Hwaro
         if sections = s["sections"]?.try(&.as_a?)
           config.feeds.sections = sections.compact_map(&.as_s?)
         end
+        config.feeds.default_language_only = bool_value(s["default_language_only"]?, config.feeds.default_language_only)
       end
 
       private def self.load_search(config : Config)

--- a/src/services/defaults/config.cr
+++ b/src/services/defaults/config.cr
@@ -43,6 +43,7 @@ module Hwaro
           truncate = 0
           limit = 10
           sections = []   # Optional: e.g. ["blog"]
+          default_language_only = true  # true: main feed = default language only, false: all languages
 
           # Plugins Configuration
           [plugins]
@@ -126,6 +127,7 @@ module Hwaro
           truncate = 0
           limit = 10
           sections = []   # Optional: e.g. ["blog"]
+          default_language_only = true  # true: main feed = default language only, false: all languages
 
           # Plugins Configuration
           [plugins]
@@ -220,7 +222,8 @@ module Hwaro
             str << "type = \"rss\"\n"
             str << "truncate = 0\n"
             str << "limit = 10\n"
-            str << "sections = []   # Optional: e.g. [\"blog\"]\n\n"
+            str << "sections = []   # Optional: e.g. [\"blog\"]\n"
+            str << "default_language_only = true  # true: main feed = default language only, false: all languages\n\n"
             str << "# Plugins Configuration\n"
             str << "[plugins]\n"
             str << "processors = [\"markdown\"]  # List of enabled processors\n\n"

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -467,6 +467,8 @@ module Hwaro
           truncate = 0              # Truncate content to N characters (0 = full content)
           limit = 10                # Maximum number of items in feed
           sections = #{sections_str}   # Limit to specific sections, e.g., ["posts"]
+          # default_language_only = true  # Multilingual: true = main feed has default language only
+          #                               #              false = main feed includes all languages
 
           TOML
         end


### PR DESCRIPTION
- Generate per-language RSS/Atom feeds for multilingual sites
- Add feeds.default_language_only config option (default: true)
- Main feed includes only default language pages when true
- Per-language feeds generated at /{lang}/rss.xml or /{lang}/atom.xml
- Update AGENTS.md, docs, scaffold defaults, and config tests
- Add comprehensive tests for multilingual feed behavior