### PR TITLE
Add 97 unit tests covering uncovered edge cases

### DIFF
--- a/spec/unit/css_minifier_spec.cr
+++ b/spec/unit/css_minifier_spec.cr
@@ -658,5 +658,38 @@ describe Hwaro::Utils::CssMinifier do
       result.should contain(".class-100{")
       result.should_not contain("\n")
     end
+
+    it "handles nested calc() expressions" do
+      css = ".box { width: calc(100% - calc(2 * 20px)); }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should contain("calc(100% - calc(2 * 20px))")
+    end
+
+    it "handles url() without quotes" do
+      css = "body { background: url(image.png); }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should contain("url(image.png)")
+    end
+
+    it "handles @import with string (no url)" do
+      css = "@import \"base.css\";\nbody { color: red; }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should contain("\"base.css\"")
+      result.should contain("color:red")
+    end
+
+    it "handles CSS with only whitespace between rules" do
+      css = ".a { color: red; }    .b { color: blue; }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should contain(".a{color:red}")
+      result.should contain(".b{color:blue}")
+    end
+
+    it "handles comment inside url() value (preserved)" do
+      css = "body { background: url('path/to/file.png'); /* actual comment */ }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should contain("url('path/to/file.png')")
+      result.should_not contain("actual comment")
+    end
   end
 end

--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -1280,6 +1280,94 @@ describe Hwaro::Content::Processors::Markdown do
   end
 
   # ---------------------------------------------------------------------------
+  # Series and expires fields
+  # ---------------------------------------------------------------------------
+  describe "series and expires fields" do
+    it "parses series from TOML" do
+      raw = <<-MD
+      +++
+      title = "Part 1"
+      series = "My Tutorial"
+      series_weight = 1
+      +++
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:series].should eq("My Tutorial")
+      result[:series_weight].should eq(1)
+    end
+
+    it "parses series from YAML" do
+      raw = <<-MD
+      ---
+      title: Part 2
+      series: My Tutorial
+      series_weight: 2
+      ---
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:series].should eq("My Tutorial")
+      result[:series_weight].should eq(2)
+    end
+
+    it "defaults series to nil" do
+      raw = <<-MD
+      ---
+      title: Post
+      ---
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:series].should be_nil
+      result[:series_weight].should eq(0)
+    end
+
+    it "parses expires from TOML" do
+      raw = <<-MD
+      +++
+      title = "Expiring"
+      expires = "2025-12-31"
+      +++
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:expires].should_not be_nil
+      result[:expires].not_nil!.year.should eq(2025)
+    end
+
+    it "parses expires from YAML" do
+      raw = <<-MD
+      ---
+      title: Expiring
+      expires: "2025-06-30"
+      ---
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:expires].should_not be_nil
+      result[:expires].not_nil!.month.should eq(6)
+    end
+
+    it "defaults expires to nil" do
+      raw = <<-MD
+      ---
+      title: Post
+      ---
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:expires].should be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Date parsing edge cases
   # ---------------------------------------------------------------------------
   describe "date parsing" do
@@ -1323,6 +1411,150 @@ describe Hwaro::Content::Processors::Markdown do
 
       result = processor.parse(raw)
       result[:date].should be_nil
