### PR TITLE
Add fail-fast: false to RPM build matrix

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -24,6 +24,7 @@ jobs:
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'release')
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: x86_64


### PR DESCRIPTION
## Summary
- Add `fail-fast: false` to RPM workflow matrix strategy
- Prevents one architecture failure from cancelling the other (consistent with deb/apk/ghcr workflows)

Found during manual testing — arm64 binary wasn't available on v0.10.0 release, which cancelled the x86_64 job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)