### PR TITLE
Add missing test coverage for hooks, scaffold, and filters

### DIFF
--- a/spec/unit/amp_hooks_spec.cr
+++ b/spec/unit/amp_hooks_spec.cr
@@ -1,0 +1,109 @@
+require "../spec_helper"
+require "../../src/content/hooks/amp_hooks"
+require "../../src/models/config"
+require "../../src/models/site"
+require "../../src/models/page"
+require "../../src/core/lifecycle"
+require "../../src/config/options/build_options"
+
+describe Hwaro::Content::Hooks::AmpHooks do
+  describe "#register_hooks" do
+    it "registers an AfterRender hook" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      hooks = Hwaro::Content::Hooks::AmpHooks.new
+      hooks.register_hooks(manager)
+
+      manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::AfterRender).should be_true
+    end
+
+    it "registers hook named amp:generate" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      hooks = Hwaro::Content::Hooks::AmpHooks.new
+      hooks.register_hooks(manager)
+
+      registered = manager.hooks_at(Hwaro::Core::Lifecycle::HookPoint::AfterRender)
+      registered.any? { |h| h.name == "amp:generate" }.should be_true
+    end
+
+    it "registers hook with priority 40" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      hooks = Hwaro::Content::Hooks::AmpHooks.new
+      hooks.register_hooks(manager)
+
+      registered = manager.hooks_at(Hwaro::Core::Lifecycle::HookPoint::AfterRender)
+      hook = registered.find { |h| h.name == "amp:generate" }
+      hook.should_not be_nil
+      hook.not_nil!.priority.should eq(40)
+    end
+
+    it "does not register hooks at other hook points" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      hooks = Hwaro::Content::Hooks::AmpHooks.new
+      hooks.register_hooks(manager)
+
+      manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::BeforeRender).should be_false
+      manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate).should be_false
+    end
+  end
+
+  describe "hook execution" do
+    it "skips when amp is disabled" do
+      Dir.mktmpdir do |output_dir|
+        config = Hwaro::Models::Config.new
+        config.amp.enabled = false
+
+        site = Hwaro::Models::Site.new(config)
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: output_dir)
+
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options: options)
+        ctx.output_dir = output_dir
+        ctx.site = site
+
+        manager = Hwaro::Core::Lifecycle::Manager.new
+        hooks = Hwaro::Content::Hooks::AmpHooks.new
+        hooks.register_hooks(manager)
+
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::AfterRender, ctx)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+      end
+    end
+
+    it "skips when site is nil" do
+      Dir.mktmpdir do |output_dir|
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: output_dir)
+
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options: options)
+        ctx.output_dir = output_dir
+
+        manager = Hwaro::Core::Lifecycle::Manager.new
+        hooks = Hwaro::Content::Hooks::AmpHooks.new
+        hooks.register_hooks(manager)
+
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::AfterRender, ctx)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+      end
+    end
+
+    it "executes without error when amp is enabled" do
+      Dir.mktmpdir do |output_dir|
+        config = Hwaro::Models::Config.new
+        config.amp.enabled = true
+        config.base_url = "https://example.com"
+
+        site = Hwaro::Models::Site.new(config)
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: output_dir)
+
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options: options)
+        ctx.output_dir = output_dir
+        ctx.site = site
+
+        manager = Hwaro::Core::Lifecycle::Manager.new
+        hooks = Hwaro::Content::Hooks::AmpHooks.new
+        hooks.register_hooks(manager)
+
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::AfterRender, ctx)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+      end
+    end
+  end
+end

--- a/spec/unit/filters_spec.cr
+++ b/spec/unit/filters_spec.cr
@@ -210,6 +210,30 @@ describe "DateFilters" do
       result = render_filter("{{ d | date }}", vars)
       result.strip.should eq("12345")
     end