+    end
+
+    it "parses RFC 3339 date with timezone" do
+      raw = <<-MD
+      ---
+      title: Post
+      date: "2024-06-15T10:30:00+09:00"
+      ---
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:date].should_not be_nil
+      result[:date].not_nil!.year.should eq(2024)
+      result[:date].not_nil!.month.should eq(6)
+    end
+
+    it "parses RFC 3339 date with Z timezone" do
+      raw = <<-MD
+      ---
+      title: Post
+      date: "2024-01-01T00:00:00Z"
+      ---
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:date].should_not be_nil
+      result[:date].not_nil!.year.should eq(2024)
+    end
+
+    it "parses date with space-separated time" do
+      raw = <<-MD
+      ---
+      title: Post
+      date: "2024-06-15 14:30:00"
+      ---
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:date].should_not be_nil
+      result[:date].not_nil!.hour.should eq(14)
+    end
+
+    it "handles empty date string gracefully" do
+      raw = <<-MD
+      ---
+      title: Post
+      date: ""
+      ---
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:date].should be_nil
+    end
+
+    it "handles invalid date string gracefully" do
+      raw = <<-MD
+      ---
+      title: Post
+      date: "not-a-date"
+      ---
+      Body
+      MD
+
+      result = processor.parse(raw)
+      result[:date].should be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Anchor links and TOC
+  # ---------------------------------------------------------------------------
+  describe "render_with_anchors" do
+    it "inserts anchor links before heading content" do
+      content = "# Hello World"
+      html, _toc = processor.render_with_anchors(content, anchor_style: "before")
+      html.should contain("anchor")
+      html.should contain("href=\"#hello-world\"")
+    end
+
+    it "inserts anchor links after heading content" do
+      content = "# Hello World"
+      html, _toc = processor.render_with_anchors(content, anchor_style: "after")
+      html.should contain("anchor")
+      html.should contain("href=\"#hello-world\"")
+    end
+
+    it "does not insert anchors with default heading style" do
+      content = "# Hello World"
+      html, _toc = processor.render_with_anchors(content, anchor_style: "heading")
+      html.should_not contain("class=\"anchor\"")
+    end
+
+    it "returns TOC headers" do
+      content = "# H1\n## H2\n### H3"
+      _html, toc = processor.render_with_anchors(content)
+      toc.size.should be >= 1
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TOC with duplicate heading IDs
+  # ---------------------------------------------------------------------------
+  describe "TOC duplicate heading IDs" do
+    it "generates unique IDs for duplicate headings" do
+      content = "## Section\n\nContent\n\n## Section\n\nMore content\n\n## Section"
+      html, toc = Hwaro::Processor::Markdown.render(content)
+      # All three headings should have unique IDs
+      html.should contain("id=\"section\"")
+      html.should contain("id=\"section-1\"")
+      html.should contain("id=\"section-2\"")
+    end
+
+    it "builds nested TOC tree" do
+      content = "## Parent\n\n### Child\n\n## Sibling"
+      _html, toc = Hwaro::Processor::Markdown.render(content)
+      toc.size.should eq(2) # Parent and Sibling at top level
+      toc[0].children.size.should eq(1) # Child under Parent
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Markdown render edge cases
+  # ---------------------------------------------------------------------------
+  describe "render edge cases" do
+    it "handles content with no headings or images" do
+      content = "Just a simple paragraph."
+      html, toc = Hwaro::Processor::Markdown.render(content)
+      html.should contain("simple paragraph")
+      toc.should be_empty
+    end
+
+    it "handles empty content" do
+      html, toc = Hwaro::Processor::Markdown.render("")
+      toc.should be_empty
+    end
+
+    it "handles content with only inline HTML" do
+      content = "Hello <strong>world</strong>"
+      html, _toc = Hwaro::Processor::Markdown.render(content)
+      html.should contain("<strong>world</strong>")
     end
   end
 end

--- a/spec/unit/html_minifier_spec.cr
+++ b/spec/unit/html_minifier_spec.cr
@@ -77,5 +77,50 @@ describe Hwaro::Utils::HtmlMinifier do
       result.should_not contain("line")
       result.should_not contain("comment")
     end
+
+    it "preserves content inside pre/code blocks unchanged" do
+      html = "<pre><code>  line1\n  line2\n  line3</code></pre>"
+      result = Hwaro::Utils::HtmlMinifier.minify(html)
+      result.should contain("line1")
+      result.should contain("line2")
+    end
+
+    it "handles nested comments edge case" do
+      html = "<p>A</p><!-- outer <!-- inner --> --><p>B</p>"
+      result = Hwaro::Utils::HtmlMinifier.minify(html)
+      result.should contain("<p>A</p>")
+      result.should contain("<p>B</p>")
+    end
+
+    it "collapses exactly 3 blank lines to 2" do
+      html = "<p>A</p>\n\n\n<p>B</p>"
+      result = Hwaro::Utils::HtmlMinifier.minify(html)
+      result.should eq("<p>A</p>\n\n<p>B</p>")
+    end
+
+    it "preserves 2 blank lines unchanged" do
+      html = "<p>A</p>\n\n<p>B</p>"
+      result = Hwaro::Utils::HtmlMinifier.minify(html)
+      result.should eq("<p>A</p>\n\n<p>B</p>")
+    end
+
+    it "handles multiple pre blocks" do
+      html = "<pre>\n  <code>first</code>\n</pre>\n<p>gap</p>\n<pre>\n  <code>second</code>\n</pre>"
+      result = Hwaro::Utils::HtmlMinifier.minify(html)
+      result.should contain("<pre><code")
+      result.should contain("first")
+      result.should contain("second")
+    end
+
+    it "handles comments adjacent to preserved more marker" do
+      html = "<!-- remove this --><!-- more -->"
+      result = Hwaro::Utils::HtmlMinifier.minify(html)
+      result.should_not contain("remove this")
+      result.should contain("<!-- more -->")
+    end
+
+    it "handles whitespace-only content" do
+      Hwaro::Utils::HtmlMinifier.minify("   \n\n\n   ").should eq("")
+    end
   end
 end

