### PR TITLE
Promote doctor to top-level command

### DIFF
--- a/spec/functional/cli_commands_spec.cr
+++ b/spec/functional/cli_commands_spec.cr
@@ -87,7 +87,7 @@ describe "CLI Tool Commands" do
     end
   end
 
-  describe "hwaro tool doctor" do
+  describe "hwaro doctor (top-level)" do
     it "runs diagnostics on a valid project" do
       temp_dir = File.tempname("hwaro_test")
       Dir.mkdir(temp_dir)
@@ -95,7 +95,27 @@ describe "CLI Tool Commands" do
         project_dir = File.join(temp_dir, "test_site")
         Dir.mkdir(project_dir)
 
-        # Initialize project
+        Process.run(File.expand_path("../../bin/hwaro", __DIR__), ["init", project_dir], output: IO::Memory.new, error: IO::Memory.new)
+
+        output_io = IO::Memory.new
+        error_io = IO::Memory.new
+        status = Process.run(File.expand_path("../../bin/hwaro", __DIR__), ["doctor"], chdir: project_dir, output: output_io, error: error_io)
+
+        status.success?.should be_true
+      ensure
+        FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
+      end
+    end
+  end
+
+  describe "hwaro tool doctor (alias)" do
+    it "still works via tool subcommand" do
+      temp_dir = File.tempname("hwaro_test")
+      Dir.mkdir(temp_dir)
+      begin
+        project_dir = File.join(temp_dir, "test_site")
+        Dir.mkdir(project_dir)
+
         Process.run(File.expand_path("../../bin/hwaro", __DIR__), ["init", project_dir], output: IO::Memory.new, error: IO::Memory.new)
 
         output_io = IO::Memory.new

--- a/spec/unit/cli_spec.cr
+++ b/spec/unit/cli_spec.cr
@@ -271,6 +271,21 @@ describe Hwaro::CLI::CommandRegistry do
     names = all.map(&.name)
     names.should contain("init")
     names.should contain("build")
+    names.should contain("doctor")
     names.should contain("completion")
+  end
+end
+
+describe Hwaro::CLI::Commands::DoctorCommand do
+  it "has correct metadata as top-level command" do
+    meta = Hwaro::CLI::Commands::DoctorCommand.metadata
+    meta.name.should eq("doctor")
+    meta.description.should_not be_empty
+  end
+
+  it "shares flags with Tool::DoctorCommand" do
+    top_flags = Hwaro::CLI::Commands::DoctorCommand.metadata.flags.map(&.long)
+    tool_flags = Hwaro::CLI::Commands::Tool::DoctorCommand.metadata.flags.map(&.long)
+    top_flags.should eq(tool_flags)
   end
 end

--- a/src/cli/commands/doctor_command.cr
+++ b/src/cli/commands/doctor_command.cr
@@ -1,0 +1,35 @@
+# Doctor command - Top-level alias for `hwaro tool doctor`
+#
+# Diagnoses config and content issues.
+# Usage:
+#   hwaro doctor [options]
+#
+# This is a convenience alias; `hwaro tool doctor` also works.
+
+require "./tool/doctor_command"
+
+module Hwaro
+  module CLI
+    module Commands
+      class DoctorCommand
+        NAME        = "doctor"
+        DESCRIPTION = Tool::DoctorCommand::DESCRIPTION
+
+        def self.metadata : CommandInfo
+          # Reuse flags from the underlying Tool::DoctorCommand
+          CommandInfo.new(
+            name: NAME,
+            description: DESCRIPTION,
+            flags: Tool::DoctorCommand::FLAGS,
+            positional_args: Tool::DoctorCommand::POSITIONAL_ARGS,
+            positional_choices: Tool::DoctorCommand::POSITIONAL_CHOICES
+          )
+        end
+
+        def run(args : Array(String))
+          Tool::DoctorCommand.new.run(args)
+        end
+      end
+    end
+  end
+end

--- a/src/cli/commands/tool/doctor_command.cr
+++ b/src/cli/commands/tool/doctor_command.cr
@@ -41,7 +41,7 @@ module Hwaro
             fix_mode = false
 
             OptionParser.parse(args) do |parser|
-              parser.banner = "Usage: hwaro tool doctor [options]"
+              parser.banner = "Usage: hwaro doctor [options]"
               CLI.register_flag(parser, CONTENT_DIR_FLAG) { |v| content_dir = v }
               parser.on("--fix", "Auto-fix issues (add missing config sections)") { fix_mode = true }
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
@@ -106,7 +106,7 @@ module Hwaro
             end
 
             unless config_missing.empty?
-              Logger.info "Missing Config Sections (run 'hwaro tool doctor --fix' to add):"
+              Logger.info "Missing Config Sections (run 'hwaro doctor --fix' to add):"
               config_missing.each { |issue| print_issue(issue) }
               Logger.info ""
             end

--- a/src/cli/runner.cr
+++ b/src/cli/runner.cr
@@ -5,6 +5,7 @@ require "./commands/serve_command"
 require "./commands/new_command"
 require "./commands/deploy_command"
 require "./commands/tool_command"
+require "./commands/doctor_command"
 require "./commands/completion_command"
 require "../utils/logger"
 
@@ -127,6 +128,11 @@ module Hwaro
           Commands::ToolCommand.new.run(args)
         end
 
+        # Register doctor command (top-level alias for `tool doctor`)
+        CommandRegistry.register(Commands::DoctorCommand.metadata) do |args|
+          Commands::DoctorCommand.new.run(args)
+        end
+
         # Register completion command
         CommandRegistry.register(Commands::CompletionCommand.metadata) do |args|
           Commands::CompletionCommand.new.run(args)
@@ -180,7 +186,7 @@ module Hwaro
         Logger.info "Commands:"
 
         # Define display order
-        priority = ["init", "build", "serve", "new", "deploy", "tool", "completion", "version", "help"]
+        priority = ["init", "build", "serve", "new", "deploy", "doctor", "tool", "completion", "version", "help"]
 
         # Print registered commands in priority order
         CommandRegistry.all.sort_by { |cmd|

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -1,5 +1,5 @@
 # Shared TOML config snippets used by both scaffold (hwaro init)
-# and doctor (hwaro tool doctor --fix).
+# and doctor (hwaro doctor --fix).
 #
 # Scaffold uses the full version (commented: false) with real values
 # and detailed documentation. Doctor uses the commented version

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -209,7 +209,7 @@ module Hwaro
         missing.each do |key|
           desc = KNOWN_CONFIG_SECTIONS[key]? || KNOWN_SUB_SECTIONS.find { |k, _| "#{k[0]}.#{k[1]}" == key }.try(&.last) || key
           issues << Issue.new(level: :info, category: "config_missing", file: @config_path,
-            message: "Missing config section [#{key}] (#{desc}) — run 'hwaro tool doctor --fix' to add it")
+            message: "Missing config section [#{key}] (#{desc}) — run 'hwaro doctor --fix' to add it")
         end
       end
 


### PR DESCRIPTION
## Summary
- Add `hwaro doctor` as a top-level command that delegates to the existing `Tool::DoctorCommand`
- `hwaro tool doctor` remains functional as a backward-compatible alias
- Update all user-facing hint messages to reference the shorter `hwaro doctor` path

Closes #233

## Test plan
- [x] All 3175 unit specs pass
- [x] Top-level `DoctorCommand` metadata and flag parity tested
- [x] `doctor` registered in `CommandRegistry`
- [x] Functional tests for both `hwaro doctor` and `hwaro tool doctor` paths