### PR TITLE
feat: add --json output to build, serve, deploy, and tool commands

### DIFF
--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -110,6 +110,20 @@ describe "hwaro tool stats" do
       status.success?.should be_true
     end
   end
+
+  it "emits JSON matching the documented schema under --json" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(["tool", "stats", "--json"], chdir: project_dir)
+      status.success?.should be_true
+      # Must be a single JSON object parseable by external tools.
+      parsed = JSON.parse(output.strip)
+      parsed["total"].as_i?.should_not be_nil
+      parsed["published"].as_i?.should_not be_nil
+      parsed["drafts"].as_i?.should_not be_nil
+      parsed["word_count"]["total"].as_i?.should_not be_nil
+      parsed["tags"].as_h?.should_not be_nil
+    end
+  end
 end
 
 describe "hwaro tool validate" do
@@ -118,6 +132,15 @@ describe "hwaro tool validate" do
       status, _, _ = run_hwaro(["tool", "validate"], chdir: project_dir)
       # Default scaffold has no validation errors → exit 0
       status.success?.should be_true
+    end
+  end
+
+  it "emits {findings:[…]} under --json" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(["tool", "validate", "--json"], chdir: project_dir)
+      status.success?.should be_true
+      parsed = JSON.parse(output.strip)
+      parsed["findings"].as_a?.should_not be_nil
     end
   end
 end
@@ -138,6 +161,15 @@ describe "hwaro tool check-links" do
       # check-links exits 0 when no broken links and 1 when some are found.
       # Anything else (e.g. signal-based exit from a crash) is a bug.
       [0, 1].includes?(status.exit_code).should be_true
+    end
+  end
+
+  it "emits {dead_internal, dead_external} under --json" do
+    with_initialized_project do |project_dir|
+      _, output, _ = run_hwaro(["tool", "check-links", "--json", "--internal-only"], chdir: project_dir)
+      parsed = JSON.parse(output.strip)
+      parsed["dead_internal"].as_a?.should_not be_nil
+      parsed["dead_external"].as_a?.should_not be_nil
     end
   end
 end

--- a/spec/unit/build_command_spec.cr
+++ b/spec/unit/build_command_spec.cr
@@ -190,6 +190,24 @@ describe Hwaro::CLI::Commands::BuildCommand do
       end
     end
 
+    it "defaults json flag to false" do
+      cmd = Hwaro::CLI::Commands::BuildCommand.new
+      _, _, json_output = cmd.parse_options([] of String)
+      json_output.should be_false
+    end
+
+    it "parses --json flag" do
+      cmd = Hwaro::CLI::Commands::BuildCommand.new
+      _, _, json_output = cmd.parse_options(["--json"])
+      json_output.should be_true
+    end
+
+    it "parses -j short json flag" do
+      cmd = Hwaro::CLI::Commands::BuildCommand.new
+      _, _, json_output = cmd.parse_options(["-j"])
+      json_output.should be_true
+    end
+
     it "CLI --memory-limit overrides HWARO_MEMORYLIMIT env var" do
       ENV["HWARO_MEMORYLIMIT"] = "1G"
       begin

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -1,3 +1,4 @@
+require "json"
 require "option_parser"
 require "../metadata"
 require "../../config/options/build_options"
@@ -47,6 +48,7 @@ module Hwaro
           QUIET_FLAG,
           PROFILE_FLAG,
           DEBUG_FLAG,
+          JSON_FLAG,
           HELP_FLAG,
         ]
 
@@ -61,11 +63,18 @@ module Hwaro
         end
 
         def run(args : Array(String))
-          result, input_dir = parse_options(args)
+          result, input_dir, json_output = parse_options(args)
           options, output_dir_explicit = result
+
+          # --json implies quiet so only the final JSON document reaches stdout.
+          Logger.quiet = true if json_output
 
           if dir = input_dir
             unless Dir.exists?(dir)
+              if json_output
+                puts({status: "error", error: {message: "Input directory does not exist: #{dir}"}}.to_json)
+                exit(1)
+              end
               Logger.error "Input directory does not exist: #{dir}"
               exit(1)
             end
@@ -92,10 +101,38 @@ module Hwaro
             builder.register(hookable)
           end
 
