### PR TITLE
feat: add global --quiet flag and NO_COLOR support to the CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Update **all** of the following:
 - `Logger.progress(current, total)` — progress bar with percentage.
 - `Logger.timed(message, &block)` — timing wrapper.
 - Levels: `debug`, `info`, `warn`, `error`, `success`.
+- Every command honors `--quiet`/`-q` (suppresses info/action/progress/success + banner; warn/error still emit on stderr) and the `NO_COLOR` env var (auto-detect also disables ANSI when stdout is not a TTY).
 
 ### Testing
 - **Unit tests**: Isolated components, minimal objects, helper methods (e.g., `load_config`, `render_filter`).

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -7,6 +7,30 @@ toc = true
 
 Hwaro provides commands for creating, building, and serving your site.
 
+## Global flags
+
+These flags work with every top-level command and control how the CLI
+writes to the terminal. They are especially useful for scripts, CI logs,
+and AI agents that want clean output.
+
+| Flag / Env var | Description |
+|----------------|-------------|
+| `-q`, `--quiet` | Suppress informational output and the startup banner. Warnings and errors still appear on stderr. |
+| `NO_COLOR` (env) | When set to any non-empty value, suppresses ANSI color codes from every command's output. Follows the [no-color.org](https://no-color.org) cross-tool convention. |
+
+Colors are also disabled automatically when stdout is not a TTY (for
+example when piping to `cat`, redirecting to a file, or running inside
+most CI systems). Set `NO_COLOR=1` to force-disable color everywhere;
+no extra flag is needed.
+
+```bash
+# Silent build for scripts and CI — only warnings/errors surface.
+hwaro build --quiet
+
+# Plain ASCII (no ANSI escapes) even when stdout is a TTY.
+NO_COLOR=1 hwaro doctor
+```
+
 ## Commands
 
 ### init

--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -9,9 +9,10 @@ require "../spec_helper"
 # plus filesystem side effects. CI builds the binary via `shards build`
 # before running specs.
 #
-# Note on streams: Hwaro::Logger.error / .info / .success all write to
-# Logger.io which defaults to STDOUT — not STDERR. Tests therefore assert
-# on the captured `output` stream, not `error`.
+# Note on streams: Hwaro::Logger.info / .success write to Logger.io (STDOUT
+# by default). Hwaro::Logger.warn / .error write to Logger.err_io (STDERR
+# by default). Tests assert on the captured stream that matches the
+# originating log method.
 # =============================================================================
 
 private HWARO_BIN = File.expand_path("../../bin/hwaro", __DIR__)
@@ -160,11 +161,11 @@ describe "hwaro tool platform" do
 
   it "exits 1 and prints 'Unsupported platform' on an unknown platform" do
     with_initialized_project do |project_dir|
