### PR TITLE
feat: add stable error taxonomy and consistent exit codes

### DIFF
--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -31,6 +31,48 @@ hwaro build --quiet
 NO_COLOR=1 hwaro doctor
 ```
 
+### Error taxonomy
+
+Classified failure paths emit a stable error code plus a matching
+process exit code so scripts, CI, and agents can branch reliably
+without parsing human messages.
+
+In text mode the error line is prefixed with the code:
+
+```
+Error [HWARO_E_USAGE]: missing <path> argument
+```
+
+Under `--json` (or `--quiet`) the classified error is emitted as a
+structured payload on stdout:
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "HWARO_E_USAGE",
+    "category": "usage",
+    "message": "missing <path> argument",
+    "hint": "Usage: hwaro new <path> [options] — run 'hwaro new --help' for details."
+  }
+}
+```
+
+Unclassified failures keep the legacy `Error: <message>` format and
+exit code `1`, so this is a strictly additive contract.
+
+| Code | Category | Exit | Description |
+|------|----------|------|-------------|
+| `HWARO_E_USAGE` | usage | 2 | Bad/missing flag, missing required argument, unknown command |
+| `HWARO_E_CONFIG` | config | 3 | `config.toml` missing, unparseable, or invalid |
+| `HWARO_E_TEMPLATE` | template | 4 | Crinja template render error |
+| `HWARO_E_CONTENT` | content | 5 | Content file parse error, invalid frontmatter |
+| `HWARO_E_IO` | io | 6 | Filesystem access error (missing dir, permission denied) |
+| `HWARO_E_NETWORK` | network | 7 | Deploy upload, remote scaffold fetch failure |
+| `HWARO_E_INTERNAL` | internal | 70 | Unrecoverable bug or unexpected state |
+| *(unclassified)* | — | 1 | Legacy/generic failure path |
+| *(success)* | — | 0 | Command completed normally |
+
 ## Commands
 
 ### init
@@ -97,7 +139,7 @@ Creates a Markdown file with front matter template. Supports **archetypes** for 
 | -s, --section NAME | Section directory (e.g. `blog`, `docs`) |
 | -a, --archetype NAME | Archetype to use |
 | --list-archetypes | List archetypes in the current project and exit |
-| --json | Emit machine-readable JSON output (with --list-archetypes) |
+| --json | Emit machine-readable JSON output (archetypes listing and classified errors) |
 
 **Archetypes:**
 

--- a/spec/unit/cli_runner_spec.cr
+++ b/spec/unit/cli_runner_spec.cr
@@ -78,6 +78,34 @@ describe Hwaro::CLI::Runner do
     end
   end
 
+  describe ".emit_hwaro_error" do
+    it "emits classified text to stderr when json_mode? is false" do
+      previous_json = Hwaro::CLI::Runner.json_mode?
+      previous_err_io = Hwaro::Logger.err_io
+      previous_color = Hwaro::Logger.color_enabled?
+      Hwaro::Logger.color_enabled = false
+      err_sink = IO::Memory.new
+      Hwaro::Logger.err_io = err_sink
+      Hwaro::CLI::Runner.json_mode = false
+
+      begin
+        err = Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_USAGE,
+          message: "missing <path> argument",
+          hint: "run hwaro new --help",
+        )
+        Hwaro::CLI::Runner.emit_hwaro_error(err, io: err_sink)
+        output = err_sink.to_s
+        output.should contain("Error [HWARO_E_USAGE]: missing <path> argument")
+        output.should contain("run hwaro new --help")
+      ensure
+        Hwaro::Logger.err_io = previous_err_io
+        Hwaro::Logger.color_enabled = previous_color
+        Hwaro::CLI::Runner.json_mode = previous_json
+      end
+    end
+  end
+
   describe ".print_help" do
     it "writes a Commands header followed by command names to Logger.io" do
       previous_io = Hwaro::Logger.io