-          builder.run(options)
+          start = Time.instant
+          begin
+            builder.run(options)
+          rescue ex
+            if json_output
+              puts({status: "error", error: {message: ex.message || "build failed"}}.to_json)
+              exit(1)
+            else
+              raise ex
+            end
+          end
+
+          if json_output
+            ctx = builder.context
+            stats = ctx.try(&.stats)
+            duration_ms = if stats && stats.elapsed > 0
+                            stats.elapsed.round(2)
+                          else
+                            (Time.instant - start).total_milliseconds.round(2)
+                          end
+            payload = {
+              "status"              => "ok",
+              "pages_generated"     => stats.try(&.pages_rendered) || 0,
+              "duration_ms"         => duration_ms,
+              "cache_hits"          => stats.try(&.cache_hits) || 0,
+              "raw_files_processed" => stats.try(&.raw_files_processed) || 0,
+            }
+            puts payload.to_json
+          end
         end
 
-        def parse_options(args : Array(String)) : { {Config::Options::BuildOptions, Bool}, String? }
+        def parse_options(args : Array(String)) : { {Config::Options::BuildOptions, Bool}, String?, Bool }
           # Path & URL
           input_dir = nil.as(String?)
           output_dir = "public"
@@ -126,6 +163,7 @@ module Hwaro
           verbose = false
           profile = false
           debug = false
+          json_output = false
 
           OptionParser.parse(args) do |parser|
             parser.banner = "Usage: hwaro build [options]"
@@ -162,6 +200,7 @@ module Hwaro
             CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, PROFILE_FLAG) { |_| profile = true }
             CLI.register_flag(parser, DEBUG_FLAG) { |_| debug = true }
+            CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
             CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
           end
 
@@ -185,7 +224,7 @@ module Hwaro
             env: env_name,
             skip_og_image: skip_og_image,
             skip_image_processing: skip_image_processing,
-          ), output_dir_explicit}, input_dir }
+          ), output_dir_explicit}, input_dir, json_output }
         end
       end
     end

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -24,7 +24,7 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--force", description: "Force upload/copy (ignore file comparisons)"),
           FlagInfo.new(short: nil, long: "--max-deletes", description: "Maximum number of deletes (default: deployment.maxDeletes or 256, -1 disables)", takes_value: true, value_hint: "N"),
           FlagInfo.new(short: nil, long: "--list-targets", description: "List configured deployment targets and exit"),
-          FlagInfo.new(short: nil, long: "--json", description: "Emit machine-readable JSON output (with --list-targets)"),
+          JSON_FLAG,
           ENV_FLAG,
           QUIET_FLAG,
           HELP_FLAG,
@@ -42,8 +42,46 @@ module Hwaro
 
         def run(args : Array(String))
           options, list_targets, json_output = parse_options(args)
+
+          # Quiet logger so --json emits only the final JSON document. Human
+          # --list-targets and --dry-run output is routed around Logger below.
+          Logger.quiet = true if json_output
+
           if list_targets
             print_targets(options.env, json: json_output)
+            return
+          end
+
+          # --dry-run + --json: return the planned ops as a JSON array and
+          # exit without actually deploying. Schema per issue #356:
+          #   [{target, action: "create"|"update"|"delete"|"command", path, source, destination}]
+          if json_output && options.dry_run == true
+            begin
+              ops = Services::Deployer.new.plan(options)
+              STDOUT.puts ops.to_json
+            rescue ex
+              STDOUT.puts({status: "error", error: {message: ex.message || "deploy plan failed"}}.to_json)
+              exit(1)
+            end
+            return
+          end
+
+          if json_output
+            # Real deploy with --json (no --dry-run) isn't part of this
+            # command's stable JSON schema yet. Fall back to returning a
+            # status document so agents aren't left with raw progress text.
+            ok = begin
+              Services::Deployer.new.run(options)
+            rescue ex
+              STDOUT.puts({status: "error", error: {message: ex.message || "deploy failed"}}.to_json)
+              exit(1)
+            end
+            if ok
+              STDOUT.puts({"status" => "ok"}.to_json)
+            else
+              STDOUT.puts({status: "error", error: {message: "deploy failed"}}.to_json)
+              exit(1)
+            end
             return
           end
 
@@ -69,7 +107,7 @@ module Hwaro
             parser.on("--force", "Force upload/copy (ignore file comparisons)") { force = true }
             parser.on("--max-deletes N", "Maximum number of deletes (default: deployment.maxDeletes or 256, -1 disables)") { |n| max_deletes = n.to_i }
             parser.on("--list-targets", "List configured deployment targets and exit") { list_targets = true }
