### PR TITLE
Optimize incremental rebuild in serve mode

### DIFF
--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -1027,6 +1027,190 @@ describe "Incremental build integration" do
     end
   end
 
+  it "updates taxonomy pages when tags change during incremental build" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "content", "posts"))
+      FileUtils.mkdir_p(File.join(dir, "templates"))
+
+      File.write(File.join(dir, "config.toml"), "title = \"Taxonomy Test\"\nbase_url = \"http://localhost\"\n\n[[taxonomies]]\nname = \"tags\"\n")
+      File.write(File.join(dir, "templates", "page.html"), "<p>{{ content }}</p>")
+      File.write(File.join(dir, "templates", "section.html"), "<div>{{ content }}</div>")
+
+      File.write(File.join(dir, "content", "posts", "_index.md"), "---\ntitle: Posts\n---\n")
+      File.write(File.join(dir, "content", "posts", "post1.md"), "---\ntitle: Tagged Post\ndate: \"2025-01-01\"\ntags:\n  - crystal\n  - web\n---\nTagged content\n")
+      File.write(File.join(dir, "content", "posts", "post2.md"), "---\ntitle: Other Post\ndate: \"2025-01-02\"\ntags:\n  - crystal\n---\nOther content\n")
+
+      Dir.cd(dir) do
+        builder = Hwaro::Core::Build::Builder.new
+        Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+        options = Hwaro::Config::Options::BuildOptions.new
+
+        builder.run(options)
+
+        # Verify taxonomy pages exist
+        File.exists?(File.join(dir, "public", "tags", "crystal", "index.html")).should be_true
+        File.exists?(File.join(dir, "public", "tags", "web", "index.html")).should be_true
+
+        # Change tags: remove "web", add "go"
+        sleep 0.05.seconds
+        File.write(File.join(dir, "content", "posts", "post1.md"), "---\ntitle: Tagged Post\ndate: \"2025-01-01\"\ntags:\n  - crystal\n  - go\n---\nUpdated tagged content\n")
+
+        builder.run_incremental(["content/posts/post1.md"], options)
+
+        # Updated content should appear
+        File.read(File.join(dir, "public", "posts", "post1", "index.html")).should contain("Updated tagged content")
+
+        # New tag page should be generated
+        File.exists?(File.join(dir, "public", "tags", "go", "index.html")).should be_true
+      end
+    end
+  end
+
+  it "updates navigation prev/next when date changes during incremental build" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "content", "posts"))
+      FileUtils.mkdir_p(File.join(dir, "templates"))
+
+      File.write(File.join(dir, "config.toml"), %(title = "Nav Test"\nbase_url = "http://localhost"\n))
+      # Template that renders navigation links
+      File.write(File.join(dir, "templates", "page.html"),
+        "<p>{{ content }}</p>" \
+        "{% if page.lower %}<a class=\"prev\" href=\"{{ page.lower.url }}\">{{ page.lower.title }}</a>{% endif %}" \
+        "{% if page.higher %}<a class=\"next\" href=\"{{ page.higher.url }}\">{{ page.higher.title }}</a>{% endif %}")
+      File.write(File.join(dir, "templates", "section.html"), "<div>{{ content }}</div>")
+
+      File.write(File.join(dir, "content", "posts", "_index.md"), "---\ntitle: Posts\n---\n")
+      # Alpha is oldest, Beta middle, Gamma newest
+      # Dates must be quoted strings for YAML (unquoted dates become Time objects)
+      File.write(File.join(dir, "content", "posts", "alpha.md"), "---\ntitle: Alpha\ndate: \"2025-01-01\"\n---\nAlpha content\n")
+      File.write(File.join(dir, "content", "posts", "beta.md"), "---\ntitle: Beta\ndate: \"2025-01-02\"\n---\nBeta content\n")
+      File.write(File.join(dir, "content", "posts", "gamma.md"), "---\ntitle: Gamma\ndate: \"2025-01-03\"\n---\nGamma content\n")
+
+      Dir.cd(dir) do
+        builder = Hwaro::Core::Build::Builder.new
+        Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+        options = Hwaro::Config::Options::BuildOptions.new
+
+        builder.run(options)
+
+        # Default sort is newest-first: [Gamma(Jan3), Beta(Jan2), Alpha(Jan1)]
+        # lower=previous in sorted order, higher=next in sorted order
+        # Beta (idx=1): lower=Gamma (idx=0), higher=Alpha (idx=2)
+        beta_html = File.read(File.join(dir, "public", "posts", "beta", "index.html"))
+        beta_html.should contain("class=\"prev\"")
+        beta_html.should contain("Gamma")
+        beta_html.should contain("class=\"next\"")
+        beta_html.should contain("Alpha")
+
+        # Now change Alpha's date to make it newest (after Gamma)
+        sleep 0.05.seconds
+        File.write(File.join(dir, "content", "posts", "alpha.md"), "---\ntitle: Alpha\ndate: \"2025-01-10\"\n---\nAlpha updated\n")
+
+        builder.run_incremental(["content/posts/alpha.md"], options)
+
+        # After re-linking, sort: [Alpha(Jan10), Gamma(Jan3), Beta(Jan2)]
+        # Beta (idx=2): lower=Gamma (idx=1), higher=nil (last element)
+        beta_html_after = File.read(File.join(dir, "public", "posts", "beta", "index.html"))
+        beta_html_after.should contain("class=\"prev\"")
+        beta_html_after.should contain("Gamma")
+        # Alpha is no longer Beta's next neighbor
+        beta_html_after.should_not contain("class=\"next\"")
+      end
+    end
+  end
+
+  it "handles page entering/leaving a series during incremental build" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "content", "posts"))
+      FileUtils.mkdir_p(File.join(dir, "templates"))
+
+      File.write(File.join(dir, "config.toml"), %(title = "Series Test"\nbase_url = "http://localhost"\n\n[series]\nenabled = true\n))
+      File.write(File.join(dir, "templates", "page.html"),
+        "<p>{{ content }}</p>" \
+        "{% if page.series != \"\" %}<span class=\"series\">{{ page.series }}</span>{% endif %}" \
+        "{% if page.series_index > 0 %}<span class=\"idx\">{{ page.series_index }}</span>{% endif %}")
+      File.write(File.join(dir, "templates", "section.html"), "<div>{{ content }}</div>")
+
+      File.write(File.join(dir, "content", "posts", "_index.md"), "---\ntitle: Posts\n---\n")
+      File.write(File.join(dir, "content", "posts", "part1.md"), "---\ntitle: Part 1\ndate: \"2025-01-01\"\nseries: my-series\nseries_weight: 1\n---\nPart 1 content\n")
+      File.write(File.join(dir, "content", "posts", "part2.md"), "---\ntitle: Part 2\ndate: \"2025-01-02\"\nseries: my-series\nseries_weight: 2\n---\nPart 2 content\n")
+
+      Dir.cd(dir) do
+        builder = Hwaro::Core::Build::Builder.new
+        Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+        options = Hwaro::Config::Options::BuildOptions.new
+
+        builder.run(options)
+
+        # Verify series is rendered
+        part1_html = File.read(File.join(dir, "public", "posts", "part1", "index.html"))
+        part1_html.should contain("my-series")
+        part1_html.should contain("<span class=\"idx\">1</span>")
+
+        # Remove part1 from the series
+        sleep 0.05.seconds
+        File.write(File.join(dir, "content", "posts", "part1.md"), "---\ntitle: Part 1\ndate: \"2025-01-01\"\n---\nPart 1 no longer in series\n")
+
+        builder.run_incremental(["content/posts/part1.md"], options)
+
+        # Part1 should no longer show series
+        part1_after = File.read(File.join(dir, "public", "posts", "part1", "index.html"))
+        part1_after.should_not contain("my-series")
+
+        # Part2 should be updated (series_index changes since part1 left)
+        part2_after = File.read(File.join(dir, "public", "posts", "part2", "index.html"))
+        part2_after.should contain("my-series")
+        part2_after.should contain("<span class=\"idx\">1</span>")
+      end
+    end
+  end
+
+  it "updates related_posts when a page gains new taxonomy terms" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "content", "posts"))
+      FileUtils.mkdir_p(File.join(dir, "templates"))
+
+      File.write(File.join(dir, "config.toml"), %(title = "Related Test"\nbase_url = "http://localhost"\ntaxonomies = ["tags"]\n\n[related]\nenabled = true\nlimit = 5\ntaxonomies = ["tags"]\n))
+      File.write(File.join(dir, "templates", "page.html"),
+        "<p>{{ content }}</p>" \
+        "{% for rp in page.related_posts %}<a class=\"related\" href=\"{{ rp.url }}\">{{ rp.title }}</a>{% endfor %}")
+      File.write(File.join(dir, "templates", "section.html"), "<div>{{ content }}</div>")
+
+      File.write(File.join(dir, "content", "posts", "_index.md"), "---\ntitle: Posts\n---\n")
+      File.write(File.join(dir, "content", "posts", "post1.md"), "---\ntitle: Post One\ndate: \"2025-01-01\"\ntags:\n  - rust\n---\nPost one content\n")
+      File.write(File.join(dir, "content", "posts", "post2.md"), "---\ntitle: Post Two\ndate: \"2025-01-02\"\ntags:\n  - go\n---\nPost two content\n")
+      File.write(File.join(dir, "content", "posts", "post3.md"), "---\ntitle: Post Three\ndate: \"2025-01-03\"\ntags:\n  - go\n---\nPost three content\n")
+
+      Dir.cd(dir) do
+        builder = Hwaro::Core::Build::Builder.new
+        Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+        options = Hwaro::Config::Options::BuildOptions.new
+
+        builder.run(options)
+
+        # Post1 has "rust" tag, no related posts with go-tagged posts
+        post1_html = File.read(File.join(dir, "public", "posts", "post1", "index.html"))
+        post1_html.should_not contain("Post Two")
+        post1_html.should_not contain("Post Three")
+
+        # Now add "go" tag to post1 — should become related to post2 and post3
+        sleep 0.05.seconds
+        File.write(File.join(dir, "content", "posts", "post1.md"), "---\ntitle: Post One\ndate: \"2025-01-01\"\ntags:\n  - rust\n  - go\n---\nPost one updated\n")
+
+        builder.run_incremental(["content/posts/post1.md"], options)
+
+        # Post1 should now list post2 and post3 as related
+        post1_after = File.read(File.join(dir, "public", "posts", "post1", "index.html"))
+        post1_after.should contain("Post Two")
+        post1_after.should contain("Post Three")
+
+        # Post2 should now list post1 as related (newly-related page)
+        post2_after = File.read(File.join(dir, "public", "posts", "post2", "index.html"))
+        post2_after.should contain("Post One")
+      end
+    end
+  end
+
   it "re-renders with updated template via run_rerender" do
     Dir.mktmpdir do |dir|
       FileUtils.mkdir_p(File.join(dir, "content"))

