### PR TITLE
feat: suggest closest match on unknown command/subcommand

### DIFF
--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -64,10 +64,28 @@ describe "hwaro tool (router)" do
     output.should contain("subcommand")
   end
 
-  it "exits 1 and prints 'Unknown subcommand' for unrecognized names" do
-    status, output, _ = run_hwaro_no_chdir(["tool", "nonexistent-subcommand"])
+  it "exits 2 and prints a concise unknown-command error to stderr" do
+    status, output, error = run_hwaro_no_chdir(["tool", "nonexistent-subcommand"])
     status.success?.should be_false
-    output.should contain("Unknown subcommand")
+    status.exit_code.should eq(2)
+    # Concise error goes to stderr, not stdout — the full help/banner
+    # must NOT be dumped on a typo.
+    error.should contain("unknown command 'tool nonexistent-subcommand'")
+    error.should contain("hwaro tool --help")
+    output.should_not contain("Available subcommands")
+  end
+
+  it "suggests the closest subcommand for near-miss typos" do
+    status, _, error = run_hwaro_no_chdir(["tool", "stts"])
+    status.exit_code.should eq(2)
+    error.should contain("Did you mean 'stats'?")
+  end
+
+  it "omits the suggestion when no candidate is close" do
+    status, _, error = run_hwaro_no_chdir(["tool", "xyzabc"])
+    status.exit_code.should eq(2)
+    error.should_not contain("Did you mean")
+    error.should contain("hwaro tool --help")
   end
 
   it "prints help and exits 0 when invoked with help" do

--- a/spec/unit/command_suggester_spec.cr
+++ b/spec/unit/command_suggester_spec.cr
@@ -1,0 +1,67 @@
+require "../spec_helper"
+
+# =============================================================================
+# Unit spec for Hwaro::Utils::CommandSuggester — used by the CLI to provide
+# "Did you mean" hints on mistyped commands / subcommands.
+# =============================================================================
+
+describe Hwaro::Utils::CommandSuggester do
+  describe ".levenshtein" do
+    it "returns 0 for identical strings" do
+      Hwaro::Utils::CommandSuggester.levenshtein("build", "build").should eq(0)
+    end
+
+    it "returns edit distance for a single transposition-like typo" do
+      # "buidl" → "build" is 2 single-char edits (adjacent transposition).
+      Hwaro::Utils::CommandSuggester.levenshtein("buidl", "build").should eq(2)
+    end
+
+    it "returns the length when one string is empty" do
+      Hwaro::Utils::CommandSuggester.levenshtein("", "build").should eq(5)
+      Hwaro::Utils::CommandSuggester.levenshtein("build", "").should eq(5)
+    end
+
+    it "counts pure insertions" do
+      Hwaro::Utils::CommandSuggester.levenshtein("buid", "build").should eq(1)
+    end
+  end
+
+  describe ".suggest" do
+    it "returns the closest candidate within distance 2" do
+      Hwaro::Utils::CommandSuggester.suggest(
+        "buidl", ["init", "build", "serve", "deploy"]
+      ).should eq("build")
+    end
+
+    it "suggests 'stats' for 'stts'" do
+      Hwaro::Utils::CommandSuggester.suggest(
+        "stts", ["stats", "validate", "list", "convert"]
+      ).should eq("stats")
+    end
+
+    it "returns nil when no candidate is close" do
+      Hwaro::Utils::CommandSuggester.suggest(
+        "xyzabc", ["init", "build", "serve"]
+      ).should be_nil
+    end
+
+    it "returns nil for an empty input" do
+      Hwaro::Utils::CommandSuggester.suggest(
+        "", ["init", "build"]
+      ).should be_nil
+    end
+
+    it "leverages shared-prefix heuristic for short inputs" do
+      # Edit distance between "bld" and "build" is 2, but shared prefix 'b'
+      # alone is 1 char. Shared-prefix >= 3 lets longer near-misses qualify
+      # without flagging every one-letter abbreviation.
+      Hwaro::Utils::CommandSuggester.suggest(
+        "buil", ["init", "build", "serve"]
+      ).should eq("build")
+    end
+
+    it "returns nil when there are no candidates" do
+      Hwaro::Utils::CommandSuggester.suggest("anything", [] of String).should be_nil
+    end
+  end
+end

--- a/src/cli/commands/tool_command.cr
+++ b/src/cli/commands/tool_command.cr
@@ -33,6 +33,7 @@ require "./tool/validate_command"
 require "./tool/unused_assets_command"
 require "./tool/agents_md_command"
 require "../../utils/logger"
+require "../../utils/command_suggester"
 
 module Hwaro
   module CLI
@@ -101,11 +102,22 @@ module Hwaro
             if handler = @@sub_handlers[subcommand]?
               handler.call(args)
             else
-              Logger.error "Unknown subcommand: #{subcommand}"
-              print_help
-              exit(1)
+              ToolCommand.report_unknown_subcommand(subcommand)
+              exit(2)
             end
           end
+        end
+
+        # Concise unknown-subcommand error emitted to stderr, mirroring the
+        # top-level Runner behavior. No full help dump here — users can run
+        # `hwaro tool --help` to see every subcommand.
+        def self.report_unknown_subcommand(subcommand : String, io : IO = STDERR)
+          io.puts "Error: unknown command 'tool #{subcommand}'"
+          candidates = ToolCommand.subcommands.map(&.name)
+          if suggestion = Utils::CommandSuggester.suggest(subcommand, candidates)
+            io.puts "Did you mean '#{suggestion}'?"
+          end
+          io.puts "Run 'hwaro tool --help' to see all subcommands."
         end
 
         # Category display order and membership for help output