--- a/spec/unit/js_minifier_spec.cr
+++ b/spec/unit/js_minifier_spec.cr
@@ -491,5 +491,38 @@ describe Hwaro::Utils::JsMinifier do
       # The */ is just literal characters
       result.should contain("*/")
     end
+
+    it "handles nested braces inside template literal interpolation" do
+      js = "var s = `${obj.map(x => { return x; })}`;"
+      result = Hwaro::Utils::JsMinifier.minify(js)
+      result.should contain("`${obj.map(x => { return x; })}`")
+    end
+
+    it "handles multiple template literal interpolations" do
+      js = "var s = `${a} + ${b} = ${a + b}`;"
+      result = Hwaro::Utils::JsMinifier.minify(js)
+      result.should contain("${a}")
+      result.should contain("${b}")
+      result.should contain("${a + b}")
+    end
+
+    it "handles comment-like pattern in template literal" do
+      js = "var s = `// not a comment\n/* also not */`;"
+      result = Hwaro::Utils::JsMinifier.minify(js)
+      result.should contain("// not a comment")
+      result.should contain("/* also not */")
+    end
+
+    it "preserves regex-like division after parenthesis" do
+      js = "var x = (a + b) / c;"
+      result = Hwaro::Utils::JsMinifier.minify(js)
+      result.should contain("(a + b) / c")
+    end
+
+    it "handles string with backslash at end" do
+      js = %{var s = "end\\\\"; var x = 1;}
+      result = Hwaro::Utils::JsMinifier.minify(js)
+      result.should contain("var x = 1;")
+    end
   end
 end

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -155,6 +155,200 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
     end
   end
 
