### PR TITLE
Add RPM package build workflow

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -88,6 +88,7 @@ jobs:
               file_info:
                 mode: 0644
           EOF
+          sed -i 's/^          //' nfpm.yaml
           nfpm package --packager rpm --target hwaro-${{ env.VERSION }}.${{ matrix.arch }}.rpm
 
       - name: Upload artifacts

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -1,0 +1,105 @@
+---
+name: Build and Release .rpm Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build (e.g., 0.0.13)"
+        required: true
+        type: string
+      upload_to_release:
+        description: "Upload .rpm to GitHub Release (requires existing tag)"
+        required: false
+        type: boolean
+        default: false
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
+permissions:
+  contents: write
+jobs:
+  build-rpm:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            binary_arch: x86_64
+          - arch: aarch64
+            binary_arch: arm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
+
+      - name: Get Version
+        id: get_version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW_VERSION="${{ github.event.inputs.version }}"
+          else
+            RAW_VERSION="${{ github.event.workflow_run.head_branch }}"
+          fi
+          VERSION="${RAW_VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Resolved version: $VERSION"
+
+      - name: Download prebuilt binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "v${{ env.VERSION }}" \
+            --pattern "hwaro-v${{ env.VERSION }}-linux-${{ matrix.binary_arch }}" \
+            --output hwaro
+          chmod +x hwaro
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Install nfpm
+        run: |
+          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
+      - name: Create nfpm config and build .rpm
+        run: |
+          cat > nfpm.yaml <<EOF
+          name: hwaro
+          arch: ${{ matrix.arch }}
+          version: v${{ env.VERSION }}
+          maintainer: HAHWUL <hahwul@gmail.com>
+          description: "Hunt every Endpoint in your code, expose Shadow APIs, map the Attack Surface."
+          license: MIT
+          depends:
+            - glibc >= 2.17
+          contents:
+            - src: hwaro
+              dst: /usr/bin/hwaro
+              file_info:
+                mode: 0755
+            - src: LICENSE
+              dst: /usr/share/licenses/hwaro/LICENSE
+              file_info:
+                mode: 0644
+          EOF
+          nfpm package --packager rpm --target hwaro-${{ env.VERSION }}.${{ matrix.arch }}.rpm
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: hwaro-${{ env.VERSION }}.${{ matrix.arch }}.rpm
+          path: hwaro-${{ env.VERSION }}.${{ matrix.arch }}.rpm
+
+      - name: Upload .rpm to Release
+        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_release)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "v${{ env.VERSION }}" \
+            "hwaro-${{ env.VERSION }}.${{ matrix.arch }}.rpm" --clobber

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -74,7 +74,7 @@ jobs:
           arch: ${{ matrix.arch }}
           version: ${{ env.VERSION }}
           maintainer: HAHWUL <hahwul@gmail.com>
-          description: "Hunt every Endpoint in your code, expose Shadow APIs, map the Attack Surface."
+          description: "Lightweight and fast Static Site Generator(SSG) written in Crystal."
           license: MIT
           depends:
             - glibc >= 2.17

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -72,7 +72,7 @@ jobs:
           cat > nfpm.yaml <<EOF
           name: hwaro
           arch: ${{ matrix.arch }}
-          version: v${{ env.VERSION }}
+          version: ${{ env.VERSION }}
           maintainer: HAHWUL <hahwul@gmail.com>
           description: "Hunt every Endpoint in your code, expose Shadow APIs, map the Attack Surface."
           license: MIT


### PR DESCRIPTION
## Summary
- Add `release-rpm.yml` workflow that builds `.rpm` packages using `nfpm`
- Supports `x86_64` and `aarch64` architectures
- Reuses prebuilt binaries from `release-binary.yml` (same pattern as deb/apk)
- Triggers via `workflow_run` after release-binary completes, or manually via `workflow_dispatch`

Closes #301

## Test plan
- [ ] Trigger workflow manually with version `0.10.0` and verify .rpm is produced
- [ ] Verify .rpm installs correctly on Fedora (`rpm -i hwaro-*.rpm`)
- [ ] Confirm release upload works when triggered via `workflow_run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)