--- a/spec/unit/errors_spec.cr
+++ b/spec/unit/errors_spec.cr
@@ -1,0 +1,76 @@
+require "../spec_helper"
+require "../../src/utils/errors"
+
+describe Hwaro::Errors do
+  describe ".category_for" do
+    it "maps known codes to their category" do
+      Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_USAGE).should eq(:usage)
+      Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_CONFIG).should eq(:config)
+      Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_TEMPLATE).should eq(:template)
+      Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_CONTENT).should eq(:content)
+      Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_IO).should eq(:io)
+      Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_NETWORK).should eq(:network)
+      Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_INTERNAL).should eq(:internal)
+    end
+
+    it "falls back to :internal for unknown codes" do
+      Hwaro::Errors.category_for("HWARO_E_UNSEEN").should eq(:internal)
+    end
+  end
+
+  describe ".exit_for" do
+    it "maps codes to their documented exit code" do
+      Hwaro::Errors.exit_for(Hwaro::Errors::HWARO_E_USAGE).should eq(2)
+      Hwaro::Errors.exit_for(Hwaro::Errors::HWARO_E_CONFIG).should eq(3)
+      Hwaro::Errors.exit_for(Hwaro::Errors::HWARO_E_TEMPLATE).should eq(4)
+      Hwaro::Errors.exit_for(Hwaro::Errors::HWARO_E_CONTENT).should eq(5)
+      Hwaro::Errors.exit_for(Hwaro::Errors::HWARO_E_IO).should eq(6)
+      Hwaro::Errors.exit_for(Hwaro::Errors::HWARO_E_NETWORK).should eq(7)
+      Hwaro::Errors.exit_for(Hwaro::Errors::HWARO_E_INTERNAL).should eq(70)
+    end
+
+    it "falls back to the legacy generic exit for unknown codes" do
+      Hwaro::Errors.exit_for("HWARO_E_UNSEEN").should eq(1)
+    end
+  end
+end
+
+describe Hwaro::HwaroError do
+  it "stores code, derived category, message, hint" do
+    err = Hwaro::HwaroError.new(
+      code: Hwaro::Errors::HWARO_E_USAGE,
+      message: "missing <path> argument",
+      hint: "run hwaro new --help",
+    )
+
+    err.code.should eq("HWARO_E_USAGE")
+    err.category.should eq(:usage)
+    err.message.should eq("missing <path> argument")
+    err.hint.should eq("run hwaro new --help")
+    err.exit_code.should eq(2)
+  end
+
+  it "defaults hint to nil" do
+    err = Hwaro::HwaroError.new(
+      code: Hwaro::Errors::HWARO_E_CONFIG,
+      message: "bad toml",
+    )
+    err.hint.should be_nil
+    err.exit_code.should eq(3)
+  end
+
+  it "produces a stable JSON payload" do
+    err = Hwaro::HwaroError.new(
+      code: Hwaro::Errors::HWARO_E_NETWORK,
+      message: "upload failed",
+      hint: "check credentials",
+    )
+    payload = err.to_error_payload
+    payload["status"].should eq("error")
+    error = payload["error"]
+    error["code"].should eq("HWARO_E_NETWORK")
+    error["category"].should eq("network")
+    error["message"].should eq("upload failed")
+    error["hint"].should eq("check credentials")
+  end
+end

--- a/spec/unit/new_command_spec.cr
+++ b/spec/unit/new_command_spec.cr
@@ -5,31 +5,31 @@ describe Hwaro::CLI::Commands::NewCommand do
   describe "#parse_options" do
     it "parses path argument" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["posts/hello.md"])
+      options, _json = cmd.parse_options(["posts/hello.md"])
       options.path.should eq("posts/hello.md")
     end
 
     it "parses title flag" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["--title", "Hello World"])
+      options, _json = cmd.parse_options(["--title", "Hello World"])
       options.title.should eq("Hello World")
 
-      options = cmd.parse_options(["-t", "My Title"])
+      options, _json = cmd.parse_options(["-t", "My Title"])
       options.title.should eq("My Title")
     end
 
     it "parses archetype flag" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["--archetype", "blog"])
+      options, _json = cmd.parse_options(["--archetype", "blog"])
       options.archetype.should eq("blog")
 
-      options = cmd.parse_options(["-a", "news"])
+      options, _json = cmd.parse_options(["-a", "news"])
       options.archetype.should eq("news")
     end
 
     it "parses combinations of flags and arguments" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["posts/new.md", "--title", "New Post", "-a", "blog"])
+      options, _json = cmd.parse_options(["posts/new.md", "--title", "New Post", "-a", "blog"])
 
       options.path.should eq("posts/new.md")
       options.title.should eq("New Post")
@@ -38,52 +38,52 @@ describe Hwaro::CLI::Commands::NewCommand do
 
     it "parses --date flag" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["post.md", "--date", "2026-03-22"])
+      options, _json = cmd.parse_options(["post.md", "--date", "2026-03-22"])
       options.date.should eq("2026-03-22")
     end
 
     it "parses --draft flag" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["post.md", "--draft"])
+      options, _json = cmd.parse_options(["post.md", "--draft"])
       options.draft.should be_true
     end
 
     it "defaults draft to nil (auto-detect)" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["post.md"])
+      options, _json = cmd.parse_options(["post.md"])
       options.draft.should be_nil
     end
 
     it "parses --tags flag" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["post.md", "--tags", "go,web,api"])
+      options, _json = cmd.parse_options(["post.md", "--tags", "go,web,api"])
       options.tags.should eq(["go", "web", "api"])
     end
 
     it "parses --tags with spaces" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["post.md", "--tags", "go, web, api"])
