### PR TITLE
Add unit specs for build phase modules

### DIFF
--- a/spec/unit/phases_finalize_spec.cr
+++ b/spec/unit/phases_finalize_spec.cr
@@ -55,7 +55,7 @@ describe Hwaro::Core::Build::Phases::Finalize do
       end
     end
 
-    it "aborts when the cache is not initialized" do
+    it "aborts when @cache is nil" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do
           builder = Hwaro::Core::Build::Builder.new
@@ -65,7 +65,7 @@ describe Hwaro::Core::Build::Phases::Finalize do
           ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
 
           profiler = Hwaro::Profiler.new(enabled: false)
-          # The phase wraps the action in run_phase, which converts a raised
+          # The phase raises "Cache not initialized"; run_phase converts the
           # exception into HookResult::Abort.
           result = builder.test_run_finalize(ctx, profiler)
           result.should eq(Hwaro::Core::Lifecycle::HookResult::Abort)

--- a/spec/unit/phases_finalize_spec.cr
+++ b/spec/unit/phases_finalize_spec.cr
@@ -1,0 +1,76 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# Reopen Builder to expose the private finalize phase entry point.
+module Hwaro::Core::Build
+  class Builder
+    def test_run_finalize(ctx : Lifecycle::BuildContext, profiler : Profiler)
+      execute_finalize_phase(ctx, profiler)
+    end
+
+    def test_set_cache(cache : Cache?)
+      @cache = cache
+    end
+  end
+end
+
+describe Hwaro::Core::Build::Phases::Finalize do
+  describe "#execute_finalize_phase" do
+    it "saves the cache when ctx.options.cache is true" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: ".hwaro_cache.json")
+          cache.update("dummy-source.md", "dummy-output.html")
+          builder.test_set_cache(cache)
+
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", cache: true)
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+          ctx.cache = cache
+
+          profiler = Hwaro::Profiler.new(enabled: false)
+          result = builder.test_run_finalize(ctx, profiler)
+
+          result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+          File.exists?(".hwaro_cache.json").should be_true
+        end
+      end
+    end
+
+    it "does not save the cache when ctx.options.cache is false" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          cache = Hwaro::Core::Build::Cache.new(enabled: false, cache_path: ".hwaro_cache.json")
+          builder.test_set_cache(cache)
+
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", cache: false)
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+
+          profiler = Hwaro::Profiler.new(enabled: false)
+          builder.test_run_finalize(ctx, profiler)
+
+          File.exists?(".hwaro_cache.json").should be_false
+        end
+      end
+    end
+
+    it "aborts when the cache is not initialized" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_set_cache(nil)
+
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", cache: true)
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+
+          profiler = Hwaro::Profiler.new(enabled: false)
+          # The phase wraps the action in run_phase, which converts a raised
+          # exception into HookResult::Abort.
+          result = builder.test_run_finalize(ctx, profiler)
+          result.should eq(Hwaro::Core::Lifecycle::HookResult::Abort)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/phases_generate_spec.cr
+++ b/spec/unit/phases_generate_spec.cr
@@ -1,0 +1,103 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# Reopen Builder to expose private Generate phase entry point.
+module Hwaro::Core::Build
+  class Builder
+    def test_run_generate(ctx : Lifecycle::BuildContext, profiler : Profiler)
+      execute_generate_phase(ctx, profiler)
+    end
+
+    def test_set_generate_site(site : Models::Site)
+      @site = site
+    end
+  end
+end
+
+describe Hwaro::Core::Build::Phases::Generate do
+  describe "#execute_generate_phase" do
+    it "returns Continue and writes baseline SEO outputs" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+
+          config = Hwaro::Models::Config.new
+          config.title = "Test Site"
+          config.base_url = "https://example.com"
+          site = Hwaro::Models::Site.new(config)
+
+          page = Hwaro::Models::Page.new("about.md")
+          page.title = "About"
+          page.url = "/about/"
+          page.date = Time.utc
+          site.pages = [page]
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_set_generate_site(site)
+
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+          ctx.config = config
+          ctx.site = site
+          ctx.pages = [page]
+
+          profiler = Hwaro::Profiler.new(enabled: false)
+          result = builder.test_run_generate(ctx, profiler)
+
+          result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+          # Robots.txt is generated unconditionally based on default config.
+          File.exists?("public/robots.txt").should be_true
+        end
+      end
+    end
+
+    it "aborts when the site is not initialized" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+
+          builder = Hwaro::Core::Build::Builder.new
+          # Site is intentionally not set on the builder
+          profiler = Hwaro::Profiler.new(enabled: false)
+          result = builder.test_run_generate(ctx, profiler)
+          result.should eq(Hwaro::Core::Lifecycle::HookResult::Abort)
+        end
+      end
+    end
+
+    it "skips default generation when a BeforeGenerate hook is registered" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+
+          config = Hwaro::Models::Config.new
+          config.title = "Test Site"
+          config.base_url = "https://example.com"
+          site = Hwaro::Models::Site.new(config)
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_set_generate_site(site)
+
+          # Register a hook so the default SEO generation is skipped
+          builder.lifecycle.before(Hwaro::Core::Lifecycle::Phase::Generate, name: "test-skip") do |_ctx|
+            Hwaro::Core::Lifecycle::HookResult::Continue
+          end
+
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+          ctx.config = config
+          ctx.site = site
+
+          profiler = Hwaro::Profiler.new(enabled: false)
+          result = builder.test_run_generate(ctx, profiler)
+          result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+          # robots.txt should NOT be generated when a BeforeGenerate hook is registered
+          File.exists?("public/robots.txt").should be_false
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/phases_initialize_spec.cr
+++ b/spec/unit/phases_initialize_spec.cr
@@ -1,0 +1,365 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# Reopen Builder to expose private Initialize-phase helpers for testing.
+module Hwaro::Core::Build
+  class Builder
+    def test_setup_output_dir(output_dir : String, incremental : Bool = false)
+      setup_output_dir(output_dir, incremental)
+    end
+
+    def test_copy_static_files(output_dir : String, verbose : Bool = false, incremental : Bool = false)
+      copy_static_files(output_dir, verbose, incremental)
+    end
+
+    def test_load_templates : Hash(String, String)
+      load_templates
+    end
+
+    def test_load_data_files(site : Models::Site)
+      load_data_files(site)
+    end
+
+    def test_create_fresh_crinja_env : Crinja
+      create_fresh_crinja_env
+    end
+
+    def test_run_initialize(ctx : Lifecycle::BuildContext, profiler : Profiler)
+      execute_initialize_phase(ctx, profiler)
+    end
+
+    def test_set_config_for_init(config : Models::Config)
+      @config = config
+    end
+
+    def test_get_site
+      @site
+    end
+
+    def test_get_cache
+      @cache
+    end
+
+    def test_get_templates
+      @templates
+    end
+  end
+end
+
+describe Hwaro::Core::Build::Phases::Initialize do
+  describe "#setup_output_dir" do
+    it "creates the output directory when it does not exist" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_setup_output_dir("public")
+          Dir.exists?("public").should be_true
+        end
+      end
+    end
+
+    it "wipes the output directory in non-incremental mode" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+          File.write("public/stale.html", "stale")
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_setup_output_dir("public", incremental: false)
+
+          Dir.exists?("public").should be_true
+          File.exists?("public/stale.html").should be_false
+        end
+      end
+    end
+
+    it "preserves existing files in incremental mode" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+          File.write("public/keep.html", "keep")
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_setup_output_dir("public", incremental: true)
+
+          File.exists?("public/keep.html").should be_true
+        end
+      end
+    end
+  end
+
+  describe "#copy_static_files" do
+    it "is a no-op when no static directory exists" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_copy_static_files("public")
+          # Nothing copied; directory still empty
+          Dir.children("public").should be_empty
+        end
+      end
+    end
+
+    it "copies all files in non-incremental mode" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("static/css")
+          File.write("static/robots.txt", "User-agent: *")
+          File.write("static/css/main.css", "body{}")
+          FileUtils.mkdir_p("public")
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_copy_static_files("public")
+
+          File.exists?("public/robots.txt").should be_true
+          File.exists?("public/css/main.css").should be_true
+          File.read("public/robots.txt").should eq("User-agent: *")
+        end
+      end
+    end
+
+    it "skips unchanged files in incremental mode" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("static")
+          File.write("static/a.txt", "src")
+
+          FileUtils.mkdir_p("public")
+          File.write("public/a.txt", "dest")
+          # Make destination newer than source so the incremental copy skips it.
+          newer = Time.utc + 1.hour
+          File.utime(newer, newer, "public/a.txt")
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_copy_static_files("public", incremental: true)
+
+          File.read("public/a.txt").should eq("dest")
+        end
+      end
+    end
+
+    it "copies new files in incremental mode" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("static")
+          File.write("static/new.txt", "new content")
+          FileUtils.mkdir_p("public")
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_copy_static_files("public", incremental: true)
+
+          File.exists?("public/new.txt").should be_true
+          File.read("public/new.txt").should eq("new content")
+        end
+      end
+    end
+  end
+
+  describe "#load_templates" do
+    it "returns an empty hash when no templates directory exists" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          templates = builder.test_load_templates
+          templates.should be_empty
+        end
+      end
+    end
+
+    it "loads template files from the templates directory" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("templates")
+          File.write("templates/page.html", "<p>{{ content }}</p>")
+          File.write("templates/section.html", "<section>{{ content }}</section>")
+
+          builder = Hwaro::Core::Build::Builder.new
+          templates = builder.test_load_templates
+
+          templates.has_key?("page").should be_true
+          templates.has_key?("section").should be_true
+          templates["page"].should contain("{{ content }}")
+        end
+      end
+    end
+
+    it "honors extension priority (html beats j2)" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("templates")
+          File.write("templates/page.html", "from-html")
+          File.write("templates/page.j2", "from-j2")
+
+          builder = Hwaro::Core::Build::Builder.new
+          templates = builder.test_load_templates
+
+          templates["page"].should eq("from-html")
+        end
+      end
+    end
+
+    it "uses default template as fallback for page when no page template exists" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("templates")
+          File.write("templates/default.html", "default-body")
+
+          builder = Hwaro::Core::Build::Builder.new
+          templates = builder.test_load_templates
+
+          templates["page"]?.should eq("default-body")
+        end
+      end
+    end
+  end
+
+  describe "#load_data_files" do
+    it "loads YAML data files into site.data" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data")
+          File.write("data/people.yml", "alice: { age: 30 }\nbob: { age: 25 }\n")
+
+          builder = Hwaro::Core::Build::Builder.new
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          builder.test_load_data_files(site)
+
+          site.data.has_key?("people").should be_true
+        end
+      end
+    end
+
+    it "loads JSON data files" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data")
+          File.write("data/menu.json", %({"home": "/"}))
+
+          builder = Hwaro::Core::Build::Builder.new
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          builder.test_load_data_files(site)
+
+          site.data.has_key?("menu").should be_true
+        end
+      end
+    end
+
+    it "loads TOML data files" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data")
+          File.write("data/config.toml", %(title = "Hello"))
+
+          builder = Hwaro::Core::Build::Builder.new
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          builder.test_load_data_files(site)
+
+          site.data.has_key?("config").should be_true
+        end
+      end
+    end
+
+    it "is a no-op when data directory does not exist" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          # Pre-populate data to verify it is cleared
+          site.data["seed"] = Crinja::Value.new("x")
+          builder.test_load_data_files(site)
+          site.data.should be_empty
+        end
+      end
+    end
+
+    it "skips invalid data files but keeps the build alive" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data")
+          File.write("data/bad.json", "not valid json")
+
+          builder = Hwaro::Core::Build::Builder.new
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          builder.test_load_data_files(site)
+
+          site.data.has_key?("bad").should be_false
+        end
+      end
+    end
+  end
+
+  describe "#create_fresh_crinja_env" do
+    it "returns a Crinja instance" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          env = builder.test_create_fresh_crinja_env
+          env.should be_a(Crinja)
+        end
+      end
+    end
+
+    it "returns a fresh instance per call" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          env_a = builder.test_create_fresh_crinja_env
+          env_b = builder.test_create_fresh_crinja_env
+          env_a.object_id.should_not eq(env_b.object_id)
+        end
+      end
+    end
+  end
+
+  describe "#execute_initialize_phase" do
+    it "initializes cache, site, and templates" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("templates")
+          File.write("templates/page.html", "{{ content }}")
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_set_config_for_init(Hwaro::Models::Config.new)
+
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", cache: false)
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+          profiler = Hwaro::Profiler.new(enabled: false)
+
+          result = builder.test_run_initialize(ctx, profiler)
+
+          result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+          builder.test_get_site.should_not be_nil
+          builder.test_get_cache.should_not be_nil
+          templates = builder.test_get_templates
+          templates.should_not be_nil
+          templates.not_nil!.has_key?("page").should be_true
+          Dir.exists?("public").should be_true
+        end
+      end
+    end
+
+    it "applies base_url override from options" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          config = Hwaro::Models::Config.new
+          config.base_url = "http://default.example"
+          builder.test_set_config_for_init(config)
+
+          options = Hwaro::Config::Options::BuildOptions.new(
+            output_dir: "public",
+            base_url: "http://override.example",
+            cache: false,
+          )
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+          profiler = Hwaro::Profiler.new(enabled: false)
+
+          builder.test_run_initialize(ctx, profiler)
+
+          ctx.config.not_nil!.base_url.should eq("http://override.example")
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/phases_initialize_spec.cr
+++ b/spec/unit/phases_initialize_spec.cr
@@ -306,7 +306,7 @@ describe Hwaro::Core::Build::Phases::Initialize do
           builder = Hwaro::Core::Build::Builder.new
           env_a = builder.test_create_fresh_crinja_env
           env_b = builder.test_create_fresh_crinja_env
