### PR TITLE
Optimize .deb build by reusing prebuilt release binaries

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -12,7 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: ubuntu-24.04-arm
+            platform: linux
+          - os: macos-latest
+            platform: macos
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Crystal
@@ -32,7 +38,7 @@ jobs:
           else
             echo "ARCH=unknown" >> $GITHUB_ENV
           fi
-      - if: matrix.os == 'ubuntu-latest'
+      - if: matrix.platform == 'linux'
         name: Build binary (Linux)
         run: |
           mkdir -p build
@@ -43,7 +49,7 @@ jobs:
             mkdir -p build &&
             crystal build src/main.cr -o build/hwaro-${GITHUB_REF_SLUG}-linux-${ARCH} --release --no-debug --static
           "
-      - if: startsWith(matrix.os, 'macos')
+      - if: matrix.platform == 'macos'
         name: Build binary (macOS)
         run: |
           mkdir -p build

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -12,44 +12,47 @@ on:
         required: false
         type: boolean
         default: false
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
 permissions:
   contents: write
 jobs:
   build-deb:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
     strategy:
       matrix:
         arch: [amd64, arm64]
     runs-on: ubuntu-latest
     steps:
-      - name: Install Crystal
-        uses: crystal-lang/install-crystal@v1
       - name: Checkout source code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.ref }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
       - name: Get Version
         id: get_version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RAW_VERSION="${{ github.event.inputs.version }}"
           else
-            RAW_VERSION="${GITHUB_REF#refs/tags/}"
+            RAW_VERSION="${{ github.event.workflow_run.head_branch }}"
           fi
           # Strip leading 'v' if present
           VERSION="${RAW_VERSION#v}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Resolved version: $VERSION"
-      - name: Build hwaro Binary
+      - name: Download prebuilt binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker run --rm --platform linux/${{ matrix.arch }} -v $(pwd):/hwaro -w /hwaro --entrypoint="" 84codes/crystal:latest-alpine sh -c "
-            apk add --no-cache yaml-dev git curl &&
-            shards install --production &&
-            crystal build src/main.cr -o hwaro --release --no-debug --static
-          "
+          ARCH_NAME=${{ matrix.arch == 'amd64' && 'x86_64' || 'arm64' }}
+          gh release download "v${{ env.VERSION }}" \
+            --pattern "hwaro-v${{ env.VERSION }}-linux-${ARCH_NAME}" \
+            --output hwaro
+          chmod +x hwaro
       - name: Create Debian Package Structure
         run: |
           mkdir -p hwaro_${{ env.VERSION }}_${{ matrix.arch }}/DEBIAN
@@ -77,7 +80,7 @@ jobs:
           name: hwaro_${{ env.VERSION }}_${{ matrix.arch }}.deb
           path: hwaro_${{ env.VERSION }}_${{ matrix.arch }}.deb
       - name: Upload .deb to Release
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_release)
+        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_release)
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ env.VERSION }}


### PR DESCRIPTION
## Summary
- Add linux/arm64 build to `release-binary.yml` using `ubuntu-24.04-arm` native runner
- Change `release-deb.yml` trigger from `release: published` to `workflow_run` on release-binary completion, eliminating race condition
- Replace Docker/QEMU/Crystal compilation with `gh release download` of prebuilt binaries
- Remove Crystal, QEMU, and Docker dependencies from deb workflow

### Flow
```
release: published
  → release-binary.yml (builds linux/amd64, linux/arm64, macOS/arm64)
    → release-deb.yml (downloads prebuilt binaries, packages .deb)
```

Closes #306

## Test plan
- [ ] Trigger `release-binary` manually and verify linux arm64 binary is produced
- [ ] Verify `release-deb` triggers after release-binary completes
- [ ] Confirm .deb packages contain the correct binary for each architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)