+
+    it "parses ISO 8601 datetime with T separator" do
+      vars = {"d" => Crinja::Value.new("2024-06-15T14:30:00")}
+      result = render_filter("{{ d | date(format='%Y-%m-%d %H:%M') }}", vars)
+      result.strip.should eq("2024-06-15 14:30")
+    end
+
+    it "parses datetime with space separator" do
+      vars = {"d" => Crinja::Value.new("2024-06-15 14:30:00")}
+      result = render_filter("{{ d | date(format='%Y-%m-%d %H:%M') }}", vars)
+      result.strip.should eq("2024-06-15 14:30")
+    end
+
+    it "parses RFC 3339 datetime with timezone" do
+      vars = {"d" => Crinja::Value.new("2024-06-15T14:30:00Z")}
+      result = render_filter("{{ d | date(format='%Y-%m-%d') }}", vars)
+      result.strip.should eq("2024-06-15")
+    end
+
+    it "parses RFC 3339 datetime with offset timezone" do
+      vars = {"d" => Crinja::Value.new("2024-06-15T14:30:00+09:00")}
+      result = render_filter("{{ d | date(format='%Y-%m-%d') }}", vars)
+      result.strip.should eq("2024-06-15")
+    end
   end
 end
 
@@ -374,6 +398,13 @@ describe "MiscFilters" do
       vars = {"text" => Crinja::Value.new("")}
       result = render_filter("{{ text | jsonify }}", vars)
       result.strip.should eq("\"\"")
+    end
+
+    it "escapes script tag closing to prevent XSS" do
+      vars = {"text" => Crinja::Value.new("</script>")}
+      result = render_filter("{{ text | jsonify }}", vars)
+      result.should_not contain("</script>")
+      result.should contain("<\\/script>")
     end
   end
 
@@ -793,6 +824,24 @@ describe "MathFilters" do
       result = render_filter("{{ val | ceil }}", vars)
       result.should eq("-2")
     end
+
+    it "handles integer input" do
+      vars = {"val" => Crinja::Value.new(7)}
+      result = render_filter("{{ val | ceil }}", vars)
+      result.should eq("7")
+    end
+
+    it "handles zero" do
+      vars = {"val" => Crinja::Value.new(0.0)}
+      result = render_filter("{{ val | ceil }}", vars)
+      result.should eq("0")
+    end
+
+    it "returns target for non-numeric input" do
+      vars = {"val" => Crinja::Value.new("hello")}
+      result = render_filter("{{ val | ceil }}", vars)
+      result.should eq("hello")
+    end
   end
 
   describe "floor" do
@@ -812,6 +861,24 @@ describe "MathFilters" do
       vars = {"val" => Crinja::Value.new(-2.3)}
       result = render_filter("{{ val | floor }}", vars)
       result.should eq("-3")
+    end
+
+    it "handles integer input" do
+      vars = {"val" => Crinja::Value.new(7)}
+      result = render_filter("{{ val | floor }}", vars)
+      result.should eq("7")
+    end
+
+    it "handles zero" do
+      vars = {"val" => Crinja::Value.new(0.0)}
+      result = render_filter("{{ val | floor }}", vars)
+      result.should eq("0")
+    end
+
+    it "returns target for non-numeric input" do
+      vars = {"val" => Crinja::Value.new("hello")}
+      result = render_filter("{{ val | floor }}", vars)
+      result.should eq("hello")
     end
   end
 end
@@ -850,6 +917,32 @@ describe "MiscFilters (extended)" do
       vars = {"val" => Crinja::Value.new(true)}
       result = render_filter("{{ val | inspect }}", vars)
       result.should eq("true")
+    end
+
+    it "inspects false boolean" do
+      vars = {"val" => Crinja::Value.new(false)}
+      result = render_filter("{{ val | inspect }}", vars)
+      result.should eq("false")
+    end
+
+    it "inspects a float" do
+      vars = {"val" => Crinja::Value.new(3.14)}
+      result = render_filter("{{ val | inspect }}", vars)
+      result.should eq("3.14")
+    end
+
+    it "inspects an empty array" do
+      items = Crinja::Value.new([] of Crinja::Value)
+      vars = {"val" => items}
+      result = render_filter("{{ val | inspect }}", vars)
+      result.should eq("[]")
+    end
+
+    it "inspects a string with special characters" do
+      vars = {"val" => Crinja::Value.new("hello \"world\"")}
+      result = render_filter("{{ val | inspect }}", vars)
+      result.should contain("hello")
+      result.should contain("world")
     end
   end
 end

