### PR TITLE
feat: enable live reload by default for `hwaro serve`

### DIFF
--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -190,14 +190,14 @@ When specified, Hwaro changes its working directory to the given path before bui
 
 ### serve
 
-Start a development server with live reload:
+Start a development server with live reload (enabled by default):
 
 ```bash
 hwaro serve
 hwaro serve --port 8080
 hwaro serve --open
 hwaro serve --access-log
-hwaro serve --live-reload
+hwaro serve --no-live-reload
 hwaro serve -i /path/to/my-site
 hwaro serve -i /path/to/my-site -p 8080
 ```
@@ -218,7 +218,8 @@ hwaro serve -i /path/to/my-site -p 8080
 | -v, --verbose | Show detailed output |
 | --debug | Print debug information after each rebuild |
 | --access-log | Show HTTP access log (e.g. GET requests) |
-| --live-reload | Enable browser live reload on file changes |
+| --live-reload | Enable browser live reload on file changes (default: enabled; kept for backwards compatibility) |
+| --no-live-reload | Disable browser live reload on file changes |
 | --cache | Enable build caching (skip unchanged files) |
 | --stream | Enable streaming build to reduce memory usage |
 | --memory-limit SIZE | Memory limit for streaming build (e.g. `2G`, `512M`) |
@@ -237,9 +238,11 @@ The server watches for file changes and rebuilds automatically. It uses **smart 
 | `static/` only | Static copy | Copies only changed static files |
 | Mixed / new / deleted files | Full rebuild | Rebuilds entire site |
 
-**About `--live-reload`:**
+**About live reload:**
 
-When enabled, the server injects a small WebSocket client script into every HTML response. After each successful rebuild, connected browsers automatically refresh the page — no manual reload needed. The client uses exponential backoff (1s–30s) for reconnection, so restarting the server won't break the connection permanently.
+Live reload is **enabled by default**. The server injects a small WebSocket client script into every HTML response, and after each successful rebuild, connected browsers automatically refresh the page — no manual reload needed. The client uses exponential backoff (1s–30s) for reconnection, so restarting the server won't break the connection permanently.
+
+Pass `--no-live-reload` to disable this behaviour (useful for testing production-like delivery locally). The `--live-reload` flag is kept as a no-op alias for backwards compatibility with existing invocations.
 
 When `-i` is specified, the server operates as if you had `cd`-ed into the given directory — watching and serving from that project root.
 
@@ -372,8 +375,8 @@ hwaro serve --drafts --verbose
 # Development with HTTP access log
 hwaro serve --access-log
 
-# Development with auto browser refresh
-hwaro serve --live-reload
+# Development without live reload (production-like serving)
+hwaro serve --no-live-reload
 
 # Production build
 hwaro build

--- a/spec/unit/serve_command_spec.cr
+++ b/spec/unit/serve_command_spec.cr
@@ -68,16 +68,22 @@ describe Hwaro::CLI::Commands::ServeCommand do
       options.port.should eq(4000)
     end
 
-    it "defaults live_reload to false" do
+    it "defaults live_reload to true" do
       cmd = Hwaro::CLI::Commands::ServeCommand.new
       _, options = cmd.test_parse_options([] of String)
-      options.live_reload.should be_false
+      options.live_reload.should be_true
     end
 
-    it "sets live_reload to true when --live-reload is passed" do
+    it "keeps live_reload true when --live-reload is passed (backwards compat no-op)" do
       cmd = Hwaro::CLI::Commands::ServeCommand.new
       _, options = cmd.test_parse_options(["--live-reload"])
       options.live_reload.should be_true
+    end
+
+    it "sets live_reload to false when --no-live-reload is passed" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options(["--no-live-reload"])
+      options.live_reload.should be_false
     end
 
     it "defaults skip_og_image to false" do
@@ -260,9 +266,22 @@ describe Hwaro::CLI::Commands::ServeCommand do
       flag_longs.should contain("--live-reload")
     end
 
+    it "has no-live-reload flag" do
+      meta = Hwaro::CLI::Commands::ServeCommand.metadata
+      flag_longs = meta.flags.map(&.long)
+      flag_longs.should contain("--no-live-reload")
+    end
+
     it "live-reload flag does not take a value" do
       meta = Hwaro::CLI::Commands::ServeCommand.metadata
       flag = meta.flags.find { |f| f.long == "--live-reload" }
+      flag.should_not be_nil
+      flag.not_nil!.takes_value.should be_false
+    end
+
+    it "no-live-reload flag does not take a value" do
+      meta = Hwaro::CLI::Commands::ServeCommand.metadata
+      flag = meta.flags.find { |f| f.long == "--no-live-reload" }
       flag.should_not be_nil
       flag.not_nil!.takes_value.should be_false
     end

