### PR TITLE
Fix infinite loop in preprocess_definition_lists with empty term

### DIFF
--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -228,6 +228,12 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       result.should contain("<dl>")
       result.should contain("Outro paragraph")
     end
+
+    it "does not infinite loop when empty line precedes orphan definition" do
+      content = "\n: orphan definition"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should_not contain("<dt></dt>")
+    end
   end
 
   describe "footnotes (extended)" do

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -58,7 +58,10 @@ module Hwaro
               result << "<dl>"
               while i < lines.size
                 term = lines[i].strip
-                break if term.empty?
+                if term.empty?
+                  i += 1
+                  break
+                end
 
                 result << "<dt>#{HTML.escape(term)}</dt>"
                 i += 1


### PR DESCRIPTION
## Summary
- Fix infinite loop when input starts with an empty line followed by a definition (e.g., `"\n: orphan definition"`)
- Advance index `i` before breaking out of the inner loop when term is empty
- Add regression test for the edge case

Closes #283

## Test plan
- [x] Existing 48 markdown_extensions specs pass
- [x] New test confirms no infinite loop with `"\n: orphan definition"` input