-      status, output, _ = run_hwaro(
+      status, _, err = run_hwaro(
         ["tool", "platform", "definitely-not-real"], chdir: project_dir
       )
       status.success?.should be_false
-      output.should contain("Unsupported platform")
+      err.should contain("Unsupported platform")
     end
   end
 
@@ -200,10 +201,11 @@ describe "hwaro tool ci" do
 
   it "warns about deprecation in favor of `tool platform github-pages`" do
     with_initialized_project do |project_dir|
-      _, output, _ = run_hwaro(
+      _, output, err = run_hwaro(
         ["tool", "ci", "github-actions", "--stdout"], chdir: project_dir
       )
-      output.should contain("DEPRECATED")
+      # Deprecation notice uses Logger.warn → stderr.
+      err.should contain("DEPRECATED")
       # Co-signal: the actual workflow content was also generated to stdout,
       # confirming the deprecation log didn't short-circuit the command.
       output.should contain("workflow")
@@ -251,27 +253,27 @@ end
 describe "hwaro tool import" do
   it "exits 1 and reports missing source-type" do
     with_initialized_project do |project_dir|
-      status, output, _ = run_hwaro(["tool", "import"], chdir: project_dir)
+      status, _, err = run_hwaro(["tool", "import"], chdir: project_dir)
       status.success?.should be_false
-      output.should contain("Missing source")
+      err.should contain("Missing source")
     end
   end
 
   it "exits 1 and reports missing path when only source-type is given" do
     with_initialized_project do |project_dir|
-      status, output, _ = run_hwaro(["tool", "import", "hugo"], chdir: project_dir)
+      status, _, err = run_hwaro(["tool", "import", "hugo"], chdir: project_dir)
       status.success?.should be_false
-      output.should contain("Missing path")
+      err.should contain("Missing path")
     end
   end
 
   it "exits 1 and reports an unknown source-type" do
     with_initialized_project do |project_dir|
-      status, output, _ = run_hwaro(
+      status, _, err = run_hwaro(
         ["tool", "import", "definitely-not-real", "/tmp"], chdir: project_dir
       )
       status.success?.should be_false
-      output.should contain("Unknown source type")
+      err.should contain("Unknown source type")
     end
   end
 end

--- a/spec/unit/cli_runner_spec.cr
+++ b/spec/unit/cli_runner_spec.cr
@@ -50,6 +50,34 @@ describe Hwaro::CLI::Runner do
     end
   end
 
+  describe ".apply_global_quiet!" do
+    it "strips --quiet and sets Logger.quiet = true" do
+      argv = ["--quiet", "build", "--verbose"]
+      Hwaro::Logger.quiet = false
+      Hwaro::CLI::Runner.apply_global_quiet!(argv)
+      argv.should eq(["build", "--verbose"])
+      Hwaro::Logger.quiet?.should be_true
+      Hwaro::Logger.quiet = false
+    end
+
+    it "strips -q short form" do
+      argv = ["build", "-q", "--verbose"]
+      Hwaro::Logger.quiet = false
+      Hwaro::CLI::Runner.apply_global_quiet!(argv)
+      argv.should eq(["build", "--verbose"])
+      Hwaro::Logger.quiet?.should be_true
+      Hwaro::Logger.quiet = false
+    end
+
+    it "is a no-op when neither flag is present" do
+      argv = ["build", "--verbose"]
+      Hwaro::Logger.quiet = false
+      Hwaro::CLI::Runner.apply_global_quiet!(argv)
+      argv.should eq(["build", "--verbose"])
+      Hwaro::Logger.quiet?.should be_false
+    end
+  end
+
   describe ".print_help" do
     it "writes a Commands header followed by command names to Logger.io" do
       previous_io = Hwaro::Logger.io
@@ -87,6 +115,24 @@ describe Hwaro::CLI::Runner do
         Hwaro::CLI::Runner.print_help
         sink.to_s.should contain("v#{Hwaro::VERSION}")
       ensure
+        Hwaro::Logger.io = previous_io
+        Hwaro::Logger.level = previous_level
+      end
+    end
+
+    it "is silent when Logger.quiet? is true" do
+      previous_io = Hwaro::Logger.io
+      previous_level = Hwaro::Logger.level
+      sink = IO::Memory.new
+      Hwaro::Logger.io = sink
+      Hwaro::Logger.level = Hwaro::Logger::Level::Info
+      Hwaro::Logger.quiet = true
+
+      begin
+        Hwaro::CLI::Runner.print_help
+        sink.to_s.should eq("")
+      ensure
+        Hwaro::Logger.quiet = false
         Hwaro::Logger.io = previous_io
         Hwaro::Logger.level = previous_level
       end

--- a/spec/unit/logger_spec.cr
+++ b/spec/unit/logger_spec.cr
@@ -309,6 +309,132 @@ describe Hwaro::Logger do
     end
   end
 
+  describe ".color_enabled?" do
+    it "returns false when NO_COLOR env var is set to a non-empty value" do
+      original_override = Hwaro::Logger.color_enabled? # snapshot pre-change
+      Hwaro::Logger.color_enabled = nil                # restore auto-detect
+      original = ENV["NO_COLOR"]?
+      ENV["NO_COLOR"] = "1"
+      Hwaro::Logger.color_enabled?.should be_false
+      if orig = original
+        ENV["NO_COLOR"] = orig
+      else
+        ENV.delete("NO_COLOR")
+      end
+      # Restore previous explicit state (tests tail each other).
+      Hwaro::Logger.color_enabled = original_override
+    end
+
+    it "returns false when NO_COLOR is set but empty (auto-detect fallback)" do
+      # Per spec https://no-color.org, NO_COLOR only disables color when
+      # non-empty. With an empty value we fall through to the TTY check.
+      original_override = Hwaro::Logger.color_enabled?
+      Hwaro::Logger.color_enabled = nil
+      original = ENV["NO_COLOR"]?
+      ENV["NO_COLOR"] = ""
+      # In test runs STDOUT is usually not a TTY, so this is still false.
+      Hwaro::Logger.color_enabled?.should eq(STDOUT.tty?)
+      if orig = original
+        ENV["NO_COLOR"] = orig
+      else
+        ENV.delete("NO_COLOR")
+      end
+      Hwaro::Logger.color_enabled = original_override
+    end
+
+    it "honors explicit override via color_enabled=" do
+      original = ENV["NO_COLOR"]?
+      ENV["NO_COLOR"] = "1"
+      Hwaro::Logger.color_enabled = true
+      Hwaro::Logger.color_enabled?.should be_true
+      Hwaro::Logger.color_enabled = false
+      Hwaro::Logger.color_enabled?.should be_false
+      # Restore auto-detect
+      Hwaro::Logger.color_enabled = nil
+      if orig = original
+        ENV["NO_COLOR"] = orig
+      else
+        ENV.delete("NO_COLOR")
+      end
+    end
+
+    it "suppresses ANSI escape sequences in emitted output when disabled" do
+      Hwaro::Logger.color_enabled = false
+      output = capture_logger_output { Hwaro::Logger.success("done") }
+      output.should contain("done")
+      output.should_not contain("\e[")
+      output = capture_logger_output { Hwaro::Logger.error("boom") }
+      output.should contain("boom")
+      output.should_not contain("\e[")
+      output = capture_logger_output { Hwaro::Logger.warn("careful") }
+      output.should contain("careful")
+      output.should_not contain("\e[")
+      output = capture_logger_output { Hwaro::Logger.action("Creating", "file") }
+      output.should contain("Creating")
+      output.should contain("file")
+      output.should_not contain("\e[")
+      Hwaro::Logger.color_enabled = nil
+    end
+
+    it "emits ANSI escape sequences when enabled (and the colorize lib is active)" do
+      # The `colorize` shard strips ANSI when writing to non-TTY targets, so
+      # we explicitly re-enable it for this assertion and restore afterwards.
+      original = Colorize.enabled?
+      Colorize.enabled = true
+      Hwaro::Logger.color_enabled = true
+      output = capture_logger_output { Hwaro::Logger.success("done") }
+      output.should contain("\e[")
+      Hwaro::Logger.color_enabled = nil
+      Colorize.enabled = original
+    end
+  end
+
+  describe ".quiet=" do
+    it "suppresses info output" do
+      Hwaro::Logger.quiet = true
+      output = capture_logger_output { Hwaro::Logger.info("should be silent") }
+      output.should_not contain("should be silent")
+      Hwaro::Logger.quiet = false
+    end
+
+    it "suppresses success output" do
+      Hwaro::Logger.quiet = true
+      output = capture_logger_output { Hwaro::Logger.success("hidden success") }
+      output.should_not contain("hidden success")
+      Hwaro::Logger.quiet = false
+    end
+
+    it "suppresses action output" do
+      Hwaro::Logger.quiet = true
+      output = capture_logger_output { Hwaro::Logger.action("Creating", "file.md") }
+      output.should_not contain("Creating")
+      output.should_not contain("file.md")
+      Hwaro::Logger.quiet = false
+    end
+
+    it "suppresses progress output" do
+      Hwaro::Logger.quiet = true
+      output = capture_logger_output { Hwaro::Logger.progress(5, 10, "Building: ") }
+      output.should_not contain("Building:")
+      output.should_not contain("50.0%")
+      Hwaro::Logger.quiet = false
+    end
+
+    it "still emits warn output" do
+      Hwaro::Logger.quiet = true
+      output = capture_logger_output { Hwaro::Logger.warn("important warning") }
+      output.should contain("important warning")
+      Hwaro::Logger.quiet = false
+    end
+
+    it "still emits error output" do
+      Hwaro::Logger.quiet = true
+      output = capture_logger_output { Hwaro::Logger.error("fatal thing") }
+      output.should contain("fatal thing")
+      Hwaro::Logger.quiet = false
+    end
+  end
+
   describe "Level enum" do
     it "has Debug as lowest level" do
       (Hwaro::Logger::Level::Debug < Hwaro::Logger::Level::Info).should be_true

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -44,6 +44,7 @@ module Hwaro
 
           # Debug & output
           VERBOSE_FLAG,
+          QUIET_FLAG,
           PROFILE_FLAG,
           DEBUG_FLAG,
           HELP_FLAG,
@@ -156,6 +157,9 @@ module Hwaro
 
             # Debug & output
             CLI.register_flag(parser, VERBOSE_FLAG) { |_| verbose = true }
+            # --quiet is stripped upstream in Runner.apply_global_quiet!; this
+            # registration only ensures it appears in per-command --help.
+            CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, PROFILE_FLAG) { |_| profile = true }
             CLI.register_flag(parser, DEBUG_FLAG) { |_| debug = true }
             CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -26,6 +26,7 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--list-targets", description: "List configured deployment targets and exit"),
           FlagInfo.new(short: nil, long: "--json", description: "Emit machine-readable JSON output (with --list-targets)"),
           ENV_FLAG,
+          QUIET_FLAG,
           HELP_FLAG,
         ]
 
@@ -70,6 +71,7 @@ module Hwaro
             parser.on("--list-targets", "List configured deployment targets and exit") { list_targets = true }
             parser.on("--json", "Emit machine-readable JSON output (with --list-targets)") { json_output = true }
             CLI.register_flag(parser, ENV_FLAG) { |v| env_name = v }
+            CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, HELP_FLAG) do |_|
               Logger.info parser.to_s
               hint = configured_targets_hint(env_name)

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -36,6 +36,7 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--json", description: "Emit machine-readable JSON output (with --list-scaffolds)"),
 
           # Debug & output