+      options, _json = cmd.parse_options(["post.md", "--tags", "go, web, api"])
       options.tags.should eq(["go", "web", "api"])
     end
 
     it "defaults tags to empty" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["post.md"])
+      options, _json = cmd.parse_options(["post.md"])
       options.tags.should be_empty
     end
 
     it "parses --section flag" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options(["post.md", "--section", "blog"])
+      options, _json = cmd.parse_options(["post.md", "--section", "blog"])
       options.section.should eq("blog")
 
-      options = cmd.parse_options(["post.md", "-s", "docs"])
+      options, _json = cmd.parse_options(["post.md", "-s", "docs"])
       options.section.should eq("docs")
     end
 
     it "handles empty arguments" do
       cmd = Hwaro::CLI::Commands::NewCommand.new
-      options = cmd.parse_options([] of String)
+      options, _json = cmd.parse_options([] of String)
 
       options.path.should be_nil
       options.title.should be_nil

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -4,6 +4,7 @@ require "../metadata"
 require "../../config/options/build_options"
 require "../../core/build/builder"
 require "../../content/hooks"
+require "../../utils/errors"
 require "../../utils/logger"
 
 module Hwaro
@@ -68,15 +69,20 @@ module Hwaro
 
           # --json implies quiet so only the final JSON document reaches stdout.
           Logger.quiet = true if json_output
+          Runner.json_mode = true if json_output
 
           if dir = input_dir
             unless Dir.exists?(dir)
+              err = Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_IO,
+                message: "Input directory does not exist: #{dir}",
+              )
               if json_output
-                puts({status: "error", error: {message: "Input directory does not exist: #{dir}"}}.to_json)
-                exit(1)
+                puts err.to_error_payload.to_json
+                exit(err.exit_code)
               end
-              Logger.error "Input directory does not exist: #{dir}"
-              exit(1)
+              Logger.error "Error [#{err.code}]: #{err.message}"
+              exit(err.exit_code)
             end
 
             # Only resolve output_dir to absolute path when -o was explicitly
@@ -105,9 +111,20 @@ module Hwaro
           begin
             builder.run(options)
           rescue ex
+            # Only wrap exceptions we can classify with confidence; others
+            # bubble up as plain Exceptions so their message keeps the
+            # legacy `Error: <message>` text form (per taxonomy scope).
+            err = classify_build_error(ex)
             if json_output
-              puts({status: "error", error: {message: ex.message || "build failed"}}.to_json)
-              exit(1)
+              payload = if err
+                          err.to_error_payload
+                        else
+                          {"status" => "error", "error" => {"message" => ex.message || "build failed"}}
+                        end
+              puts payload.to_json
+              exit(err ? err.exit_code : 1)
+            elsif err
+              raise err
             else
               raise ex
             end
@@ -130,6 +147,25 @@ module Hwaro
             }
             puts payload.to_json
           end
+        end
+
+        # Best-effort classification of build-time exceptions onto the
+        # taxonomy. Returns `nil` when we can't classify with confidence —
+        # the caller then rethrows the original exception so behavior stays
+        # backwards-compatible (generic `Error: <message>`, exit 1).
+        private def classify_build_error(ex : Exception) : Hwaro::HwaroError?
+          return ex if ex.is_a?(Hwaro::HwaroError)
+          msg = ex.message || "build failed"
+          lower = msg.downcase
+          code = if lower.includes?("config.toml") || lower.includes?("config file") ||
+                    lower.includes?("failed to load config") || lower.includes?("invalid config")
+                   Hwaro::Errors::HWARO_E_CONFIG
+                 elsif ex.class.name.includes?("Crinja")
+                   Hwaro::Errors::HWARO_E_TEMPLATE
+                 else
+                   return nil
+                 end
+          Hwaro::HwaroError.new(code: code, message: msg)
         end
 
         def parse_options(args : Array(String)) : { {Config::Options::BuildOptions, Bool}, String?, Bool }

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -4,6 +4,7 @@ require "../metadata"
 require "../../config/options/deploy_options"
 require "../../models/config"
 require "../../services/deployer"
+require "../../utils/errors"
 require "../../utils/logger"
 
 module Hwaro
@@ -46,6 +47,7 @@ module Hwaro
           # Quiet logger so --json emits only the final JSON document. Human
           # --list-targets and --dry-run output is routed around Logger below.
           Logger.quiet = true if json_output
+          Runner.json_mode = true if json_output
 
           if list_targets
             print_targets(options.env, json: json_output)
@@ -60,8 +62,9 @@ module Hwaro
               ops = Services::Deployer.new.plan(options)
               STDOUT.puts ops.to_json
             rescue ex
