### PR TITLE
fix: remove spurious feeds.filename doctor warning

### DIFF
--- a/docs/content/start/tools/doctor.md
+++ b/docs/content/start/tools/doctor.md
@@ -44,7 +44,6 @@ hwaro doctor --json
 - `base_url` doesn't start with `http://` or `https://`
 - `base_url` has a trailing slash
 - `title` is still the default value
-- `feeds.enabled` is true but `feeds.filename` is empty
 - `sitemap.changefreq` has an invalid value
 - `sitemap.priority` is out of range (0.0–1.0)
 - Duplicate taxonomy names
@@ -69,12 +68,11 @@ Running diagnostics...
 
 Config:
   ⚠ config.toml: base_url is not set
-  ⚠ config.toml: feeds.enabled is true but feeds.filename is not set
 
 Structure:
   ℹ content/docs: Section directory missing _index.md: docs/
 
-Found 0 error(s), 2 warning(s), 1 info(s)
+Found 0 error(s), 1 warning(s), 1 info(s)
 
 Tip: Use 'hwaro tool validate' for content checks
 ```
@@ -103,7 +101,6 @@ Use `hwaro doctor --json` to find rule IDs in the output. Ignored issues are com
 | `base-url-scheme` | config | base_url doesn't start with http(s) |
 | `base-url-trailing-slash` | config | base_url has trailing slash |
 | `title-default` | config | Title is still default value |
-| `feeds-filename-missing` | config | feeds.enabled but filename empty |
 | `sitemap-changefreq-invalid` | config | Invalid sitemap.changefreq |
 | `sitemap-priority-range` | config | sitemap.priority out of range |
 | `taxonomy-duplicate` | config | Duplicate taxonomy name |

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -52,9 +52,9 @@ describe Hwaro::Services::Doctor do
         issues.any? { |i| i.message.includes?("default value") }.should be_false
       end
 
-      it "warns when feeds enabled but filename empty" do
+      it "does not warn when feeds enabled with empty filename (uses runtime default)" do
         issues = run_doctor(base_config("\n[feeds]\nenabled = true\nfilename = \"\"\n"))
-        issues.any? { |i| i.message.includes?("feeds.filename") }.should be_true
+        issues.any? { |i| i.message.includes?("feeds.filename") }.should be_false
       end
 
       it "does not warn when feeds disabled" do

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -173,11 +173,6 @@ module Hwaro
           issues << Issue.new(id: "title-default", level: :warning, category: "config", file: @config_path, message: "title is still the default value \"Hwaro Site\"")
         end
 
-        # feeds: enabled but filename empty
-        if config.feeds.enabled && config.feeds.filename.empty?
-          issues << Issue.new(id: "feeds-filename-missing", level: :warning, category: "config", file: @config_path, message: "feeds.enabled is true but feeds.filename is not set")
-        end
-
         # sitemap changefreq validity
         unless VALID_CHANGEFREQS.includes?(config.sitemap.changefreq)
           issues << Issue.new(id: "sitemap-changefreq-invalid", level: :warning, category: "config", file: @config_path,


### PR DESCRIPTION
## Summary

- A fresh `hwaro init` followed by `hwaro doctor` always emitted `feeds.enabled is true but feeds.filename is not set`, contradicting the scaffold's own generated config (`filename = ""` is shipped with a comment that explicitly states "Leave empty for default").
- The runtime already treats an empty `feeds.filename` as "use the default for `feeds.type`" — `src/content/seo/feeds.cr` falls back to `rss.xml` or `atom.xml`, and `process_feed` does the same for `custom_filename`. The doctor rule was therefore spurious.
- Removed the `feeds-filename-missing` check from `Doctor`, flipped the relevant spec to assert the warning is *not* produced, and updated `docs/content/start/tools/doctor.md` (rule list, example output, diagnostics bullet).

## Test plan

- [x] `crystal spec spec/unit/doctor_spec.cr` — 43 examples, 0 failures
- [x] `crystal spec` — 4360 examples, 0 failures
- [ ] Manual: `cd $(mktemp -d) && hwaro init && hwaro doctor` reports zero warnings on a fresh scaffold (and likewise for `--scaffold blog` / `docs` / `book`)

Closes #349

---

기본 스캐폴드가 `filename = ""`로 RSS/Atom 기본 파일명 사용을 의도하고 있어 doctor 규칙을 제거했습니다.