### PR TITLE
feat: add per-target summary to hwaro deploy --json

### DIFF
--- a/spec/unit/deployer_service_spec.cr
+++ b/spec/unit/deployer_service_spec.cr
@@ -214,6 +214,103 @@ describe Hwaro::Services::Deployer do
       end
     end
 
+    it "returns per-target DeployResult list for #deploy_structured happy path" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(src_dir)
+        File.write(File.join(src_dir, "index.html"), "Hello")
+        File.write(File.join(src_dir, "style.css"), "body{}")
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{dest_dir}"
+        config.deployment.targets << target
+
+        deployer = Hwaro::Services::Deployer.new
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: src_dir,
+          targets: ["local"]
+        )
+
+        results = deployer.deploy_structured(options, config)
+        results.size.should eq(1)
+        r = results.first
+        r.name.should eq("local")
+        r.status.should eq("ok")
+        r.created.should eq(2)
+        r.updated.should eq(0)
+        r.deleted.should eq(0)
+        r.duration_ms.should be >= 0.0
+        r.error.should be_nil
+
+        # Second run: same content should produce all-skipped (no create/update/delete)
+        results2 = deployer.deploy_structured(options, config)
+        r2 = results2.first
+        r2.status.should eq("ok")
+        r2.created.should eq(0)
+        r2.updated.should eq(0)
+        r2.deleted.should eq(0)
+      end
+    end
+
+    it "serializes DeployResult as JSON with required fields" do
+      result = Hwaro::Services::Deployer::DeployResult.new(
+        name: "production",
+        status: "ok",
+        created: 3,
+        updated: 7,
+        deleted: 0,
+        duration_ms: 2410.0,
+        error: nil,
+      )
+      json = result.to_json
+      parsed = JSON.parse(json)
+      parsed["name"].as_s.should eq("production")
+      parsed["status"].as_s.should eq("ok")
+      parsed["created"].as_i.should eq(3)
+      parsed["updated"].as_i.should eq(7)
+      parsed["deleted"].as_i.should eq(0)
+      parsed["duration_ms"].as_f.should eq(2410.0)
+    end
+
+    it "captures per-target error without aborting siblings in #deploy_structured" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(src_dir)
+        File.write(File.join(src_dir, "index.html"), "Hi")
+
+        config = Hwaro::Models::Config.new
+
+        # First target succeeds, second fails (missing url + command).
+        ok_target = Hwaro::Models::DeploymentTarget.new
+        ok_target.name = "ok"
+        ok_target.url = "file://#{dest_dir}"
+        config.deployment.targets << ok_target
+
+        bad_target = Hwaro::Models::DeploymentTarget.new
+        bad_target.name = "bad"
+        bad_target.url = ""
+        config.deployment.targets << bad_target
+
+        deployer = Hwaro::Services::Deployer.new
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: src_dir,
+          targets: ["ok", "bad"]
+        )
+
+        results = deployer.deploy_structured(options, config)
+        results.size.should eq(2)
+        results[0].name.should eq("ok")
+        results[0].status.should eq("ok")
+        results[1].name.should eq("bad")
+        results[1].status.should eq("error")
+        results[1].error.should_not be_nil
+      end
+    end
+
     it "auto-generates command for gs:// URL in dry_run" do
       Dir.mktmpdir do |dir|
         src_dir = File.join(dir, "src")

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -70,31 +70,48 @@ module Hwaro
           end
 
           if json_output
-            # Real deploy with --json (no --dry-run) isn't part of this
-            # command's stable JSON schema yet. Fall back to returning a
-            # status document so agents aren't left with raw progress text.
-            ok = begin
-              Services::Deployer.new.run(options)
+            # Real deploy with --json (no --dry-run) returns a per-target
+            # summary. Schema per issue #374:
+            #   {"status": "ok"|"error",
+            #    "targets": [{"name","status","created","updated",
+            #                 "deleted","duration_ms","error"?}]}
+            # Config-load errors bubble up here and become a top-level
+            # error payload (shape unchanged from #356).
+            results = begin
+              Services::Deployer.new.deploy_structured(options)
             rescue ex
               err = classify_deploy_error(ex, fallback_message: "deploy failed")
               STDOUT.puts err.to_error_payload.to_json
               exit(err.exit_code)
             end
