### PR TITLE
fix: avoid interactive prompt hang in non-TTY environments for `hwaro new`

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -236,6 +236,24 @@ describe Hwaro::Services::Creator do
       end
     end
 
+    it "fails fast in non-TTY environments when title cannot be inferred" do
+      # Running under `crystal spec`, STDIN is not a TTY. The Creator must
+      # raise a clear usage error instead of hanging on `gets` at the
+      # interactive "Enter title:" prompt.
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+
+          options = Hwaro::Config::Options::NewOptions.new
+          creator = Hwaro::Services::Creator.new
+
+          expect_raises(Exception, /missing --title/) do
+            creator.run(options)
+          end
+        end
+      end
+    end
+
     it "creates a file from a directory path using title slug" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -38,6 +38,17 @@ module Hwaro
 
         def run(args : Array(String))
           options = parse_options(args)
+
+          # Fail fast in non-TTY environments when required input would be missing.
+          # Without this, Services::Creator falls back to an interactive `gets`
+          # prompt that hangs in CI, agent runs, or `hwaro new < /dev/null`.
+          if options.path.nil? && !STDIN.tty?
+            STDERR.puts "Error: missing <path> argument"
+            STDERR.puts "Usage: hwaro new <path> [options]"
+            STDERR.puts "Run 'hwaro new --help' for details."
+            exit(2)
+          end
+
           Services::Creator.new.run(options)
         end
 

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -63,10 +63,16 @@ module Hwaro
           end
         end
 
-        # Prompt for title if still empty and no file path
+        # Prompt for title if still empty and no file path.
+        # Only prompt when stdin is an interactive TTY — otherwise fail fast
+        # so CI/agent environments don't hang on `gets`.
         if !full_path && title.empty?
-          print "Enter title: "
-          title = gets.try(&.chomp) || ""
+          if STDIN.tty?
+            print "Enter title: "
+            title = gets.try(&.chomp) || ""
+          else
+            raise "missing --title (or <path>.md) argument\nUsage: hwaro new <path> [options]\nRun 'hwaro new --help' for details."
+          end
         end
 
         if !full_path


### PR DESCRIPTION
## Summary
- `hwaro new` with no `<path>` argument used to fall through to an interactive `Enter title:` prompt via `gets`, which hangs in non-TTY contexts like CI, agent runs, or `hwaro new < /dev/null`.
- `NewCommand#run` now checks `STDIN.tty?` and, when the path argument is missing and stdin is not a TTY, prints a usage hint to stderr and exits with code `2` (usage error).
- `Services::Creator` likewise only invokes the interactive prompt when a TTY is attached; otherwise it raises a clear usage error so the "path is a directory with no title" path also fails fast instead of blocking on `gets`.
- Existing interactive behavior is preserved when a TTY is attached.

## Behavior
Non-TTY, missing path:
```
$ hwaro new < /dev/null
Error: missing <path> argument
Usage: hwaro new <path> [options]
Run 'hwaro new --help' for details.
$ echo $?
2
```

Happy path still works:
```
$ hwaro new posts/hello.md --title "x"
```

## Test plan
- [x] `crystal spec spec/unit/` passes (4044 examples, 0 failures).
- [x] Added a regression spec in `spec/unit/creator_spec.cr` that asserts `Services::Creator#run` raises a clear usage error under non-TTY stdin when title cannot be inferred.
- [x] Manual: `bin/hwaro new < /dev/null` exits with code 2 and prints the usage error instead of hanging.
- [x] Manual: `bin/hwaro new --help` still prints the help text.

Closes #350

---
비-TTY 환경에서 `hwaro new`가 stdin 프롬프트로 멈추지 않고 사용법 오류와 종료 코드 2로 즉시 실패하도록 수정했습니다.