### PR TITLE
Add unit specs for Book / BookDark scaffolds and Base abstract class

### DIFF
--- a/spec/unit/scaffolds_book_spec.cr
+++ b/spec/unit/scaffolds_book_spec.cr
@@ -47,7 +47,11 @@ describe Hwaro::Services::Scaffolds::Book do
 
     it "produces non-empty content for every file" do
       files = Hwaro::Services::Scaffolds::Book.new.content_files
-      files.each_value { |c| c.should_not be_empty }
+      files.each do |path, content|
+        # Custom failure message names the offending file so a regression
+        # is immediately localized.
+        fail "content for #{path} was empty" if content.empty?
+      end
     end
   end
 
@@ -81,10 +85,12 @@ describe Hwaro::Services::Scaffolds::Book do
       files.has_key?("js/book.js").should be_true
     end
 
-    it "ships non-empty CSS and JS payloads" do
+    it "ships real CSS and JS payloads (not just placeholders)" do
       files = Hwaro::Services::Scaffolds::Book.new.static_files
-      files["css/style.css"].size.should be > 100
-      files["js/book.js"].size.should be > 100
+      # Structural fingerprints catch a wider class of regression than an
+      # arbitrary byte-count threshold (e.g., truncation to a stub).
+      files["css/style.css"].should contain(":root")
+      files["js/book.js"].should contain("function")
     end
   end
 
@@ -102,7 +108,10 @@ describe Hwaro::Services::Scaffolds::Book do
 
     it "uses the light highlight.js theme by default" do
       config = Hwaro::Services::Scaffolds::Book.new.config_content
-      config.should contain(%(theme = "github"))
+      # `theme = "github"` is a prefix of `theme = "github-dark"`, so a
+      # negative-lookahead regex disambiguates the two values. (The line
+      # has a trailing comment, so a simple newline guard would miss.)
+      config.should match(/theme = "github"(?!-)/)
       config.should_not contain(%(theme = "github-dark"))
     end
 
@@ -138,12 +147,15 @@ describe Hwaro::Services::Scaffolds::BookDark do
     it "reuses Book's content_files (chapter structure)" do
       light = Hwaro::Services::Scaffolds::Book.new.content_files
       dark = Hwaro::Services::Scaffolds::BookDark.new.content_files
+      # Guard against the both-empty trivial case before comparing key sets.
+      dark.size.should be > 0
       dark.keys.sort.should eq(light.keys.sort)
     end
 
     it "reuses Book's template files structure" do
       light = Hwaro::Services::Scaffolds::Book.new.template_files
       dark = Hwaro::Services::Scaffolds::BookDark.new.template_files
+      dark.size.should be > 0
       dark.keys.sort.should eq(light.keys.sort)
     end
 
@@ -158,7 +170,8 @@ describe Hwaro::Services::Scaffolds::BookDark do
     it "uses the github-dark highlight theme" do
       config = Hwaro::Services::Scaffolds::BookDark.new.config_content
       config.should contain(%(theme = "github-dark"))
-      config.should_not contain(%(theme = "github"\n))
+      # Negative lookahead — see the matching Book test for rationale.
+      config.should_not match(/theme = "github"(?!-)/)
     end
 
     it "still names the scaffold 'My Book'" do
@@ -174,6 +187,9 @@ describe Hwaro::Services::Scaffolds::BookDark do
 end
 
 # A minimal concrete subclass to exercise Base's default and protected helpers.
+# Type returns Bare arbitrarily — this class is never registered with the
+# scaffold registry; it exists only so the abstract Base methods can be
+# instantiated and called.
 private class TestBaseScaffold < Hwaro::Services::Scaffolds::Base
   def type : Hwaro::Config::Options::ScaffoldType
     Hwaro::Config::Options::ScaffoldType::Bare
@@ -207,7 +223,10 @@ describe Hwaro::Services::Scaffolds::Base do
     it "ships the shared alert shortcode" do
       files = TestBaseScaffold.new.shortcode_files
       files.has_key?("shortcodes/alert.html").should be_true
-      # Alert shortcode references body and type via Jinja
+      # Alert shortcode references body and type via Jinja. The `{{ type`
+      # substring is intentionally truncated — the source uses
+      # `{{ type | upper }}`, and the partial form matches both the filtered
+      # and unfiltered forms.
       files["shortcodes/alert.html"].should contain("{{ body }}")
       files["shortcodes/alert.html"].should contain("{{ type")
     end
