### PR TITLE
Add AUR package and auto-publish workflow

### DIFF
--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -1,0 +1,51 @@
+---
+name: Publish AUR Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 0.10.0)"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
+jobs:
+  publish-aur:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
+
+      - name: Get Version
+        id: get_version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW_VERSION="${{ github.event.inputs.version }}"
+          else
+            RAW_VERSION="${{ github.event.workflow_run.head_branch }}"
+          fi
+          VERSION="${RAW_VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Resolved version: $VERSION"
+
+      - name: Update PKGBUILD version
+        run: |
+          sed -i "s/^pkgver=.*/pkgver=${{ env.VERSION }}/" aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+          cat aur/PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+        with:
+          pkgname: hwaro-bin
+          pkgbuild: aur/PKGBUILD
+          commit_username: hahwul
+          commit_email: hahwul@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
         with:
-          pkgname: hwaro-bin
+          pkgname: hwaro
           pkgbuild: aur/PKGBUILD
           commit_username: hahwul
           commit_email: hahwul@gmail.com

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,13 +1,11 @@
 # Maintainer: HAHWUL <hahwul@gmail.com>
-pkgname=hwaro-bin
+pkgname=hwaro
 pkgver=0.10.0
 pkgrel=1
 pkgdesc="Lightweight and fast Static Site Generator(SSG) written in Crystal."
 arch=('x86_64')
 url="https://github.com/hahwul/hwaro"
 license=('MIT')
-provides=('hwaro')
-conflicts=('hwaro')
 source=("hwaro-${pkgver}::https://github.com/hahwul/hwaro/releases/download/v${pkgver}/hwaro-v${pkgver}-linux-x86_64")
 sha256sums=('SKIP')
 

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,17 @@
+# Maintainer: HAHWUL <hahwul@gmail.com>
+pkgname=hwaro-bin
+pkgver=0.10.0
+pkgrel=1
+pkgdesc="Hunt every Endpoint in your code, expose Shadow APIs, map the Attack Surface."
+arch=('x86_64')
+url="https://github.com/hahwul/hwaro"
+license=('MIT')
+provides=('hwaro')
+conflicts=('hwaro')
+source=("hwaro-${pkgver}::https://github.com/hahwul/hwaro/releases/download/v${pkgver}/hwaro-v${pkgver}-linux-x86_64")
+sha256sums=('SKIP')
+
+package() {
+  install -Dm755 "${srcdir}/hwaro-${pkgver}" "${pkgdir}/usr/bin/hwaro"
+  install -Dm644 "${srcdir}/../LICENSE" "${pkgdir}/usr/share/licenses/hwaro/LICENSE"
+}

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=hwaro-bin
 pkgver=0.10.0
 pkgrel=1
-pkgdesc="Hunt every Endpoint in your code, expose Shadow APIs, map the Attack Surface."
+pkgdesc="Lightweight and fast Static Site Generator(SSG) written in Crystal."
 arch=('x86_64')
 url="https://github.com/hahwul/hwaro"
 license=('MIT')


### PR DESCRIPTION
## Summary
- Add `aur/PKGBUILD` for `hwaro-bin` AUR package (prebuilt binary from GitHub Releases)
- Add `release-aur.yml` workflow that auto-updates PKGBUILD version and publishes to AUR
- Triggers via `workflow_run` after release-binary completes, or manually via `workflow_dispatch`
- Requires `AUR_SSH_PRIVATE_KEY` secret to be configured

### Usage after publish
```
yay -S hwaro-bin
```

Closes #302

## Test plan
- [ ] Verify PKGBUILD is valid with `makepkg --printsrcinfo`
- [ ] Configure `AUR_SSH_PRIVATE_KEY` secret
- [ ] Register `hwaro-bin` on AUR
- [ ] Trigger workflow manually and verify AUR package is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)