--- a/spec/unit/serve_options_spec.cr
+++ b/spec/unit/serve_options_spec.cr
@@ -17,7 +17,7 @@ describe Hwaro::Config::Options::ServeOptions do
       opts.debug.should be_false
       opts.access_log.should be_false
       opts.error_overlay.should be_true
-      opts.live_reload.should be_false
+      opts.live_reload.should be_true
       opts.profile.should be_false
       opts.cache_busting.should be_true
       opts.env.should be_nil

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -38,7 +38,8 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--open", description: "Open browser after starting server"),
           FlagInfo.new(short: nil, long: "--access-log", description: "Show HTTP access log (e.g. GET requests)"),
           FlagInfo.new(short: nil, long: "--no-error-overlay", description: "Disable error overlay in browser"),
-          FlagInfo.new(short: nil, long: "--live-reload", description: "Enable live reload on file changes"),
+          FlagInfo.new(short: nil, long: "--live-reload", description: "Enable live reload on file changes (default: enabled; kept for backwards compatibility)"),
+          FlagInfo.new(short: nil, long: "--no-live-reload", description: "Disable live reload on file changes"),
 
           # Skip options
           SKIP_OG_IMAGE_FLAG,
@@ -100,7 +101,7 @@ module Hwaro
           open_browser = false
           access_log = false
           error_overlay = true
-          live_reload = false
+          live_reload = true
 
           # Skip options
           skip_og_image = false
@@ -137,7 +138,8 @@ module Hwaro
             parser.on("--open", "Open browser after starting server") { open_browser = true }
             parser.on("--access-log", "Show HTTP access log (e.g. GET requests)") { access_log = true }
             parser.on("--no-error-overlay", "Disable error overlay in browser") { error_overlay = false }
-            parser.on("--live-reload", "Enable live reload on file changes") { live_reload = true }
+            parser.on("--live-reload", "Enable live reload on file changes (default: enabled; kept for backwards compatibility)") { live_reload = true }
+            parser.on("--no-live-reload", "Disable live reload on file changes") { live_reload = false }
 
             # Skip options
             CLI.register_flag(parser, SKIP_OG_IMAGE_FLAG) { |_| skip_og_image = true }

--- a/src/config/options/serve_options.cr
+++ b/src/config/options/serve_options.cr
@@ -37,7 +37,7 @@ module Hwaro
           @debug : Bool = false,
           @access_log : Bool = false,
           @error_overlay : Bool = true,
-          @live_reload : Bool = false,
+          @live_reload : Bool = true,
           @profile : Bool = false,
           @cache_busting : Bool = true,
           @env : String? = nil,


### PR DESCRIPTION
## Summary

- Flip `hwaro serve` default: **live reload is now on by default**, matching Vite, Next.js dev, Hugo, Zola, and Jekyll.
- Add `--no-live-reload` for users who want the static-serving behaviour (production-like local testing).
- Keep `--live-reload` as a no-op alias so existing scripts and documented invocations keep working unchanged — no deprecation warning.
- Update `docs/content/start/cli.md` and relevant specs.

## Behaviour change

| Invocation | Before | After |
|---|---|---|
| `hwaro serve` | live reload **off** | live reload **on** |
| `hwaro serve --live-reload` | live reload on | live reload on (no-op alias) |
| `hwaro serve --no-live-reload` | n/a | live reload **off** |

## Pre-check findings

Grepped the server and live-reload handler for known caveats (fsnotify quirks, performance notes, TODO/FIXME, watcher bugs). None found — the watcher and WebSocket handler are production-quality, and the Origin-check is already in place for the WS endpoint. Flipping the default is safe.

## Test plan

- [x] `just build` succeeds
- [x] `bin/hwaro serve --port 4321 -i docs` — log contains `Live reload enabled`
- [x] `bin/hwaro serve --no-live-reload --port 4322 -i docs` — log does **not** contain `Live reload enabled`
- [x] `bin/hwaro serve --live-reload --port 4323 -i docs` — still works, log contains `Live reload enabled` (backwards compat)
- [x] `crystal spec` — 4385 examples, 0 failures
- [x] `crystal tool format --check` clean on touched files

---

개발 서버 기본이 라이브 리로드가 됩니다. 끄고 싶으면 `--no-live-reload`를 사용하세요. 기존 `--live-reload`는 호환을 위해 no-op 별칭으로 유지됩니다.

Closes #354