--- a/src/cli/runner.cr
+++ b/src/cli/runner.cr
@@ -8,6 +8,7 @@ require "./commands/tool_command"
 require "./commands/doctor_command"
 require "./commands/completion_command"
 require "../utils/logger"
+require "../utils/command_suggester"
 
 module Hwaro
   module CLI
@@ -84,9 +85,8 @@ module Hwaro
           if handler = CommandRegistry.get(command)
             handler.call(args)
           else
-            Logger.error "Unknown command: #{command}"
-            Runner.print_help
-            exit(1)
+            Runner.report_unknown_command(command)
+            exit(2)
           end
         end
       rescue ex : OptionParser::InvalidOption
@@ -147,6 +147,17 @@ module Hwaro
         CommandRegistry.register(CommandInfo.new(name: "help", description: "Show help")) do |_|
           Runner.print_help
         end
+      end
+
+      # Write a concise unknown-command error to stderr with an optional
+      # "Did you mean" suggestion. Intentionally avoids dumping the ASCII
+      # banner or full command list — users can run `hwaro --help` for that.
+      def self.report_unknown_command(command : String, io : IO = STDERR)
+        io.puts "Error: unknown command '#{command}'"
+        if suggestion = Utils::CommandSuggester.suggest(command, CommandRegistry.names)
+          io.puts "Did you mean '#{suggestion}'?"
+        end
+        io.puts "Run 'hwaro --help' to see all commands."
       end
 
       def self.print_help

--- a/src/utils/command_suggester.cr
+++ b/src/utils/command_suggester.cr
@@ -1,0 +1,83 @@
+# Command suggester utility
+#
+# Suggests the closest match from a list of candidates for a mistyped
+# command. Uses Levenshtein distance with a small threshold, and falls
+# back to a shared-prefix heuristic so very short inputs still get useful
+# hints (e.g. "bld" -> "build").
+#
+# Keep the implementation tiny — the candidate list is always small
+# (a few dozen entries at most).
+
+module Hwaro
+  module Utils
+    module CommandSuggester
+      extend self
+
+      # Return the closest candidate to `input`, or nil when no candidate
+      # is close enough to confidently suggest.
+      def suggest(input : String, candidates : Enumerable(String)) : String?
+        return nil if input.empty?
+
+        best : String? = nil
+        best_distance = Int32::MAX
+
+        candidates.each do |candidate|
+          distance = levenshtein(input, candidate)
+          if distance < best_distance
+            best_distance = distance
+            best = candidate
+          end
+        end
+
+        return nil if best.nil?
+
+        # Accept the match if it is close by edit distance, or if the
+        # input and candidate share a meaningful (>= 3 char) prefix.
+        if best_distance <= 2
+          best
+        elsif shared_prefix_length(input, best) >= 3 &&
+              best_distance <= (input.size // 2 + 1)
+          best
+        end
+      end
+
+      # Simple iterative Levenshtein distance over UTF-8 chars.
+      def levenshtein(a : String, b : String) : Int32
+        return b.size if a.empty?
+        return a.size if b.empty?
+
+        a_chars = a.chars
+        b_chars = b.chars
+        m = a_chars.size
+        n = b_chars.size
+
+        prev = Array(Int32).new(n + 1) { |j| j }
+        curr = Array(Int32).new(n + 1, 0)
+
+        m.times do |i|
+          curr[0] = i + 1
+          n.times do |j|
+            cost = a_chars[i] == b_chars[j] ? 0 : 1
+            curr[j + 1] = Math.min(
+              Math.min(curr[j] + 1, prev[j + 1] + 1),
+              prev[j] + cost
+            )
+          end
+          prev, curr = curr, prev
+        end
+
+        prev[n]
+      end
+
+      private def shared_prefix_length(a : String, b : String) : Int32
+        count = 0
+        a.each_char_with_index do |ch, i|
+          break if i >= b.size
+          break if ch != b[i]
+          count += 1
+        end
+        count
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `hwaro <typo>` and `hwaro tool <typo>` no longer dump the ASCII banner + full command list. The dispatcher now writes a concise `Error: unknown command '...'` to stderr and exits with code 2 (usage error).
- When a close match exists we append `Did you mean '...'?`. A match is considered close if the Levenshtein distance to the typed input is at most 2, or if the input shares a >= 3-char prefix with a candidate (so very short near-misses like `buil` still resolve to `build`). Only the single best candidate is ever suggested.
- Both the top-level `Runner` dispatch and the `tool` subcommand router share a new `Hwaro::Utils::CommandSuggester` helper, so suggestions stay consistent across the two call sites.
- `hwaro --help` and `hwaro tool --help` are untouched — the full banner / subcommand listing is still available on demand.

## Test plan
- [x] `crystal spec spec/unit/command_suggester_spec.cr` — new unit coverage for the Levenshtein + shared-prefix heuristic
- [x] `crystal spec spec/functional/cli_tool_subcommands_spec.cr` — functional specs updated to assert exit code 2, stderr output, suggestion on `tool stts`, and no suggestion on `tool xyzabc`
- [x] `crystal spec` — full suite (4372 examples) green
- [x] `just build` succeeds

Closes #351

---

이슈 #351 대응: 오타 입력 시 긴 배너와 전체 명령 목록 대신 짧은 에러와 가장 가까운 후보 하나를 제시하도록 디스패처를 단순화했습니다.