--- a/src/content/hooks/markdown_hooks.cr
+++ b/src/content/hooks/markdown_hooks.cr
@@ -74,6 +74,13 @@ module Hwaro
           page.insert_anchor_links = data[:insert_anchor_links]
           page.weight = data[:weight]
 
+          # Expiry support
+          page.expires = data[:expires]
+
+          # Series support
+          page.series = data[:series]
+          page.series_weight = data[:series_weight]
+
           if page.is_a?(Models::Section)
             page.transparent = data[:transparent]
             page.generate_feeds = data[:generate_feeds]

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -219,19 +219,34 @@ module Hwaro
             return
           end
 
-          # Filter out drafts if not including them
-          unless include_drafts
-            changed_pages.reject! { |p| p.draft }
-          end
+          # --- 2. Incrementally update relationships ---
+          # Run taxonomy update on ALL re-parsed pages first (including those about
+          # to be excluded), so excluded pages' old entries are properly removed.
+          update_taxonomies_incremental(site, changed_pages, old_taxonomies_snapshot)
 
-          # Filter out expired content
+          # Now identify pages that should be excluded (draft/expired)
+          excluded_pages = [] of Models::Page
+          unless include_drafts
+            excluded = changed_pages.select(&.draft)
+            excluded_pages.concat(excluded)
+            changed_pages.reject!(&.draft)
+          end
+          expired = changed_pages.select { |p| p.expires.try { |e| e <= Time.utc } || false }
+          excluded_pages.concat(expired)
           changed_pages.reject! { |p| p.expires.try { |e| e <= Time.utc } || false }
 
