### PR TITLE
feat: make `hwaro new` flag-only (drop interactive title prompt)

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -236,15 +236,32 @@ describe Hwaro::Services::Creator do
       end
     end
 
-    it "fails fast in non-TTY environments when title cannot be inferred" do
-      # Running under `crystal spec`, STDIN is not a TTY. The Creator must
-      # raise a clear usage error instead of hanging on `gets` at the
-      # interactive "Enter title:" prompt.
+    it "fails fast when title cannot be inferred (flag-only, no prompt)" do
+      # `hwaro new` is flag-only: the Creator must raise a clear usage error
+      # rather than falling back to an interactive `gets` prompt. This holds
+      # in both TTY and non-TTY environments.
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do
           FileUtils.mkdir_p("content/drafts")
 
           options = Hwaro::Config::Options::NewOptions.new
+          creator = Hwaro::Services::Creator.new
+
+          expect_raises(Exception, /missing --title/) do
+            creator.run(options)
+          end
+        end
+      end
+    end
+
+    it "fails fast when path is a directory and title is missing" do
+      # Regression: `hwaro new posts/` (directory, no --title) should raise
+      # the same usage error since no title can be inferred from a directory.
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/blog")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "blog")
           creator = Hwaro::Services::Creator.new
 
           expect_raises(Exception, /missing --title/) do

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -53,10 +53,10 @@ module Hwaro
 
           options = parse_options(args)
 
-          # Fail fast in non-TTY environments when required input would be missing.
-          # Without this, Services::Creator falls back to an interactive `gets`
-          # prompt that hangs in CI, agent runs, or `hwaro new < /dev/null`.
-          if options.path.nil? && !STDIN.tty?
+          # `hwaro new` is flag-only: there is no interactive prompt, so a
+          # missing <path> always fails fast with a clear usage error. This
+          # keeps behavior identical across TTY, CI, and agent environments.
+          if options.path.nil?
             STDERR.puts "Error: missing <path> argument"
             STDERR.puts "Usage: hwaro new <path> [options]"
             STDERR.puts "Run 'hwaro new --help' for details."

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -21,7 +21,7 @@ module Hwaro
             full_path = File.join("content", section, path)
             full_path += ".md" unless full_path.ends_with?(".md")
           else
-            # No path given, will prompt for title below
+            # No path given; title must be supplied via --title.
             full_path = nil
           end
 
@@ -63,16 +63,11 @@ module Hwaro
           end
         end
 
-        # Prompt for title if still empty and no file path.
-        # Only prompt when stdin is an interactive TTY — otherwise fail fast
-        # so CI/agent environments don't hang on `gets`.
+        # Require `--title` (or an explicit `<path>.md`) whenever the title
+        # cannot be inferred. The `new` command is flag-only: no interactive
+        # prompts, so behavior is predictable in TTY, CI, and agent runs.
         if !full_path && title.empty?
-          if STDIN.tty?
-            print "Enter title: "
-            title = gets.try(&.chomp) || ""
-          else
-            raise "missing --title (or <path>.md) argument\nUsage: hwaro new <path> [options]\nRun 'hwaro new --help' for details."
-          end
+          raise "missing --title (or <path>.md) argument\nUsage: hwaro new <path> [options]\nRun 'hwaro new --help' for details."
         end
 
         if !full_path


### PR DESCRIPTION
## Summary

Closes #352. This PR removes the interactive `Enter title:` prompt from `hwaro new`, adopting **Option 1 (flag-only)** from the issue.

`hwaro new` previously prompted for `title` when missing, but never prompted for `section`, `tags`, `draft`, or `archetype` — users got a half-finished wizard and inconsistent UX. Going fully flag-only is simpler, more predictable, and pairs naturally with the TTY fix landed in #362 (issue #350).

### Behavior change (intentional)

- `hwaro new` with no `<path>` and no `--title` now fails fast with a clear usage error and exit code 2 in **both TTY and non-TTY** modes. It no longer drops into an interactive `gets` prompt.
- `hwaro new posts/hello.md --title "x"` — still works.
- `hwaro new posts/hello.md` — still works (title inferred from filename slug).
- `hwaro new posts/` (directory, no `--title`) — fails with the same clear usage error.

### Changes

- `src/services/creator.cr`: removed the `STDIN.tty?` / `Enter title:` / `gets` branch; a missing title now raises the usage error unconditionally.
- `src/cli/commands/new_command.cr`: the early-exit guard now fires whenever `options.path.nil?` regardless of TTY, since there is no longer an interactive fallback.
- `spec/unit/creator_spec.cr`: updated the existing non-TTY regression spec description (the assertion still applies to both TTY and non-TTY) and added a spec covering the directory-path + missing-title case.

## Test plan

- [x] `crystal spec` — 4383 examples, 0 failures.
- [x] `just build` succeeds.
- [x] `creator_spec` now asserts the error is raised in both TTY and non-TTY modes (no `STDIN.tty?` dependency in the test).

## Context

- Follow-up to #362 (TTY detection for `hwaro new`, issue #350).
- Implements Option 1 from #352: flag-only, no interactive wizard.

---

한국어 메모: `hwaro new` 의 대화형 title 입력 프롬프트를 제거하고, 누락 시 TTY 여부와 무관하게 바로 사용법 에러로 종료하도록 변경합니다 (이슈 #352 Option 1).