-            parser.on("--json", "Emit machine-readable JSON output (with --list-targets)") { json_output = true }
+            CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
             CLI.register_flag(parser, ENV_FLAG) { |v| env_name = v }
             CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, HELP_FLAG) do |_|
@@ -102,7 +140,7 @@ module Hwaro
             Models::Config.load(env: env)
           rescue ex
             if json
-              STDOUT.puts({error: {message: ex.message || "Failed to load config"}}.to_json)
+              STDOUT.puts({status: "error", error: {message: ex.message || "Failed to load config"}}.to_json)
             else
               Logger.error(ex.message || "Failed to load config")
             end

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -51,6 +51,7 @@ module Hwaro
           QUIET_FLAG,
           PROFILE_FLAG,
           DEBUG_FLAG,
+          JSON_FLAG,
           HELP_FLAG,
         ]
 
@@ -66,6 +67,10 @@ module Hwaro
 
         def run(args : Array(String))
           input_dir, options = parse_options(args)
+
+          # --json suppresses banners/action lines so the ready event is the
+          # first line on stdout. Errors still go to stderr via Logger.error.
+          Logger.quiet = true if options.json
 
           if input_dir
             unless Dir.exists?(input_dir)
@@ -113,6 +118,7 @@ module Hwaro
           verbose = false
           profile = false
           debug = false
+          json_output = false
 
           OptionParser.parse(args) do |parser|
             parser.banner = "Usage: hwaro serve [options]"
@@ -152,6 +158,7 @@ module Hwaro
             CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, PROFILE_FLAG) { |_| profile = true }
             CLI.register_flag(parser, DEBUG_FLAG) { |_| debug = true }
+            CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
             CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
           end
 
@@ -177,6 +184,7 @@ module Hwaro
             cache: cache,
             stream: stream,
             memory_limit: memory_limit,
+            json: json_output,
           )}
         end
       end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -84,6 +84,8 @@ module Hwaro
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
 
+            Logger.quiet = true if json_output
+
             if external_only && internal_only
               Logger.warn "--external-only and --internal-only cancel each other out; checking all links"
               external_only = false
@@ -91,6 +93,10 @@ module Hwaro
             end
 
             unless Dir.exists?(target_dir)
+              if json_output
+                puts({status: "error", error: {message: "Directory not found: #{target_dir}"}}.to_json)
+                exit(1)
+              end
               Logger.error "Directory not found: #{target_dir}"
               return
             end
@@ -103,11 +109,8 @@ module Hwaro
             if external_links.empty? && internal_links.empty?
               if json_output
                 puts({
-                  "dead_links"      => [] of Result,
-                  "total_links"     => 0,
-                  "external_links"  => 0,
-                  "internal_links"  => 0,
-                  "dead_link_count" => 0,
+                  "dead_internal" => [] of Result,
+                  "dead_external" => [] of Result,
                 }.to_json)
               else
                 Logger.info "✔ No links found."
@@ -127,11 +130,8 @@ module Hwaro
 
             if json_output
               puts({
-                "dead_links"      => dead_external + dead_internal,
-                "total_links"     => total,
-                "external_links"  => external_links.size,
-                "internal_links"  => internal_links.size,
-                "dead_link_count" => dead_total,
+                "dead_internal" => dead_internal,
+                "dead_external" => dead_external,
               }.to_json)
               return
             end
@@ -284,7 +284,7 @@ module Hwaro
                   ip == "::1" ||
                   ip == "::" ||
                   ip.starts_with?("fc") || ip.starts_with?("fd") || # IPv6 ULA
-                  ip.starts_with?("fe80") ||                         # IPv6 link-local
+                  ip.starts_with?("fe80") ||                        # IPv6 link-local
                   private_172?(ip)
               end
             rescue

--- a/src/cli/commands/tool/list_command.cr
+++ b/src/cli/commands/tool/list_command.cr
@@ -55,7 +55,13 @@ module Hwaro
               end
             end
 
+            Logger.quiet = true if json_output
+
             unless filter
+              if json_output
+                puts({status: "error", error: {message: "Missing filter argument. Use 'all', 'drafts', or 'published'"}}.to_json)
+                exit(1)
+              end
               Logger.error "Missing filter argument. Use 'all', 'drafts', or 'published'"
               Logger.info ""
               Logger.info "Usage: hwaro tool list <all|drafts|published> [options]"
@@ -82,6 +88,10 @@ module Hwaro
                              when "published", "pub"
                                Services::ContentFilter::Published
                              else
