### PR TITLE
feat: emit deterministic ready signal from hwaro serve

### DIFF
--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -11,6 +11,10 @@ module Hwaro
       def test_sanitize_output_dir(dir : String)
         sanitize_output_dir(dir)
       end
+
+      def test_ready_signal_line(host : String, port : Int32) : String
+        ready_signal_line(host, port)
+      end
     end
   end
 end
@@ -54,6 +58,32 @@ describe Hwaro::Services::Server do
     it "defaults to 'public' for absolute paths" do
       server = Hwaro::Services::Server.new
       server.test_sanitize_output_dir("/foo").should eq("public")
+    end
+  end
+
+  describe "#ready_signal_line" do
+    it "formats a single deterministic ready line with url and pid" do
+      server = Hwaro::Services::Server.new
+      line = server.test_ready_signal_line("127.0.0.1", 3000)
+      line.should eq("hwaro serve: ready url=http://127.0.0.1:3000 pid=#{Process.pid}")
+    end
+
+    it "is a single line (no embedded newlines)" do
+      server = Hwaro::Services::Server.new
+      line = server.test_ready_signal_line("127.0.0.1", 4567)
+      line.includes?('\n').should be_false
+    end
+
+    it "contains no ANSI color escape codes" do
+      server = Hwaro::Services::Server.new
+      line = server.test_ready_signal_line("0.0.0.0", 8080)
+      line.includes?('\e').should be_false
+    end
+
+    it "reflects the requested host and port" do
+      server = Hwaro::Services::Server.new
+      line = server.test_ready_signal_line("0.0.0.0", 8080)
+      line.should contain("url=http://0.0.0.0:8080")
     end
   end
 end

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -296,7 +296,35 @@ module Hwaro
         server = HTTP::Server.new(handlers)
 
         address = server.bind_tcp host, port
+        emit_ready_signal(host, port)
         server.listen
+      end
+
+      # Emit a single deterministic, machine-parseable line indicating the
+      # server is bound and ready to accept connections. Scripts and agents
+      # can block on this line to know when `hwaro serve` is ready.
+      #
+      # Emitted AFTER `bind_tcp` succeeds (so the OS-level listening socket
+      # already accepts connections) and BEFORE `listen` starts the blocking
+      # accept loop. Written directly to STDOUT (no color, no log prefix) and
+      # flushed immediately so subprocess consumers see it without buffering
+      # delay.
+      #
+      # Coexists with the pretty "Serving site at …" banner logged earlier —
+      # this is an additional single line, not a replacement.
+      #
+      # See issue #360. A JSON variant will be added alongside the global
+      # `--json` flag in issue #356.
+      private def emit_ready_signal(host : String, port : Int32)
+        STDOUT.puts ready_signal_line(host, port)
+        STDOUT.flush
+      end
+
+      # Build the deterministic ready-signal line. Kept separate from
+      # `emit_ready_signal` so specs can assert on the format without
+      # capturing stdout.
+      protected def ready_signal_line(host : String, port : Int32) : String
+        "hwaro serve: ready url=http://#{host}:#{port} pid=#{Process.pid}"
       end
 
       private def sanitize_output_dir(dir : String) : String


### PR DESCRIPTION
## Summary
- Emit a single, machine-parseable line on stdout once the dev server is bound and ready to accept connections: `hwaro serve: ready url=http://127.0.0.1:3000 pid=12345`.
- Line is written after `bind_tcp` succeeds (socket is already listening at the OS level) and before `listen` starts its blocking accept loop, so subprocess consumers can deterministically block on it.
- Written directly to STDOUT (no color, no log prefix) and flushed, coexisting with the existing pretty `Serving site at …` banner.

## Why
Scripts and agents that spawn `hwaro serve` currently have no reliable stdout line to wait on, forcing them to poll the port or sleep arbitrarily before issuing requests. This gives them a single deterministic marker to block on.

## Notes
- `--json` is not a global flag today, so JSON output is intentionally deferred to the follow-up in #356, as suggested in the issue.
- Optional `reload` event for rebuilds was skipped to keep the PR small; it can be added alongside the JSON variant.

## Test plan
- [x] `just build` succeeds
- [x] `crystal spec` — 4364 examples, 0 failures (includes 4 new specs covering the ready-line format, single-line invariant, and absence of ANSI escapes)
- [ ] Manual smoke: spawn `hwaro serve --port 4567` in background and grep stdout for `hwaro serve: ready url=http://127.0.0.1:4567`

---

한국어: `hwaro serve`가 소켓 바인드 완료 직후 `hwaro serve: ready url=… pid=…` 한 줄을 표준출력에 내보내 스크립트/에이전트가 준비 완료 시점을 결정적으로 감지할 수 있게 합니다.

Closes #360