### PR TITLE
feat: add JSON introspection for scaffolds, archetypes, deploy targets

### DIFF
--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -45,6 +45,8 @@ Remote scaffolds fetch `config.toml`, `templates/`, `static/`, and content struc
 | --skip-sample-content | Skip creating sample content files |
 | --skip-taxonomies | Skip taxonomies configuration and templates |
 | --include-multilingual LANGS | Enable multilingual support (e.g., `en,ko,ja`) |
+| --list-scaffolds | List available built-in scaffolds and exit |
+| --json | Emit machine-readable JSON output (with --list-scaffolds) |
 
 ### new
 
@@ -70,6 +72,8 @@ Creates a Markdown file with front matter template. Supports **archetypes** for 
 | --tags TAGS | Comma-separated tags |
 | -s, --section NAME | Section directory (e.g. `blog`, `docs`) |
 | -a, --archetype NAME | Archetype to use |
+| --list-archetypes | List archetypes in the current project and exit |
+| --json | Emit machine-readable JSON output (with --list-archetypes) |
 
 **Archetypes:**
 
@@ -258,6 +262,7 @@ hwaro deploy --dry-run
 | --force | Force upload/copy (ignore file comparisons) |
 | --max-deletes N | Maximum number of deletes (default: deployment.maxDeletes or 256, -1 disables) |
 | --list-targets | List configured deployment targets and exit |
+| --json | Emit machine-readable JSON output (with --list-targets) |
 
 ### doctor
 

--- a/spec/unit/deploy_command_spec.cr
+++ b/spec/unit/deploy_command_spec.cr
@@ -5,7 +5,7 @@ describe Hwaro::CLI::Commands::DeployCommand do
   describe "#parse_options" do
     it "returns default options" do
       cmd = Hwaro::CLI::Commands::DeployCommand.new
-      options, list_targets = cmd.parse_options([] of String)
+      options, list_targets, json_output = cmd.parse_options([] of String)
 
       options.source_dir.should be_nil
       options.dry_run.should be_nil
@@ -14,20 +14,21 @@ describe Hwaro::CLI::Commands::DeployCommand do
       options.max_deletes.should be_nil
       options.targets.should be_empty
       list_targets.should be_false
+      json_output.should be_false
     end
 
     it "parses source directory" do
       cmd = Hwaro::CLI::Commands::DeployCommand.new
-      options, _ = cmd.parse_options(["--source", "dist"])
+      options, _, _ = cmd.parse_options(["--source", "dist"])
       options.source_dir.should eq("dist")
 
-      options, _ = cmd.parse_options(["-s", "public"])
+      options, _, _ = cmd.parse_options(["-s", "public"])
       options.source_dir.should eq("public")
     end
 
     it "parses boolean flags" do
       cmd = Hwaro::CLI::Commands::DeployCommand.new
-      options, _ = cmd.parse_options(["--dry-run", "--confirm", "--force"])
+      options, _, _ = cmd.parse_options(["--dry-run", "--confirm", "--force"])
 
       options.dry_run.should be_true
       options.confirm.should be_true
@@ -36,28 +37,34 @@ describe Hwaro::CLI::Commands::DeployCommand do
 
     it "parses max deletes" do
       cmd = Hwaro::CLI::Commands::DeployCommand.new
-      options, _ = cmd.parse_options(["--max-deletes", "10"])
+      options, _, _ = cmd.parse_options(["--max-deletes", "10"])
       options.max_deletes.should eq(10)
 
-      options, _ = cmd.parse_options(["--max-deletes", "-1"])
+      options, _, _ = cmd.parse_options(["--max-deletes", "-1"])
       options.max_deletes.should eq(-1)
     end
 
     it "parses list targets" do
       cmd = Hwaro::CLI::Commands::DeployCommand.new
-      _, list_targets = cmd.parse_options(["--list-targets"])
+      _, list_targets, _ = cmd.parse_options(["--list-targets"])
       list_targets.should be_true
+    end
+
+    it "parses json flag" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+      _, _, json_output = cmd.parse_options(["--list-targets", "--json"])
+      json_output.should be_true
     end
 
     it "parses positional arguments as targets" do
       cmd = Hwaro::CLI::Commands::DeployCommand.new
-      options, _ = cmd.parse_options(["production", "staging"])
+      options, _, _ = cmd.parse_options(["production", "staging"])
       options.targets.should eq(["production", "staging"])
     end
 
     it "parses mixed flags and arguments" do
       cmd = Hwaro::CLI::Commands::DeployCommand.new
-      options, _ = cmd.parse_options(["--dry-run", "production", "-s", "dist"])
+      options, _, _ = cmd.parse_options(["--dry-run", "production", "-s", "dist"])
 
       options.dry_run.should be_true
       options.source_dir.should eq("dist")

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -1,4 +1,5 @@
 require "option_parser"
+require "json"
 require "../metadata"
 require "../../config/options/deploy_options"
 require "../../models/config"