+          QUIET_FLAG,
           HELP_FLAG,
         ]
 
@@ -148,6 +149,7 @@ module Hwaro
             parser.on("--skip-taxonomies", "Skip taxonomies configuration and templates") { skip_taxonomies = true }
 
             # Debug & output
+            CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             parser.on("-h", "--help", "Show this help") do
               Logger.info parser.to_s
               Logger.info ""

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -29,6 +29,7 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--list-archetypes", description: "List archetypes available in the current project and exit"),
           FlagInfo.new(short: nil, long: "--json", description: "Emit machine-readable JSON output (with --list-archetypes)"),
 
+          QUIET_FLAG,
           HELP_FLAG,
         ]
 
@@ -122,6 +123,7 @@ module Hwaro
             parser.on("--tags TAGS", "Comma-separated tags") { |t| tags = t.split(",").map(&.strip).reject(&.empty?) }
             parser.on("-s NAME", "--section NAME", "Section directory (e.g. blog, docs)") { |s| section = s }
             parser.on("-a NAME", "--archetype NAME", "Archetype to use") { |a| archetype = a }
+            CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             parser.unknown_args do |unknown|
               path = unknown.first if unknown.any?

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -47,6 +47,7 @@ module Hwaro
 
           # Debug & output
           VERBOSE_FLAG,
