### PR TITLE
Show draft content paths when using --drafts flag

### DIFF
--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -93,6 +93,19 @@ module Hwaro::Core::Build::Phases::ParseContent
 
     Logger.warn "  #{failed_count} page(s) skipped due to parse errors." if failed_count > 0
     Logger.info "  Excluded #{expired_count} expired page#{"s" if expired_count > 1}" if expired_count > 0
+
+    # Show included draft content paths when --drafts flag is used
+    if include_drafts
+      draft_pages = ctx.all_pages.select(&.draft)
+      if draft_pages.size > 0
+        max_url_len = draft_pages.max_of { |p| p.url.size }
+        pad = {max_url_len, 24}.max
+        Logger.info "Including #{draft_pages.size} draft(s):"
+        draft_pages.each do |p|
+          Logger.info "  #{p.url.ljust(pad)} <- content/#{p.path}"
+        end
+      end
+    end
   end
 
   # Parse a single page: read file, parse frontmatter, assign properties


### PR DESCRIPTION
## Summary
- `--drafts` 플래그 사용 시 포함된 draft 문서의 URL 경로와 소스 파일 경로를 출력
- draft가 없으면 메시지를 출력하지 않음 (기존 동작 유지)
- URL 길이에 맞춰 동적으로 정렬

```
Including 3 draft(s):
  /blog/wip-post/          <- content/blog/wip-post.md
  /ideas/new-feature/      <- content/ideas/new-feature.md
  /about-v2/               <- content/about-v2.md
```

Closes #251

## Test plan
- [x] 기존 build integration 테스트 85개 통과
- [x] 기존 filters 테스트 24개 통과
- [x] `crystal build` 성공 확인