### PR TITLE
Add missing config sections to doctor detection and unify snippets

### DIFF
--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -13,23 +13,51 @@ module Hwaro
       # Each key maps to a human-readable description.
       # doctor_snippet_for(key) must return non-nil for every key listed here.
       KNOWN_SECTIONS = {
-        "pwa"              => "Progressive Web App (manifest.json, service worker)",
-        "amp"              => "AMP page generation",
-        "series"           => "Series grouping",
-        "related"          => "Related posts",
+        "plugins"          => "Content processors and extensions",
+        "highlight"        => "Syntax highlighting (Highlight.js)",
+        "og"               => "OpenGraph & Twitter Cards",
         "search"           => "Client-side search index",
         "pagination"       => "Pagination settings",
+        "series"           => "Series grouping",
+        "related"          => "Related posts",
         "markdown"         => "Markdown parser options",
+        "sitemap"          => "Sitemap generation",
+        "robots"           => "Robots.txt generation",
+        "llms"             => "LLM crawler instructions (llms.txt)",
+        "feeds"            => "RSS/Atom feed generation",
+        "build"            => "Build hooks (pre/post commands)",
+        "permalinks"       => "URL path overrides",
+        "auto_includes"    => "Automatic CSS/JS loading",
         "assets"           => "Asset pipeline (bundling, minification)",
         "deployment"       => "Deployment targets",
         "image_processing" => "Image resizing and LQIP placeholder generation",
+        "pwa"              => "Progressive Web App (manifest.json, service worker)",
+        "amp"              => "AMP page generation",
       }
 
       # Sub-sections that doctor checks when the parent section exists
       KNOWN_SUB_SECTIONS = {
+        {"content", "files"}         => "Non-Markdown file publishing from content/",
         {"og", "auto_image"}         => "Auto-generated OG images",
         {"image_processing", "lqip"} => "Low-Quality Image Placeholder (LQIP) generation",
       }
+
+      def self.content_files : String
+        <<-TOML
+
+          # =============================================================================
+          # Content Files (Optional)
+          # =============================================================================
+          # Publish non-Markdown files from content/ into the output directory
+          # Example: content/about/profile.jpg -> /about/profile.jpg
+
+          # [content.files]
+          # allow_extensions = ["jpg", "jpeg", "png", "gif", "svg", "webp"]
+          # disallow_extensions = ["psd"]
+          # disallow_paths = ["private/**", "**/_*"]
+
+          TOML
+      end
 
       def self.pwa(commented : Bool = false) : String
         if commented
@@ -101,6 +129,341 @@ module Hwaro
           # enabled = true
           # path_prefix = "amp"        # Output under /amp/ prefix
           # sections = ["posts"]       # Limit to specific sections (empty = all)
