### PR TITLE
Fix package descriptions in deb and apk workflows

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -81,7 +81,7 @@ jobs:
           pkgname=hwaro
           pkgver=${{ env.VERSION }}
           pkgrel=0
-          pkgdesc="Hunt every Endpoint in your code, expose Shadow APIs, map the Attack Surface."
+          pkgdesc="Lightweight and fast Static Site Generator(SSG) written in Crystal."
           url="https://github.com/hahwul/hwaro"
           arch="${{ matrix.arch }}"
           license="MIT"

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -68,7 +68,7 @@ jobs:
           Version: ${{ env.VERSION }}
           Architecture: ${{ matrix.arch }}
           Maintainer: HAHWUL <hahwul@gmail.com>, KSG <ksg97031@gmail.com>
-          Description: Hunt every Endpoint in your code, expose Shadow APIs, map the Attack Surface.
+          Description: Lightweight and fast Static Site Generator(SSG) written in Crystal.
           Depends: libc6 (>= 2.17)
           EOF
       - name: Build .deb Package


### PR DESCRIPTION
## Summary
- Fix incorrect package description in `release-deb.yml` and `release-apk.yml`
- Was using noir's description, now uses hwaro's: "Lightweight and fast Static Site Generator(SSG) written in Crystal."

🤖 Generated with [Claude Code](https://claude.com/claude-code)