+  describe "task lists (extended)" do
+    it "handles * marker" do
+      content = "* [x] Done with star"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_task_lists(content)
+      result.should contain("checked disabled")
+    end
+
+    it "handles + marker" do
+      content = "+ [ ] Todo with plus"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_task_lists(content)
+      result.should contain("<input type=\"checkbox\" disabled>")
+    end
+
+    it "handles indented task items" do
+      content = "  - [x] Indented done\n    - [ ] Deeper indent"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_task_lists(content)
+      result.should contain("checked disabled")
+      result.should contain("checkbox\" disabled>")
+    end
+
+    it "does not match inside paragraphs (no list marker)" do
+      content = "This is [x] not a task"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_task_lists(content)
+      result.should eq(content)
+    end
+
+    it "handles empty content" do
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_task_lists("")
+      result.should eq("")
+    end
+  end
+
+  describe "definition lists (extended)" do
+    it "escapes HTML in terms" do
+      content = "<script>alert(1)</script>\n: Safe definition"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain("&lt;script&gt;")
+      result.should_not contain("<script>alert")
+    end
+
+    it "escapes HTML in definitions" do
+      content = "Term\n: <b>bold</b> text"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain("&lt;b&gt;")
+    end
+
+    it "does not create dl when definition is on first line only" do
+      content = ": orphan definition"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      # No term before the definition, so it should not be parsed as dl
+      result.should_not contain("<dl>")
+    end
+
+    it "handles definition with leading whitespace" do
+      content = "Term\n  : Indented definition"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain("<dd>Indented definition</dd>")
+    end
+
+    it "handles multiple terms with blank line between groups" do
+      content = "Term1\n: Def1\n\nTerm2\n: Def2"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain("<dt>Term1</dt>")
+      result.should contain("<dd>Def1</dd>")
+    end
+
+    it "handles content before and after definition list" do
+      content = "Intro paragraph\n\nTerm\n: Definition\n\nOutro paragraph"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain("Intro paragraph")
+      result.should contain("<dl>")
+      result.should contain("Outro paragraph")
+    end
+  end
+
+  describe "footnotes (extended)" do
+    it "handles footnote keys with special characters (dashes)" do
+      content = "Text[^my--note].\n\n[^my--note]: Note with dashes"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_footnotes(content)
+      result.should contain("fnref-")
+      result.should contain("[1]")
+    end
+
+    it "handles footnote keys with colons" do
+      content = "Text[^key:val].\n\n[^key:val]: Note with colon"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_footnotes(content)
+      result.should contain("[1]")
+    end
+
+    it "ignores undefined footnote references" do
+      content = "Text[^undefined] here."
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_footnotes(content)
+      result.should contain("[^undefined]")
+    end
+
+    it "handles duplicate references to same footnote" do
+      content = "First[^1] and second[^1].\n\n[^1]: Shared note"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_footnotes(content)
+      # Both should get the same number
+      matches = result.scan(/\[1\]/)
+      matches.size.should eq(2)
+    end
+
+    it "handles footnote content with HTML" do
+      content = "Text[^1].\n\n[^1]: Note with <em>emphasis</em>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_footnotes(content)
+      result.should contain("HWARO-FN")
+    end
+
+    it "postprocess handles footnotes with special chars roundtrip" do
+      # Simulate the preprocess -> postprocess cycle
+      content = "Text[^a--b].\n\n[^a--b]: Note with -- dashes"
+      preprocessed = Hwaro::Content::Processors::MarkdownExtensions.preprocess_footnotes(content)
+      # Wrap in paragraph tags like Markd would
+      html = "<p>#{preprocessed}</p>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_footnotes(html)
+      result.should contain("<section class=\"footnotes\">")
+      result.should contain("Note with -- dashes")
+    end
+
+    it "postprocess skips invalid footnote numbers" do
+      html = "<p>Text</p>\n<!--HWARO-FOOTNOTES-START-->\n<!--HWARO-FN:key:0:text-->\n<!--HWARO-FOOTNOTES-END-->\n"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_footnotes(html)
+      # num <= 0 should be skipped, resulting in no footnotes section
+      result.should_not contain("<section class=\"footnotes\">")
+    end
+  end
+
+  describe "math (extended)" do
+    it "handles multiline display math" do
+      content = "$$\na + b\n= c\n$$"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.should contain("math-display")
+      result.should contain("a + b")
+    end
+
+    it "does not match escaped dollar signs" do
+      content = "Price is \\$5 each"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.should_not contain("math-inline")
+    end
+
+    it "does not match dollar amount like $100" do
+      content = "It costs $100 to buy"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      # $100 ends with digit, should not match due to (?!\d) lookahead
+      result.should_not contain("math-inline")
+    end
+
+    it "handles math with ampersand" do
+      content = "$$a & b$$"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.should contain("&amp;")
+    end
+
+    it "handles multiple inline math expressions" do
+      content = "Both $x$ and $y$ are variables."
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      matches = result.scan(/math-inline/)
+      matches.size.should eq(2)
+    end
+
+    it "handles empty display math" do
+      content = "$$$$"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.should contain("math-display")
+    end
+  end
+
+  describe "mermaid (extended)" do
+    it "decodes &amp; in mermaid content" do
+      html = "<pre><code class=\"language-mermaid\">A --&amp;gt;|label&amp;| B</code></pre>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_mermaid(html)
+      result.should contain("<div class=\"mermaid\">")
+      result.should contain("A --&gt;|label&| B")
+    end
+
+    it "handles mermaid block with multiple lines" do
+      html = "<pre><code class=\"language-mermaid\">graph TD\n  A --> B\n  B --> C</code></pre>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_mermaid(html)
+      result.should contain("<div class=\"mermaid\">")
+      result.should contain("A --> B")
+      result.should contain("B --> C")
+      result.should_not contain("<pre>")
+    end
+
+    it "preserves multiple mermaid blocks" do
+      html = "<pre><code class=\"language-mermaid\">graph LR\nA-->B</code></pre><p>text</p><pre><code class=\"language-mermaid\">pie\n\"A\": 50</code></pre>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_mermaid(html)
+      matches = result.scan(/class="mermaid"/)
+      matches.size.should eq(2)
+    end
+  end
+
   describe "preprocess integration" do
     it "applies all enabled extensions" do
       config = make_config(task_lists: true, footnotes: true, definition_lists: true, math: true)