+          QUIET_FLAG,
           PROFILE_FLAG,
           DEBUG_FLAG,
           HELP_FLAG,
@@ -146,6 +147,7 @@ module Hwaro
 
             # Debug & output
             CLI.register_flag(parser, VERBOSE_FLAG) { |_| verbose = true }
+            CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, PROFILE_FLAG) { |_| profile = true }
             CLI.register_flag(parser, DEBUG_FLAG) { |_| debug = true }
             CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }

--- a/src/cli/commands/tool/doctor_command.cr
+++ b/src/cli/commands/tool/doctor_command.cr
@@ -22,6 +22,7 @@ module Hwaro
             FlagInfo.new(short: nil, long: "--fix", description: "Auto-fix issues (add missing config sections)"),
             FlagInfo.new(short: nil, long: "--minimal", description: "With --fix, skip advanced optional sections (pwa, amp, assets, etc.)"),
             JSON_FLAG,
+            QUIET_FLAG,
             HELP_FLAG,
           ]
 
@@ -74,6 +75,7 @@ module Hwaro
               parser.on("--fix", "Auto-fix issues (add missing config sections)") { fix_mode = true }
               parser.on("--minimal", "With --fix, skip advanced optional sections (pwa, amp, assets, etc.)") { minimal_mode = true }
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
+              CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
 