@@ -23,6 +24,7 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--force", description: "Force upload/copy (ignore file comparisons)"),
           FlagInfo.new(short: nil, long: "--max-deletes", description: "Maximum number of deletes (default: deployment.maxDeletes or 256, -1 disables)", takes_value: true, value_hint: "N"),
           FlagInfo.new(short: nil, long: "--list-targets", description: "List configured deployment targets and exit"),
+          FlagInfo.new(short: nil, long: "--json", description: "Emit machine-readable JSON output (with --list-targets)"),
           ENV_FLAG,
           HELP_FLAG,
         ]
@@ -38,9 +40,9 @@ module Hwaro
         end
 
         def run(args : Array(String))
-          options, list_targets = parse_options(args)
+          options, list_targets, json_output = parse_options(args)
           if list_targets
-            print_targets(options.env)
+            print_targets(options.env, json: json_output)
             return
           end
 
@@ -48,13 +50,14 @@ module Hwaro
           exit(1) unless ok
         end
 
-        def parse_options(args : Array(String)) : {Config::Options::DeployOptions, Bool}
+        def parse_options(args : Array(String)) : {Config::Options::DeployOptions, Bool, Bool}
           source_dir = nil.as(String?)
           dry_run = nil.as(Bool?)
           confirm = nil.as(Bool?)
           force = nil.as(Bool?)
           max_deletes = nil.as(Int32?)
           list_targets = false
+          json_output = false
           env_name = ENV["HWARO_ENV"]? || nil
 
           OptionParser.parse(args) do |parser|
@@ -65,6 +68,7 @@ module Hwaro
             parser.on("--force", "Force upload/copy (ignore file comparisons)") { force = true }
             parser.on("--max-deletes N", "Maximum number of deletes (default: deployment.maxDeletes or 256, -1 disables)") { |n| max_deletes = n.to_i }
             parser.on("--list-targets", "List configured deployment targets and exit") { list_targets = true }
+            parser.on("--json", "Emit machine-readable JSON output (with --list-targets)") { json_output = true }
             CLI.register_flag(parser, ENV_FLAG) { |v| env_name = v }
             CLI.register_flag(parser, HELP_FLAG) do |_|
               Logger.info parser.to_s
@@ -87,12 +91,36 @@ module Hwaro
               env: env_name,
             ),
             list_targets,
+            json_output,
           }
         end
 
-        private def print_targets(env : String? = nil)
-          config = Models::Config.load(env: env)
+        private def print_targets(env : String? = nil, json : Bool = false)
+          config = begin
+            Models::Config.load(env: env)
+          rescue ex
+            if json
+              STDOUT.puts({error: {message: ex.message || "Failed to load config"}}.to_json)
+            else
+              Logger.error(ex.message || "Failed to load config")
+            end
+            exit(1)
+          end
+
           deployment = config.deployment
+
+          if json
+            mapped = deployment.targets.map do |t|
+              {
+                name:    t.name,
+                url:     t.url,
+                command: t.command,
+              }
+            end
+            STDOUT.puts mapped.to_json
+            return
+          end
+
           if deployment.targets.empty?
             Logger.info "No deployment targets configured."
             return

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -1,7 +1,9 @@
 require "option_parser"
+require "json"
 require "../metadata"
 require "../../config/options/init_options"
 require "../../services/initializer"
+require "../../services/scaffolds/registry"
 require "../../services/scaffolds/remote"
 require "../../utils/logger"
 
@@ -29,6 +31,10 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--skip-sample-content", description: "Skip creating sample content files"),
           FlagInfo.new(short: nil, long: "--skip-taxonomies", description: "Skip taxonomies configuration and templates"),
 
+          # Introspection
+          FlagInfo.new(short: nil, long: "--list-scaffolds", description: "List available built-in scaffolds and exit"),
+          FlagInfo.new(short: nil, long: "--json", description: "Emit machine-readable JSON output (with --list-scaffolds)"),
+
           # Debug & output
           HELP_FLAG,
         ]
@@ -44,8 +50,36 @@ module Hwaro
         end
 
         def run(args : Array(String))
+          # Handle introspection flags before full option parsing so users can
+          # list scaffolds without supplying any other arguments.
+          if args.includes?("--list-scaffolds")
+            json_mode = args.includes?("--json")
+            print_scaffolds(json_mode)
+            return
+          end
+
           options = parse_options(args)
           Services::Initializer.new.run(options)
+        end
+
+        # Print the list of built-in scaffolds.
+        #
+        # Remote scaffolds are user-supplied (e.g. `github:owner/repo`) and
+        # cannot be enumerated without additional input, so only built-ins
+        # are listed here.
+        private def print_scaffolds(json : Bool)
+          entries = Services::Scaffolds::Registry.all.map do |scaffold|
+            {name: scaffold.type.to_s, description: scaffold.description, kind: "builtin"}
+          end
+
+          if json
+            STDOUT.puts entries.to_json
+          else
+            Logger.info "Available scaffolds:"
+            entries.each do |e|
+              Logger.info "  #{e[:name].ljust(10)} - #{e[:description]}"
+            end
+          end
         end
 
         def parse_options(args : Array(String)) : Config::Options::InitOptions

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -1,4 +1,5 @@
 require "option_parser"
