### PR TITLE
fix: avoid stray dots in `init` output for current directory

### DIFF
--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -68,7 +68,8 @@ module Hwaro
           exit(1)
         end
 
-        Logger.info "Initializing new Hwaro project in #{target_path}..."
+        target_label = target_path == "." ? "current directory" : "'#{target_path}'"
+        Logger.info "Initializing new Hwaro project in #{target_label}..."
         Logger.info "Using scaffold: #{scaffold.description}"
 
         is_multilingual = multilingual_languages.size > 1


### PR DESCRIPTION
## Summary
- `hwaro init` without a path logged `Initializing new Hwaro project in ....` because the default path (`.`) was concatenated with the ellipsis.
- Render `.` as `current directory` and quote other paths for a cleaner, unambiguous message.

## Test plan
- [x] `hwaro init` in an empty dir now prints `Initializing new Hwaro project in current directory...`
- [x] `hwaro init /tmp/somepath` prints `Initializing new Hwaro project in '/tmp/somepath'...`
- [x] `just build` succeeds

Closes #348