### PR TITLE
Expose pagination_obj for custom pagination markup (#240)

### DIFF
--- a/spec/functional/pagination_spec.cr
+++ b/spec/functional/pagination_spec.cr
@@ -185,6 +185,134 @@ describe "Pagination: Large per_page value" do
   end
 end
 
+describe "Pagination: pagination_obj exposes individual variables" do
+  it "exposes current_page, total_pages, has_previous, has_next on each page" do
+    build_site(
+      PAGINATION_CONFIG,
+      content_files: {
+        "blog/_index.md" => "---\ntitle: Blog\n---\n",
+        "blog/p1.md"     => "---\ntitle: P1\n---\nP1",
+        "blog/p2.md"     => "---\ntitle: P2\n---\nP2",
+        "blog/p3.md"     => "---\ntitle: P3\n---\nP3",
+      },
+      template_files: {
+        "page.html"    => "{{ content }}",
+        "section.html" => "CP={{ pagination_obj.current_page }}|TP={{ pagination_obj.total_pages }}|HP={{ pagination_obj.has_previous }}|HN={{ pagination_obj.has_next }}",
+      },
+    ) do
+      page1 = File.read("public/blog/index.html")
+      page1.should contain("CP=1")
+      page1.should contain("TP=2")
+      page1.should contain("HP=false")
+      page1.should contain("HN=true")
+
+      page2 = File.read("public/blog/page/2/index.html")
+      page2.should contain("CP=2")
+      page2.should contain("TP=2")
+      page2.should contain("HP=true")
+      page2.should contain("HN=false")
+    end
+  end
+
+  it "exposes previous_url and next_url" do
+    build_site(
+      PAGINATION_CONFIG,
+      content_files: {
+        "blog/_index.md" => "---\ntitle: Blog\n---\n",
+        "blog/p1.md"     => "---\ntitle: P1\n---\nP1",
+        "blog/p2.md"     => "---\ntitle: P2\n---\nP2",
+        "blog/p3.md"     => "---\ntitle: P3\n---\nP3",
+        "blog/p4.md"     => "---\ntitle: P4\n---\nP4",
+        "blog/p5.md"     => "---\ntitle: P5\n---\nP5",
+      },
+      template_files: {
+        "page.html"    => "{{ content }}",
+        "section.html" => "PREV={{ pagination_obj.previous_url }}|NEXT={{ pagination_obj.next_url }}",
+      },
+    ) do
+      # Page 1: no previous, next is page 2
+      page1 = File.read("public/blog/index.html")
+      page1.should contain("PREV=|NEXT=/blog/page/2/")
+
+      # Page 2: previous is page 1, next is page 3
+      page2 = File.read("public/blog/page/2/index.html")
+      page2.should contain("PREV=/blog/|NEXT=/blog/page/3/")
+
+      # Page 3: previous is page 2, no next
+      page3 = File.read("public/blog/page/3/index.html")
+      page3.should contain("PREV=/blog/page/2/|NEXT=")
+    end
+  end
+
+  it "exposes per_page and total_items" do
+    build_site(
+      PAGINATION_CONFIG,
+      content_files: {
+        "blog/_index.md" => "---\ntitle: Blog\n---\n",
+        "blog/p1.md"     => "---\ntitle: P1\n---\nP1",
+        "blog/p2.md"     => "---\ntitle: P2\n---\nP2",
+        "blog/p3.md"     => "---\ntitle: P3\n---\nP3",
+      },
+      template_files: {
+        "page.html"    => "{{ content }}",
+        "section.html" => "PP={{ pagination_obj.per_page }}|TI={{ pagination_obj.total_items }}",
+      },
+    ) do
+      page1 = File.read("public/blog/index.html")
+      page1.should contain("PP=2")
+      page1.should contain("TI=3")
+    end
+  end
+
+  it "renders empty when pagination is disabled" do
+    config = <<-TOML
+    title = "Test"
+    base_url = "http://localhost"
+
+    [pagination]
+    enabled = false
+    per_page = 1
+    TOML
+
+    build_site(
+      config,
+      content_files: {
+        "blog/_index.md" => "---\ntitle: Blog\n---\n",
+        "blog/p1.md"     => "---\ntitle: P1\n---\nP1",
+        "blog/p2.md"     => "---\ntitle: P2\n---\nP2",
+      },
+      template_files: {
+        "page.html"    => "{{ content }}",
+        "section.html" => "CP={{ pagination_obj.current_page }}|TP={{ pagination_obj.total_pages }}",
+      },
+    ) do
+      # pagination_obj still available with single-page defaults when disabled
+      html = File.read("public/blog/index.html")
+      html.should contain("CP=1|TP=1")
+    end
+  end
+
+  it "exposes pagination_obj.html with pre-rendered HTML" do
+    build_site(
+      PAGINATION_CONFIG,
+      content_files: {
+        "blog/_index.md" => "---\ntitle: Blog\n---\n",
+        "blog/p1.md"     => "---\ntitle: P1\n---\nP1",
+        "blog/p2.md"     => "---\ntitle: P2\n---\nP2",
+        "blog/p3.md"     => "---\ntitle: P3\n---\nP3",
+      },
+      template_files: {
+        "page.html"    => "{{ content }}",
+        "section.html" => "{{ pagination_obj.html }}",
+      },
+    ) do
+      page1 = File.read("public/blog/index.html")
+      page1.should contain("pagination")
+      page1.should contain("pagination-prev")
+    end
+  end
+end
+
 describe "Pagination: Disabled pagination" do
   it "does not paginate when pagination is disabled" do
     config = <<-TOML

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -560,6 +560,11 @@ module Hwaro::Core::Build::Phases::Render
     vars["toc_obj"] = Crinja::Value.new({"html" => Crinja::Value.new(toc)})
     vars["pagination"] = Crinja::Value.new(pagination)
     vars["pagination_seo_links"] = Crinja::Value.new(pagination_seo_links)
+
+    # NOTE: pagination_obj is not updated here because its fields (URLs, page
+    # numbers, booleans) are stable across the shortcode pre-render and final
+    # render passes. The html field is set from the same pagination string
+    # that was used when build_template_variables originally created it.
   end
 
   # Unified Page→Crinja::Value conversion with per-page caching.
@@ -1103,9 +1108,26 @@ module Hwaro::Core::Build::Phases::Render
         "next"          => Crinja::Value.new(paginator.next_url),
         "pages"         => Crinja::Value.new(section_pages_array),
         "current_index" => Crinja::Value.new(paginator.page_number),
-        "total_pages"   => Crinja::Value.new(paginator.total_items),
+        "total_pages"   => Crinja::Value.new(paginator.total_pages),
       }
       vars["paginator"] = Crinja::Value.new(paginator_obj)