--- a/spec/unit/pwa_hooks_spec.cr
+++ b/spec/unit/pwa_hooks_spec.cr
@@ -1,0 +1,115 @@
+require "../spec_helper"
+require "../../src/content/hooks/pwa_hooks"
+require "../../src/models/config"
+require "../../src/models/site"
+require "../../src/core/lifecycle"
+require "../../src/config/options/build_options"
+
+describe Hwaro::Content::Hooks::PwaHooks do
+  describe "#register_hooks" do
+    it "registers a BeforeGenerate hook" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      hooks = Hwaro::Content::Hooks::PwaHooks.new
+      hooks.register_hooks(manager)
+
+      manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate).should be_true
+    end
+
+    it "registers hook named pwa:generate" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      hooks = Hwaro::Content::Hooks::PwaHooks.new
+      hooks.register_hooks(manager)
+
+      registered = manager.hooks_at(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate)
+      registered.any? { |h| h.name == "pwa:generate" }.should be_true
+    end
+
+    it "registers hook with priority 50" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      hooks = Hwaro::Content::Hooks::PwaHooks.new
+      hooks.register_hooks(manager)
+
+      registered = manager.hooks_at(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate)
+      hook = registered.find { |h| h.name == "pwa:generate" }
+      hook.should_not be_nil
+      hook.not_nil!.priority.should eq(50)
+    end
+
+    it "does not register hooks at other hook points" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      hooks = Hwaro::Content::Hooks::PwaHooks.new
+      hooks.register_hooks(manager)
+
+      manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::AfterRender).should be_false
+      manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::BeforeRender).should be_false
+    end
+  end
+
+  describe "hook execution" do
+    it "skips when site is nil" do
+      Dir.mktmpdir do |output_dir|
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: output_dir)
+
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options: options)
+        ctx.output_dir = output_dir
+
+        manager = Hwaro::Core::Lifecycle::Manager.new
+        hooks = Hwaro::Content::Hooks::PwaHooks.new
+        hooks.register_hooks(manager)
+
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate, ctx)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+      end
+    end
+
+    it "executes without error when site exists and pwa is enabled" do
+      Dir.mktmpdir do |output_dir|
+        config = Hwaro::Models::Config.new
+        config.pwa.enabled = true
+        config.title = "Test Site"
+        config.base_url = "https://example.com"
+
+        site = Hwaro::Models::Site.new(config)
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: output_dir)
+
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options: options)
+        ctx.output_dir = output_dir
+        ctx.site = site
+
+        manager = Hwaro::Core::Lifecycle::Manager.new
+        hooks = Hwaro::Content::Hooks::PwaHooks.new
+        hooks.register_hooks(manager)
+
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate, ctx)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+
+        # PWA manifest should be generated
+        File.exists?(File.join(output_dir, "manifest.json")).should be_true
+      end
+    end
+
+    it "executes without error when site exists and pwa is disabled" do
+      Dir.mktmpdir do |output_dir|
+        config = Hwaro::Models::Config.new
+        config.pwa.enabled = false
+
+        site = Hwaro::Models::Site.new(config)
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: output_dir)
+
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options: options)
+        ctx.output_dir = output_dir
+        ctx.site = site
+
+        manager = Hwaro::Core::Lifecycle::Manager.new
+        hooks = Hwaro::Content::Hooks::PwaHooks.new
+        hooks.register_hooks(manager)
+
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate, ctx)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+
+        # PWA manifest should NOT be generated when disabled
+        File.exists?(File.join(output_dir, "manifest.json")).should be_false
+      end
+    end
+  end
+end