-          # --- 2. Incrementally update relationships ---
-          all_pages = (site.pages + site.sections).as(Array(Models::Page))
+          # Remove excluded pages from site indices and delete stale output files
+          unless excluded_pages.empty?
+            excluded_paths = excluded_pages.map(&.path).to_set
+            site.pages.reject! { |p| excluded_paths.includes?(p.path) }
+            site.sections.reject! { |p| excluded_paths.includes?(p.path) }
+            excluded_pages.each do |p|
+              stale_output = get_output_path(p, output_dir)
+              File.delete(stale_output) if File.exists?(stale_output)
+            end
+          end
 
-          # Diff-based taxonomy update (only touches changed pages' entries)
-          update_taxonomies_incremental(site, changed_pages, old_taxonomies_snapshot)
+          all_pages = (site.pages + site.sections).as(Array(Models::Page))
 
           # Rebuild lookup index (page data may have changed)
           site.build_lookup_index
@@ -239,9 +254,9 @@ module Hwaro
           # Re-link navigation only for affected sections
           relink_navigation_for_sections(site, affected_sections)
 
-          # Recompute series for affected series (if enabled)
+          # Recompute series for affected series (if enabled), including old memberships
           affected_series = if site.config.series.enabled
-                              recompute_series_for_pages(site, changed_pages)
+                              recompute_series_for_pages(site, changed_pages, old_series_names)
                             else
                               Set(String).new
                             end
