### PR TITLE
Fix XSS, duplicate slug detection, and i18n improvements

### DIFF
--- a/spec/unit/defaults_templates_spec.cr
+++ b/spec/unit/defaults_templates_spec.cr
@@ -5,9 +5,9 @@ describe Hwaro::Services::Defaults::TemplateSamples do
   describe ".header" do
     it "returns a string containing expected tags" do
       header = Hwaro::Services::Defaults::TemplateSamples.header
-      header.should contain("{{ site.description }}")
-      header.should contain("{{ page.title }}")
-      header.should contain("{{ site.title }}")
+      header.should contain("{{ site.description | e }}")
+      header.should contain("{{ page.title | e }}")
+      header.should contain("{{ site.title | e }}")
       header.should contain("{{ page.section }}")
       header.should contain("{{ base_url }}")
     end
@@ -32,7 +32,7 @@ describe Hwaro::Services::Defaults::TemplateSamples do
   describe ".section" do
     it "returns a string containing expected tags" do
       section = Hwaro::Services::Defaults::TemplateSamples.section
-      section.should contain("{{ page.title }}")
+      section.should contain("{{ page.title | e }}")
       section.should contain("{{ section.list }}")
       section.should contain("{{ pagination }}")
     end
@@ -50,7 +50,7 @@ describe Hwaro::Services::Defaults::TemplateSamples do
     it "returns a string containing expected tags" do
       alert = Hwaro::Services::Defaults::TemplateSamples.alert
       alert.should contain("{{ type | upper }}")
-      alert.should contain("{{ message }}")
+      alert.should contain("{{ body }}")
     end
   end
 
@@ -58,7 +58,7 @@ describe Hwaro::Services::Defaults::TemplateSamples do
     it "returns a string containing expected tags" do
       taxonomy = Hwaro::Services::Defaults::TemplateSamples.taxonomy
       taxonomy.should contain("Browse all terms in this taxonomy")
-      taxonomy.should contain("{{ page.title }}")
+      taxonomy.should contain("{{ page.title | e }}")
     end
   end
 
@@ -66,7 +66,7 @@ describe Hwaro::Services::Defaults::TemplateSamples do
     it "returns a string containing expected tags" do
       taxonomy_term = Hwaro::Services::Defaults::TemplateSamples.taxonomy_term
       taxonomy_term.should contain("Posts tagged with this term")
-      taxonomy_term.should contain("{{ page.title }}")
+      taxonomy_term.should contain("{{ page.title | e }}")
     end
   end
 end

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -22,6 +22,10 @@ module Hwaro
         # Filter out draft pages and pages with in_search_index = false
         search_pages = pages.reject { |p| p.draft || !p.in_search_index }
 
+        # Deduplicate by URL (keep last occurrence, matching build behavior)
+        seen_urls = Set(String).new
+        search_pages = search_pages.reverse.select { |p| seen_urls.add?(p.url) }.reverse
+
         # Filter out excluded paths
         unless config.search.exclude.empty?
           excluded_paths = config.search.exclude.map do |path|

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -24,6 +24,10 @@ module Hwaro
           if config.feeds.enabled
             site_pages = pages.reject { |p| p.draft || !p.render || p.is_a?(Models::Section) }
 