+                               if json_output
+                                 puts({status: "error", error: {message: "Unknown filter: #{filter}"}}.to_json)
+                                 exit(1)
+                               end
                                Logger.error "Unknown filter: #{filter}"
                                Logger.info "Use 'all', 'drafts', or 'published'"
                                exit(1)

--- a/src/cli/commands/tool/stats_command.cr
+++ b/src/cli/commands/tool/stats_command.cr
@@ -48,11 +48,35 @@ module Hwaro
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
 
+            Logger.quiet = true if json_output
+
             stats = Services::ContentStats.new(content_dir: content_dir)
-            result = stats.run
+            begin
+              result = stats.run
+            rescue ex
+              if json_output
+                puts({status: "error", error: {message: ex.message || "stats failed"}}.to_json)
+                exit(1)
+              else
+                raise ex
+              end
+            end
 
             if json_output
-              puts result.to_json
+              payload = {
+                "total"      => result.total,
+                "published"  => result.published,
+                "drafts"     => result.drafts,
+                "word_count" => {
+                  "total"   => result.words_total,
+                  "average" => result.words_avg,
+                  "min"     => result.words_min,
+                  "max"     => result.words_max,
+                },
+                "tags"    => result.tags,
+                "monthly" => result.monthly,
+              }
+              puts payload.to_json
               return
             end
 

--- a/src/cli/commands/tool/validate_command.cr
+++ b/src/cli/commands/tool/validate_command.cr
@@ -49,20 +49,31 @@ module Hwaro
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
 
+            Logger.quiet = true if json_output
+
             validator = Services::ContentValidator.new(content_dir: content_dir)
-            issues = validator.run
+            begin
+              issues = validator.run
+            rescue ex
+              if json_output
+                puts({status: "error", error: {message: ex.message || "validate failed"}}.to_json)
+                exit(1)
+              else
+                raise ex
+              end
+            end
 
             if json_output
-              result = {
-                "issues"  => issues,
-                "summary" => {
-                  "errors"   => issues.count { |i| i.level == :error },
-                  "warnings" => issues.count { |i| i.level == :warning },
-                  "infos"    => issues.count { |i| i.level == :info },
-                  "total"    => issues.size,
-                },
-              }
-              puts result.to_json
+              findings = issues.map do |issue|
+                {
+                  "file"     => issue.file,
+                  "line"     => nil.as(Int32?),
+                  "rule"     => issue.id,
+                  "severity" => issue.level.to_s,
+                  "message"  => issue.message,
+                }
+              end
+              puts({"findings" => findings}.to_json)
               return
             end
 

--- a/src/config/options/serve_options.cr
+++ b/src/config/options/serve_options.cr
@@ -23,6 +23,7 @@ module Hwaro
         property cache : Bool
         property stream : Bool
         property memory_limit : String?
+        property json : Bool
 
         def initialize(
           @host : String = "127.0.0.1",
@@ -46,6 +47,7 @@ module Hwaro
           @cache : Bool = false,
           @stream : Bool = false,
           @memory_limit : String? = nil,
+          @json : Bool = false,
         )
         end
 

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -125,6 +125,12 @@ module Hwaro
           @cache_manager
         end
 
+        # Access build context for external inspection (e.g. emitting JSON
+        # output after a build). Returns nil before `run` has been invoked.
+        def context : Lifecycle::BuildContext?
+          @context
+        end
+
         # Register all cache layers with the unified manager
         private def setup_cache_manager
           @cache_manager.register("compiled_templates", "Compiled Crinja template ASTs", runtime: true) do

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -1,5 +1,6 @@
 require "file_utils"
 require "digest/sha256"
+require "json"
 require "set"
 require "uri"
 
@@ -17,6 +18,96 @@ module Hwaro
 
         def initialize(@copied : Int32 = 0, @deleted : Int32 = 0, @skipped : Int32 = 0)
         end
