### PR TITLE
Fix deb/apk workflows: add fail-fast and fix git safe directory

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -36,7 +36,11 @@ jobs:
     steps:
       - name: Install build tools
         run: |
-          apk add --no-cache alpine-sdk sudo github-cli
+          apk add --no-cache alpine-sdk sudo github-cli git
+
+      - name: Fix git safe directory
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Checkout source code
         uses: actions/checkout@v6

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -24,6 +24,7 @@ jobs:
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'release')
     strategy:
+      fail-fast: false
       matrix:
         arch: [amd64, arm64]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `fail-fast: false` to deb workflow matrix (was missing, causing amd64 to cancel when arm64 fails)
- Fix git safe directory error in apk workflow's Alpine container (`gh` needs git access)

Found during manual testing with v0.10.0 (no arm64 binary available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)