-              STDOUT.puts({status: "error", error: {message: ex.message || "deploy plan failed"}}.to_json)
-              exit(1)
+              err = classify_deploy_error(ex, fallback_message: "deploy plan failed")
+              STDOUT.puts err.to_error_payload.to_json
+              exit(err.exit_code)
             end
             return
           end
@@ -73,20 +76,45 @@ module Hwaro
             ok = begin
               Services::Deployer.new.run(options)
             rescue ex
-              STDOUT.puts({status: "error", error: {message: ex.message || "deploy failed"}}.to_json)
-              exit(1)
+              err = classify_deploy_error(ex, fallback_message: "deploy failed")
+              STDOUT.puts err.to_error_payload.to_json
+              exit(err.exit_code)
             end
             if ok
               STDOUT.puts({"status" => "ok"}.to_json)
             else
-              STDOUT.puts({status: "error", error: {message: "deploy failed"}}.to_json)
-              exit(1)
+              err = Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_NETWORK,
+                message: "deploy failed",
+              )
+              STDOUT.puts err.to_error_payload.to_json
+              exit(err.exit_code)
             end
             return
           end
 
           ok = Services::Deployer.new.run(options)
           exit(1) unless ok
+        end
+
+        # Map deploy-time exceptions onto the taxonomy. Config-related errors
+        # get HWARO_E_CONFIG; anything else that bubbles up from the deployer
+        # is treated as HWARO_E_NETWORK since it almost always originates in
+        # an upload/remote step.
+        private def classify_deploy_error(ex : Exception, fallback_message : String) : Hwaro::HwaroError
+          return ex if ex.is_a?(Hwaro::HwaroError)
+          msg = ex.message || fallback_message
+          if config_error_message?(msg)
+            Hwaro::HwaroError.new(code: Hwaro::Errors::HWARO_E_CONFIG, message: msg)
+          else
+            Hwaro::HwaroError.new(code: Hwaro::Errors::HWARO_E_NETWORK, message: msg)
+          end
+        end
+
+        private def config_error_message?(msg : String) : Bool
+          lower = msg.downcase
+          lower.includes?("config.toml") || lower.includes?("config file") ||
+            lower.includes?("failed to load config") || lower.includes?("invalid config")
         end
 
         def parse_options(args : Array(String)) : {Config::Options::DeployOptions, Bool, Bool}
@@ -139,12 +167,16 @@ module Hwaro
           config = begin
             Models::Config.load(env: env)
           rescue ex
+            err = Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_CONFIG,
+              message: ex.message || "Failed to load config",
+            )
             if json
-              STDOUT.puts({status: "error", error: {message: ex.message || "Failed to load config"}}.to_json)
+              STDOUT.puts err.to_error_payload.to_json
             else
-              Logger.error(ex.message || "Failed to load config")
+              Logger.error "Error [#{err.code}]: #{err.message}"
             end
-            exit(1)
+            exit(err.exit_code)
           end
 
           deployment = config.deployment

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -3,6 +3,7 @@ require "json"
 require "../metadata"
 require "../../config/options/new_options"
 require "../../services/creator"
+require "../../utils/errors"
 require "../../utils/logger"
 
 module Hwaro
@@ -52,16 +53,23 @@ module Hwaro
             return
           end
 
-          options = parse_options(args)
+          options, json_output = parse_options(args)
+
+          # Signal json mode to the Runner so any HwaroError we raise is
+          # rendered as the structured payload on stdout instead of the
+          # human "Error [CODE]: …" line on stderr.
+          Runner.json_mode = true if json_output
 
           # `hwaro new` is flag-only: there is no interactive prompt, so a
-          # missing <path> always fails fast with a clear usage error. This
-          # keeps behavior identical across TTY, CI, and agent environments.
+          # missing <path> always fails fast with a classified usage error.
+          # Keeping this a HwaroError lets both text and --json consumers see
+          # the same taxonomy (code/category/exit).
           if options.path.nil?
-            STDERR.puts "Error: missing <path> argument"
-            STDERR.puts "Usage: hwaro new <path> [options]"
-            STDERR.puts "Run 'hwaro new --help' for details."
-            exit(2)
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "missing <path> argument",
+              hint: "Usage: hwaro new <path> [options] — run 'hwaro new --help' for details.",
+            )
           end
 
           Services::Creator.new.run(options)
@@ -104,7 +112,7 @@ module Hwaro
           results
         end
 
-        def parse_options(args : Array(String)) : Config::Options::NewOptions
+        def parse_options(args : Array(String)) : {Config::Options::NewOptions, Bool}
           path = nil.as(String?)
           title = nil.as(String?)
           archetype = nil.as(String?)
@@ -112,6 +120,7 @@ module Hwaro
           draft = nil.as(Bool?)
           tags = [] of String
           section = nil.as(String?)