+
+          TOML
+        end
+      end
+
+      def self.plugins(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # Plugins
+          # =============================================================================
+          # Configure content processors and extensions
+
+          # [plugins]
+          # processors = ["markdown"]
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # Plugins
+          # =============================================================================
+          # Configure content processors and extensions
+
+          [plugins]
+          processors = ["markdown"]
+
+          TOML
+        end
+      end
+
+      def self.highlight(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # Syntax Highlighting
+          # =============================================================================
+          # Code block syntax highlighting using Highlight.js
+
+          # [highlight]
+          # enabled = true
+          # theme = "github"
+          # use_cdn = true
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # Syntax Highlighting
+          # =============================================================================
+          # Code block syntax highlighting using Highlight.js
+
+          [highlight]
+          enabled = true
+          theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
+          use_cdn = true            # Set to false to use local assets
+
+          TOML
+        end
+      end
+
+      def self.og(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # OpenGraph & Twitter Cards
+          # =============================================================================
+          # Default meta tags for social sharing
+
+          # [og]
+          # default_image = "/images/og-default.png"
+          # type = "article"
+          # twitter_card = "summary_large_image"
+          # twitter_site = "@yourusername"
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # OpenGraph & Twitter Cards
+          # =============================================================================
+          # Default meta tags for social sharing
+          # Page-level settings (front matter) override these defaults
+
+          [og]
+          default_image = "/images/og-default.png"   # Default image for social sharing
+          type = "article"                           # OpenGraph type (website, article, etc.)
+          twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
+          # twitter_site = "@yourusername"           # Twitter @username for the site
+          # twitter_creator = "@authorusername"      # Twitter @username for content creator
+          # fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
+
+          TOML
+        end
+      end
+
+      def self.sitemap(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # Sitemap
+          # =============================================================================
+          # Generates sitemap.xml for search engine crawlers
+
+          # [sitemap]
+          # enabled = true
+          # filename = "sitemap.xml"
+          # changefreq = "weekly"
+          # priority = 0.5
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # Sitemap
+          # =============================================================================
+          # Generates sitemap.xml for search engine crawlers
+
+          [sitemap]
+          enabled = true
+          filename = "sitemap.xml"
+          changefreq = "weekly"
+          priority = 0.5
+          exclude = []              # Exclude paths or patterns from sitemap
+
+          TOML
+        end
+      end
+
+      def self.robots(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # Robots.txt
+          # =============================================================================
+          # Controls search engine crawler access
+
+          # [robots]
+          # enabled = true
+          # filename = "robots.txt"
+          # rules = [
+          #   { user_agent = "*", disallow = ["/admin", "/private"] }
+          # ]
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # Robots.txt
+          # =============================================================================
+          # Controls search engine crawler access
+
+          [robots]
+          enabled = true
+          filename = "robots.txt"
+          rules = [
+            { user_agent = "*", disallow = ["/admin", "/private"] },
+            { user_agent = "GPTBot", disallow = ["/"] }
+          ]
+
+          TOML
+        end
+      end
+
+      def self.llms(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # LLMs.txt
+          # =============================================================================
+          # Instructions for AI/LLM crawlers
+
+          # [llms]
+          # enabled = true
+          # filename = "llms.txt"
+          # instructions = "Do not use for AI training without permission."
+          # full_enabled = false
+          # full_filename = "llms-full.txt"
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # LLMs.txt
+          # =============================================================================
+          # Instructions for AI/LLM crawlers
+
+          [llms]
+          enabled = true
+          filename = "llms.txt"
+          instructions = "Do not use for AI training without permission."
+          # Optional: Generate a single text file containing all Markdown pages
+          full_enabled = false
+          full_filename = "llms-full.txt"
+
+          TOML
+        end
+      end
+
+      def self.feeds(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # RSS/Atom Feeds
+          # =============================================================================
+          # Generates RSS or Atom feed for content syndication
+
+          # [feeds]
+          # enabled = true
+          # type = "rss"
+          # limit = 10
+          # sections = []
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # RSS/Atom Feeds
+          # =============================================================================
+          # Generates RSS or Atom feed for content syndication
+
+          [feeds]
+          enabled = true
+          filename = ""             # Leave empty for default (rss.xml or atom.xml)
+          type = "rss"              # "rss" or "atom"
+          truncate = 0              # Truncate content to N characters (0 = full content)
+          limit = 10                # Maximum number of items in feed
+          sections = []             # Limit to specific sections, e.g., ["posts"]
+
+          TOML
+        end
+      end
+
+      def self.build(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # Build Hooks (Optional)
+          # =============================================================================
+          # Run custom shell commands before/after build process
+
+          # [build]
+          # hooks.pre = ["npm install"]
+          # hooks.post = ["npm run minify"]
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # Build Hooks (Optional)
+          # =============================================================================
+          # Run custom shell commands before/after build process
+
+          # [build]
+          # hooks.pre = ["npm install", "python scripts/preprocess.py"]
+          # hooks.post = ["npm run minify", "./scripts/deploy.sh"]
+
+          TOML
+        end
+      end
+
+      def self.permalinks(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # Permalinks (Optional)
+          # =============================================================================
+          # Override the output path for specific sections or taxonomies
+
+          # [permalinks]
+          # posts = "/posts/:year/:month/:slug/"
+          # tags = "/topic/:slug/"
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # Permalinks (Optional)
+          # =============================================================================
+          # Override the output path for specific sections or taxonomies.
+          # Placeholders: :year, :month, :day, :title, :slug, :section
+
+          # [permalinks]
+          # posts = "/posts/:year/:month/:slug/"
+          # tags = "/topic/:slug/"
+
+          TOML
+        end
+      end
+
+      def self.auto_includes(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+          # =============================================================================
+          # Auto Includes (Optional)
+          # =============================================================================
+          # Automatically load CSS/JS files from static directories
+
+          # [auto_includes]
+          # enabled = true
+          # dirs = ["assets/css", "assets/js"]
+
+          TOML
+        else
+          <<-TOML
+
+          # =============================================================================
+          # Auto Includes (Optional)
+          # =============================================================================
+          # Automatically load CSS/JS files from static directories
+          # Files are included alphabetically - use numeric prefixes for ordering
+          # Example: 01-reset.css, 02-typography.css, 03-layout.css
+
+          # [auto_includes]
+          # enabled = true
+          # dirs = ["assets/css", "assets/js"]
 
           TOML
         end
@@ -467,17 +830,28 @@ module Hwaro
       # Convenience method for doctor --fix (all commented)
       def self.doctor_snippet_for(key : String) : String?
         case key
-        when "pwa"                   then pwa(commented: true)
-        when "amp"                   then amp(commented: true)
-        when "og.auto_image"         then og_auto_image
-        when "series"                then series(commented: true)
-        when "related"               then related(commented: true)
+        when "plugins"               then plugins(commented: true)
+        when "highlight"             then highlight(commented: true)
+        when "og"                    then og(commented: true)
         when "search"                then search(commented: true)
         when "pagination"            then pagination(commented: true)
+        when "series"                then series(commented: true)
+        when "related"               then related(commented: true)
         when "markdown"              then markdown(commented: true)
+        when "sitemap"               then sitemap(commented: true)
+        when "robots"                then robots(commented: true)
+        when "llms"                  then llms(commented: true)
+        when "feeds"                 then feeds(commented: true)
+        when "build"                 then build(commented: true)
+        when "permalinks"            then permalinks(commented: true)
+        when "auto_includes"         then auto_includes(commented: true)
         when "assets"                then assets(commented: true)
         when "deployment"            then deployment(commented: true)
         when "image_processing"      then image_processing(commented: true)
+        when "pwa"                   then pwa(commented: true)
+        when "amp"                   then amp(commented: true)
+        when "content.files"         then content_files
+        when "og.auto_image"         then og_auto_image
         when "image_processing.lqip" then image_processing_lqip
         else                              nil
         end

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -104,7 +104,7 @@ module Hwaro
       end
 
       # Sections that are advanced/niche — skipped when minimal: true
-      OPTIONAL_SECTIONS = Set{"pwa", "amp", "assets", "deployment", "image_processing", "og.auto_image", "image_processing.lqip"}
+      OPTIONAL_SECTIONS = Set{"pwa", "amp", "assets", "deployment", "image_processing", "og.auto_image", "image_processing.lqip", "build", "permalinks", "auto_includes"}
 
       # Append missing config sections to config.toml.
       # When minimal is true, skip advanced optional sections (pwa, amp, assets, etc.)

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -316,17 +316,7 @@ module Hwaro
         end
 
         protected def plugins_config : String
-          <<-TOML
-
-          # =============================================================================
-          # Plugins
-          # =============================================================================
-          # Configure content processors and extensions
-
-          [plugins]
-          processors = ["markdown"]
-
-          TOML
+          ConfigSnippets.plugins
         end
 
         protected def pagination_config : String
@@ -351,39 +341,11 @@ module Hwaro
         end
 
         protected def highlight_config : String
-          <<-TOML
-
-          # =============================================================================
-          # Syntax Highlighting
-          # =============================================================================
-          # Code block syntax highlighting using Highlight.js
-
-          [highlight]
-          enabled = true
-          theme = "github"          # Available: github, monokai, atom-one-dark, vs2015, etc.
-          use_cdn = true            # Set to false to use local assets
-
-          TOML
+          ConfigSnippets.highlight
         end
 
         protected def og_config : String
-          <<-TOML
-
-          # =============================================================================
-          # OpenGraph & Twitter Cards
-          # =============================================================================
-          # Default meta tags for social sharing
-          # Page-level settings (front matter) override these defaults
-
-          [og]
-          default_image = "/images/og-default.png"   # Default image for social sharing
-          type = "article"                           # OpenGraph type (website, article, etc.)
-          twitter_card = "summary_large_image"       # Twitter card type (summary, summary_large_image)
-          # twitter_site = "@yourusername"           # Twitter @username for the site
-          # twitter_creator = "@authorusername"      # Twitter @username for content creator
-          # fb_app_id = "your_fb_app_id"             # Facebook App ID (optional)
-
-          TOML
+          ConfigSnippets.og
         end
 
         protected def search_config : String
@@ -391,59 +353,15 @@ module Hwaro
         end
 
         protected def sitemap_config : String
-          <<-TOML
-
-          # =============================================================================
-          # SEO: Sitemap
-          # =============================================================================
-          # Generates sitemap.xml for search engine crawlers
-
-          [sitemap]
-          enabled = true
-          filename = "sitemap.xml"
-          changefreq = "weekly"
-          priority = 0.5
-          exclude = []              # Exclude paths or patterns from sitemap
-
-          TOML
+          ConfigSnippets.sitemap
         end
 
         protected def robots_config : String
-          <<-TOML
-
-          # =============================================================================
-          # SEO: Robots.txt
-          # =============================================================================
-          # Controls search engine crawler access
-
-          [robots]
-          enabled = true
-          filename = "robots.txt"
-          rules = [
-            { user_agent = "*", disallow = ["/admin", "/private"] },
-            { user_agent = "GPTBot", disallow = ["/"] }
-          ]
-
-          TOML
+          ConfigSnippets.robots
         end
 
         protected def llms_config : String
-          <<-TOML
-
-          # =============================================================================
-          # SEO: LLMs.txt
-          # =============================================================================
-          # Instructions for AI/LLM crawlers
-
-          [llms]
-          enabled = true
-          filename = "llms.txt"
-          instructions = "Do not use for AI training without permission."
-          # Optional: Generate a single text file containing all Markdown pages
-          full_enabled = false
-          full_filename = "llms-full.txt"
-
-          TOML
+          ConfigSnippets.llms
         end
 
         protected def series_config : String
@@ -500,36 +418,11 @@ module Hwaro
         end
 
         protected def permalinks_config : String
-          <<-TOML
-
-          # =============================================================================
-          # Permalinks (Optional)
-          # =============================================================================
-          # Override the output path for specific sections or taxonomies.
-          # Placeholders: :year, :month, :day, :title, :slug, :section
-          #
-          # [permalinks]
-          # posts = "/posts/:year/:month/:slug/"
-          # tags = "/topic/:slug/"
-
-          TOML
+          ConfigSnippets.permalinks
         end
 
         protected def auto_includes_config : String
-          <<-TOML
-
-          # =============================================================================
-          # Auto Includes (Optional)
-          # =============================================================================
-          # Automatically load CSS/JS files from static directories
-          # Files are included alphabetically - use numeric prefixes for ordering
-          # Example: 01-reset.css, 02-typography.css, 03-layout.css
-
-          # [auto_includes]
-          # enabled = true
-          # dirs = ["assets/css", "assets/js"]
-
-          TOML
+          ConfigSnippets.auto_includes
         end
 
         protected def assets_config : String
@@ -541,17 +434,7 @@ module Hwaro
         end
 
         protected def build_hooks_config : String
-          <<-TOML
-
-          # =============================================================================
-          # Build Hooks (Optional)
-          # =============================================================================
-          # Run custom shell commands before/after build process
-
-          # [build]
-          # hooks.pre = ["npm install", "python scripts/preprocess.py"]
-          # hooks.post = ["npm run minify", "./scripts/deploy.sh"]
-          TOML
+          ConfigSnippets.build
         end
 
         protected def pwa_config : String


### PR DESCRIPTION
## Summary
- `ConfigSnippets.KNOWN_SECTIONS`에 누락된 10개 config 섹션 추가 (`plugins`, `highlight`, `og`, `sitemap`, `robots`, `llms`, `feeds`, `build`, `permalinks`, `auto_includes`)
- `KNOWN_SUB_SECTIONS`에 `content.files` 추가
- `scaffold/base.cr`의 인라인 config 메서드(`plugins_config`, `highlight_config`, `og_config`, `sitemap_config`, `robots_config`, `llms_config`)를 `ConfigSnippets`로 위임하여 중복 제거
- commented/non-commented 버전 간 섹션 헤더 네이밍 통일 (`SEO:` prefix, `(Optional)` suffix 불일치 해소)

## Test plan
- [x] `crystal spec spec/unit/doctor_spec.cr` — 56 examples, 0 failures
- [x] `crystal spec` — 3674 examples, 0 failures (10 errors는 bin/hwaro 미빌드로 인한 기존 functional test 이슈)
- [x] `crystal build src/main.cr` — 컴파일 성공