### PR TITLE
Fix serve -p flag not reflecting in base_url

### DIFF
--- a/spec/unit/serve_options_spec.cr
+++ b/spec/unit/serve_options_spec.cr
@@ -79,5 +79,23 @@ describe Hwaro::Config::Options::ServeOptions do
       build.should_not be_nil
       build.streaming?.should be_false
     end
+
+    it "derives base_url from host and port when not explicitly set" do
+      serve = Hwaro::Config::Options::ServeOptions.new(host: "0.0.0.0", port: 8080)
+      build = serve.to_build_options
+      build.base_url.should eq("http://0.0.0.0:8080")
+    end
+
+    it "uses default host:port for base_url when no options provided" do
+      serve = Hwaro::Config::Options::ServeOptions.new
+      build = serve.to_build_options
+      build.base_url.should eq("http://127.0.0.1:3000")
+    end
+
+    it "preserves explicit --base-url over derived host:port" do
+      serve = Hwaro::Config::Options::ServeOptions.new(port: 8080, base_url: "https://example.com")
+      build = serve.to_build_options
+      build.base_url.should eq("https://example.com")
+    end
   end
 end

--- a/src/config/options/serve_options.cr
+++ b/src/config/options/serve_options.cr
@@ -51,9 +51,13 @@ module Hwaro
 
         # Convert to BuildOptions for initial build
         def to_build_options : BuildOptions
+          # When no explicit --base-url is provided, derive from serve host:port
+          # so that generated URLs reflect the actual server address
+          effective_base_url = @base_url || "http://#{@host}:#{@port}"
+
           BuildOptions.new(
             output_dir: "public",
-            base_url: @base_url,
+            base_url: effective_base_url,
             drafts: @drafts,
             include_expired: @include_expired,
             include_future: @include_future,


### PR DESCRIPTION
## Summary
- `hwaro serve -p <port>`에서 `--base-url`을 명시하지 않으면, config.toml의 기본값(port 3000)이 그대로 사용되던 버그 수정
- `ServeOptions.to_build_options()`에서 `--base-url` 미지정 시 serve의 host:port로 base_url을 자동 생성하도록 변경
- 관련 테스트 3건 추가

Closes #322

## Test plan
- [x] 기존 테스트 전체 통과 확인 (128 examples, 0 failures)
- [x] 커스텀 port 지정 시 base_url 반영 테스트
- [x] 기본값(127.0.0.1:3000) base_url 생성 테스트
- [x] 명시적 `--base-url`이 자동 생성보다 우선하는지 테스트