+          json_output = args.includes?("--json")
 
           OptionParser.parse(args) do |parser|
             parser.banner = "Usage: hwaro new <path> [options]"
@@ -123,6 +132,7 @@ module Hwaro
             parser.on("--tags TAGS", "Comma-separated tags") { |t| tags = t.split(",").map(&.strip).reject(&.empty?) }
             parser.on("-s NAME", "--section NAME", "Section directory (e.g. blog, docs)") { |s| section = s }
             parser.on("-a NAME", "--archetype NAME", "Archetype to use") { |a| archetype = a }
+            parser.on("--json", "Emit machine-readable JSON output") { json_output = true }
             CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             parser.unknown_args do |unknown|
@@ -130,7 +140,7 @@ module Hwaro
             end
           end
 
-          Config::Options::NewOptions.new(
+          {Config::Options::NewOptions.new(
             path: path,
             title: title,
             archetype: archetype,
@@ -138,7 +148,7 @@ module Hwaro
             draft: draft,
             tags: tags,
             section: section,
-          )
+          ), json_output}
         end
       end
     end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -5,6 +5,7 @@ require "uri"
 require "file"
 require "option_parser"
 require "../../metadata"
+require "../../../utils/errors"
 require "../../../utils/logger"
 
 module Hwaro
@@ -85,6 +86,7 @@ module Hwaro
             end
 
             Logger.quiet = true if json_output
+            Runner.json_mode = true if json_output
 
             if external_only && internal_only
               Logger.warn "--external-only and --internal-only cancel each other out; checking all links"
@@ -93,12 +95,16 @@ module Hwaro
             end
 
             unless Dir.exists?(target_dir)
+              err = Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_IO,
+                message: "Directory not found: #{target_dir}",
+              )
               if json_output
-                puts({status: "error", error: {message: "Directory not found: #{target_dir}"}}.to_json)
-                exit(1)
+                puts err.to_error_payload.to_json
+                exit(err.exit_code)
               end
-              Logger.error "Directory not found: #{target_dir}"
-              return
+              Logger.error "Error [#{err.code}]: #{err.message}"
+              exit(err.exit_code)
             end
 
             Logger.info "Starting dead link check in '#{target_dir}'..." unless json_output

--- a/src/cli/commands/tool/list_command.cr
+++ b/src/cli/commands/tool/list_command.cr
@@ -10,6 +10,7 @@ require "json"
 require "option_parser"
 require "../../metadata"
 require "../../../services/content_lister"
+require "../../../utils/errors"
 require "../../../utils/logger"
 
 module Hwaro
@@ -56,11 +57,16 @@ module Hwaro
             end
 
             Logger.quiet = true if json_output
+            Runner.json_mode = true if json_output
 
             unless filter
               if json_output
-                puts({status: "error", error: {message: "Missing filter argument. Use 'all', 'drafts', or 'published'"}}.to_json)
-                exit(1)
+                err = Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "Missing filter argument. Use 'all', 'drafts', or 'published'",
+                )
+                puts err.to_error_payload.to_json
+                exit(err.exit_code)
               end
               Logger.error "Missing filter argument. Use 'all', 'drafts', or 'published'"
               Logger.info ""
@@ -89,8 +95,12 @@ module Hwaro
                                Services::ContentFilter::Published
                              else
                                if json_output
-                                 puts({status: "error", error: {message: "Unknown filter: #{filter}"}}.to_json)
-                                 exit(1)
+                                 err = Hwaro::HwaroError.new(
+                                   code: Hwaro::Errors::HWARO_E_USAGE,
+                                   message: "Unknown filter: #{filter}",
+                                 )
+                                 puts err.to_error_payload.to_json
+                                 exit(err.exit_code)
                                end
                                Logger.error "Unknown filter: #{filter}"
                                Logger.info "Use 'all', 'drafts', or 'published'"

--- a/src/cli/commands/tool/stats_command.cr
+++ b/src/cli/commands/tool/stats_command.cr
@@ -9,6 +9,7 @@ require "json"
 require "option_parser"
 require "../../metadata"
 require "../../../services/content_stats"
+require "../../../utils/errors"
 require "../../../utils/logger"
 
 module Hwaro
@@ -49,14 +50,19 @@ module Hwaro
             end
 
             Logger.quiet = true if json_output
+            Runner.json_mode = true if json_output
 
             stats = Services::ContentStats.new(content_dir: content_dir)
             begin
               result = stats.run
             rescue ex
               if json_output
-                puts({status: "error", error: {message: ex.message || "stats failed"}}.to_json)
-                exit(1)
+                err = Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_CONTENT,
+                  message: ex.message || "stats failed",
+                )
+                puts err.to_error_payload.to_json
+                exit(err.exit_code)
               else
                 raise ex
               end

