### PR TITLE
Add category grouping to tool help output

### DIFF
--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -307,16 +307,15 @@ hwaro tool convert to-yaml --json
 
 **Subcommands:**
 
-| Subcommand | Description |
-|------------|-------------|
-| [convert](/start/tools/convert/) | Convert frontmatter between YAML and TOML formats |
-| [list](/start/tools/list/) | List content files by status (all, drafts, published) |
-| [check-links](/start/tools/deadlink/) | Check for dead links in content files |
-| [doctor](/start/tools/doctor/) | Diagnose config and content issues |
-| [platform](/start/tools/platform/) | Generate platform config and CI/CD workflow files |
-| ci *(deprecated)* | Use `tool platform github-pages` instead |
-| import | Import content from WordPress, Jekyll, Hugo, Notion, Obsidian, Hexo, Astro, or Eleventy |
-| [agents-md](/start/tools/agents-md/) | Generate or update AGENTS.md file |
+| Category | Subcommand | Description |
+|----------|------------|-------------|
+| Content | [list](/start/tools/list/) | List content files by status (all, drafts, published) |
+| Content | [convert](/start/tools/convert/) | Convert frontmatter between YAML and TOML formats |
+| Content | [check-links](/start/tools/deadlink/) | Check for dead links in content files |
+| Site | [platform](/start/tools/platform/) | Generate platform config and CI/CD workflow files |
+| Site | [doctor](/start/tools/doctor/) | Diagnose config and content issues |
+| Site | import | Import content from WordPress, Jekyll, Hugo, Notion, Obsidian, Hexo, Astro, or Eleventy |
+| Site | [agents-md](/start/tools/agents-md/) | Generate or update AGENTS.md file |
 
 **Common Options:**
 

--- a/src/cli/commands/tool_command.cr
+++ b/src/cli/commands/tool_command.cr
@@ -102,9 +102,13 @@ module Hwaro
           "Site"    => ["platform", "doctor", "import", "agents-md"],
         }
 
+        # Hidden from help but still executable (e.g. deprecated commands)
+        HIDDEN = Set{"ci"}
+
         private def print_help
-          max_len = ToolCommand.subcommands.max_of(&.name.size)
-          sub_by_name = ToolCommand.subcommands.index_by(&.name)
+          visible = ToolCommand.subcommands.reject { |s| HIDDEN.includes?(s.name) }
+          max_len = visible.max_of(&.name.size)
+          sub_by_name = visible.index_by(&.name)
 
           Logger.info "Usage: hwaro tool <subcommand> [options]"
           Logger.info ""
@@ -122,8 +126,8 @@ module Hwaro
             end
           end
 
-          # Show uncategorized commands (e.g. deprecated ones)
-          uncategorized = ToolCommand.subcommands.reject { |s| categorized.includes?(s.name) }
+          # Show uncategorized commands
+          uncategorized = visible.reject { |s| categorized.includes?(s.name) }
           unless uncategorized.empty?
             Logger.info ""
             Logger.info "  Other:"


### PR DESCRIPTION
## Summary
- `hwaro tool --help` 출력에서 서브커맨드를 Content / Site 카테고리로 그룹핑
- 카테고리에 속하지 않는 커맨드(e.g. deprecated `ci`)는 "Other"로 자동 분류

Closes #299
Related: #267

## Test plan
- [x] `shards build` 성공
- [x] `crystal spec` 전체 통과 (3912 examples, 0 failures)
- [x] `hwaro tool --help` 출력 확인