+require "json"
 require "../metadata"
 require "../../config/options/new_options"
 require "../../services/creator"
@@ -23,6 +24,11 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--tags", description: "Comma-separated tags", takes_value: true, value_hint: "TAGS"),
           FlagInfo.new(short: "-s", long: "--section", description: "Section directory (e.g. blog, docs)", takes_value: true, value_hint: "NAME"),
           FlagInfo.new(short: "-a", long: "--archetype", description: "Archetype to use", takes_value: true, value_hint: "NAME"),
+
+          # Introspection
+          FlagInfo.new(short: nil, long: "--list-archetypes", description: "List archetypes available in the current project and exit"),
+          FlagInfo.new(short: nil, long: "--json", description: "Emit machine-readable JSON output (with --list-archetypes)"),
+
           HELP_FLAG,
         ]
 
@@ -36,7 +42,15 @@ module Hwaro
           )
         end
 
+        ARCHETYPES_DIR = "archetypes"
+
         def run(args : Array(String))
+          if args.includes?("--list-archetypes")
+            json_mode = args.includes?("--json")
+            print_archetypes(json_mode)
+            return
+          end
+
           options = parse_options(args)
 
           # Fail fast in non-TTY environments when required input would be missing.
@@ -50,6 +64,43 @@ module Hwaro
           end
 
           Services::Creator.new.run(options)
+        end
+
+        # Print archetypes found under the current project's archetypes/ dir.
+        # When the directory does not exist, the list is empty (not an error).
+        private def print_archetypes(json : Bool)
+          entries = discover_archetypes
+
+          if json
+            mapped = entries.map { |e| {name: e[:name], path: e[:path]} }
+            STDOUT.puts mapped.to_json
+          else
+            if entries.empty?
+              Logger.info "No archetypes found."
+              return
+            end
+
+            Logger.info "Available archetypes:"
+            entries.each do |e|
+              Logger.info "  #{e[:name].ljust(16)} #{e[:path]}"
+            end
+          end
+        end
+
+        private def discover_archetypes : Array(NamedTuple(name: String, path: String))
+          results = [] of NamedTuple(name: String, path: String)
+          return results unless Dir.exists?(ARCHETYPES_DIR)
+
+          Dir.glob(File.join(ARCHETYPES_DIR, "**", "*.md")).sort.each do |path|
+            # Strip the leading "archetypes/" segment and the ".md" suffix so
+            # the name matches how users pass it via --archetype.
+            prefix = "#{ARCHETYPES_DIR}/"
+            rel = path.starts_with?(prefix) ? path[prefix.size..] : path
+            name = rel.ends_with?(".md") ? rel[0...-3] : rel
+            results << {name: name, path: path}
+          end
+
+          results
         end
 
         def parse_options(args : Array(String)) : Config::Options::NewOptions


### PR DESCRIPTION
## Summary

Expose machine-readable lists on existing CLI surfaces so tooling (shell completions, IDE plugins, AI agents) can enumerate valid values without parsing `--help` text or `config.toml`.

- `hwaro init --list-scaffolds [--json]` — lists built-in scaffolds from `Services::Scaffolds::Registry`. Remote scaffolds are user-supplied sources and are not enumerable without additional input, so only builtins are reported (`kind: "builtin"`).
- `hwaro new --list-archetypes [--json]` — walks the current project's `archetypes/` directory. When the directory is missing, JSON output is `[]` rather than an error.
- `hwaro deploy --list-targets --json` — extends the existing `--list-targets` flag with a JSON form. If `config.toml` fails to load, emits `{"error":{"message":"..."}}` on stdout and exits `1`.

All JSON output goes to stdout only (no banner, colors, or extra text), and exits `0` on success.

The issue also mentioned an optional unified `hwaro introspect --json` capability manifest covering commands, flags, scaffolds, archetypes, and deploy targets in one shot. That is intentionally left as a follow-up so this PR stays narrowly scoped to the three discovery gaps.

Docs (`docs/content/start/cli.md`) updated to document the new flags.

## Test plan

- [x] `just build` succeeds
- [x] `crystal spec` — all 4361 examples pass
- [x] `bin/hwaro init --list-scaffolds --json | jq .` returns valid JSON array of 8 builtins
- [x] `bin/hwaro init --list-scaffolds` prints a human-readable list
- [x] `bin/hwaro new --list-archetypes --json` in a project without `archetypes/` returns `[]`
- [x] `bin/hwaro new --list-archetypes --json` in a project with `archetypes/default.md` and `archetypes/blog/post.md` returns both entries with `name` and `path`
- [x] `bin/hwaro deploy --list-targets --json` returns a valid JSON array of configured targets
- [x] With a broken `config.toml`, `bin/hwaro deploy --list-targets --json` prints `{"error":{"message":"..."}}` and exits `1`

---

Agent/completion 도구가 scaffold/archetype/deploy target 값을 프로그램적으로 조회할 수 있도록 세 CLI 표면에 JSON 출력을 추가합니다.

Closes #358