--- a/src/cli/commands/tool/validate_command.cr
+++ b/src/cli/commands/tool/validate_command.cr
@@ -10,6 +10,7 @@ require "colorize"
 require "option_parser"
 require "../../metadata"
 require "../../../services/content_validator"
+require "../../../utils/errors"
 require "../../../utils/logger"
 
 module Hwaro
@@ -50,14 +51,19 @@ module Hwaro
             end
 
             Logger.quiet = true if json_output
+            Runner.json_mode = true if json_output
 
             validator = Services::ContentValidator.new(content_dir: content_dir)
             begin
               issues = validator.run
             rescue ex
               if json_output
-                puts({status: "error", error: {message: ex.message || "validate failed"}}.to_json)
-                exit(1)
+                err = Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_CONTENT,
+                  message: ex.message || "validate failed",
+                )
+                puts err.to_error_payload.to_json
+                exit(err.exit_code)
               else
                 raise ex
               end

--- a/src/cli/runner.cr
+++ b/src/cli/runner.cr
@@ -1,3 +1,4 @@
+require "json"
 require "./metadata"
 require "./commands/init_command"
 require "./commands/build_command"
@@ -7,6 +8,7 @@ require "./commands/deploy_command"
 require "./commands/tool_command"
 require "./commands/doctor_command"
 require "./commands/completion_command"
+require "../utils/errors"
 require "../utils/logger"
 require "../utils/command_suggester"
 
@@ -91,16 +93,69 @@ module Hwaro
           if handler = CommandRegistry.get(command)
             handler.call(args)
           else
-            Runner.report_unknown_command(command)
-            exit(2)
+            # Classified usage error. The "Did you mean …" suggestion prints
+            # to stderr here (text mode only) so the final error line emitted
+            # by the rescue block below is the `Error [CODE]: …` form.
+            if args.any? { |a| a == "--json" }
+              @@json_mode = true
+            else
+              if suggestion = Utils::CommandSuggester.suggest(command, CommandRegistry.names)
+                STDERR.puts "Did you mean '#{suggestion}'?"
+              end
+            end
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "unknown command '#{command}'",
+              hint: "Run 'hwaro --help' to see all commands.",
+            )
           end
         end
+      rescue ex : Hwaro::HwaroError
+        Runner.emit_hwaro_error(ex)
+        exit(ex.exit_code)
       rescue ex : OptionParser::InvalidOption
-        Logger.error "Error: #{ex.message}"
-        exit(1)
+        # Treat bad flags as classified usage errors so exit codes stay
+        # consistent with the documented taxonomy.
+        err = Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_USAGE,
+          message: ex.message || "invalid option",
+        )
+        Runner.emit_hwaro_error(err)
+        exit(err.exit_code)
       rescue ex : Exception
         Logger.error "Error: #{ex.message}"
         exit(1)
+      end
+
+      # Track --json globally so the Runner's top-level rescue can emit the
+      # structured payload even after the subcommand consumed the flag.
+      # Command handlers set this via `Runner.json_mode = true` as soon as
+      # they parse the flag.
+      @@json_mode : Bool = false
+
+      def self.json_mode? : Bool
+        @@json_mode
+      end
+
+      def self.json_mode=(value : Bool)
+        @@json_mode = value
+      end
+
+      # Emit a classified error in either the quiet/JSON machine shape or the
+      # human-friendly `Error [CODE]: message` form. JSON mode is detected
+      # from `Runner.json_mode?` (set by commands that saw `--json`) or from
+      # the raw ARGV (unknown-command path, before any parser runs).
+      def self.emit_hwaro_error(err : Hwaro::HwaroError, io : IO = STDERR)
+        json = @@json_mode || ARGV.includes?("--json")
+        if json
+          STDOUT.puts err.to_error_payload.to_json
+        else
+          msg = "Error [#{err.code}]: #{err.message}"
+          Logger.error msg
+          if hint = err.hint
+            io.puts hint unless hint.empty?
+          end
+        end
       end
 
       # Strip `--quiet` / `-q` from argv and enable Logger.quiet when present.

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -41,6 +41,7 @@ require "../../content/seo/jsonld"
 require "../../content/search"
 require "../../content/pagination/paginator"
 require "../../content/pagination/renderer"
+require "../../utils/errors"
 require "../../utils/logger"
 require "../../utils/profiler"
 require "../../utils/text_utils"
@@ -546,8 +547,19 @@ module Hwaro
           memory_limit : String? = nil,
           env : String? = nil,
         )