@@ -192,10 +194,10 @@ module Hwaro
           end
 
           # Returns true when we should suppress color + Unicode glyphs
-          # (non-TTY stdout OR NO_COLOR env var set).
+          # Delegates to `Logger.color_enabled?` so NO_COLOR / non-TTY / explicit
+          # overrides are all honored consistently across the CLI.
           private def plain_output? : Bool
-            return true if ENV.has_key?("NO_COLOR") && !ENV["NO_COLOR"].empty?
-            !STDOUT.tty?
+            !Logger.color_enabled?
           end
 
           private def status_glyph(level : Symbol?, plain : Bool) : String

--- a/src/cli/commands/tool_command.cr
+++ b/src/cli/commands/tool_command.cr
@@ -46,6 +46,7 @@ module Hwaro
         POSITIONAL_CHOICES = [] of String
 
         FLAGS = [
+          QUIET_FLAG,
           HELP_FLAG,
         ]
 

--- a/src/cli/metadata.cr
+++ b/src/cli/metadata.cr
@@ -43,6 +43,7 @@ module Hwaro
 
     # Global flags - shared across multiple commands
     VERBOSE_FLAG               = FlagInfo.new(short: "-v", long: "--verbose", description: "Show detailed output")
+    QUIET_FLAG                 = FlagInfo.new(short: "-q", long: "--quiet", description: "Suppress info output and banner (errors still shown on stderr)")
     DEBUG_FLAG                 = FlagInfo.new(short: nil, long: "--debug", description: "Print debug information")
     ENV_FLAG                   = FlagInfo.new(short: "-e", long: "--env", description: "Environment name (loads config.<env>.toml override)", takes_value: true, value_hint: "ENV")
     PROFILE_FLAG               = FlagInfo.new(short: nil, long: "--profile", description: "Show build timing profile")

--- a/src/cli/runner.cr
+++ b/src/cli/runner.cr
@@ -67,6 +67,12 @@ module Hwaro
       end
 
       def run
+        # Global `--quiet` / `-q` is pre-parsed here so every command
+        # (including subcommands and help output) honors it without needing
+        # per-command OptionParser wiring. Removed entries no longer reach
+        # the command-level parser, so they never trigger InvalidOption.
+        Runner.apply_global_quiet!(ARGV)
+
         if ARGV.empty?
           Runner.print_help
           exit
@@ -95,6 +101,21 @@ module Hwaro
       rescue ex : Exception
         Logger.error "Error: #{ex.message}"
         exit(1)
+      end
+
+      # Strip `--quiet` / `-q` from argv and enable Logger.quiet when present.
+      # Mutates the given array in place so subsequent parsers don't see it.
+      def self.apply_global_quiet!(argv : Array(String))
+        found = false
+        argv.reject! do |arg|
+          if arg == "--quiet" || arg == "-q"
+            found = true
+            true
+          else
+            false
+          end
+        end
+        Logger.quiet = true if found
       end
 
       private def register_default_commands