+      end
+
+      # A single planned deployment operation produced by `#plan`. Used by
+      # `hwaro deploy --dry-run --json` so agents/CI can parse the list of
+      # files that would be copied, updated, or deleted for each target.
+      record PlannedOp,
+        target : String,
+        action : String,
+        path : String,
+        source : String?,
+        destination : String? do
+        include JSON::Serializable
+      end
+
+      # Build a list of planned operations across all configured (or explicitly
+      # requested) targets without performing any filesystem writes or external
+      # commands. Returns an empty array when no targets resolve (caller is
+      # responsible for surfacing that as a friendly message or JSON error).
+      def plan(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Array(PlannedOp)
+        ops = [] of PlannedOp
+        config ||= Models::Config.load(env: options.env)
+        deployment = config.deployment
+
+        source_dir = options.source_dir || deployment.source_dir
+        source_dir = File.expand_path(source_dir)
+        return ops unless Dir.exists?(source_dir)
+
+        target_names =
+          if options.targets.any?
+            options.targets
+          elsif target = deployment.target
+            [target]
+          elsif deployment.targets.size > 0
+            [deployment.targets.first.name]
+          else
+            [] of String
+          end
+        return ops if target_names.empty?
+
+        targets = target_names.compact_map { |name| deployment.target_named(name) }
+        return ops if targets.empty?
+
+        targets.each do |target|
+          if command = target.command
+            ops << PlannedOp.new(
+              target: target.name,
+              action: "command",
+              path: expand_placeholders(command, source_dir, target),
+              source: source_dir,
+              destination: target.url,
+            )
+            next
+          end
+
+          url = target.url
+          next if url.empty?
+
+          if directory_destination = local_directory_destination(url)
+            dest_dir = File.expand_path(directory_destination)
+            desired = build_desired_map(source_dir, target)
+            existing = list_existing_files(dest_dir)
+
+            desired.each do |dest_rel, src_path|
+              dest_path = File.join(dest_dir, dest_rel)
+              if File.exists?(dest_path)
+                next if same_file?(src_path, dest_path)
+                ops << PlannedOp.new(target: target.name, action: "update", path: dest_rel, source: src_path, destination: dest_path)
+              else
+                ops << PlannedOp.new(target: target.name, action: "create", path: dest_rel, source: src_path, destination: dest_path)
+              end
+            end
+
+            desired_set = desired.keys.to_set
+            existing.each do |rel|
+              next if desired_set.includes?(rel)
+              next unless delete_candidate?(rel, target)
+              ops << PlannedOp.new(target: target.name, action: "delete", path: rel, source: nil, destination: File.join(dest_dir, rel))
+            end
+          elsif auto_command = auto_command_for_url(url, source_dir)
+            ops << PlannedOp.new(
+              target: target.name,
+              action: "command",
+              path: expand_placeholders(auto_command, source_dir, target),
+              source: source_dir,
+              destination: url,
+            )
+          end
+        end
+
+        ops
       end
 
       def run(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Bool

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -10,6 +10,7 @@
 # - Static-only copy when only static files change
 
 require "http/server"
+require "json"
 require "../../core/build/builder"
 require "../../content/hooks"
 require "../../utils/logger"
@@ -249,15 +250,15 @@ module Hwaro
 
       def run(options : Config::Options::ServeOptions)
         build_options = options.to_build_options
-        run_with_options(options.host, options.port, options.open_browser, options.access_log, options.live_reload, build_options)
+        run_with_options(options.host, options.port, options.open_browser, options.access_log, options.live_reload, build_options, options.json)
       end
 
       def run(host : String = "127.0.0.1", port : Int32 = 3000, drafts : Bool = false)
         build_options = Config::Options::BuildOptions.new(drafts: drafts)
-        run_with_options(host, port, false, false, false, build_options)
+        run_with_options(host, port, false, false, false, build_options, false)
       end
 
-      private def run_with_options(host : String, port : Int32, open_browser : Bool, access_log : Bool, live_reload : Bool, build_options : Config::Options::BuildOptions)
+      private def run_with_options(host : String, port : Int32, open_browser : Bool, access_log : Bool, live_reload : Bool, build_options : Config::Options::BuildOptions, json_output : Bool = false)
         Logger.info "Performing initial build..."
         @builder.run(build_options)
 
@@ -296,7 +297,7 @@ module Hwaro
         server = HTTP::Server.new(handlers)
 
         address = server.bind_tcp host, port
-        emit_ready_signal(host, port)
+        emit_ready_signal(host, port, json_output)
         server.listen
       end
 
@@ -313,10 +314,13 @@ module Hwaro
       # Coexists with the pretty "Serving site at …" banner logged earlier —
       # this is an additional single line, not a replacement.
       #
-      # See issue #360. A JSON variant will be added alongside the global
-      # `--json` flag in issue #356.
-      private def emit_ready_signal(host : String, port : Int32)
-        STDOUT.puts ready_signal_line(host, port)
+      # With `json: true` (the `--json` flag), the emitted line is a
+      # compact JSON document matching the schema from issue #356:
+      #   {"event":"ready","url":"...","host":"...","port":N,"pid":P}
+      # Otherwise the human-readable `hwaro serve: ready url=... pid=...`
+      # line from issue #360 is emitted.
+      private def emit_ready_signal(host : String, port : Int32, json : Bool = false)
+        STDOUT.puts(json ? ready_signal_json(host, port) : ready_signal_line(host, port))
         STDOUT.flush
       end
 
@@ -325,6 +329,18 @@ module Hwaro
       # capturing stdout.
       protected def ready_signal_line(host : String, port : Int32) : String
         "hwaro serve: ready url=http://#{host}:#{port} pid=#{Process.pid}"
+      end
+
+      # JSON variant of the ready signal — single-line document on stdout so
+      # CI scripts and agents can parse it with `jq` / `JSON.parse`.
+      protected def ready_signal_json(host : String, port : Int32) : String
+        {
+          "event" => "ready",
+          "url"   => "http://#{host}:#{port}",
+          "host"  => host,
+          "port"  => port,
+          "pid"   => Process.pid,
+        }.to_json
       end
 
       private def sanitize_output_dir(dir : String) : String


### PR DESCRIPTION
## Summary

Adds stable, agent-parseable `--json` output on the commands that CI
pipelines and AI agents most commonly need to consume. Human output is
unchanged when `--json` is not set; `doctor --json` is intentionally left
as-is.

When `--json` is set each command flips `Logger.quiet = true` so only the
final JSON document reaches stdout. Errors emit
`{"status":"error","error":{"message":"…"}}` on stdout and exit non-zero.

### Commands & schemas

| Command | Schema |
| --- | --- |
| `hwaro build --json` | `{"status":"ok","pages_generated":N,"duration_ms":X,"cache_hits":C,"raw_files_processed":R}` (or `{"status":"error",…}` on failure) |
| `hwaro serve --json` | `{"event":"ready","url":"http://host:port","host":"…","port":N,"pid":P}` — replaces the human `hwaro serve: ready …` line when `--json` is set |
| `hwaro deploy --dry-run --json` | `[{"target":"…","action":"create\|update\|delete\|command","path":"…","source":"…","destination":"…"}, …]` |
| `hwaro tool stats --json` | `{"total":N,"published":N,"drafts":N,"word_count":{"total","average","min","max"},"tags":{…},"monthly":{…}}` |
| `hwaro tool validate --json` | `{"findings":[{"file":"…","line":null,"rule":"…","severity":"…","message":"…"}, …]}` |
| `hwaro tool check-links --json` | `{"dead_internal":[…],"dead_external":[…]}` |
| `hwaro tool list --json` | `[{"path":"…","title":"…","draft":false,"date":"…"}, …]` |

`hwaro doctor --json` is unchanged (shipped in a prior PR).

### Implementation notes

- Promotes `JSON_FLAG` usage across all affected commands (already shared in `src/cli/metadata.cr`).
- `Services::Deployer` gains a `plan(options)` method that returns a typed `Array(PlannedOp)` without touching the filesystem or running external commands, reused by `deploy --dry-run --json`.
- `Core::Build::Builder` exposes a `context` getter so the CLI can read `BuildStats` after the run to produce the JSON payload.
- `Services::Server#emit_ready_signal` now takes a `json` flag and emits either the existing human `hwaro serve: ready …` line or a single-line JSON document matching the issue's proposal.

Closes #356

## Test plan

- [x] `crystal spec` — 4407 examples, 0 failures
- [x] `bin/hwaro build --json -i <site> | jq .status` → `"ok"`
- [x] `bin/hwaro tool stats --json` → object with `total`, `word_count`, `tags`
- [x] `bin/hwaro tool validate --json` → `{findings:[…]}`
- [x] `bin/hwaro tool check-links --json` → `{dead_internal, dead_external}`
- [x] `bin/hwaro tool list all --json` → array of `{path, title, draft, date}`
- [x] `bin/hwaro deploy --dry-run --json` — valid JSON even without targets configured (empty array)
- [x] `bin/hwaro serve --json --port 4567` — first stdout line is the JSON ready event

---

한국어 요약: 에이전트/CI가 파싱하기 쉬운 `--json` 옵션을 build, serve, deploy(`--dry-run`), 그리고 주요 `tool` 서브커맨드에 추가했습니다. `doctor --json`은 그대로 둡니다.