+
+      # Structured pagination object for custom markup in themes
+      # Allows: {{ pagination_obj.previous_url }}, {{ pagination_obj.current_page }}, etc.
+      pagination_obj_hash = {
+        "html"         => Crinja::Value.new(pagination),
+        "previous_url" => Crinja::Value.new(paginator.has_prev ? (paginator.prev_url || "") : ""),
+        "next_url"     => Crinja::Value.new(paginator.has_next ? (paginator.next_url || "") : ""),
+        "first_url"    => Crinja::Value.new(paginator.first_url),
+        "last_url"     => Crinja::Value.new(paginator.last_url),
+        "current_page" => Crinja::Value.new(paginator.page_number),
+        "total_pages"  => Crinja::Value.new(paginator.total_pages),
+        "total_items"  => Crinja::Value.new(paginator.total_items),
+        "per_page"     => Crinja::Value.new(paginator.per_page),
+        "has_previous" => Crinja::Value.new(paginator.has_prev),
+        "has_next"     => Crinja::Value.new(paginator.has_next),
+      }
+      vars["pagination_obj"] = Crinja::Value.new(pagination_obj_hash)
     end
 
     # NOTE: highlight_css/js/tags and auto_includes_css/js are now in


### PR DESCRIPTION
## Summary
- Add `pagination_obj` template variable with individual pagination fields (`previous_url`, `next_url`, `current_page`, `total_pages`, `has_previous`, `has_next`, `per_page`, `total_items`, `first_url`, `last_url`, `html`)
- Themes can now build custom pagination markup instead of relying solely on pre-rendered `{{ pagination }}` HTML
- Fix existing bug where `paginator.total_pages` incorrectly mapped to `total_items`

## Usage
```jinja
{% if pagination_obj.has_previous %}
  <a href="{{ pagination_obj.previous_url }}">← Newer</a>
{% endif %}
<span>Page {{ pagination_obj.current_page }} of {{ pagination_obj.total_pages }}</span>
{% if pagination_obj.has_next %}
  <a href="{{ pagination_obj.next_url }}">Older →</a>
{% endif %}
```

The existing `{{ pagination }}` (pre-rendered HTML) remains available for backward compatibility.

## Test plan
- [x] Functional tests for `current_page`, `total_pages`, `has_previous`, `has_next`
- [x] Functional tests for `previous_url`, `next_url` across first/middle/last pages
- [x] Functional tests for `per_page`, `total_items`
- [x] Functional test for `pagination_obj.html` pre-rendered output
- [x] Functional test for disabled pagination (single-page defaults)
- [x] All 12 pagination tests pass

Closes #240