### PR TITLE
Fix robots.txt rule merging bug and remove GPTBot default

### DIFF
--- a/docs/content/features/seo.md
+++ b/docs/content/features/seo.md
@@ -147,6 +147,25 @@ Control search engine crawling.
 enabled = true
 ```
 
+With custom rules:
+
+```toml
+[robots]
+enabled = true
+rules = [
+  { user_agent = "*", disallow = ["/admin", "/private"] },
+  { user_agent = "GPTBot", disallow = ["/"] }
+]
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| enabled | bool | true | Generate `robots.txt` |
+| filename | string | "robots.txt" | Output filename |
+| rules | array | [] | List of user-agent rules with `allow` and `disallow` paths |
+
+When no rules are configured, Hwaro generates a default allow-all rule. If a rule has both `allow` and `disallow` empty, an explicit `Allow: /` is added to prevent ambiguous behavior.
+
 ### Output
 
 ```

--- a/spec/unit/robots_spec.cr
+++ b/spec/unit/robots_spec.cr
@@ -251,7 +251,7 @@ describe Hwaro::Content::Seo::Robots do
       end
     end
 
-    it "handles a rule with empty allow and disallow lists" do
+    it "adds explicit Allow: / when both allow and disallow are empty" do
       config = Hwaro::Models::Config.new
       config.robots.enabled = true
 
@@ -265,8 +265,34 @@ describe Hwaro::Content::Seo::Robots do
 
         content = File.read(File.join(output_dir, "robots.txt"))
         content.should contain("User-agent: SomeBot")
-        content.should_not contain("Allow:")
-        content.should_not contain("Disallow:")
+        content.should contain("Allow: /")
+      end
+    end
+
+    it "does not add implicit Allow when disallow is present" do
+      config = Hwaro::Models::Config.new
+      config.robots.enabled = true
+
+      rule1 = Hwaro::Models::RobotsRule.new("*")
+      rule1.allow = [] of String
+      rule1.disallow = [] of String
+
+      rule2 = Hwaro::Models::RobotsRule.new("GPTBot")
+      rule2.allow = [] of String
+      rule2.disallow = ["/"]
+
+      config.robots.rules = [rule1, rule2]
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Robots.generate(config, output_dir)
+
+        content = File.read(File.join(output_dir, "robots.txt"))
+        # First rule should have explicit Allow: /
+        # Second rule should only have Disallow: /
+        lines = content.lines
+        gptbot_idx = lines.index { |l| l.includes?("User-agent: GPTBot") }.not_nil!
+        # The line after GPTBot should be Disallow, not Allow
+        lines[gptbot_idx + 1].should contain("Disallow: /")
       end
     end
 

--- a/src/content/seo/robots.cr
+++ b/src/content/seo/robots.cr
@@ -21,6 +21,11 @@ module Hwaro
                 str << "Disallow: #{path.gsub('\n', ' ')}\n"
               end
 
+              # When both allow and disallow are empty, explicitly allow all
+              if rule.allow.empty? && rule.disallow.empty?
+                str << "Allow: /\n"
+              end
+
               str << "\n"
             end
 

--- a/src/services/defaults/config.cr
+++ b/src/services/defaults/config.cr
@@ -24,8 +24,7 @@ module Hwaro
           enabled = true
           filename = "robots.txt"
           rules = [
-            { user_agent = "*", disallow = ["/admin", "/private"] },
-            { user_agent = "GPTBot", disallow = ["/"] }
+            { user_agent = "*", disallow = ["/admin", "/private"] }
           ]
 
           [llms]
@@ -118,8 +117,7 @@ module Hwaro
           enabled = true
           filename = "robots.txt"
           rules = [
-            { user_agent = "*", disallow = ["/admin", "/private"] },
-            { user_agent = "GPTBot", disallow = ["/"] }
+            { user_agent = "*", disallow = ["/admin", "/private"] }
           ]
 
           [llms]
@@ -229,8 +227,7 @@ module Hwaro
             str << "enabled = true\n"
             str << "filename = \"robots.txt\"\n"
             str << "rules = [\n"
-            str << "  { user_agent = \"*\", disallow = [\"/admin\", \"/private\"] },\n"
-            str << "  { user_agent = \"GPTBot\", disallow = [\"/\"] }\n"
+            str << "  { user_agent = \"*\", disallow = [\"/admin\", \"/private\"] }\n"
             str << "]\n\n"
             str << "[llms]\n"
             str << "enabled = true\n"


### PR DESCRIPTION
## Summary
- Add explicit `Allow: /` when a robots rule has both `allow` and `disallow` empty, preventing ambiguous user-agent merging by crawlers
- Remove `GPTBot` rule from default init config to avoid accidental misconfiguration
- Expand robots.txt documentation with custom rules example and config reference table

## Test plan
- [x] Unit tests pass (30 examples, 0 failures)
- [x] Defaults config tests pass (46 examples, 0 failures)

Closes #275