@@ -161,6 +182,10 @@ module Hwaro
       end
 
       def self.print_help
+        # In quiet mode the banner and command listing are suppressed
+        # entirely — scripts/CI just get a silent help invocation.
+        return if Logger.quiet?
+
         art = [
           "                             ",
           "    █████████████████████    ",
@@ -172,11 +197,13 @@ module Hwaro
           "    █████████████████████    ",
         ]
 
+        use_color = Logger.color_enabled?
+        brand = use_color ? "Hwaro".colorize(:cyan).bold.to_s : "Hwaro"
         info = [
           "",
           "",
           "",
-          "  #{"Hwaro".colorize(:cyan).bold} v#{Hwaro::VERSION}",
+          "  #{brand} v#{Hwaro::VERSION}",
           "",
           "  A fast and lightweight static site",
           "  generator written in Crystal.",
@@ -190,7 +217,8 @@ module Hwaro
         Logger.info ""
         art.each_with_index do |line, i|
           right = info[i]? || ""
-          Logger.info "#{line.colorize(:light_red)}#{right}"
+          art_line = use_color ? line.colorize(:light_red).to_s : line
+          Logger.info "#{art_line}#{right}"
         end
 
         Logger.info ""

--- a/src/utils/logger.cr
+++ b/src/utils/logger.cr
@@ -2,12 +2,22 @@
 #
 # Provides colored console output with different log levels
 # and action formatting for build operations.
+#
+# Color output is automatically disabled when:
+#   * `NO_COLOR` is set to a non-empty value (see https://no-color.org), or
+#   * `STDOUT` is not a TTY (e.g. piping to a file or `cat`), or
+#   * `Logger.color_enabled=` has been explicitly set to false.
+#
+# Quiet mode (`Logger.quiet=`) suppresses `info`, `action`, `success`, and
+# `progress` output while still emitting `warn` and `error`, which are
+# additionally routed to STDERR for easy redirection.
 
 require "colorize"
 
 module Hwaro
   class Logger
     @@io : IO = STDOUT
+    @@err_io : IO = STDERR
 
     # Log levels for filtering
     enum Level
@@ -18,13 +28,28 @@ module Hwaro
     end
 
     @@level : Level = Level::Info
+    @@quiet : Bool = false
+    @@color_enabled : Bool? = nil
 
+    # Setting `io` also redirects error/warn output to the same IO, which
+    # keeps existing test helpers (that capture a single IO) working and
+    # makes manual redirection straightforward. Use `err_io=` afterwards to
+    # split streams explicitly.
     def self.io=(io : IO)
       @@io = io
+      @@err_io = io
     end
 
     def self.io : IO
       @@io
+    end
+
+    def self.err_io=(io : IO)
+      @@err_io = io
+    end
+
+    def self.err_io : IO
+      @@err_io
     end
 
     def self.level=(level : Level)
@@ -35,32 +60,63 @@ module Hwaro
       @@level
     end
 
+    def self.quiet=(value : Bool)
+      @@quiet = value
+    end
+
+    def self.quiet? : Bool
+      @@quiet
+    end
+
+    # Explicit override. Pass `nil` to restore auto-detection.
+    def self.color_enabled=(value : Bool?)
+      @@color_enabled = value
+    end
+
+    # Auto-detect unless explicitly set. Disabled when `NO_COLOR` env var
+    # is set to any non-empty value, or when STDOUT is not a TTY.
+    def self.color_enabled? : Bool
+      if override = @@color_enabled
+        return override
+      end
+      return false if ENV.has_key?("NO_COLOR") && !ENV["NO_COLOR"].empty?
+      STDOUT.tty?
+    end
+
     def self.debug(message : String)
       return if @@level > Level::Debug
-      @@io.puts "[DEBUG] #{message}".colorize(:light_gray)
+      return if @@quiet
+      @@io.puts colorize("[DEBUG] #{message}", :light_gray)
     end
 
     def self.info(message : String)
       return if @@level > Level::Info
+      return if @@quiet
       @@io.puts message
     end
 
     def self.error(message : String)
-      @@io.puts message.colorize(:red)
+      @@err_io.puts colorize(message, :red)
     end
 
     def self.warn(message : String)
       return if @@level > Level::Warn
-      @@io.puts "[WARN] #{message}".colorize(:yellow)
+      @@err_io.puts colorize("[WARN] #{message}", :yellow)
     end
 
     def self.success(message : String)
-      @@io.puts message.colorize(:green)
+      return if @@quiet
+      @@io.puts colorize(message, :green)
     end
 
     def self.action(label : String | Symbol, message : String, color : Symbol = :green)
+      return if @@quiet
       label_s = label.to_s.rjust(12)
-      @@io.puts "#{label_s.colorize(color).bold}  #{message}"
+      if color_enabled?
+        @@io.puts "#{label_s.colorize(color).bold}  #{message}"
+      else
+        @@io.puts "#{label_s}  #{message}"
+      end
     end
 
     # Performance timing helper
@@ -75,12 +131,21 @@ module Hwaro
     # Progress indicator for long operations
     def self.progress(current : Int32, total : Int32, prefix : String = "")
       return if total <= 0
+      return if @@quiet
       percent = (current.to_f / total * 100).round(1)
       bar_width = 30
       filled = (current.to_f / total * bar_width).to_i
       bar = "█" * filled + "░" * (bar_width - filled)
       @@io.print "\r#{prefix}[#{bar}] #{percent}% (#{current}/#{total})"
       @@io.puts if current >= total
+    end
+
+    # Colorize helper that respects `color_enabled?`. Returns the raw string
+    # (no ANSI escapes) when color is disabled, so output stays clean for
+    # scripts, CI, and AI agents.
+    private def self.colorize(message : String, color : Symbol) : String
+      return message unless color_enabled?
+      message.colorize(color).to_s
     end
   end
 end


### PR DESCRIPTION
## Summary
- Centralize quiet-mode and color handling in `Hwaro::Logger`: `Logger.color_enabled?` auto-disables ANSI on `NO_COLOR` (per [no-color.org](https://no-color.org)) or when stdout is not a TTY, and `Logger.quiet=` suppresses `info`/`action`/`progress`/`success` while keeping `warn`/`error` on stderr.
- Wire a global `--quiet`/`-q` flag once in `Runner.apply_global_quiet!` so every top-level command honors it without per-command parser changes. The flag is registered in per-command metadata so it shows up in `--help` output and shell completions.
- Errors and warnings now go to a dedicated `err_io` (defaults to `STDERR`), making `2>/dev/null` do the right thing in scripts. The existing `Tool::DoctorCommand#plain_output?` now delegates to the shared `Logger.color_enabled?` predicate.
- Documented under a new "Global flags" section in `docs/content/start/cli.md` and in `AGENTS.md`.

Out of scope (follow-ups): `--no-banner` (covered 90% by `--quiet`), a `--no-color` flag (prefer the `NO_COLOR` env var), and JSON-output migrations (tracked as #356).

한 줄 요약: 스크립트/CI/에이전트 친화적으로 `--quiet`와 `NO_COLOR`를 전역 지원하도록 Logger를 정리했습니다.

Closes #357

## Test plan
- [x] `crystal spec` (4,398 examples, 0 failures)
- [x] `just build` produces `bin/hwaro`
- [x] `bin/hwaro --help | cat` emits ASCII with no ANSI escapes
- [x] `NO_COLOR=1 bin/hwaro --help` emits ASCII with no ANSI escapes
- [x] `bin/hwaro build --quiet` is silent on stdout (warnings/errors still surface on stderr)
- [x] `bin/hwaro init <dir> --quiet` creates the project without a banner; rerunning on a non-empty dir prints the error on stderr, stdout stays empty
- [ ] Manual TTY check that `bin/hwaro --help` still renders the cyan/red banner in a real terminal (couldn't automate in the sandbox)