@@ -235,7 +254,8 @@ describe Hwaro::Services::Scaffolds::Base do
 
     it "uses the light highlight theme via the default config_highlight_theme" do
       out = TestBaseScaffold.new.config_content
-      out.should contain(%(theme = "github"))
+      # Negative lookahead disambiguates "github" from "github-dark".
+      out.should match(/theme = "github"(?!-)/)
       out.should_not contain(%(theme = "github-dark"))
     end
   end

--- a/spec/unit/scaffolds_book_spec.cr
+++ b/spec/unit/scaffolds_book_spec.cr
@@ -1,0 +1,242 @@
+require "../spec_helper"
+require "../../src/services/scaffolds/registry"
+
+# =============================================================================
+# Unit specs for the Book / BookDark scaffolds and the abstract Base class.
+#
+# Existing scaffolds_spec.cr (600 lines) covers Simple, Docs, BlogDark,
+# DocsDark, and Registry. scaffolds_blog_spec.cr / scaffolds_bare_spec.cr
+# / scaffolds_docs_spec.cr cover the remaining named scaffolds. Book and
+# BookDark were referenced only in scaffold_registry_spec.cr (lookup) and
+# had no functional coverage; Base (abstract class) likewise had no spec.
+# =============================================================================
+
+describe Hwaro::Services::Scaffolds::Book do
+  describe "#type" do
+    it "returns Book scaffold type" do
+      Hwaro::Services::Scaffolds::Book.new.type
+        .should eq(Hwaro::Config::Options::ScaffoldType::Book)
+    end
+  end
+
+  describe "#description" do
+    it "is a non-empty string mentioning Book-style structure" do
+      desc = Hwaro::Services::Scaffolds::Book.new.description
+      desc.should_not be_empty
+      desc.should contain("Book-style")
+    end
+  end
+
+  describe "#content_files" do
+    it "includes the root index" do
+      files = Hwaro::Services::Scaffolds::Book.new.content_files
+      files.has_key?("index.md").should be_true
+    end
+
+    it "includes 3 chapter sections with their pages" do
+      files = Hwaro::Services::Scaffolds::Book.new.content_files
+      files.has_key?("chapter-1/_index.md").should be_true
+      files.has_key?("chapter-1/getting-started.md").should be_true
+      files.has_key?("chapter-1/installation.md").should be_true
+      files.has_key?("chapter-2/_index.md").should be_true
+      files.has_key?("chapter-2/basic-usage.md").should be_true
+      files.has_key?("chapter-2/configuration.md").should be_true
+      files.has_key?("chapter-3/_index.md").should be_true
+      files.has_key?("chapter-3/advanced-topics.md").should be_true
+    end
+
+    it "produces non-empty content for every file" do
+      files = Hwaro::Services::Scaffolds::Book.new.content_files
+      files.each_value { |c| c.should_not be_empty }
+    end
+  end
+
+  describe "#template_files" do
+    it "includes the standard 5 templates" do
+      files = Hwaro::Services::Scaffolds::Book.new.template_files
+      files.has_key?("header.html").should be_true
+      files.has_key?("footer.html").should be_true
+      files.has_key?("page.html").should be_true
+      files.has_key?("section.html").should be_true
+      files.has_key?("404.html").should be_true
+    end
+
+    it "includes taxonomy templates by default" do
+      files = Hwaro::Services::Scaffolds::Book.new.template_files
+      files.has_key?("taxonomy.html").should be_true
+      files.has_key?("taxonomy_term.html").should be_true
+    end
+
+    it "excludes taxonomy templates when skip_taxonomies is true" do
+      files = Hwaro::Services::Scaffolds::Book.new.template_files(skip_taxonomies: true)
+      files.has_key?("taxonomy.html").should be_false
+      files.has_key?("taxonomy_term.html").should be_false
+    end
+  end
+
+  describe "#static_files" do
+    it "ships the book CSS and JS assets" do
+      files = Hwaro::Services::Scaffolds::Book.new.static_files
+      files.has_key?("css/style.css").should be_true
+      files.has_key?("js/book.js").should be_true
+    end
+
+    it "ships non-empty CSS and JS payloads" do
+      files = Hwaro::Services::Scaffolds::Book.new.static_files
+      files["css/style.css"].size.should be > 100
+      files["js/book.js"].size.should be > 100
+    end
+  end
+
+  describe "#config_content" do
+    it "returns non-empty TOML config" do
+      config = Hwaro::Services::Scaffolds::Book.new.config_content
+      config.should_not be_empty
+    end
+
+    it "uses the Book scaffold's title and description" do
+      config = Hwaro::Services::Scaffolds::Book.new.config_content
+      config.should contain(%(title = "My Book"))
+      config.should contain("A book powered by Hwaro.")
+    end
+
+    it "uses the light highlight.js theme by default" do
+      config = Hwaro::Services::Scaffolds::Book.new.config_content
+      config.should contain(%(theme = "github"))
+      config.should_not contain(%(theme = "github-dark"))
+    end
+
+    it "includes taxonomies block by default" do
+      config = Hwaro::Services::Scaffolds::Book.new.config_content
+      config.should contain("[[taxonomies]]")
+    end
+
+    it "omits taxonomies block when skip_taxonomies is true" do
+      config = Hwaro::Services::Scaffolds::Book.new.config_content(skip_taxonomies: true)
+      config.should_not contain("[[taxonomies]]")
+    end
+  end
+end
+
+describe Hwaro::Services::Scaffolds::BookDark do
+  describe "#type" do
+    it "returns BookDark scaffold type" do
+      Hwaro::Services::Scaffolds::BookDark.new.type
+        .should eq(Hwaro::Config::Options::ScaffoldType::BookDark)
+    end
+  end
+
+  describe "#description" do
+    it "mentions both Book-style and dark theme" do
+      desc = Hwaro::Services::Scaffolds::BookDark.new.description
+      desc.should contain("Book-style")
+      desc.should contain("dark")
+    end
+  end
+
+  describe "inheritance from Book" do
+    it "reuses Book's content_files (chapter structure)" do
+      light = Hwaro::Services::Scaffolds::Book.new.content_files
+      dark = Hwaro::Services::Scaffolds::BookDark.new.content_files
+      dark.keys.sort.should eq(light.keys.sort)
+    end
+
+    it "reuses Book's template files structure" do
+      light = Hwaro::Services::Scaffolds::Book.new.template_files
+      dark = Hwaro::Services::Scaffolds::BookDark.new.template_files
+      dark.keys.sort.should eq(light.keys.sort)
+    end
+
+    it "ships its own static assets via the inherited static_files" do
+      files = Hwaro::Services::Scaffolds::BookDark.new.static_files
+      files.has_key?("css/style.css").should be_true
+      files.has_key?("js/book.js").should be_true
+    end
+  end
+
+  describe "#config_content" do
+    it "uses the github-dark highlight theme" do
+      config = Hwaro::Services::Scaffolds::BookDark.new.config_content
+      config.should contain(%(theme = "github-dark"))
+      config.should_not contain(%(theme = "github"\n))
+    end
+
+    it "still names the scaffold 'My Book'" do
+      config = Hwaro::Services::Scaffolds::BookDark.new.config_content
+      config.should contain(%(title = "My Book"))
+    end
+
+    it "omits taxonomies block when skip_taxonomies is true" do
+      config = Hwaro::Services::Scaffolds::BookDark.new.config_content(skip_taxonomies: true)
+      config.should_not contain("[[taxonomies]]")
+    end
+  end
+end
+
+# A minimal concrete subclass to exercise Base's default and protected helpers.
+private class TestBaseScaffold < Hwaro::Services::Scaffolds::Base
+  def type : Hwaro::Config::Options::ScaffoldType
+    Hwaro::Config::Options::ScaffoldType::Bare
+  end
+
+  def description : String
+    "test scaffold"
+  end
+
+  def content_files(skip_taxonomies : Bool = false) : Hash(String, String)
+    {} of String => String
+  end
+
+  def template_files(skip_taxonomies : Bool = false) : Hash(String, String)
+    {} of String => String
+  end
+
+  def config_content(skip_taxonomies : Bool = false) : String
+    minimal_config_content(skip_taxonomies)
+  end
+end
+
+describe Hwaro::Services::Scaffolds::Base do
+  describe "#static_files (default)" do
+    it "is empty unless the subclass overrides it" do
+      TestBaseScaffold.new.static_files.should be_empty
+    end
+  end
+
+  describe "#shortcode_files (default)" do
+    it "ships the shared alert shortcode" do
+      files = TestBaseScaffold.new.shortcode_files
+      files.has_key?("shortcodes/alert.html").should be_true
+      # Alert shortcode references body and type via Jinja
+      files["shortcodes/alert.html"].should contain("{{ body }}")
+      files["shortcodes/alert.html"].should contain("{{ type")
+    end
+  end
+
+  describe "#minimal_config_content" do
+    it "renders title, base_url, and processors plugin entries" do
+      out = TestBaseScaffold.new.config_content
+      out.should contain(%(title = "My Hwaro Site"))
+      out.should contain("base_url")
+      out.should contain("[plugins]")
+      out.should contain(%(processors = ["markdown"]))
+    end
+
+    it "includes taxonomies block by default" do
+      out = TestBaseScaffold.new.config_content(skip_taxonomies: false)
+      out.should contain("[[taxonomies]]")
+      out.should contain(%(name = "tags"))
+    end
+
+    it "omits taxonomies block when skip_taxonomies is true" do
+      out = TestBaseScaffold.new.config_content(skip_taxonomies: true)
+      out.should_not contain("[[taxonomies]]")
+    end
+
+    it "uses the light highlight theme via the default config_highlight_theme" do
+      out = TestBaseScaffold.new.config_content
+      out.should contain(%(theme = "github"))
+      out.should_not contain(%(theme = "github-dark"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Issue #334 lists 8 scaffold source files needing spec coverage. Auditing reveals **5 of those already have coverage** across the existing 1,144-line scaffold spec suite — this PR fills the 3 remaining gaps.

### Coverage map

| Source | Existing spec | Status |
|---|---|---|
| `simple.cr`, `docs.cr`, `docs_dark.cr`, `blog_dark.cr` | `scaffolds_spec.cr` (600 lines) | ✓ |
| `bare.cr`, `blog.cr`, `docs.cr` | `scaffolds_{bare,blog,docs}_spec.cr` (261 lines combined) | ✓ |
| `registry.cr` | `scaffold_registry_spec.cr` (104 lines) | ✓ |
| `remote.cr` | `remote_scaffold_spec.cr` (179 lines) | ✓ |
| **`base.cr`** (464 lines) | none | **NEW** |
| **`book.cr`** (1,660 lines) | only Registry lookup test | **NEW** |
| **`book_dark.cr`** (392 lines) | only Registry lookup test | **NEW** |

### What's covered (29 examples)

**Book** (10 examples)
- `type` returns `ScaffoldType::Book`
- `description` mentions "Book-style structure"
- `content_files`: root index + 3 chapters (`chapter-1`, `chapter-2`, `chapter-3`) with their pages; every value non-empty
- `template_files`: standard 5 templates + taxonomy templates (default-on, opt-out via `skip_taxonomies`)
- `static_files`: ships book CSS / JS; non-empty payloads
- `config_content`: scaffold-specific title (`"My Book"`) + description, light highlight theme (`github`), taxonomies block respect

**BookDark** (8 examples)
- `type` / `description` (mentions "dark")
- Inheritance: identical `content_files` keys and `template_files` keys as Book; `static_files` inherited
- `config_content` overrides: `github-dark` highlight theme; same title; `skip_taxonomies` still respected

**Base** (via `TestBaseScaffold` subclass, 6 examples)
- `static_files` default is empty
- `shortcode_files` ships `shortcodes/alert.html` with `{{ body }}` / `{{ type }}` Jinja refs
- `minimal_config_content`: title / `base_url` / processors plugin entries; taxonomies block default-on / opt-out; light highlight theme via default `config_highlight_theme`

### Note on shared helpers

The issue suggests "Consider a shared test helper given scaffold similarity." Existing `scaffolds_spec.cr` follows a per-scaffold-`describe` pattern with repetitive setup; this PR mirrors that convention. A shared helper would be a separate refactor across all 6+ scaffold specs and is out of scope here.

Closes #334

## Test plan
- [x] `crystal spec spec/unit/scaffolds_book_spec.cr` — 29 examples pass
- [x] `crystal spec spec/unit/scaffolds_book_spec.cr spec/unit/scaffolds_spec.cr spec/unit/scaffolds_{bare,blog,docs}_spec.cr spec/unit/scaffold_registry_spec.cr spec/unit/remote_scaffold_spec.cr` — 180 examples pass together
- [ ] CI on Crystal 1.19.0 / 1.20.0