--- a/spec/unit/scaffolds_bare_spec.cr
+++ b/spec/unit/scaffolds_bare_spec.cr
@@ -1,0 +1,144 @@
+require "../spec_helper"
+require "../../src/services/scaffolds/bare"
+
+describe Hwaro::Services::Scaffolds::Bare do
+  describe "#type" do
+    it "returns Bare scaffold type" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      scaffold.type.should eq(Hwaro::Config::Options::ScaffoldType::Bare)
+    end
+  end
+
+  describe "#description" do
+    it "returns a non-empty description" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      scaffold.description.should_not be_empty
+      scaffold.description.should contain("Minimal")
+    end
+  end
+
+  describe "#content_files" do
+    it "generates index.md and about.md" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      files = scaffold.content_files
+
+      files.has_key?("index.md").should be_true
+      files.has_key?("about.md").should be_true
+    end
+
+    it "generates index.md with title" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      files = scaffold.content_files
+
+      files["index.md"].should contain("title")
+      files["index.md"].should contain("Welcome to Hwaro")
+    end
+
+    it "generates about.md with title" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      files = scaffold.content_files
+
+      files["about.md"].should contain("title")
+      files["about.md"].should contain("About")
+    end
+
+    it "returns same files regardless of skip_taxonomies" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      with_tax = scaffold.content_files(skip_taxonomies: false)
+      without_tax = scaffold.content_files(skip_taxonomies: true)
+
+      with_tax.keys.sort.should eq(without_tax.keys.sort)
+    end
+  end
+
+  describe "#template_files" do
+    it "generates core template files" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      files = scaffold.template_files
+
+      files.has_key?("header.html").should be_true
+      files.has_key?("footer.html").should be_true
+      files.has_key?("page.html").should be_true
+      files.has_key?("section.html").should be_true
+      files.has_key?("404.html").should be_true
+    end
+
+    it "includes taxonomy templates by default" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      files = scaffold.template_files
+
+      files.has_key?("taxonomy.html").should be_true
+      files.has_key?("taxonomy_term.html").should be_true
+    end
+
+    it "excludes taxonomy templates when skip_taxonomies is true" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      files = scaffold.template_files(skip_taxonomies: true)
+
+      files.has_key?("taxonomy.html").should be_false
+      files.has_key?("taxonomy_term.html").should be_false
+    end
+
+    it "generates semantic HTML templates without styles" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      files = scaffold.template_files
+
+      # Header should have semantic HTML
+      files["header.html"].should contain("<!DOCTYPE html>")
+      files["header.html"].should contain("<header>")
+      files["header.html"].should contain("<nav>")
+
+      # Footer should have semantic HTML
+      files["footer.html"].should contain("<footer>")
+      files["footer.html"].should contain("</html>")
+    end
+
+    it "generates 404 template" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      files = scaffold.template_files
+
+      files["404.html"].should contain("404")
+      files["404.html"].should contain("Not Found")
+    end
+  end
+
+  describe "#static_files" do
+    it "returns empty hash" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      scaffold.static_files.should be_empty
+    end
+  end
+
+  describe "#shortcode_files" do
+    it "returns empty hash" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      scaffold.shortcode_files.should be_empty
+    end
+  end
+
+  describe "#config_content" do
+    it "generates valid config" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      config = scaffold.config_content
+
+      config.should_not be_empty
+      config.should contain("title")
+    end
+
+    it "includes taxonomies config by default" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      config = scaffold.config_content(skip_taxonomies: false)
+
+      config.should contain("taxonomies")
+    end
+
+    it "excludes taxonomies config when skip_taxonomies is true" do
+      scaffold = Hwaro::Services::Scaffolds::Bare.new
+      config_with = scaffold.config_content(skip_taxonomies: false)
+      config_without = scaffold.config_content(skip_taxonomies: true)
+
+      # Without taxonomies should be shorter
+      config_without.size.should be < config_with.size
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add unit tests for **AMP hooks** (hook registration at AfterRender with priority 40, disabled/nil/enabled execution paths)
- Add unit tests for **PWA hooks** (hook registration at BeforeGenerate with priority 50, nil site skip, enabled manifest generation, disabled no-op)
- Add unit tests for **Bare scaffold** (type, description, content/template/static/shortcode/config generation, skip_taxonomies behavior)
- Strengthen **filter edge cases**: date filter ISO 8601/RFC 3339 parsing, math filter integer/zero/non-numeric input, jsonify XSS script-tag prevention, inspect additional types (false, float, empty array, special chars)

**Test count: 3546 → 3591 (+45), 0 failures**

## Test plan
- [x] `crystal spec` passes with 3591 examples, 0 failures, 0 errors
- [x] All existing tests remain green (no regressions)
- [x] New tests follow project conventions (same patterns as `og_image_hooks_spec.cr`, `scaffolds_blog_spec.cr`, `filters_spec.cr`)