@@ -280,10 +295,6 @@ module Hwaro
 
           # Pages in affected series (their series_index may have changed)
           unless affected_series.empty?
-            # Also include series from old snapshot (page may have left a series)
-            old_series_names.each_value do |name|
-              affected_series << name if name
-            end
             site.pages.each do |p|
               pages_to_render << p if p.series && affected_series.includes?(p.series)
             end
@@ -314,7 +325,10 @@ module Hwaro
 
           cache.save if options.cache
 
-          # --- 5. Regenerate lightweight SEO / search files in parallel ---
+          # --- 5. Regenerate taxonomy index/term pages ---
+          Content::Taxonomies.generate(site, output_dir, templates, verbose)
+
+          # --- 6. Regenerate lightweight SEO / search files in parallel ---
           seo_tasks = [
             -> { Content::Seo::Sitemap.generate(all_pages, site, output_dir, verbose); nil },
             -> { Content::Seo::Feeds.generate(all_pages, site.config, output_dir, verbose); nil },
@@ -342,7 +356,9 @@ module Hwaro
 
           pages_map = @pages_by_path || build_pages_by_path(site)
           changed_pages = [] of Models::Page
+          affected_sections = Set(String).new
           old_taxonomies_snapshot = {} of String => Hash(String, Array(String))
+          old_series_names = {} of String => String?
 
           changed_content_files.each do |file|
             relative_path = begin
@@ -356,15 +372,21 @@ module Hwaro
 
             # Snapshot before re-parse
             old_taxonomies_snapshot[page.path] = page.taxonomies.transform_values(&.dup)
+            old_series_names[page.path] = page.series
 
             parse_single_page(page)
             page.generate_permalink(config.base_url)
             changed_pages << page
+            affected_sections << page.section
+            page.ancestors.each { |ancestor| affected_sections << ancestor.section }
           end
 
-          # Diff-based taxonomy update and rebuild lookup
+          # Update all derived relationships before full re-render
           update_taxonomies_incremental(site, changed_pages, old_taxonomies_snapshot)
           site.build_lookup_index
+          relink_navigation_for_sections(site, affected_sections)
+          recompute_series_for_pages(site, changed_pages, old_series_names) if site.config.series.enabled
+          recompute_related_posts_for_pages(site, changed_pages) if site.config.related.enabled
 
           # Now do a full re-render with reloaded templates (caches cleared there)
           run_rerender(options)

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -168,6 +168,8 @@ module Hwaro::Core::Build::Phases::Transform
               tax_terms.delete(term) if term_pages.empty?
             end
           end
+          # Clean up empty taxonomy when all terms have been removed
+          site.taxonomies.delete(name) if tax_terms.empty?
         end
       end
 
@@ -221,16 +223,25 @@ module Hwaro::Core::Build::Phases::Transform
   end
 
   # Recompute series only for series that contain changed pages.
+  # Includes old_series_names so that series a page has left are also recomputed.
   # Returns the set of affected series names.
   private def recompute_series_for_pages(
     site : Models::Site,
     changed_pages : Array(Models::Page),
+    old_series_names : Hash(String, String?) = {} of String => String?,
   ) : Set(String)
     affected_series = Set(String).new
+
+    # Include current series from changed pages
     changed_pages.each do |page|
       if name = page.series
         affected_series << name
       end
+    end
+
+    # Include old series names (page may have left a series)
+    old_series_names.each_value do |name|
+      affected_series << name if name
     end
 
     return affected_series if affected_series.empty?
@@ -256,6 +267,17 @@ module Hwaro::Core::Build::Phases::Transform
       end
     end
 
+    # Clear series data for pages whose series became empty
+    affected_series.each do |series_name|
+      next if groups.has_key?(series_name)
+      site.pages.each do |page|
+        if page.series == series_name
+          page.series_index = 0
+          page.series_pages = [] of Models::Page
+        end
+      end
+    end
+
     affected_series
   end
 
@@ -272,17 +294,7 @@ module Hwaro::Core::Build::Phases::Transform
     limit = config.limit
     all_pages = site.pages.reject { |p| p.draft || p.is_index || p.generated || !p.render }
 
-    # Collect paths of pages that need related_posts recomputed
-    changed_paths = changed_pages.map(&.path).to_set
-    pages_to_update = Set(String).new(changed_paths)
-
-    all_pages.each do |page|
-      if page.related_posts.any? { |rp| changed_paths.includes?(rp.path) }
-        pages_to_update << page.path
-      end
-    end
-
-    # Build inverted index (same structure as compute_related_posts)
+    # Build inverted index first (needed for both candidate discovery and scoring)
     inverted = {} of String => Hash(String, Array(String))
     page_lookup = {} of String => Models::Page
 
@@ -294,6 +306,33 @@ module Hwaro::Core::Build::Phases::Transform
           inv_tax = inverted[tax_name]? || (inverted[tax_name] = {} of String => Array(String))
           arr = inv_tax[term]? || (inv_tax[term] = [] of String)
           arr << page.path
+        end
+      end
+    end
+
+    # Collect paths of pages that need related_posts recomputed:
+    # 1. Changed pages themselves
+    # 2. Pages that previously referenced a changed page
+    # 3. Pages sharing any taxonomy term with changed pages (may become newly related)
+    changed_paths = changed_pages.map(&.path).to_set
+    pages_to_update = Set(String).new(changed_paths)
+
+    all_pages.each do |page|
+      if page.related_posts.any? { |rp| changed_paths.includes?(rp.path) }
+        pages_to_update << page.path
+      end
+    end
+
+    # Include pages sharing taxonomy terms with changed pages
+    changed_pages.each do |page|
+      taxonomy_names.each do |tax_name|
+        values = page.taxonomies[tax_name]? || (tax_name == "tags" ? page.tags : [] of String)
+        inv_tax = inverted[tax_name]?
+        next unless inv_tax
+        values.each do |term|
+          if candidates = inv_tax[term]?
+            candidates.each { |path| pages_to_update << path }
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary
- Diff-based taxonomy update: O(changed_pages) instead of O(all_pages)
- Selective navigation re-linking for affected sections only
- Selective series/related posts recomputation for affected pages only
- Fix stale Crinja cache entries during incremental builds (correctness bug)
- Expanded render set to include old/new neighbors, series peers, and related post peers

## Test plan
- [ ] `crystal build src/hwaro.cr --no-codegen` passes
- [ ] `hwaro serve` with single content file change: only affected pages re-rendered
- [ ] Taxonomy pages reflect changes after incremental rebuild
- [ ] Navigation (prev/next) links correct after incremental rebuild
- [ ] Series ordering correct after incremental rebuild
- [ ] Related posts updated after incremental rebuild
- [ ] Adding/removing files still triggers full rebuild

Closes #254