--- a/spec/unit/path_utils_spec.cr
+++ b/spec/unit/path_utils_spec.cr
@@ -62,5 +62,43 @@ describe Hwaro::Utils::PathUtils do
     it "rejects dot segments" do
       Hwaro::Utils::PathUtils.sanitize_path("/./foo/./bar").should eq("foo/bar")
     end
+
+    it "handles Unicode paths" do
+      Hwaro::Utils::PathUtils.sanitize_path("/한글/경로/파일").should eq("한글/경로/파일")
+    end
+
+    it "handles Unicode paths with traversal (drops .. segment)" do
+      # sanitize_path drops ".." segments rather than resolving them
+      Hwaro::Utils::PathUtils.sanitize_path("/한글/../비밀").should eq("한글/비밀")
+    end
+
+    it "handles path with only dots" do
+      Hwaro::Utils::PathUtils.sanitize_path("..").should eq("")
+    end
+
+    it "handles triple-encoded traversal" do
+      # %25252E%25252E = triple-encoded ..
+      Hwaro::Utils::PathUtils.sanitize_path("%25252E%25252E%25252Fetc").should eq("etc")
+    end
+
+    it "handles mixed forward and backslash" do
+      Hwaro::Utils::PathUtils.sanitize_path("foo\\bar/baz").should eq("foo/bar/baz")
+    end
+
+    it "handles path with spaces" do
+      Hwaro::Utils::PathUtils.sanitize_path("/path with spaces/file").should eq("path with spaces/file")
+    end
+
+    it "handles percent-encoded spaces" do
+      Hwaro::Utils::PathUtils.sanitize_path("/path%20with%20spaces/file").should eq("path with spaces/file")
+    end
+
+    it "handles single segment path" do
+      Hwaro::Utils::PathUtils.sanitize_path("filename.txt").should eq("filename.txt")
+    end
+
+    it "strips dot-dot segments from deep paths" do
+      Hwaro::Utils::PathUtils.sanitize_path("/a/b/c/../../d").should eq("a/b/c/d")
+    end
   end
 end

--- a/spec/unit/text_utils_spec.cr
+++ b/spec/unit/text_utils_spec.cr
@@ -63,6 +63,42 @@ describe Hwaro::Utils::TextUtils do
     end
   end
 
+  describe ".slugify (extended)" do
+    it "handles consecutive separators of mixed types" do
+      Hwaro::Utils::TextUtils.slugify("a - _ - b").should eq("a-b")
+    end
+
+    it "handles CJK followed immediately by ASCII" do
+      Hwaro::Utils::TextUtils.slugify("한글abc").should eq("한글abc")
+    end
+
+    it "handles ASCII followed immediately by CJK" do
+      Hwaro::Utils::TextUtils.slugify("abc한글").should eq("abc한글")
+    end
+
+    it "drops emoji characters" do
+      Hwaro::Utils::TextUtils.slugify("Hello 👋 World").should eq("hello-world")
+    end
+
+    it "handles very long string" do
+      long = "a" * 1000
+      Hwaro::Utils::TextUtils.slugify(long).should eq(long)
+    end
+
+    it "handles string ending with symbols" do
+      Hwaro::Utils::TextUtils.slugify("hello!!!").should eq("hello")
+    end
+
+    it "handles only spaces" do
+      Hwaro::Utils::TextUtils.slugify("   ").should eq("")
+    end
+
+    it "handles Hangul Jamo characters" do
+      # ㄱ is in Hangul Jamo range 0x1100-0x11FF
+      Hwaro::Utils::TextUtils.slugify("ᄀᄁ test").should eq("ᄀᄁ-test")
+    end
+  end
+
   describe ".escape_xml" do
     it "escapes ampersand" do
       Hwaro::Utils::TextUtils.escape_xml("Tom & Jerry").should eq("Tom &amp; Jerry")
@@ -131,6 +167,42 @@ describe Hwaro::Utils::TextUtils do
     end
   end
 