-          env_a.object_id.should_not eq(env_b.object_id)
+          env_a.should_not be(env_b)
         end
       end
     end

--- a/spec/unit/phases_parse_content_spec.cr
+++ b/spec/unit/phases_parse_content_spec.cr
@@ -1,0 +1,259 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# Reopen Builder to expose private ParseContent helpers for testing.
+module Hwaro::Core::Build
+  class Builder
+    def test_parse_single_page(page : Models::Page)
+      parse_single_page(page)
+    end
+
+    def test_parse_content_sequential(pages : Array(Models::Page))
+      parse_content_sequential(pages)
+    end
+
+    def test_parse_content_parallel(pages : Array(Models::Page))
+      parse_content_parallel(pages)
+    end
+
+    def test_parse_content_default(ctx : Lifecycle::BuildContext)
+      parse_content_default(ctx)
+    end
+
+    def test_set_parse_config(config : Models::Config)
+      @config = config
+    end
+
+    def test_run_parse_content(ctx : Lifecycle::BuildContext, profiler : Profiler)
+      execute_parse_content_phase(ctx, profiler)
+    end
+  end
+end
+
+private def with_content_dir(files : Hash(String, String), &)
+  Dir.mktmpdir do |dir|
+    Dir.cd(dir) do
+      FileUtils.mkdir_p("content")
+      files.each do |path, body|
+        full = File.join("content", path)
+        FileUtils.mkdir_p(File.dirname(full))
+        File.write(full, body)
+      end
+      yield dir
+    end
+  end
+end
+
+describe Hwaro::Core::Build::Phases::ParseContent do
+  describe "#parse_single_page" do
+    it "populates frontmatter fields on the page" do
+      with_content_dir({
+        "post.md" => "---\ntitle: Hello\ndescription: A post\ndraft: false\ntags: [a, b]\n---\nBody content",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        page = Hwaro::Models::Page.new("post.md")
+        builder.test_parse_single_page(page)
+
+        page.title.should eq("Hello")
+        page.description.should eq("A post")
+        page.draft.should be_false
+        page.tags.sort.should eq(["a", "b"])
+        page.raw_content.should contain("Body content")
+      end
+    end
+
+    it "computes word count and reading time" do
+      with_content_dir({
+        "p.md" => "---\ntitle: P\n---\n#{"word " * 50}",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+        page = Hwaro::Models::Page.new("p.md")
+        builder.test_parse_single_page(page)
+
+        page.word_count.should be > 0
+        page.reading_time.should be >= 1
+      end
+    end
+
+    it "calculates the URL using calculate_page_url" do
+      with_content_dir({
+        "blog/intro.md" => "---\ntitle: Intro\n---\nx",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+        page = Hwaro::Models::Page.new("blog/intro.md")
+        builder.test_parse_single_page(page)
+        page.url.should eq("/blog/intro/")
+      end
+    end
+
+    it "handles section-specific frontmatter on Section instances" do
+      with_content_dir({
+        "blog/_index.md" => "---\ntitle: Blog\nsort_by: weight\nreverse: true\ntransparent: true\n---\nBlog index",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+        section = Hwaro::Models::Section.new("blog/_index.md")
+        builder.test_parse_single_page(section)
+
+        section.sort_by.should eq("weight")
+        section.reverse.should eq(true)
+        section.transparent.should be_true
+      end
+    end
+
+    it "is a no-op when the source file is missing" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_set_parse_config(Hwaro::Models::Config.new)
+          page = Hwaro::Models::Page.new("missing.md")
+          # Should not raise
+          builder.test_parse_single_page(page)
+          page.title.should eq("Untitled")
+        end
+      end
+    end
+  end
+
+  describe "#parse_content_sequential" do
+    it "marks pages with parse failures rather than raising" do
+      with_content_dir({
+        "good.md" => "---\ntitle: Good\n---\nfine",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        good = Hwaro::Models::Page.new("good.md")
+        # Missing file simulates a transient I/O failure
+        missing = Hwaro::Models::Page.new("missing.md")
+
+        builder.test_parse_content_sequential([good, missing])
+        good.title.should eq("Good")
+        good.parse_failed.should be_false
+        # Missing file is silently skipped (parse_single_page returns early)
+        missing.parse_failed.should be_false
+      end
+    end
+  end
+
+  describe "#parse_content_parallel" do
+    it "parses multiple pages concurrently with the same results as sequential" do
+      with_content_dir({
+        "a.md" => "---\ntitle: A\n---\na",
+        "b.md" => "---\ntitle: B\n---\nb",
+        "c.md" => "---\ntitle: C\n---\nc",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        pages = ["a.md", "b.md", "c.md"].map { |p| Hwaro::Models::Page.new(p) }
+        builder.test_parse_content_parallel(pages)
+
+        pages.map(&.title).sort.should eq(["A", "B", "C"])
+      end
+    end
+  end
+
+  describe "#parse_content_default" do
+    it "filters out drafts unless include_drafts is true" do
+      with_content_dir({
+        "draft.md"     => "---\ntitle: Draft\ndraft: true\n---\nbody",
+        "published.md" => "---\ntitle: Published\n---\nbody",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+        ctx.config = Hwaro::Models::Config.new
+        ctx.pages = [
+          Hwaro::Models::Page.new("draft.md"),
+          Hwaro::Models::Page.new("published.md"),
+        ]
+
+        builder.test_parse_content_default(ctx)
+        ctx.pages.map(&.title).sort.should eq(["Published"])
+      end
+    end
+
+    it "keeps drafts when include_drafts is true" do
+      with_content_dir({
+        "draft.md" => "---\ntitle: Draft\ndraft: true\n---\nbody",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false, drafts: true)
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+        ctx.config = Hwaro::Models::Config.new
+        ctx.pages = [Hwaro::Models::Page.new("draft.md")]
+
+        builder.test_parse_content_default(ctx)
+        ctx.pages.size.should eq(1)
+      end
+    end
+
+    it "filters out future-dated pages by default" do
+      future_date = (Time.utc + 30.days).to_s("%Y-%m-%dT%H:%M:%SZ")
+      with_content_dir({
+        "future.md" => %(---\ntitle: Future\ndate: "#{future_date}"\n---\nbody),
+        "now.md"    => "---\ntitle: Now\n---\nbody",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+        ctx.config = Hwaro::Models::Config.new
+        ctx.pages = [Hwaro::Models::Page.new("future.md"), Hwaro::Models::Page.new("now.md")]
+
+        builder.test_parse_content_default(ctx)
+        ctx.pages.map(&.title).sort.should eq(["Now"])
+      end
+    end
+
+    it "filters out expired pages by default" do
+      past_date = (Time.utc - 30.days).to_s("%Y-%m-%dT%H:%M:%SZ")
+      with_content_dir({
+        "old.md"  => %(---\ntitle: Old\nexpires: "#{past_date}"\n---\nbody),
+        "live.md" => "---\ntitle: Live\n---\nbody",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+        ctx.config = Hwaro::Models::Config.new
+        ctx.pages = [Hwaro::Models::Page.new("old.md"), Hwaro::Models::Page.new("live.md")]
+
+        builder.test_parse_content_default(ctx)
+        ctx.pages.map(&.title).sort.should eq(["Live"])
+      end
+    end
+  end
+
+  describe "#execute_parse_content_phase" do
+    it "returns Continue and parses queued pages" do
+      with_content_dir({
+        "p.md" => "---\ntitle: P\n---\nbody",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+        ctx.config = Hwaro::Models::Config.new
+        ctx.pages = [Hwaro::Models::Page.new("p.md")]
+
+        profiler = Hwaro::Profiler.new(enabled: false)
+        result = builder.test_run_parse_content(ctx, profiler)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+        ctx.pages.first.title.should eq("P")
+      end
+    end
+  end
+end

--- a/spec/unit/phases_read_content_spec.cr
+++ b/spec/unit/phases_read_content_spec.cr
@@ -1,0 +1,197 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# Reopen Builder to expose private ReadContent helpers for testing.
+module Hwaro::Core::Build
+  class Builder
+    def test_collect_content_paths(ctx : Lifecycle::BuildContext, include_drafts : Bool = false)
+      collect_content_paths(ctx, include_drafts)
+    end
+
+    def test_extract_language_from_filename(basename : String, config : Models::Config?)
+      extract_language_from_filename(basename, config)
+    end
+
+    def test_run_read_content(ctx : Lifecycle::BuildContext, profiler : Profiler)
+      execute_read_content_phase(ctx, profiler)
+    end
+  end
+end
+
+private def make_ctx(config : Hwaro::Models::Config? = nil) : Hwaro::Core::Lifecycle::BuildContext
+  options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+  ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+  ctx.config = config
+  ctx
+end
+
+describe Hwaro::Core::Build::Phases::ReadContent do
+  describe "#extract_language_from_filename" do
+    it "returns nil for non-multilingual config" do
+      builder = Hwaro::Core::Build::Builder.new
+      config = Hwaro::Models::Config.new
+      builder.test_extract_language_from_filename("about.ko.md", config).should be_nil
+    end
+
+    it "returns nil for nil config" do
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_extract_language_from_filename("about.ko.md", nil).should be_nil
+    end
+
+    it "extracts a registered language code" do
+      builder = Hwaro::Core::Build::Builder.new
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new(code: "ko")
+      config.languages["en"] = Hwaro::Models::LanguageConfig.new(code: "en")
+      builder.test_extract_language_from_filename("about.ko.md", config).should eq("ko")
+    end
+
+    it "ignores unknown language codes" do
+      builder = Hwaro::Core::Build::Builder.new
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new(code: "ko")
+      builder.test_extract_language_from_filename("about.zz.md", config).should be_nil
+    end
+
+    it "matches the default language too" do
+      builder = Hwaro::Core::Build::Builder.new
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new(code: "ko")
+      builder.test_extract_language_from_filename("about.en.md", config).should eq("en")
+    end
+
+    it "returns nil for plain filenames without a language token" do
+      builder = Hwaro::Core::Build::Builder.new
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new(code: "ko")
+      builder.test_extract_language_from_filename("about.md", config).should be_nil
+    end
+  end
+
+  describe "#collect_content_paths" do
+    it "collects markdown pages and sections" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/blog")
+          File.write("content/about.md", "---\ntitle: About\n---\nbody")
+          File.write("content/blog/_index.md", "---\ntitle: Blog\n---\n")
+          File.write("content/blog/post.md", "---\ntitle: Post\n---\nbody")
+
+          builder = Hwaro::Core::Build::Builder.new
+          ctx = make_ctx(Hwaro::Models::Config.new)
+          builder.test_collect_content_paths(ctx)
+
+          ctx.pages.size.should eq(2)
+          ctx.sections.size.should eq(1)
+          ctx.sections.first.section.should eq("blog")
+        end
+      end
+    end
+
+    it "marks index pages with is_index" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/blog/post")
+          File.write("content/blog/_index.md", "---\ntitle: Blog\n---\n")
+          File.write("content/blog/post/index.md", "---\ntitle: Post\n---\nbody")
+
+          builder = Hwaro::Core::Build::Builder.new
+          ctx = make_ctx(Hwaro::Models::Config.new)
+          builder.test_collect_content_paths(ctx)
+
+          ctx.sections.any?(&.is_index).should be_true
+          ctx.pages.any?(&.is_index).should be_true
+        end
+      end
+    end
+
+    it "computes the correct section path for nested pages" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/docs/guide")
+          File.write("content/docs/guide/topic.md", "---\ntitle: T\n---\nbody")
+
+          builder = Hwaro::Core::Build::Builder.new
+          ctx = make_ctx(Hwaro::Models::Config.new)
+          builder.test_collect_content_paths(ctx)
+
+          ctx.pages.first.section.should eq("docs/guide")
+        end
+      end
+    end
+
+    it "collects raw JSON and XML files" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          File.write("content/data.json", "{}")
+          File.write("content/feed.xml", "<rss/>")
+
+          builder = Hwaro::Core::Build::Builder.new
+          ctx = make_ctx(Hwaro::Models::Config.new)
+          builder.test_collect_content_paths(ctx)
+
+          ctx.raw_files.map(&.relative_path).sort.should eq(["data.json", "feed.xml"])
+        end
+      end
+    end
+
+    it "extracts language code for multilingual filenames" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          File.write("content/about.ko.md", "---\ntitle: 소개\n---\n")
+
+          builder = Hwaro::Core::Build::Builder.new
+          config = Hwaro::Models::Config.new
+          config.default_language = "en"
+          config.languages["ko"] = Hwaro::Models::LanguageConfig.new(code: "ko")
+          ctx = make_ctx(config)
+
+          builder.test_collect_content_paths(ctx)
+          page = ctx.pages.first
+          page.language.should eq("ko")
+        end
+      end
+    end
+
+    it "handles empty content directory gracefully" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+
+          builder = Hwaro::Core::Build::Builder.new
+          ctx = make_ctx(Hwaro::Models::Config.new)
+          builder.test_collect_content_paths(ctx)
+
+          ctx.pages.should be_empty
+          ctx.sections.should be_empty
+          ctx.raw_files.should be_empty
+        end
+      end
+    end
+  end
+
+  describe "#execute_read_content_phase" do
+    it "returns Continue and populates the context" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          File.write("content/index.md", "---\ntitle: Home\n---\nhome")
+
+          builder = Hwaro::Core::Build::Builder.new
+          ctx = make_ctx(Hwaro::Models::Config.new)
+          profiler = Hwaro::Profiler.new(enabled: false)
+
+          result = builder.test_run_read_content(ctx, profiler)
+          result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+          ctx.all_pages.size.should eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/phases_render_spec.cr
+++ b/spec/unit/phases_render_spec.cr
@@ -19,7 +19,6 @@ module Hwaro::Core::Build
     def test_build_pages_by_path(site : Models::Site)
       build_pages_by_path(site)
     end
-
   end
 end
 
@@ -157,5 +156,4 @@ describe Hwaro::Core::Build::Phases::Render do
       result["blog/_index.md"].should eq(section)
     end
   end
-
 end

--- a/spec/unit/phases_render_spec.cr
+++ b/spec/unit/phases_render_spec.cr
@@ -1,0 +1,161 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# Reopen Builder to expose private Render helpers for testing.
+module Hwaro::Core::Build
+  class Builder
+    def test_get_output_path(page : Models::Page, output_dir : String)
+      get_output_path(page, output_dir)
+    end
+
+    def test_determine_template(page : Models::Page, templates : Hash(String, String))
+      determine_template(page, templates)
+    end
+
+    def test_filter_changed_pages(pages, output_dir, cache)
+      filter_changed_pages(pages, output_dir, cache)
+    end
+
+    def test_build_pages_by_path(site : Models::Site)
+      build_pages_by_path(site)
+    end
+
+  end
+end
+
+describe Hwaro::Core::Build::Phases::Render do
+  describe "#get_output_path" do
+    it "appends index.html to a section URL" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          page = Hwaro::Models::Page.new("blog/post.md")
+          page.url = "/blog/post/"
+          builder.test_get_output_path(page, "public").should end_with("public/blog/post/index.html")
+        end
+      end
+    end
+
+    it "produces public/index.html for the root URL" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          page = Hwaro::Models::Page.new("index.md")
+          page.url = "/"
+          builder.test_get_output_path(page, "public").should end_with("public/index.html")
+        end
+      end
+    end
+
+    it "produces a path inside the output directory for nested pages" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          page = Hwaro::Models::Page.new("nested/page.md")
+          page.url = "/nested/page/"
+          result = builder.test_get_output_path(page, "public")
+          result.should contain("public/nested/page/index.html")
+        end
+      end
+    end
+  end
+
+  describe "#determine_template" do
+    it "returns 'page' as the default for regular pages" do
+      builder = Hwaro::Core::Build::Builder.new
+      page = Hwaro::Models::Page.new("about.md")
+      templates = {"page" => "x"}
+      builder.test_determine_template(page, templates).should eq("page")
+    end
+
+    it "returns 'section' for Section instances when available" do
+      builder = Hwaro::Core::Build::Builder.new
+      section = Hwaro::Models::Section.new("blog/_index.md")
+      templates = {"page" => "p", "section" => "s"}
+      builder.test_determine_template(section, templates).should eq("section")
+    end
+
+    it "returns 'index' for the root index page when an index template exists" do
+      builder = Hwaro::Core::Build::Builder.new
+      page = Hwaro::Models::Page.new("_index.md")
+      page.is_index = true
+      page.section = ""
+      templates = {"page" => "p", "index" => "i"}
+      builder.test_determine_template(page, templates).should eq("index")
+    end
+
+    it "honors a page-level custom template when present" do
+      builder = Hwaro::Core::Build::Builder.new
+      page = Hwaro::Models::Page.new("about.md")
+      page.template = "landing"
+      templates = {"page" => "p", "landing" => "l"}
+      builder.test_determine_template(page, templates).should eq("landing")
+    end
+
+    it "warns and falls back when the custom template is missing" do
+      builder = Hwaro::Core::Build::Builder.new
+      page = Hwaro::Models::Page.new("about.md")
+      page.template = "missing"
+      templates = {"page" => "p"}
+      builder.test_determine_template(page, templates).should eq("page")
+      page.build_warnings.any? { |w| w.includes?("missing") }.should be_true
+    end
+  end
+
+  describe "#filter_changed_pages" do
+    it "returns all pages when none are cached" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          File.write("content/p.md", "x")
+
+          builder = Hwaro::Core::Build::Builder.new
+          page = Hwaro::Models::Page.new("p.md")
+          page.url = "/p/"
+
+          cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: ".cache.json")
+          result = builder.test_filter_changed_pages([page], "public", cache)
+          result.size.should eq(1)
+        end
+      end
+    end
+
+    it "skips pages that are unchanged in the cache" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          File.write("content/p.md", "x")
+          FileUtils.mkdir_p("public/p")
+          File.write("public/p/index.html", "<html/>")
+
+          builder = Hwaro::Core::Build::Builder.new
+          page = Hwaro::Models::Page.new("p.md")
+          page.url = "/p/"
+
+          cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: ".cache.json")
+          # Mark page as cached
+          cache.update("content/p.md", "public/p/index.html")
+
+          result = builder.test_filter_changed_pages([page], "public", cache)
+          result.size.should eq(0)
+        end
+      end
+    end
+  end
+
+  describe "#build_pages_by_path" do
+    it "indexes both pages and sections by path" do
+      builder = Hwaro::Core::Build::Builder.new
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      page = Hwaro::Models::Page.new("blog/post.md")
+      section = Hwaro::Models::Section.new("blog/_index.md")
+      site.pages = [page]
+      site.sections = [section]
+
+      result = builder.test_build_pages_by_path(site)
+      result["blog/post.md"].should eq(page)
+      result["blog/_index.md"].should eq(section)
+    end
+  end
+
+end

--- a/spec/unit/phases_transform_spec.cr
+++ b/spec/unit/phases_transform_spec.cr
@@ -1,0 +1,295 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# Reopen Builder to expose private Transform helpers for testing.
+module Hwaro::Core::Build
+  class Builder
+    def test_build_subsections(ctx : Lifecycle::BuildContext)
+      build_subsections(ctx)
+    end
+
+    def test_link_page_navigation(ctx : Lifecycle::BuildContext)
+      link_page_navigation(ctx)
+    end
+
+    def test_collect_assets(ctx : Lifecycle::BuildContext)
+      collect_assets(ctx)
+    end
+
+    def test_populate_taxonomies(ctx : Lifecycle::BuildContext)
+      populate_taxonomies(ctx)
+    end
+
+    def test_rebuild_taxonomies(site : Models::Site, pages : Array(Models::Page))
+      rebuild_taxonomies(site, pages)
+    end
+
+    def test_update_taxonomies_incremental(site, changed_pages, snapshot)
+      update_taxonomies_incremental(site, changed_pages, snapshot)
+    end
+
+    def test_compute_series(site : Models::Site)
+      compute_series(site)
+    end
+
+    def test_recompute_series_for_pages(site, changed, old_names = {} of String => String?)
+      recompute_series_for_pages(site, changed, old_names)
+    end
+
+    def test_run_transform(ctx : Lifecycle::BuildContext, profiler : Profiler)
+      execute_transform_phase(ctx, profiler)
+    end
+
+    def test_set_transform_site(site : Models::Site)
+      @site = site
+    end
+  end
+end
+
+private def make_section(path : String, name : String) : Hwaro::Models::Section
+  s = Hwaro::Models::Section.new(path)
+  s.section = name
+  s
+end
+
+private def make_page(path : String, section : String = "") : Hwaro::Models::Page
+  p = Hwaro::Models::Page.new(path)
+  p.section = section
+  p
+end
+
+describe Hwaro::Core::Build::Phases::Transform do
+  describe "#build_subsections" do
+    it "links subsections to their parent" do
+      options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+
+      parent = make_section("docs/_index.md", "docs")
+      child = make_section("docs/guide/_index.md", "docs/guide")
+      ctx.sections = [parent, child]
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_build_subsections(ctx)
+
+      parent.subsections.size.should eq(1)
+      parent.subsections.first.section.should eq("docs/guide")
+      child.ancestors.size.should eq(1)
+      child.ancestors.first.section.should eq("docs")
+    end
+
+    it "links page ancestors based on section path" do
+      options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+
+      docs = make_section("docs/_index.md", "docs")
+      guide = make_section("docs/guide/_index.md", "docs/guide")
+      page = make_page("docs/guide/topic.md", "docs/guide")
+      ctx.sections = [docs, guide]
+      ctx.pages = [page]
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_build_subsections(ctx)
+
+      page.ancestors.map(&.section).should eq(["docs", "docs/guide"])
+    end
+  end
+
+  describe "#link_page_navigation" do
+    it "links pages with lower/higher in flat order" do
+      options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+
+      section = make_section("blog/_index.md", "blog")
+      section.is_index = true
+      section.weight = 1
+      page_a = make_page("blog/a.md", "blog")
+      page_a.title = "A"
+      page_a.weight = 1
+      page_b = make_page("blog/b.md", "blog")
+      page_b.title = "B"
+      page_b.weight = 2
+
+      ctx.sections = [section]
+      ctx.pages = [page_a, page_b]
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_link_page_navigation(ctx)
+
+      # The first page in the flat list has no lower neighbor
+      [section, page_a, page_b].count(&.lower.nil?).should be >= 1
+      [section, page_a, page_b].count(&.higher.nil?).should be >= 1
+    end
+  end
+
+  describe "#populate_taxonomies / #rebuild_taxonomies" do
+    it "groups pages by taxonomy term" do
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      page1 = make_page("p1.md")
+      page1.taxonomies = {"tags" => ["crystal", "ssg"]}
+      page2 = make_page("p2.md")
+      page2.taxonomies = {"tags" => ["crystal"]}
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_rebuild_taxonomies(site, [page1, page2])
+
+      site.taxonomies["tags"]["crystal"].size.should eq(2)
+      site.taxonomies["tags"]["ssg"].size.should eq(1)
+    end
+
+    it "clears existing taxonomies before rebuilding" do
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      site.taxonomies["stale"] = {"old" => [] of Hwaro::Models::Page}
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_rebuild_taxonomies(site, [] of Hwaro::Models::Page)
+
+      site.taxonomies.has_key?("stale").should be_false
+    end
+
+    it "populates taxonomies via the context-aware variant" do
+      options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      ctx.site = site
+
+      page = make_page("p.md")
+      page.taxonomies = {"categories" => ["news"]}
+      ctx.pages = [page]
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_populate_taxonomies(ctx)
+
+      site.taxonomies["categories"]["news"].size.should eq(1)
+    end
+  end
+
+  describe "#update_taxonomies_incremental" do
+    it "removes old assignments and adds new ones for changed pages" do
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      page = make_page("p.md")
+      page.taxonomies = {"tags" => ["new"]}
+      site.taxonomies["tags"] = {"old" => [page], "shared" => [page]}
+
+      snapshot = {"p.md" => {"tags" => ["old", "shared"]}}
+
+      builder = Hwaro::Core::Build::Builder.new
+      affected = builder.test_update_taxonomies_incremental(site, [page], snapshot)
+
+      affected.includes?("tags:old").should be_true
+      affected.includes?("tags:new").should be_true
+      site.taxonomies["tags"].has_key?("old").should be_false
+      site.taxonomies["tags"]["new"].size.should eq(1)
+    end
+  end
+
+  describe "#compute_series" do
+    it "assigns series_index and series_pages within a series" do
+      config = Hwaro::Models::Config.new
+      config.series.enabled = true
+      site = Hwaro::Models::Site.new(config)
+
+      p1 = make_page("a.md")
+      p1.title = "A"
+      p1.series = "tutorial"
+      p1.series_weight = 2
+      p2 = make_page("b.md")
+      p2.title = "B"
+      p2.series = "tutorial"
+      p2.series_weight = 1
+
+      site.pages = [p1, p2]
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_compute_series(site)
+
+      # Lower series_weight comes first
+      p2.series_index.should eq(1)
+      p1.series_index.should eq(2)
+      p1.series_pages.size.should eq(2)
+    end
+
+    it "skips drafts and non-renderable pages" do
+      config = Hwaro::Models::Config.new
+      config.series.enabled = true
+      site = Hwaro::Models::Site.new(config)
+
+      published = make_page("p.md")
+      published.title = "P"
+      published.series = "guide"
+      draft = make_page("d.md")
+      draft.title = "D"
+      draft.series = "guide"
+      draft.draft = true
+
+      site.pages = [published, draft]
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_compute_series(site)
+
+      published.series_index.should eq(1)
+      published.series_pages.size.should eq(1)
+    end
+  end
+
+  describe "#recompute_series_for_pages" do
+    it "recomputes only the affected series" do
+      config = Hwaro::Models::Config.new
+      config.series.enabled = true
+      site = Hwaro::Models::Site.new(config)
+
+      p1 = make_page("p1.md"); p1.title = "P1"; p1.series = "tutorial"
+      p2 = make_page("p2.md"); p2.title = "P2"; p2.series = "tutorial"
+      other = make_page("o.md"); other.title = "O"; other.series = "other"
+      site.pages = [p1, p2, other]
+
+      builder = Hwaro::Core::Build::Builder.new
+      affected = builder.test_recompute_series_for_pages(site, [p1])
+      affected.includes?("tutorial").should be_true
+      affected.includes?("other").should be_false
+    end
+  end
+
+  describe "#collect_assets" do
+    it "collects co-located assets for pages and sections" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/blog/post")
+          File.write("content/blog/post/index.md", "---\ntitle: P\n---\nbody")
+          File.write("content/blog/post/cover.png", "binary")
+
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+          page = make_page("blog/post/index.md", "blog")
+          page.is_index = true
+          ctx.pages = [page]
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_collect_assets(ctx)
+
+          page.assets.any? { |a| a.ends_with?("cover.png") }.should be_true
+        end
+      end
+    end
+  end
+
+  describe "#execute_transform_phase" do
+    it "populates the site model with pages and sections" do
+      options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+      ctx.config = Hwaro::Models::Config.new
+
+      site = Hwaro::Models::Site.new(ctx.config.not_nil!)
+
+      page = make_page("p.md")
+      page.title = "P"
+      ctx.pages = [page]
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_set_transform_site(site)
+
+      profiler = Hwaro::Profiler.new(enabled: false)
+      result = builder.test_run_transform(ctx, profiler)
+
+      result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+      site.pages.size.should eq(1)
+    end
+  end
+end

--- a/spec/unit/phases_transform_spec.cr
+++ b/spec/unit/phases_transform_spec.cr
@@ -95,13 +95,14 @@ describe Hwaro::Core::Build::Phases::Transform do
   end
 
   describe "#link_page_navigation" do
-    it "links pages with lower/higher in flat order" do
+    it "links pages with lower/higher in flat reading order" do
       options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
       ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
 
       section = make_section("blog/_index.md", "blog")
       section.is_index = true
       section.weight = 1
+      # Sorted by weight ascending within the section
       page_a = make_page("blog/a.md", "blog")
       page_a.title = "A"
       page_a.weight = 1
@@ -115,9 +116,15 @@ describe Hwaro::Core::Build::Phases::Transform do
       builder = Hwaro::Core::Build::Builder.new
       builder.test_link_page_navigation(ctx)
 
-      # The first page in the flat list has no lower neighbor
-      [section, page_a, page_b].count(&.lower.nil?).should be >= 1
-      [section, page_a, page_b].count(&.higher.nil?).should be >= 1
+      # Flat order: section index → page_a (weight 1) → page_b (weight 2)
+      section.lower.should be_nil
+      section.higher.should eq(page_a)
+
+      page_a.lower.should eq(section)
+      page_a.higher.should eq(page_b)
+
+      page_b.lower.should eq(page_a)
+      page_b.higher.should be_nil
     end
   end
 

--- a/spec/unit/phases_write_spec.cr
+++ b/spec/unit/phases_write_spec.cr
@@ -1,0 +1,177 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# Reopen Builder to expose private Write helpers for testing.
+module Hwaro::Core::Build
+  class Builder
+    def test_generate_404_page(site, templates, output_dir, minify, verbose)
+      generate_404_page(site, templates, output_dir, minify, verbose)
+    end
+
+    def test_process_raw_files(raw_files, output_dir, minify, verbose) : Int32
+      process_raw_files(raw_files, output_dir, minify, verbose)
+    end
+
+    def test_process_assets(pages, output_dir, verbose)
+      process_assets(pages, output_dir, verbose)
+    end
+
+    def test_ensure_dir(dir : String)
+      ensure_dir(dir)
+    end
+  end
+end
+
+describe Hwaro::Core::Build::Phases::Write do
+  describe "#generate_404_page" do
+    it "writes 404.html when a 404 template exists" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          templates = {"404" => "<h1>404 - {{ page_title }}</h1>"}
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_generate_404_page(site, templates, "public", false, false)
+
+          File.exists?("public/404.html").should be_true
+          File.read("public/404.html").should contain("404")
+        end
+      end
+    end
+
+    it "is a no-op when no 404 template exists" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          templates = {} of String => String
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_generate_404_page(site, templates, "public", false, false)
+
+          File.exists?("public/404.html").should be_false
+        end
+      end
+    end
+  end
+
+  describe "#process_raw_files" do
+    it "copies raw files to the output directory" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          File.write("content/data.json", "{}")
+          FileUtils.mkdir_p("public")
+
+          raw = Hwaro::Core::Lifecycle::RawFile.new("content/data.json", "data.json")
+          builder = Hwaro::Core::Build::Builder.new
+
+          count = builder.test_process_raw_files([raw], "public", false, false)
+
+          count.should eq(1)
+          File.exists?("public/data.json").should be_true
+          File.read("public/data.json").should eq("{}")
+        end
+      end
+    end
+
+    it "creates intermediate directories for nested raw paths" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/data")
+          File.write("content/data/feed.xml", "<rss/>")
+          FileUtils.mkdir_p("public")
+
+          raw = Hwaro::Core::Lifecycle::RawFile.new("content/data/feed.xml", "data/feed.xml")
+          builder = Hwaro::Core::Build::Builder.new
+
+          builder.test_process_raw_files([raw], "public", false, false)
+          File.exists?("public/data/feed.xml").should be_true
+        end
+      end
+    end
+
+    it "returns zero when no raw files are provided" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_process_raw_files([] of Hwaro::Core::Lifecycle::RawFile, "public", false, false).should eq(0)
+        end
+      end
+    end
+  end
+
+  describe "#process_assets" do
+    it "copies a page's collected assets next to the page output" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/blog/post")
+          File.write("content/blog/post/index.md", "---\ntitle: Post\n---\n")
+          File.write("content/blog/post/cover.png", "image-bytes")
+          FileUtils.mkdir_p("public")
+
+          page = Hwaro::Models::Page.new("blog/post/index.md")
+          page.url = "/blog/post/"
+          page.assets = ["blog/post/cover.png"]
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_process_assets([page], "public", false)
+
+          File.exists?("public/blog/post/cover.png").should be_true
+          File.read("public/blog/post/cover.png").should eq("image-bytes")
+        end
+      end
+    end
+
+    it "skips pages with no assets" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+          page = Hwaro::Models::Page.new("about.md")
+          page.url = "/about/"
+          page.assets = [] of String
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_process_assets([page], "public", false)
+          # No public/about/ should be created when there are no assets
+          Dir.exists?("public/about").should be_false
+        end
+      end
+    end
+
+    it "is a no-op when the source asset is missing" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+          page = Hwaro::Models::Page.new("blog/post/index.md")
+          page.url = "/blog/post/"
+          page.assets = ["blog/post/missing.png"]
+
+          builder = Hwaro::Core::Build::Builder.new
+          # Must not raise even though the source file doesn't exist
+          builder.test_process_assets([page], "public", false)
+          File.exists?("public/blog/post/missing.png").should be_false
+        end
+      end
+    end
+  end
+
+  describe "#ensure_dir" do
+    it "creates the directory once" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          target = File.join(dir, "ensured")
+          builder.test_ensure_dir(target)
+          Dir.exists?(target).should be_true
+
+          # Calling again should be a no-op (idempotent)
+          builder.test_ensure_dir(target)
+          Dir.exists?(target).should be_true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds 8 new unit spec files under `spec/unit/phases_*.cr`, one per phase module in `src/core/build/phases/`
- 83 new examples covering each phase's public entry point and notable private helpers in isolation (previously only exercised through `spec/functional/build_integration_spec.cr`)
- Follows the existing `spec/unit/calculate_page_url_spec.cr` pattern: re-opens `Builder` with `test_*` shims so private phase methods can be invoked directly

Coverage breakdown:

| Phase | Spec file | Examples |
|---|---|---|
| Initialize | `phases_initialize_spec.cr` | 20 |
| ReadContent | `phases_read_content_spec.cr` | 13 |
| ParseContent | `phases_parse_content_spec.cr` | 12 |
| Transform | `phases_transform_spec.cr` | 12 |
| Render | `phases_render_spec.cr` | 11 |
| Generate | `phases_generate_spec.cr` | 3 |
| Write | `phases_write_spec.cr` | 9 |
| Finalize | `phases_finalize_spec.cr` | 3 |

Closes #327

## Test plan
- [x] `crystal spec spec/unit/phases_*.cr` — all 83 examples pass
- [x] Run alongside existing builder-reopening specs (`calculate_page_url_spec.cr`, `related_posts_spec.cr`) to confirm no `test_*` method name conflicts
- [x] CI (`crystal spec` on Crystal 1.19.0)