### PR TITLE
fix: always emit `date` in `tool list --json` entries

### DIFF
--- a/src/services/content_lister.cr
+++ b/src/services/content_lister.cr
@@ -25,7 +25,7 @@ module Hwaro
       property title : String
       property draft : Bool
 
-      @[JSON::Field(converter: Hwaro::Services::ContentInfo::TimeConverter)]
+      @[JSON::Field(converter: Hwaro::Services::ContentInfo::TimeConverter, emit_null: true)]
       property date : Time?
 
       def initialize(


### PR DESCRIPTION
## Summary
- Follow-up to #356. Each entry from `hwaro tool list --json` was supposed to be `{path, title, draft, date}`, but `JSON::Serializable` omits nil fields by default, so entries without a frontmatter `date` dropped the key entirely:
  ```
  [{"path":"content/index.md","title":"Welcome","draft":false}]
  ```
- Setting `emit_null: true` on the `date` field forces the existing `TimeConverter` to produce `"date": null` so the schema stays stable across dated and undated entries:
  ```
  [{"path":"content/index.md","title":"Welcome","draft":false,"date":null},
   {"path":"content/dated.md","title":"Dated post","draft":false,"date":"2026-04-15T01:00:00+00:00"}]
  ```

## Test plan
- [x] `crystal spec spec/unit/content_lister_spec.cr` passes (31 examples)
- [x] `crystal spec spec/functional/cli_tool_subcommands_spec.cr` passes (30 examples)
- [x] Manual: `hwaro tool list all --json` in a scaffolded project now shows `"date":null` for undated entries and the formatted timestamp for dated entries

---
`date`가 nil인 엔트리에서도 키가 유지되도록 `emit_null: true`를 추가해 #356 스키마를 맞췄습니다.