+  describe ".strip_html (extended)" do
+    it "handles unclosed tag at end" do
+      Hwaro::Utils::TextUtils.strip_html("Hello <b>world").should eq("Hello world")
+    end
+
+    it "handles tag-only input" do
+      Hwaro::Utils::TextUtils.strip_html("<div><span></span></div>").should eq("")
+    end
+
+    it "does not add space before punctuation after tag" do
+      Hwaro::Utils::TextUtils.strip_html("Hello</b>!").should eq("Hello!")
+    end
+
+    it "handles deeply nested tags" do
+      Hwaro::Utils::TextUtils.strip_html("<div><p><span><b><i>deep</i></b></span></p></div>").should eq("deep")
+    end
+
+    it "handles multiple consecutive tags" do
+      Hwaro::Utils::TextUtils.strip_html("<br/><br/><hr/>Text").should eq("Text")
+    end
+
+    it "handles mixed inline and block tags" do
+      Hwaro::Utils::TextUtils.strip_html("<p>Para 1</p><p>Para 2</p>").should eq("Para 1 Para 2")
+    end
+
+    it "handles tags with complex attributes" do
+      Hwaro::Utils::TextUtils.strip_html("<a href=\"url\" class=\"link\" data-x=\"y\">text</a>").should eq("text")
+    end
+
+    it "handles > in text content (treated as tag close)" do
+      # The simple parser treats < as tag-open and > as tag-close,
+      # so bare > in text gets consumed as a tag boundary
+      Hwaro::Utils::TextUtils.strip_html("a > b").should eq("a b")
+    end
+  end
+
   describe ".cjk_char?" do
     it "returns true for CJK Unified Ideograph" do
       Hwaro::Utils::TextUtils.cjk_char?('中').should be_true
@@ -188,6 +260,43 @@ describe Hwaro::Utils::TextUtils do
 
     it "handles pure ASCII" do
       Hwaro::Utils::TextUtils.tokenize_cjk("abc def").should eq("abc def")
+    end
+
+    it "handles multiple CJK runs separated by ASCII" do
+      Hwaro::Utils::TextUtils.tokenize_cjk("한글test테스트").should eq("한글test테스 스트")
+    end
+
+    it "handles CJK run of exactly 3 characters" do
+      Hwaro::Utils::TextUtils.tokenize_cjk("가나다").should eq("가나 나다")
+    end
+
+    it "handles mixed hiragana and kanji" do
+      Hwaro::Utils::TextUtils.tokenize_cjk("あ漢字").should eq("あ漢 漢字")
+    end
+  end
+
+  describe ".cjk_char? (extended)" do
+    it "returns true for CJK Extension A" do
+      # U+3400 is in CJK Extension A range
+      Hwaro::Utils::TextUtils.cjk_char?('\u{3400}').should be_true
+    end
+
+    it "returns true for CJK Compatibility" do
+      # U+3300 is in CJK Compatibility range
+      Hwaro::Utils::TextUtils.cjk_char?('\u{3300}').should be_true
+    end
+
+    it "returns true for CJK Compatibility Forms" do
+      # U+FE30 is in CJK Compatibility Forms range
+      Hwaro::Utils::TextUtils.cjk_char?('\u{FE30}').should be_true
+    end
+
+    it "returns false for space" do
+      Hwaro::Utils::TextUtils.cjk_char?(' ').should be_false
+    end
+
+    it "returns false for emoji" do
+      Hwaro::Utils::TextUtils.cjk_char?('😀').should be_false
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add 97 new test cases across 7 spec files to cover previously untested edge cases
- Covers markdown extensions (task list markers, definition list HTML escaping, footnote special chars, math multiline/boundary), text utils (slugify CJK↔ASCII, emoji dropping, strip_html nesting/punctuation, tokenize_cjk multi-run), frontmatter parsing (series/expires fields, RFC 3339 dates, render_with_anchors styles, TOC duplicate IDs), HTML/CSS/JS minifiers (nested constructs, template literal interpolation), and path utils (unicode, triple-encoded traversal)
- Discovered 2 potential bugs during testing, filed as separate issues

## Test plan
- [x] All 3901 examples pass (0 failures, same 10 pre-existing errors unchanged)
- [x] Each new test verified against actual implementation behavior
- [x] `crystal spec` full suite run confirmed