-          # Load config once and reuse throughout the build
-          config = Models::Config.load(env: env)
+          # Load config once and reuse throughout the build. Wrap config
+          # load failures with a classified HwaroError so callers (and
+          # `--json` consumers) can reliably branch on HWARO_E_CONFIG.
+          config = begin
+            Models::Config.load(env: env)
+          rescue ex : Hwaro::HwaroError
+            raise ex
+          rescue ex
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_CONFIG,
+              message: ex.message || "Failed to load config",
+            )
+          end
           @config = config
           pre_hooks = config.build.hooks.pre
           post_hooks = config.build.hooks.post

--- a/src/hwaro.cr
+++ b/src/hwaro.cr
@@ -26,6 +26,7 @@ require "toml"
 require "emoji"
 
 # Load utilities
+require "./utils/errors"
 require "./utils/logger"
 require "./utils/profiler"
 require "./utils/command_runner"

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -6,6 +6,7 @@ require "uri"
 
 require "../models/config"
 require "../utils/command_runner"
+require "../utils/errors"
 require "../utils/logger"
 
 module Hwaro
@@ -38,7 +39,7 @@ module Hwaro
       # responsible for surfacing that as a friendly message or JSON error).
       def plan(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Array(PlannedOp)
         ops = [] of PlannedOp
-        config ||= Models::Config.load(env: options.env)
+        config ||= load_config_or_classify(options.env)
         deployment = config.deployment
 
         source_dir = options.source_dir || deployment.source_dir
@@ -111,7 +112,7 @@ module Hwaro
       end
 
       def run(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Bool
-        config ||= Models::Config.load(env: options.env)
+        config ||= load_config_or_classify(options.env)
         deployment = config.deployment
 
         source_dir = options.source_dir || deployment.source_dir
@@ -160,6 +161,20 @@ module Hwaro
         end
 
         true
+      end
+
+      # Wrap config load errors with a classified HwaroError so the CLI
+      # surface consistently reports HWARO_E_CONFIG / exit 3 for bad
+      # `config.toml` instead of a generic exit 1.
+      private def load_config_or_classify(env : String?) : Models::Config
+        Models::Config.load(env: env)
+      rescue ex : Hwaro::HwaroError
+        raise ex
+      rescue ex
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          message: ex.message || "Failed to load config",
+        )
       end
 
       private class EffectiveOptions

--- a/src/utils/errors.cr
+++ b/src/utils/errors.cr
@@ -1,0 +1,108 @@
+# Stable error taxonomy for Hwaro.
+#
+# Provides a small enum of error codes and categories so that scripts,
+# CI pipelines, and agents can reliably branch on *what kind of failure*
+# occurred instead of parsing human-readable messages. Each code also
+# maps to a stable process exit code.
+#
+# Only the highest-traffic error sites are classified today. Other
+# failure paths continue to surface as plain `Exception`s and keep the
+# legacy exit code (1) / text format (`Error: <message>`). Classified
+# errors get the prefixed text form (`Error [HWARO_E_USAGE]: <message>`)
+# and, under `--json` or `Logger.quiet?`, the structured JSON payload
+# `{"status":"error","error":{"code":"…","category":"…","message":"…","hint":"…"}}`.
+#
+# See `docs/content/start/cli.md` for the user-facing reference table.
+
+module Hwaro
+  module Errors
+    # Exit code mapping (see docs/content/start/cli.md). Kept in one place
+    # so `bin/hwaro` process-exit codes stay consistent across call sites.
+    EXIT_SUCCESS  =  0
+    EXIT_GENERIC  =  1 # legacy/default failure
+    EXIT_USAGE    =  2
+    EXIT_CONFIG   =  3
+    EXIT_TEMPLATE =  4
+    EXIT_CONTENT  =  5
+    EXIT_IO       =  6
+    EXIT_NETWORK  =  7
+    EXIT_INTERNAL = 70
+
+    # Error code identifiers — kept as stable strings that surface in
+    # user-facing output (text prefix and JSON `code` field). Changing
+    # these is a breaking change for downstream consumers.
+    HWARO_E_USAGE    = "HWARO_E_USAGE"
+    HWARO_E_CONFIG   = "HWARO_E_CONFIG"
+    HWARO_E_TEMPLATE = "HWARO_E_TEMPLATE"
+    HWARO_E_CONTENT  = "HWARO_E_CONTENT"
+    HWARO_E_IO       = "HWARO_E_IO"
+    HWARO_E_NETWORK  = "HWARO_E_NETWORK"
+    HWARO_E_INTERNAL = "HWARO_E_INTERNAL"
+
+    # Canonical category for each code. Categories are short symbol-like
+    # strings agents can group/filter on without stringly matching every
+    # individual code.
+    CATEGORY_FOR = {
+      HWARO_E_USAGE    => :usage,
+      HWARO_E_CONFIG   => :config,
+      HWARO_E_TEMPLATE => :template,
+      HWARO_E_CONTENT  => :content,
+      HWARO_E_IO       => :io,
+      HWARO_E_NETWORK  => :network,
+      HWARO_E_INTERNAL => :internal,
+    } of String => Symbol
+
+    # Exit code per error code.
+    EXIT_FOR = {
+      HWARO_E_USAGE    => EXIT_USAGE,
+      HWARO_E_CONFIG   => EXIT_CONFIG,
+      HWARO_E_TEMPLATE => EXIT_TEMPLATE,
+      HWARO_E_CONTENT  => EXIT_CONTENT,
+      HWARO_E_IO       => EXIT_IO,
+      HWARO_E_NETWORK  => EXIT_NETWORK,
+      HWARO_E_INTERNAL => EXIT_INTERNAL,
+    } of String => Int32
+
+    def self.category_for(code : String) : Symbol
+      CATEGORY_FOR[code]? || :internal
+    end
+
+    def self.exit_for(code : String) : Int32
+      EXIT_FOR[code]? || EXIT_GENERIC
+    end
+  end
+
+  # Exception carrying a classified error code, category and optional hint.
+  # Callers raise this from high-value paths; the Runner (and a handful of
+  # JSON-emitting command sites) pick it up and render the structured form.
+  class HwaroError < Exception
+    getter code : String
+    getter category : Symbol
+    getter hint : String?
+
+    def initialize(code : String, message : String, hint : String? = nil)
+      super(message)
+      @code = code
+      @category = Errors.category_for(code)
+      @hint = hint
+    end
+
+    def exit_code : Int32
+      Errors.exit_for(@code)
+    end
+
+    # Structured payload used by --json / quiet-mode emission sites.
+    def to_error_payload
+      payload = {
+        "status" => "error",
+        "error"  => {
+          "code"     => @code,
+          "category" => @category.to_s,
+          "message"  => message || "",
+          "hint"     => @hint,
+        },
+      }
+      payload
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Introduce `Hwaro::Errors` with seven classified error codes plus `HwaroError` exception (code, category, message, hint). Each code maps to a stable process exit code.
- Text mode emits `Error [HWARO_E_CODE]: message`. Under `--json` / `--quiet` the Runner emits `{"status":"error","error":{"code","category","message","hint"}}` on stdout with the matching exit code.
- Unclassified failures keep the legacy `Error: <message>` / exit `1` format — this PR is strictly additive for the taxonomy.
- Retrofit the highest-traffic sites only: `new` missing-path usage, unknown commands in the Runner (now `HWARO_E_USAGE`), config-load failures in `build` / `deploy` (now `HWARO_E_CONFIG`), and the already-structured JSON emissions in `build`, `deploy`, `tool stats`, `tool validate`, `tool list`, `tool check-links`.
- Document the taxonomy with a compact code/category/exit table in `docs/content/start/cli.md` under Global flags, plus worked examples of the text and JSON shapes.

## Taxonomy

| Code | Category | Exit | Description |
|------|----------|------|-------------|
| `HWARO_E_USAGE` | usage | 2 | Bad/missing flag, missing required argument, unknown command |
| `HWARO_E_CONFIG` | config | 3 | `config.toml` missing, unparseable, or invalid |
| `HWARO_E_TEMPLATE` | template | 4 | Crinja template render error |
| `HWARO_E_CONTENT` | content | 5 | Content file parse error, invalid frontmatter |
| `HWARO_E_IO` | io | 6 | Filesystem access error (missing dir, permission denied) |
| `HWARO_E_NETWORK` | network | 7 | Deploy upload, remote scaffold fetch failure |
| `HWARO_E_INTERNAL` | internal | 70 | Unrecoverable bug or unexpected state |
| *(unclassified)* | — | 1 | Legacy/generic failure path |
| *(success)* | — | 0 | Command completed normally |

## Test plan

- [x] `crystal spec` — 4415 examples, 0 failures (adds `spec/unit/errors_spec.cr` and extends `cli_runner_spec.cr` / `new_command_spec.cr`)
- [x] `just build`
- [ ] `bin/hwaro new` prints `Error [HWARO_E_USAGE]: missing <path> argument` on stderr, exit 2
- [ ] `bin/hwaro new --json` prints `{"status":"error","error":{"code":"HWARO_E_USAGE",...}}` on stdout, exit 2
- [ ] `bin/hwaro xyz` prints `Error [HWARO_E_USAGE]: unknown command 'xyz'`, exit 2
- [ ] `bin/hwaro build --json` in a project with a broken `config.toml` returns JSON with `code: HWARO_E_CONFIG`, exit 3

Closes #359

---

에러 코드 분류 체계와 종료 코드 매핑을 추가했습니다. 기존 미분류 실패 경로는 그대로 `Error: <message>` / exit 1을 유지합니다.