### PR TITLE
Use ARM native runners for CI Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,20 +33,18 @@ jobs:
       - name: Build
         run: shards build
   build-docker:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        arch: [linux/amd64, linux/arm64]
+        include:
+          - arch: linux/amd64
+            runner: ubuntu-latest
+          - arch: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.0.0
-        with:
-          cosign-release: v2.1.1
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
       - name: Extract Docker metadata


### PR DESCRIPTION
## Summary
- Replace QEMU emulation with native ARM runner (`ubuntu-24.04-arm`) for arm64 Docker builds
- Remove unused cosign install step (CI only builds, never pushes)
- Remove QEMU setup step (no longer needed with native runners)
- Add `fail-fast: false` to matrix strategy

arm64 builds should be ~5-10x faster without QEMU overhead.

Closes #307

## Test plan
- [ ] Verify amd64 job runs on `ubuntu-latest`
- [ ] Verify arm64 job runs on `ubuntu-24.04-arm` natively
- [ ] Confirm both Docker builds succeed in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)