-            if ok
-              STDOUT.puts({"status" => "ok"}.to_json)
-            else
-              err = Hwaro::HwaroError.new(
-                code: Hwaro::Errors::HWARO_E_NETWORK,
-                message: "deploy failed",
-              )
-              STDOUT.puts err.to_error_payload.to_json
-              exit(err.exit_code)
-            end
+
+            overall = results.all? { |r| r.status == "ok" } ? "ok" : "error"
+            payload = {"status" => overall, "targets" => results}
+            STDOUT.puts payload.to_json
+            exit(overall == "ok" ? 0 : worst_exit_for(results))
             return
           end
 
           ok = Services::Deployer.new.run(options)
           exit(1) unless ok
+        end
+
+        # Pick the most severe exit code across failing targets so CI can
+        # branch on whether a partial failure was config- vs upload-related.
+        # Numerically higher exit codes win (HWARO_E_NETWORK=7 beats
+        # HWARO_E_CONFIG=3). Falls back to EXIT_GENERIC (1) when there is
+        # no classified error (shouldn't happen in practice).
+        private def worst_exit_for(results : Array(Services::Deployer::DeployResult)) : Int32
+          worst = Hwaro::Errors::EXIT_GENERIC
+          results.each do |r|
+            next if r.status == "ok"
+            if err = r.error
+              code = err["code"]?
+              exit_code = code ? Hwaro::Errors.exit_for(code) : Hwaro::Errors::EXIT_GENERIC
+              worst = exit_code if exit_code > worst
+            end
+          end
+          worst
         end
 
         # Map deploy-time exceptions onto the taxonomy. Config-related errors

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -33,6 +33,36 @@ module Hwaro
         include JSON::Serializable
       end
 
+      # Per-target summary emitted by `#deploy_structured` for
+      # `hwaro deploy --json` (non dry-run). Shape is part of the stable
+      # JSON schema per issue #374 — agents/CI consume these fields.
+      #
+      # `error` is nil when `status == "ok"`. When set, it mirrors the
+      # classified `HwaroError` payload (`code`, `category`, `message`,
+      # `hint`) so the shape lines up with top-level error payloads.
+      record DeployResult,
+        name : String,
+        status : String,
+        created : Int32,
+        updated : Int32,
+        deleted : Int32,
+        duration_ms : Float64,
+        error : Hash(String, String?)? = nil do
+        include JSON::Serializable
+      end
+
+      # Counts collected while deploying a single target. Command-based
+      # targets report zeros since we can't introspect what the external
+      # tool did.
+      private struct TargetCounts
+        property created : Int32
+        property updated : Int32
+        property deleted : Int32
+
+        def initialize(@created : Int32 = 0, @updated : Int32 = 0, @deleted : Int32 = 0)
+        end
+      end
+
       # Build a list of planned operations across all configured (or explicitly
       # requested) targets without performing any filesystem writes or external
       # commands. Returns an empty array when no targets resolve (caller is
@@ -109,6 +139,180 @@ module Hwaro
         end
 
         ops
