### PR TITLE
Add functional tests for hwaro tool subcommands

### DIFF
--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -16,53 +16,68 @@ require "../spec_helper"
 
 private HWARO_BIN = File.expand_path("../../bin/hwaro", __DIR__)
 
+# Pre-flight check: surface a clear error if the binary is missing rather
+# than letting every test fail with an inscrutable Process.run error.
+Spec.before_suite do
+  unless File.exists?(HWARO_BIN) && File::Info.executable?(HWARO_BIN)
+    raise "Binary #{HWARO_BIN} is missing or not executable. Run `shards build` first."
+  end
+end
+
 private def with_initialized_project(&)
   temp_dir = File.tempname("hwaro_test")
   Dir.mkdir(temp_dir)
   project_dir = File.join(temp_dir, "test_site")
   Dir.mkdir(project_dir)
   begin
-    Process.run(HWARO_BIN, ["init", project_dir],
+    init_status = Process.run(HWARO_BIN, ["init", project_dir],
       output: IO::Memory.new, error: IO::Memory.new)
+    init_status.success?.should be_true
     yield project_dir
   ensure
     FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
   end
 end
 
-private def run_hwaro(args : Array(String), chdir : String? = nil)
+# Every test in this file runs the binary inside a temp project directory,
+# so chdir is required (not optional). Process.run is invoked uniformly.
+private def run_hwaro(args : Array(String), chdir : String)
   output = IO::Memory.new
   error = IO::Memory.new
-  status = if chdir
-             Process.run(HWARO_BIN, args, chdir: chdir, output: output, error: error)
-           else
-             Process.run(HWARO_BIN, args, output: output, error: error)
-           end
+  status = Process.run(HWARO_BIN, args, chdir: chdir, output: output, error: error)
+  {status, output.to_s, error.to_s}
+end
+
+# Variant for router-level tests that don't require an initialized project.
+private def run_hwaro_no_chdir(args : Array(String))
+  output = IO::Memory.new
+  error = IO::Memory.new
+  status = Process.run(HWARO_BIN, args, output: output, error: error)
   {status, output.to_s, error.to_s}
 end
 
 describe "hwaro tool (router)" do
   it "exits 1 and prints help when no subcommand is given" do
-    status, output, _ = run_hwaro(["tool"])
+    status, output, _ = run_hwaro_no_chdir(["tool"])
     status.success?.should be_false
     output.should contain("Usage")
     output.should contain("subcommand")
   end
 
   it "exits 1 and prints 'Unknown subcommand' for unrecognized names" do
-    status, output, _ = run_hwaro(["tool", "nonexistent-subcommand"])
+    status, output, _ = run_hwaro_no_chdir(["tool", "nonexistent-subcommand"])
     status.success?.should be_false
     output.should contain("Unknown subcommand")
   end
 
   it "prints help and exits 0 when invoked with help" do
-    status, output, _ = run_hwaro(["tool", "help"])
+    status, output, _ = run_hwaro_no_chdir(["tool", "help"])
     status.success?.should be_true
     output.should contain("Available subcommands")
   end
 
   it "categorizes visible subcommands under Content / Site headings" do
-    status, output, _ = run_hwaro(["tool", "--help"])
+    status, output, _ = run_hwaro_no_chdir(["tool", "--help"])
     status.success?.should be_true
     output.should contain("Content:")
     output.should contain("Site:")
@@ -98,12 +113,12 @@ describe "hwaro tool unused-assets" do
 end
 
 describe "hwaro tool check-links" do
-  it "runs against an initialized project without crashing" do
+  it "exits 0 or 1 (no crash) on an initialized project" do
     with_initialized_project do |project_dir|
       status, _, _ = run_hwaro(["tool", "check-links"], chdir: project_dir)
-      # check-links may exit non-zero if the scaffold has broken links;
-      # we only verify it terminates with a defined exit code.
-      status.exit_code.should_not be_nil
+      # check-links exits 0 when no broken links and 1 when some are found.
+      # Anything else (e.g. signal-based exit from a crash) is a bug.
+      [0, 1].includes?(status.exit_code).should be_true
     end
   end
 end
@@ -171,6 +186,9 @@ describe "hwaro tool ci" do
         ["tool", "ci", "github-actions", "--stdout"], chdir: project_dir
       )
       output.should contain("DEPRECATED")
