### PR TITLE
Switch to official crystallang/crystal image

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           mkdir -p build
           # Use Alpine/musl-based Crystal container for proper static binary
-          docker run --rm -v $(pwd):/hwaro -w /hwaro --entrypoint="" 84codes/crystal:latest-alpine sh -c "
+          docker run --rm -v $(pwd):/hwaro -w /hwaro --entrypoint="" crystallang/crystal:1.19.1-alpine sh -c "
             apk add --no-cache yaml-dev git curl &&
             shards install --release --no-debug --production &&
             mkdir -p build &&

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ##= BUILDER =##
-FROM 84codes/crystal:latest-debian-13 AS builder
+FROM crystallang/crystal:1.19.1 AS builder
 WORKDIR /hwaro
 COPY . .
 


### PR DESCRIPTION
## Summary
- Crystal now provides [official Linux ARM64 builds](https://crystal-lang.org/2026/04/07/official-linux-arm64-builds/), so we can drop the 84codes images that were previously needed for multi-arch coverage.
- `docker/Dockerfile`: `84codes/crystal:latest-debian-13` → `crystallang/crystal:1.19.1`
- `.github/workflows/release-binary.yml`: `84codes/crystal:latest-alpine` → `crystallang/crystal:1.19.1-alpine`

## Test plan
- [x] `docker build -f docker/Dockerfile .` succeeds on linux/arm64; binary runs (`hwaro --version` → `0.11.1`)
- [x] Alpine static build produces a statically linked aarch64 ELF binary
- [ ] CI release workflow green