+      end
+
+      # Run a real deploy and return a per-target summary suitable for
+      # `hwaro deploy --json` (no `--dry-run`). Each target is deployed
+      # independently — an exception in one target is captured in its
+      # `DeployResult.error` and does NOT abort the remaining targets,
+      # so partial failures are visible to agents/CI.
+      #
+      # Config-load errors intentionally propagate as `HwaroError` so the
+      # caller can emit a top-level error payload (shape unchanged).
+      def deploy_structured(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Array(DeployResult)
+        results = [] of DeployResult
+        config ||= load_config_or_classify(options.env)
+        deployment = config.deployment
+
+        source_dir = options.source_dir || deployment.source_dir
+        source_dir = File.expand_path(source_dir)
+
+        unless Dir.exists?(source_dir)
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONFIG,
+            message: "Source directory not found: #{source_dir}",
+            hint: "Run 'hwaro build' first, or pass '--source DIR'.",
+          )
+        end
+
+        target_names =
+          if options.targets.any?
+            options.targets
+          elsif target = deployment.target
+            [target]
+          elsif deployment.targets.size > 0
+            [deployment.targets.first.name]
+          else
+            [] of String
+          end
+
+        return results if target_names.empty?
+
+        targets = target_names.compact_map do |name|
+          target = deployment.target_named(name)
+          unless target
+            results << DeployResult.new(
+              name: name,
+              status: "error",
+              created: 0, updated: 0, deleted: 0,
+              duration_ms: 0.0,
+              error: {
+                "code"     => Hwaro::Errors::HWARO_E_CONFIG,
+                "category" => Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_CONFIG).to_s,
+                "message"  => "Unknown deploy target: #{name}",
+                "hint"     => nil.as(String?),
+              } of String => String?,
+            )
+            nil
+          else
+            target
+          end
+        end
+
+        effective = EffectiveOptions.new(deployment, options)
+
+        targets.each do |target|
+          results << deploy_target_structured(target, source_dir, effective, deployment)
+        end
+
+        results
+      end
+
+      # Deploy a single target while capturing counts, timing, and any
+      # classified error. Exceptions raised below are caught here rather
+      # than propagating so one failing target doesn't abort the run.
+      private def deploy_target_structured(
+        target : Models::DeploymentTarget,
+        source_dir : String,
+        effective : EffectiveOptions,
+        deployment : Models::DeploymentConfig,
+      ) : DeployResult
+        started = Time.instant
+        counts = TargetCounts.new
+        ok = false
+        error : Hwaro::HwaroError? = nil
+
+        begin
+          ok, counts = deploy_target_with_counts(target, source_dir, effective, deployment)
+        rescue ex : Hwaro::HwaroError
+          error = ex
+        rescue ex
+          error = Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_NETWORK,
+            message: ex.message || "Deploy target '#{target.name}' failed",
+          )
+        end
+
+        duration_ms = ((Time.instant - started).total_milliseconds * 100).round / 100
+
+        if err = error
+          return DeployResult.new(
+            name: target.name,
+            status: "error",
+            created: counts.created,
+            updated: counts.updated,
+            deleted: counts.deleted,
+            duration_ms: duration_ms,
+            error: {
+              "code"     => err.code,
+              "category" => err.category.to_s,
+              "message"  => err.message || "",
+              "hint"     => err.hint,
+            } of String => String?,
+          )
+        end
+
+        unless ok
+          return DeployResult.new(
+            name: target.name,
+            status: "error",
+            created: counts.created,
+            updated: counts.updated,
+            deleted: counts.deleted,
+            duration_ms: duration_ms,
+            error: {
+              "code"     => Hwaro::Errors::HWARO_E_NETWORK,
+              "category" => Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_NETWORK).to_s,
+              "message"  => "Deploy target '#{target.name}' failed",
+              "hint"     => nil.as(String?),
+            } of String => String?,
+          )
+        end
+
+        DeployResult.new(
+          name: target.name,
+          status: "ok",
+          created: counts.created,
+          updated: counts.updated,
+          deleted: counts.deleted,
+          duration_ms: duration_ms,
+          error: nil,
+        )
+      end
+
+      # Deploy a single target, returning both success and the collected
+      # counts so `#deploy_structured` can surface file-level stats.
+      private def deploy_target_with_counts(
+        target : Models::DeploymentTarget,
+        source_dir : String,
+        effective : EffectiveOptions,
+        deployment : Models::DeploymentConfig,
+      ) : {Bool, TargetCounts}
+        Logger.action(:Deploy, "Target: #{target.name}")
+
+        if command = target.command
+          ok = deploy_via_command(target, source_dir, command, effective)
+          return {ok, TargetCounts.new}
+        end
+
+        url = target.url
+        if url.empty?
+          Logger.error "Target '#{target.name}' is missing 'url' (or 'command')."
+          return {false, TargetCounts.new}
+        end
+
+        if directory_destination = local_directory_destination(url)
+          return deploy_to_directory_with_counts(target, source_dir, directory_destination, effective)
+        end
+
+        if auto_command = auto_command_for_url(url, source_dir)
+          Logger.debug "  Auto-generated command for #{url}"
+          ok = deploy_via_command(target, source_dir, auto_command, effective)
+          return {ok, TargetCounts.new}
+        end
+
+        Logger.error "Unsupported deploy target URL scheme for '#{target.name}': #{url}"
+        {false, TargetCounts.new}
       end
 
       def run(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Bool
@@ -281,6 +485,71 @@ module Hwaro
 
         Logger.success "Deploy command completed."
         true
+      end
+
+      # Variant of `#deploy_to_directory` that also returns per-action
+      # counts (created/updated/deleted) for JSON summary output.
+      private def deploy_to_directory_with_counts(
+        target : Models::DeploymentTarget,
+        source_dir : String,
+        dest_dir : String,
+        effective : EffectiveOptions,
+      ) : {Bool, TargetCounts}
+        counts = TargetCounts.new
+        dest_dir_expanded = File.expand_path(dest_dir)
+
+        if nested_path?(source_dir, dest_dir_expanded) || nested_path?(dest_dir_expanded, source_dir)
+          Logger.error "Refusing to deploy: source and destination overlap."
+          return {false, counts}
+        end
+
+        FileUtils.mkdir_p(dest_dir_expanded)
+
+        desired = build_desired_map(source_dir, target)
+        existing = list_existing_files(dest_dir_expanded)
+
+        return {false, counts} unless validate_strip_index_html_for_filesystem(target, desired.keys)
+        return {false, counts} unless validate_destination_paths(dest_dir_expanded, desired.keys)
+
+        to_delete = compute_deletes(existing, desired.keys, target)
+        if effective.max_deletes != -1 && to_delete.size > effective.max_deletes
+          Logger.error "Refusing to delete #{to_delete.size} files (max_deletes: #{effective.max_deletes})."
+          return {false, counts}
+        end
+
+        to_copy, _skipped = compute_copies(desired, dest_dir_expanded, effective.force)
+
+        if effective.dry_run
+          return {true, counts}
+        end
+
+        if effective.confirm && !confirm?("Proceed with deploy to #{dest_dir_expanded}?")
+          Logger.warn "Cancelled."
+          return {true, counts}
+        end
+
+        to_copy.each_with_index do |(dest_rel, src_path), idx|
+          Logger.progress(idx + 1, to_copy.size, "Copying ")
+          dest_path = File.join(dest_dir_expanded, dest_rel)
+          existed_before = File.exists?(dest_path)
+          FileUtils.mkdir_p(File.dirname(dest_path))
+          FileUtils.cp(src_path, dest_path)
+          if existed_before
+            counts.updated += 1
+          else
+            counts.created += 1
+          end
+        end
+
+        to_delete.each_with_index do |rel, idx|
+          Logger.progress(idx + 1, to_delete.size, "Deleting ")
+          FileUtils.rm(File.join(dest_dir_expanded, rel))
+          counts.deleted += 1
+        end
+
+        remove_empty_directories(dest_dir_expanded)
+        Logger.success "Deployed to #{dest_dir_expanded} (created #{counts.created}, updated #{counts.updated}, deleted #{counts.deleted})"
+        {true, counts}
       end
 
       private def deploy_to_directory(


### PR DESCRIPTION
## Summary

Replaces the stopgap `{"status":"ok"}` payload emitted by `hwaro deploy --json` (non `--dry-run`) with a structured, per-target summary so agents/CI can see which targets ran, what each one changed, and which one failed.

## Schema

```json
{
  "status": "ok",
  "targets": [
    {
      "name": "production",
      "status": "ok",
      "created": 3,
      "updated": 7,
      "deleted": 0,
      "duration_ms": 2410.12
    }
  ]
}
```

On partial failure, top-level `status` becomes `"error"`, each target retains its own `status`, and the process exits with the most severe classified exit code across failing targets (`HWARO_E_NETWORK` = 7 beats `HWARO_E_CONFIG` = 3). Failed targets carry an `error` object with the same `{code, category, message, hint}` shape used by the top-level error payload.

## Implementation notes

- `Services::Deployer#deploy_structured(options, config)` runs each target independently: exceptions are captured into the target's `error` field so one failing target never aborts siblings.
- `DeployResult` is a `record` with `JSON::Serializable`. `duration_ms` is measured with `Time.instant` and rounded to 2 decimals.
- Directory deploys now split "copy" into `created` vs `updated` based on whether the destination file existed beforehand. Command-based targets report zeros for file counts (we can't introspect external tools).
- Plain `Exception`s from the deploy path are wrapped as `HWARO_E_NETWORK` so the target error shape stays uniform.
- `--dry-run --json` (existing `PlannedOp[]` schema) is unchanged.
- Top-level error payload on config-load failure is unchanged (shape from #356/#359).
- "No targets configured" returns `{"status":"ok","targets":[]}` and exits 0.
- NDJSON event streaming (`--json-events`) is deferred per the issue.

## Test plan

- [x] `crystal spec` — 4418 examples, 0 failures
- [x] New specs cover the happy path (single-target success), JSON serialization shape, and partial-failure behavior (one target ok, one error) in `spec/unit/deployer_service_spec.cr`
- [x] `just build` — clean, no warnings

Closes #374

---
실제 `hwaro deploy --json` 출력을 타겟별 요약 스키마로 확정하고 부분 실패 시 가장 엄격한 종료 코드를 반환하도록 변경했습니다.