### PR TITLE
feat: show configured deploy targets in `deploy --help`

### DIFF
--- a/spec/unit/deploy_command_spec.cr
+++ b/spec/unit/deploy_command_spec.cr
@@ -64,4 +64,60 @@ describe Hwaro::CLI::Commands::DeployCommand do
       options.targets.should eq(["production"])
     end
   end
+
+  describe "#configured_targets_hint" do
+    it "returns empty string when config.toml is missing" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      Dir.mktmpdir do |dir|
+        missing = File.join(dir, "missing.toml")
+        cmd.configured_targets_hint(nil, missing).should eq("")
+      end
+    end
+
+    it "reports no targets when config has none" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.toml")
+        File.write(path, "title = \"Empty\"\n")
+        hint = cmd.configured_targets_hint(nil, path)
+        hint.should contain("Configured targets")
+        hint.should contain("(none defined in")
+      end
+    end
+
+    it "lists configured deployment targets" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.toml")
+        File.write(path, <<-TOML)
+        title = "Demo"
+
+        [[deployment.targets]]
+        name = "production"
+        url = "s3://my-bucket"
+
+        [[deployment.targets]]
+        name = "staging"
+        url = "netlify:site-id"
+        TOML
+
+        hint = cmd.configured_targets_hint(nil, path)
+        hint.should contain("Configured targets (from")
+        hint.should contain("production")
+        hint.should contain("s3://my-bucket")
+        hint.should contain("staging")
+        hint.should contain("netlify:site-id")
+      end
+    end
+
+    it "returns a friendly note when config.toml cannot be parsed" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.toml")
+        File.write(path, "this is = = invalid toml [[\n")
+        hint = cmd.configured_targets_hint(nil, path)
+        hint.should contain("could not read")
+      end
+    end
+  end
 end

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -66,7 +66,12 @@ module Hwaro
             parser.on("--max-deletes N", "Maximum number of deletes (default: deployment.maxDeletes or 256, -1 disables)") { |n| max_deletes = n.to_i }
             parser.on("--list-targets", "List configured deployment targets and exit") { list_targets = true }
             CLI.register_flag(parser, ENV_FLAG) { |v| env_name = v }
-            CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
+            CLI.register_flag(parser, HELP_FLAG) do |_|
+              Logger.info parser.to_s
+              hint = configured_targets_hint(env_name)
+              Logger.info hint unless hint.empty?
+              exit
+            end
           end
 
           targets = args.dup
@@ -95,10 +100,41 @@ module Hwaro
 
           Logger.info "Deployment targets:"
           deployment.targets.each do |t|
-            url = t.url.empty? ? "(no url)" : t.url
-            extra = t.command ? " (command)" : ""
-            Logger.info "  #{t.name.ljust(16)} #{url}#{extra}"
+            Logger.info "  #{t.name.ljust(16)} #{format_target_destination(t)}"
           end
+        end
+
+        # Builds the "Configured targets" hint appended to `--help` output.
+        # Returns an empty string when no `config.toml` is present so help stays
+        # unchanged outside of project directories. Parsing failures surface a
+        # friendly note instead of aborting `--help`.
+        def configured_targets_hint(env : String?, config_path : String = "config.toml") : String
+          return "" unless File.exists?(config_path)
+
+          begin
+            config = Models::Config.load(config_path, env: env)
+          rescue ex
+            return "\nConfigured targets: (could not read #{config_path}: #{ex.message})"
+          end
+
+          targets = config.deployment.targets
+          if targets.empty?
+            return "\nConfigured targets: (none defined in #{config_path})"
+          end
+
+          String.build do |str|
+            str << "\nConfigured targets (from " << config_path << "):\n"
+            targets.each do |t|
+              str << "  " << t.name.ljust(16) << ' ' << format_target_destination(t) << '\n'
+            end
+          end
+        end
+
+        # Render the most informative destination string for a deployment target.
+        private def format_target_destination(target : Models::DeploymentTarget) : String
+          url = target.url.empty? ? "(no url)" : target.url
+          extra = target.command ? " (command)" : ""
+          "#{url}#{extra}"
         end
       end
     end


### PR DESCRIPTION
## Summary
- Append a `Configured targets` section to `hwaro deploy --help` when the current directory has a readable `config.toml`, so users can see valid target arguments without running `--list-targets` separately.
- Gracefully handle the three cases: missing config (unchanged help), empty targets list (`(none defined in …)` note), parse failure (friendly `(could not read …)` note; `--help` never fails).
- Factor shared target-destination formatting out of `print_targets` so `--list-targets` and `--help` stay in sync.

## Test plan
- [x] `crystal spec` — all 4364 specs pass, including new coverage for `configured_targets_hint` (missing file, empty targets, populated targets, malformed TOML).
- [x] `just build` — binary builds cleanly.
- [ ] Manual smoke: run `bin/hwaro deploy --help` in a directory without `config.toml` (help unchanged), inside `docs/` (shows `(none defined)` since targets are commented out), and inside a project with active `[[deployment.targets]]` entries (shows the listing).

Closes #355

---
`deploy --help` 에서 현재 프로젝트에 설정된 배포 타겟이 바로 보이도록 하여 `--list-targets` 별도 호출 없이 유효한 인자를 확인할 수 있습니다.