+            # Deduplicate by URL (keep last occurrence, matching build behavior)
+            seen_urls = Set(String).new
+            site_pages = site_pages.reverse.select { |p| seen_urls.add?(p.url) }.reverse
+
             # Filter by section if configured for main feed
             if !config.feeds.sections.empty?
               site_pages = site_pages.select { |p|

--- a/src/content/seo/sitemap.cr
+++ b/src/content/seo/sitemap.cr
@@ -18,6 +18,10 @@ module Hwaro
 
           sitemap_pages = pages.select { |p| p.in_sitemap && p.render }
 
+          # Deduplicate by URL (keep last occurrence, matching build behavior)
+          seen_urls = Set(String).new
+          sitemap_pages = sitemap_pages.reverse.select { |p| seen_urls.add?(p.url) }.reverse
+
           # Filter out excluded paths
           unless site.config.sitemap.exclude.empty?
             excluded_paths = site.config.sitemap.exclude.map do |path|

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -37,6 +37,17 @@ module Hwaro::Core::Build::Phases::Render
 
     error_overlay = ctx.options.error_overlay
 
+    # Detect duplicate output paths (slug collisions)
+    seen_urls = Hash(String, String).new
+    all_pages.each do |page|
+      url = page.url
+      if prev_path = seen_urls[url]?
+        Logger.warn "Duplicate output path '#{url}' — '#{page.path}' overwrites '#{prev_path}'"
+      else
+        seen_urls[url] = page.path
+      end
+    end
+
     profiler.start_phase("Render")
     result = @lifecycle.run_phase(Lifecycle::Phase::Render, ctx) do
       global_vars = build_global_vars(site, ctx.options.cache_busting)

--- a/src/services/defaults/templates.cr
+++ b/src/services/defaults/templates.cr
@@ -5,12 +5,12 @@ module Hwaro
         def self.header : String
           <<-HTML
           <!DOCTYPE html>
-          <html lang="en">
+          <html lang="{{ page_language }}">
           <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta name="description" content="{{ site.description }}">
-            <title>{{ page.title }} - {{ site.title }}</title>
+            <meta name="description" content="{{ site.description | e }}">
+            <title>{{ page.title | e }} - {{ site.title | e }}</title>
             <style>
               body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; max-width: 800px; margin: 0 auto; padding: 2rem; color: #333; }
               header { margin-bottom: 2rem; border-bottom: 1px solid #eaeaea; padding-bottom: 1rem; }
@@ -65,7 +65,7 @@ module Hwaro
           <<-HTML
           {% include "header.html" %}
           <main>
-            <h1>{{ page.title }}</h1>
+            <h1>{{ page.title | e }}</h1>
             {{ content }}
 
           <ul class="section-list">
@@ -93,7 +93,7 @@ module Hwaro
         def self.alert : String
           <<-HTML
           <div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
-            <strong>{{ type | upper }}:</strong> {{ message }}
+            <strong>{{ type | upper }}:</strong> {{ body }}
           </div>
           HTML
         end
@@ -102,7 +102,7 @@ module Hwaro
           <<-HTML
           {% include "header.html" %}
           <main>
-            <h1>{{ page.title }}</h1>
+            <h1>{{ page.title | e }}</h1>
             <p>Browse all terms in this taxonomy:</p>
             {{ content }}
           </main>
@@ -114,7 +114,7 @@ module Hwaro
           <<-HTML
           {% include "header.html" %}
           <main>
-            <h1>{{ page.title }}</h1>
+            <h1>{{ page.title | e }}</h1>
             <p>Posts tagged with this term:</p>
             {{ content }}
           </main>

--- a/src/services/scaffolds/bare.cr
+++ b/src/services/scaffolds/bare.cr
@@ -66,12 +66,12 @@ module Hwaro
         private def bare_header_template : String
           <<-HTML
           <!DOCTYPE html>
-          <html lang="en">
+          <html lang="{{ page_language }}">
           <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta name="description" content="{{ page.description }}">
-            <title>{{ page.title }} - {{ site.title }}</title>
+            <meta name="description" content="{{ page.description | e }}">
+            <title>{{ page.title | e }} - {{ site.title | e }}</title>
           </head>
           <body>
             <header>
@@ -101,7 +101,7 @@ module Hwaro
           <<-HTML
           {% include "header.html" %}
             <main>
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               {{ content }}
               <ul>
                 {{ section.list }}
@@ -130,7 +130,7 @@ module Hwaro
           <<-HTML
           {% include "header.html" %}
             <main>
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               {{ content }}
             </main>
           {% include "footer.html" %}
@@ -142,7 +142,7 @@ module Hwaro
           <<-HTML
           {% include "header.html" %}
             <main>
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               {{ content }}
             </main>
           {% include "footer.html" %}

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -97,7 +97,7 @@ module Hwaro
         protected def alert_shortcode : String
           <<-HTML
           <div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
-            <strong>{{ type | upper }}:</strong> {{ message }}
+            <strong>{{ type | upper }}:</strong> {{ body }}
           </div>
           HTML
         end
@@ -106,13 +106,14 @@ module Hwaro
         protected def header_template : String
           <<-HTML
           <!DOCTYPE html>
-          <html lang="en">
+          <html lang="{{ page_language }}">
           <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <meta name="description" content="{{ page.description | e }}">
             <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
             {{ og_all_tags }}
+            {{ hreflang_tags }}
             #{styles}
             {{ highlight_css }}
             {{ auto_includes_css }}
@@ -157,7 +158,7 @@ module Hwaro
           <<-HTML
           {% include "header.html" %}
             <main class="site-main">
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               {{ content }}
               <ul class="section-list">
                 {{ section.list }}
@@ -186,7 +187,7 @@ module Hwaro
           <<-HTML
           {% include "header.html" %}
             <main class="site-main">
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               <p class="taxonomy-desc">Browse all terms in this taxonomy:</p>
               {{ content }}
             </main>
@@ -199,7 +200,7 @@ module Hwaro
           <<-HTML
           {% include "header.html" %}
             <main class="site-main">
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               <p class="taxonomy-desc">Posts tagged with this term:</p>
               {{ content }}
             </main>

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -117,13 +117,14 @@ module Hwaro
         protected def header_template : String
           <<-HTML
           <!DOCTYPE html>
-          <html lang="en">
+          <html lang="{{ page_language }}">
           <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta name="description" content="{{ page.description }}">
-            <title>{{ page.title }} - {{ site.title }}</title>
+            <meta name="description" content="{{ page.description | e }}">
+            <title>{{ page.title | e }} - {{ site.title | e }}</title>
             {{ og_all_tags }}
+            {{ hreflang_tags }}
             #{styles}
             {{ highlight_css }}
             {{ auto_includes_css }}
@@ -796,7 +797,7 @@ module Hwaro
           #{search_overlay_html}
           <div class="blog-container">
             <main class="blog-main">
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               {{ content }}
           {% include "footer.html" %}
           HTML
@@ -810,7 +811,7 @@ module Hwaro
           #{search_overlay_html}
           <div class="blog-container">
             <main class="blog-main">
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               {{ content }}
 
               <ul class="section-list">
@@ -831,7 +832,7 @@ module Hwaro
             <main class="blog-main">
               <article class="post">
                 <header class="post-header">
-                  <h1>{{ page.title }}</h1>
+                  <h1>{{ page.title | e }}</h1>
                   <div class="post-meta">
                     <time>{{ page.date }}</time>
                   </div>
@@ -926,8 +927,6 @@ module Hwaro
           <<-CONTENT
 +++
 title = "Posts"
-paginate = 10
-pagination_enabled = true
 +++
 
 Browse all blog posts below.

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -110,13 +110,14 @@ module Hwaro
         protected def header_template : String
           <<-HTML
           <!DOCTYPE html>
-          <html lang="en">
+          <html lang="{{ page_language }}">
           <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta name="description" content="{{ page.description }}">
-            <title>{{ page.title }} - {{ site.title }}</title>
+            <meta name="description" content="{{ page.description | e }}">
+            <title>{{ page.title | e }} - {{ site.title | e }}</title>
             {{ og_all_tags }}
+            {{ hreflang_tags }}
             #{styles}
             {{ highlight_css }}
             {{ auto_includes_css }}
@@ -983,7 +984,7 @@ module Hwaro
           <div class="docs-container">
           #{docs_sidebar_html}
             <main class="docs-main">
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               {{ content }}
           {% include "footer.html" %}
           HTML
@@ -998,7 +999,7 @@ module Hwaro
           <div class="docs-container">
           #{docs_sidebar_html}
             <main class="docs-main">
-              <h1>{{ page.title }}</h1>
+              <h1>{{ page.title | e }}</h1>
               {{ content }}
 
               <h2>In This Section</h2>
@@ -1327,7 +1328,7 @@ Shortcodes are reusable content snippets you can embed in your Markdown.
 In your Markdown content:
 
 ```jinja
-{{ alert(type="info", message="This is an info alert") }}
+{{ alert(type="info", body="This is an info alert") }}
 ```
 
 ## Built-in Shortcodes
@@ -1337,7 +1338,7 @@ In your Markdown content:
 Display an alert box:
 
 ```jinja
-{{ alert(type="warning", message="Be careful!") }}
+{{ alert(type="warning", body="Be careful!") }}
 ```
 
 Types: `info`, `warning`, `tip`, `note`
@@ -1361,9 +1362,9 @@ Types: `info`, `warning`, `tip`, `note`
 
 ```jinja
 {# templates/shortcodes/alert.html #}
-{% if type and message %}
+{% if type and body %}
 <div class="alert alert-{{ type }}">
-  {{ message | safe }}
+  {{ body | safe }}
 </div>
 {% endif %}
 ```


### PR DESCRIPTION
## Summary

- **Fix stored XSS** in scaffold/default templates — escape `page.title`, `site.title`, `page.description` with `| e` filter in `<title>`, `<meta>`, and `<h1>` tags
- **Detect duplicate slugs** — warn during render phase when two pages resolve to the same output path
- **Deduplicate URLs** in sitemap, search index, and RSS feed when slug collisions occur
- **Fix pagination** — remove hardcoded `paginate = 10` from blog scaffold `_index.md` so `config.toml` global settings take effect
- **Fix i18n `lang` attribute** — replace hardcoded `lang="en"` with `{{ page_language }}` across all scaffolds
- **Add `hreflang` tags** — include `{{ hreflang_tags }}` in scaffold headers for multilingual SEO
- **Fix alert shortcode** — align scaffold `{{ message }}` → `{{ body }}` to match built-in shortcode

## Test plan

- [x] All 3909 existing tests pass
- [ ] `hwaro init --scaffold blog` → verify `<title>` uses `| e` filter
- [ ] Create posts with HTML in title → confirm escaped in output
- [ ] Create duplicate slug posts → confirm `[WARN]` during build
- [ ] Enable pagination with `per_page = 3` → confirm correct page counts
- [ ] `hwaro init --scaffold blog --include-multilingual en,ko` → verify `lang="ko"` and `hreflang` tags on Korean pages
- [ ] Verify sitemap/search/feed have no duplicate URLs with conflicting slugs