+      # Co-signal: the actual workflow content was also generated to stdout,
+      # confirming the deprecation log didn't short-circuit the command.
+      output.should contain("workflow")
     end
   end
 end
@@ -180,7 +198,8 @@ describe "hwaro tool agents-md" do
     with_initialized_project do |project_dir|
       # `init` writes AGENTS.md by default — remove it to verify the no-write
       # path of `tool agents-md` doesn't touch the file.
-      File.delete(File.join(project_dir, "AGENTS.md"))
+      agents_md = File.join(project_dir, "AGENTS.md")
+      File.delete(agents_md) if File.exists?(agents_md)
 
       status, output, _ = run_hwaro(["tool", "agents-md"], chdir: project_dir)
       status.success?.should be_true
@@ -191,7 +210,8 @@ describe "hwaro tool agents-md" do
 
   it "writes AGENTS.md when --write is passed" do
     with_initialized_project do |project_dir|
-      File.delete(File.join(project_dir, "AGENTS.md"))
+      agents_md = File.join(project_dir, "AGENTS.md")
+      File.delete(agents_md) if File.exists?(agents_md)
 
       status, _, _ = run_hwaro(
         ["tool", "agents-md", "--write", "--force"], chdir: project_dir
@@ -224,6 +244,16 @@ describe "hwaro tool import" do
       status, output, _ = run_hwaro(["tool", "import", "hugo"], chdir: project_dir)
       status.success?.should be_false
       output.should contain("Missing path")
+    end
+  end
+
+  it "exits 1 and reports an unknown source-type" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(
+        ["tool", "import", "definitely-not-real", "/tmp"], chdir: project_dir
+      )
+      status.success?.should be_false
+      output.should contain("Unknown source type")
     end
   end
 end

--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -1,0 +1,266 @@
+require "../spec_helper"
+
+# =============================================================================
+# Functional CLI integration tests for `hwaro tool` subcommands that were
+# previously uncovered by `cli_commands_spec.cr` (which already covers
+# tool list, tool convert, tool doctor, and the top-level doctor).
+#
+# Each test spawns the built binary at bin/hwaro and asserts on exit status
+# plus filesystem side effects. CI builds the binary via `shards build`
+# before running specs.
+#
+# Note on streams: Hwaro::Logger.error / .info / .success all write to
+# Logger.io which defaults to STDOUT — not STDERR. Tests therefore assert
+# on the captured `output` stream, not `error`.
+# =============================================================================
+
+private HWARO_BIN = File.expand_path("../../bin/hwaro", __DIR__)
+
+private def with_initialized_project(&)
+  temp_dir = File.tempname("hwaro_test")
+  Dir.mkdir(temp_dir)
+  project_dir = File.join(temp_dir, "test_site")
+  Dir.mkdir(project_dir)
+  begin
+    Process.run(HWARO_BIN, ["init", project_dir],
+      output: IO::Memory.new, error: IO::Memory.new)
+    yield project_dir
+  ensure
+    FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
+  end
+end
+
+private def run_hwaro(args : Array(String), chdir : String? = nil)
+  output = IO::Memory.new
+  error = IO::Memory.new
+  status = if chdir
+             Process.run(HWARO_BIN, args, chdir: chdir, output: output, error: error)
+           else
+             Process.run(HWARO_BIN, args, output: output, error: error)
+           end
+  {status, output.to_s, error.to_s}
+end
+
+describe "hwaro tool (router)" do
+  it "exits 1 and prints help when no subcommand is given" do
+    status, output, _ = run_hwaro(["tool"])
+    status.success?.should be_false
+    output.should contain("Usage")
+    output.should contain("subcommand")
+  end
+
+  it "exits 1 and prints 'Unknown subcommand' for unrecognized names" do
+    status, output, _ = run_hwaro(["tool", "nonexistent-subcommand"])
+    status.success?.should be_false
+    output.should contain("Unknown subcommand")
+  end
+
+  it "prints help and exits 0 when invoked with help" do
+    status, output, _ = run_hwaro(["tool", "help"])
+    status.success?.should be_true
+    output.should contain("Available subcommands")
+  end
+
+  it "categorizes visible subcommands under Content / Site headings" do
+    status, output, _ = run_hwaro(["tool", "--help"])
+    status.success?.should be_true
+    output.should contain("Content:")
+    output.should contain("Site:")
+  end
+end
+
+describe "hwaro tool stats" do
+  it "prints statistics for an initialized project" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(["tool", "stats"], chdir: project_dir)
+      status.success?.should be_true
+    end
+  end
+end
+
+describe "hwaro tool validate" do
+  it "validates content of an initialized project" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(["tool", "validate"], chdir: project_dir)
+      # Default scaffold has no validation errors → exit 0
+      status.success?.should be_true
+    end
+  end
+end
+
+describe "hwaro tool unused-assets" do
+  it "scans an initialized project without errors" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(["tool", "unused-assets"], chdir: project_dir)
+      status.success?.should be_true
+    end
+  end
+end
+
+describe "hwaro tool check-links" do
+  it "runs against an initialized project without crashing" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(["tool", "check-links"], chdir: project_dir)
+      # check-links may exit non-zero if the scaffold has broken links;
+      # we only verify it terminates with a defined exit code.
+      status.exit_code.should_not be_nil
+    end
+  end
+end
+
+describe "hwaro tool platform" do
+  it "generates vercel.json for the vercel platform" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(["tool", "platform", "vercel", "--force"], chdir: project_dir)
+      status.success?.should be_true
+      File.exists?(File.join(project_dir, "vercel.json")).should be_true
+    end
+  end
+
+  it "generates netlify.toml for the netlify platform" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(["tool", "platform", "netlify", "--force"], chdir: project_dir)
+      status.success?.should be_true
+      File.exists?(File.join(project_dir, "netlify.toml")).should be_true
+    end
+  end
+
+  it "exits 1 and prints 'Unsupported platform' on an unknown platform" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(
+        ["tool", "platform", "definitely-not-real"], chdir: project_dir
+      )
+      status.success?.should be_false
+      output.should contain("Unsupported platform")
+    end
+  end
+
+  it "prints to stdout and writes no file when --stdout is passed" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(
+        ["tool", "platform", "vercel", "--stdout"], chdir: project_dir
+      )
+      status.success?.should be_true
+      output.size.should be > 0
+      File.exists?(File.join(project_dir, "vercel.json")).should be_false
+    end
+  end
+end
+
+describe "hwaro tool ci" do
+  it "generates .github/workflows/deploy.yml for github-actions" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(
+        ["tool", "ci", "github-actions", "--force"], chdir: project_dir
+      )
+      status.success?.should be_true
+      File.exists?(File.join(project_dir, ".github/workflows/deploy.yml")).should be_true
+    end
+  end
+
+  it "exits 1 when no provider is given" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(["tool", "ci"], chdir: project_dir)
+      status.success?.should be_false
+    end
+  end
+
+  it "warns about deprecation in favor of `tool platform github-pages`" do
+    with_initialized_project do |project_dir|
+      _, output, _ = run_hwaro(
+        ["tool", "ci", "github-actions", "--stdout"], chdir: project_dir
+      )
+      output.should contain("DEPRECATED")
+    end
+  end
+end
+
+describe "hwaro tool agents-md" do
+  it "prints local-mode AGENTS.md content to stdout by default" do
+    with_initialized_project do |project_dir|
+      # `init` writes AGENTS.md by default — remove it to verify the no-write
+      # path of `tool agents-md` doesn't touch the file.
+      File.delete(File.join(project_dir, "AGENTS.md"))
+
+      status, output, _ = run_hwaro(["tool", "agents-md"], chdir: project_dir)
+      status.success?.should be_true
+      output.should contain("AGENTS.md")
+      File.exists?(File.join(project_dir, "AGENTS.md")).should be_false
+    end
+  end
+
+  it "writes AGENTS.md when --write is passed" do
+    with_initialized_project do |project_dir|
+      File.delete(File.join(project_dir, "AGENTS.md"))
+
+      status, _, _ = run_hwaro(
+        ["tool", "agents-md", "--write", "--force"], chdir: project_dir
+      )
+      status.success?.should be_true
+      File.exists?(File.join(project_dir, "AGENTS.md")).should be_true
+    end
+  end
+
+  it "supports --remote mode" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(["tool", "agents-md", "--remote"], chdir: project_dir)
+      status.success?.should be_true
+      output.size.should be > 0
+    end
+  end
+end
+
+describe "hwaro tool import" do
+  it "exits 1 and reports missing source-type" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(["tool", "import"], chdir: project_dir)
+      status.success?.should be_false
+      output.should contain("Missing source")
+    end
+  end
+
+  it "exits 1 and reports missing path when only source-type is given" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(["tool", "import", "hugo"], chdir: project_dir)
+      status.success?.should be_false
+      output.should contain("Missing path")
+    end
+  end
+end
+
+describe "hwaro tool export" do
+  it "exits 1 and prints an error when no target-type is given" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(["tool", "export"], chdir: project_dir)
+      status.success?.should be_false
+      output.size.should be > 0
+    end
+  end
+end
+
+describe "hwaro doctor (top-level alias)" do
+  # Note: top-level command registration with CommandRegistry is exercised
+  # via `cli_commands_spec.cr` (which instantiates Runner). This block
+  # focuses on the alias's metadata equivalence with Tool::DoctorCommand.
+
+  it "exposes the same description as Tool::DoctorCommand" do
+    Hwaro::CLI::Commands::DoctorCommand::DESCRIPTION.should eq(
+      Hwaro::CLI::Commands::Tool::DoctorCommand::DESCRIPTION
+    )
+  end
+
+  it "exposes the same flags as Tool::DoctorCommand" do
+    Hwaro::CLI::Commands::DoctorCommand.metadata.flags.should eq(
+      Hwaro::CLI::Commands::Tool::DoctorCommand::FLAGS
+    )
+  end
+
+  it "exposes the same positional args/choices" do
+    Hwaro::CLI::Commands::DoctorCommand.metadata.positional_args.should eq(
+      Hwaro::CLI::Commands::Tool::DoctorCommand::POSITIONAL_ARGS
+    )
+    Hwaro::CLI::Commands::DoctorCommand.metadata.positional_choices.should eq(
+      Hwaro::CLI::Commands::Tool::DoctorCommand::POSITIONAL_CHOICES
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Adds 24 functional integration tests for `hwaro tool` subcommands that previously had no execute-path coverage. Existing tests in `spec/unit/tool_commands_spec.cr` only exercised `.metadata`, and `spec/functional/cli_commands_spec.cr` already covered `tool list`, `tool convert`, `tool doctor`, and the top-level `doctor`.

### What's now covered

| Area | Tests |
|---|---|
| `tool` router | 4 — missing arg, unknown subcommand, `help`, categorized `--help` output (Content/Site headings) |
| `tool stats` | 1 — success on initialized scaffold |
| `tool validate` | 1 — success on initialized scaffold |
| `tool unused-assets` | 1 — success on initialized scaffold |
| `tool check-links` | 1 — terminates with a defined exit code |
| `tool platform` | 4 — `vercel.json` + `netlify.toml` generation, unknown-platform error, `--stdout` no-write |
| `tool ci` | 3 — `.github/workflows/deploy.yml` generation, missing-provider error, deprecation warning |
| `tool agents-md` | 3 — stdout default, `--write` writes file, `--remote` mode |
| `tool import` | 2 — missing source-type, missing path |
| `tool export` | 1 — missing target-type |
| `doctor` (top-level alias) | 3 — description / flags / positional args equivalence with `Tool::DoctorCommand` |

### Implementation notes (worth reviewing)

- All commands write user-facing messages via `Hwaro::Logger`, which goes to **STDOUT** (not STDERR). Tests therefore assert on the captured `output` stream — caught and fixed during local iteration when initial assertions on `error` failed.
- `hwaro init` creates `AGENTS.md` by default. The agents-md no-write test removes it first so the "should not exist" assertion is meaningful.
- `tool ci github-actions` writes `deploy.yml`, not `build.yml`. Initial guess corrected after running the binary.
- The doctor alias's `CommandRegistry.has?("doctor")` registration check requires `Hwaro::CLI::Runner.new`, which transitively force-compiles the build pipeline (and hits the pre-existing Crystal 1.20.0 type-inference issue at `render.cr:1089`). That registration is already covered by `cli_commands_spec.cr`; this file uses metadata-equivalence assertions instead.

Closes #330

## Test plan
- [x] `crystal spec spec/functional/cli_tool_subcommands_spec.cr` — 24 examples pass locally
- [x] `crystal spec spec/functional/cli_tool_subcommands_spec.cr spec/unit/tool_commands_spec.cr` — 95 examples pass together
- [ ] CI on Crystal 1.19.0 (full suite incl. cli_commands_spec which forces builder compilation)