### PR TITLE
feat: classify template and content errors with HwaroError

### DIFF
--- a/spec/unit/content_validator_spec.cr
+++ b/spec/unit/content_validator_spec.cr
@@ -2,10 +2,12 @@ require "../spec_helper"
 
 describe Hwaro::Services::ContentValidator do
   describe "#run" do
-    it "returns empty array when content directory does not exist" do
+    it "raises HwaroError(HWARO_E_CONTENT) when content directory does not exist" do
       validator = Hwaro::Services::ContentValidator.new("/nonexistent/path/content")
-      result = validator.run
-      result.should eq([] of Hwaro::Services::Issue)
+      err = expect_raises(Hwaro::HwaroError) { validator.run }
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+      err.exit_code.should eq(5)
+      (err.message || "").should contain("/nonexistent/path/content")
     end
 
     it "returns no issues for well-formed content" do

--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -956,7 +956,7 @@ describe Hwaro::Content::Processors::Markdown do
   # Malformed front matter recovery
   # ---------------------------------------------------------------------------
   describe "malformed front matter" do
-    it "recovers from invalid TOML and returns defaults" do
+    it "raises HWARO_E_CONTENT for invalid TOML when a file path is given" do
       raw = <<-MD
       +++
       title = "Valid"
@@ -965,12 +965,15 @@ describe Hwaro::Content::Processors::Markdown do
       Body content
       MD
 
-      result = processor.parse(raw, "test.md")
-      # Should not crash; falls back to defaults for fields it can't parse
-      result[:content].should contain("Body content")
+      err = expect_raises(Hwaro::HwaroError) do
+        processor.parse(raw, "test.md")
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+      err.exit_code.should eq(5)
+      (err.message || "").should contain("test.md")
     end
 
-    it "recovers from invalid YAML and returns defaults" do
+    it "raises HWARO_E_CONTENT for invalid YAML when a file path is given" do
       raw = <<-MD
       ---
       title: Valid
@@ -979,8 +982,34 @@ describe Hwaro::Content::Processors::Markdown do
       Body content
       MD
 
-      result = processor.parse(raw, "test.md")
-      # Should not crash; falls back to defaults
+      err = expect_raises(Hwaro::HwaroError) do
+        processor.parse(raw, "test.md")
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+      err.exit_code.should eq(5)
+      (err.message || "").should contain("test.md")
+    end
+
+    it "falls back to defaults when no file path is given (library use)" do
+      raw_toml = <<-MD
+      +++
+      title = "Valid"
+      invalid_syntax :::
+      +++
+      Body content
+      MD
+      result = processor.parse(raw_toml)
+      # Library-style invocation preserves the previous graceful behaviour
+      result[:content].should contain("Body content")
+
+      raw_yaml = <<-MD
+      ---
+      title: Valid
+      invalid: [unterminated
+      ---
+      Body content
+      MD
+      result = processor.parse(raw_yaml)
       result[:content].should contain("Body content")
     end
 

--- a/spec/unit/template_spec.cr
+++ b/spec/unit/template_spec.cr
@@ -883,4 +883,37 @@ describe Hwaro::Content::Processors::Template do
       result.should eq("© #{Time.local.year} My Site")
     end
   end
+
+  describe "error classification" do
+    it "raises HwaroError(HWARO_E_TEMPLATE) for a broken template string" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/about/"
+      config = Hwaro::Models::Config.new
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+
+      # Unclosed `{{` — Crinja raises a parse error which the engine
+      # wraps as HwaroError(HWARO_E_TEMPLATE).
+      err = expect_raises(Hwaro::HwaroError) do
+        Hwaro::Content::Processors::Template.process("{{ unclosed", context)
+      end
+
+      err.code.should eq(Hwaro::Errors::HWARO_E_TEMPLATE)
+      err.category.should eq(:template)
+      err.exit_code.should eq(4)
+      (err.message || "").should contain("Template error")
+    end
+
+    it "raises HwaroError(HWARO_E_TEMPLATE) for an unclosed block tag" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+
+      err = expect_raises(Hwaro::HwaroError) do
+        Hwaro::Content::Processors::Template.process("{% if true %}oops", context)
+      end
+
+      err.code.should eq(Hwaro::Errors::HWARO_E_TEMPLATE)
+      err.exit_code.should eq(4)
+    end
+  end
 end

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -153,6 +153,15 @@ module Hwaro
         # taxonomy. Returns `nil` when we can't classify with confidence —
         # the caller then rethrows the original exception so behavior stays
         # backwards-compatible (generic `Error: <message>`, exit 1).
+        #
+        # Template and content errors are now raised as `HwaroError`
+        # directly from their rescue sites (see
+        # `src/content/processors/template.cr`,
+        # `src/core/build/phases/render.cr`, and
+        # `src/content/processors/markdown.cr`), so this method only keeps
+        # the string-match fallback for config-load paths that still raise
+        # plain exceptions. That branch will be retired once config loading
+        # surfaces HwaroError directly.
         private def classify_build_error(ex : Exception) : Hwaro::HwaroError?
           return ex if ex.is_a?(Hwaro::HwaroError)
           msg = ex.message || "build failed"
@@ -160,8 +169,6 @@ module Hwaro
           code = if lower.includes?("config.toml") || lower.includes?("config file") ||
                     lower.includes?("failed to load config") || lower.includes?("invalid config")
                    Hwaro::Errors::HWARO_E_CONFIG
-                 elsif ex.class.name.includes?("Crinja")
-                   Hwaro::Errors::HWARO_E_TEMPLATE
                  else
                    return nil
                  end

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -14,6 +14,7 @@ require "./base"
 require "./syntax_highlighter"
 require "./markdown_extensions"
 require "../../models/toc"
+require "../../utils/errors"
 require "../../utils/logger"
 require "../../utils/text_utils"
 
@@ -238,7 +239,23 @@ module Hwaro
 
         # Extract front matter fields from TOML content
         private def extract_from_toml(raw : String, file_path : String)
-          toml_fm = TOML.parse(raw)
+          toml_fm = begin
+            TOML.parse(raw)
+          rescue ex
+            # Top-level frontmatter parse failure — surface as HWARO_E_CONTENT
+            # so `hwaro build --json` emits a structured error with exit 5.
+            # When called without a file_path (library use), preserve the
+            # previous graceful-nil behaviour.
+            if file_path.empty?
+              Logger.warn "Invalid TOML: #{ex.message}"
+              return nil
+            end
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_CONTENT,
+              message: "Invalid TOML frontmatter in #{file_path}: #{ex.message}",
+              hint: "Check TOML frontmatter between `+++` fences",
+            )
+          end
 
           date = parse_toml_time(toml_fm["date"]?)
           updated = parse_toml_time(toml_fm["updated"]?)
@@ -260,6 +277,8 @@ module Hwaro
 
           result = build_front_matter_result(toml_fm, date, updated, extra, front_matter_keys, taxonomies, tags)
           result.merge({expires: expires})
+        rescue ex : Hwaro::HwaroError
+          raise ex
         rescue ex
           Logger.warn "Invalid TOML in #{file_path}: #{ex.message}" unless file_path.empty?
           nil
@@ -267,7 +286,23 @@ module Hwaro
 
         # Extract front matter fields from YAML content
         private def extract_from_yaml(raw : String, file_path : String)
-          yaml_fm = YAML.parse(raw)
+          yaml_fm = begin
+            YAML.parse(raw)
+          rescue ex
+            # Top-level frontmatter parse failure — surface as HWARO_E_CONTENT
+            # so `hwaro build --json` emits a structured error with exit 5.
+            # When called without a file_path (library use), preserve the
+            # previous graceful-nil behaviour.
+            if file_path.empty?
+              Logger.warn "Invalid YAML: #{ex.message}"
+              return nil
+            end
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_CONTENT,
+              message: "Invalid YAML frontmatter in #{file_path}: #{ex.message}",
+              hint: "Check YAML frontmatter between `---` fences",
+            )
+          end
           return nil unless yaml_fm.as_h?
 
           date = parse_time(yaml_fm["date"]?.try(&.as_s?))
@@ -294,6 +329,8 @@ module Hwaro
 
           result = build_front_matter_result(yaml_fm, date, updated, extra, front_matter_keys, taxonomies, tags)
           result.merge({expires: expires})
+        rescue ex : Hwaro::HwaroError
+          raise ex
         rescue ex
           Logger.warn "Invalid YAML in #{file_path}: #{ex.message}" unless file_path.empty?
           nil

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -16,6 +16,7 @@ require "csv"
 require "crinja"
 require "./filters/*"
 require "../../utils/crinja_utils"
+require "../../utils/errors"
 
 module Hwaro
   module Content
@@ -171,24 +172,44 @@ module Hwaro
         def render(template_string : String, context : TemplateContext) : String
           template = @env.from_string(template_string)
           template.render(context.to_crinja_vars)
+        rescue ex : Crinja::Error
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_TEMPLATE,
+            message: "Template error: #{ex.message}",
+          )
         end
 
         # Render a template string with raw hash
         def render(template_string : String, variables : Hash(String, Crinja::Value)) : String
           template = @env.from_string(template_string)
           template.render(variables)
+        rescue ex : Crinja::Error
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_TEMPLATE,
+            message: "Template error: #{ex.message}",
+          )
         end
 
         # Load and render a template by name
         def render_template(template_name : String, context : TemplateContext) : String
           template = @env.get_template(template_name)
           template.render(context.to_crinja_vars)
+        rescue ex : Crinja::Error
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_TEMPLATE,
+            message: "Template error in '#{template_name}': #{ex.message}",
+          )
         end
 
         # Load and render a template by name with raw hash
         def render_template(template_name : String, variables : Hash(String, Crinja::Value)) : String
           template = @env.get_template(template_name)
           template.render(variables)
+        rescue ex : Crinja::Error
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_TEMPLATE,
+            message: "Template error in '#{template_name}': #{ex.message}",
+          )
         end
 
         # Register custom filters specific to Hwaro

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -186,6 +186,11 @@ module Hwaro::Core::Build::Phases::ParseContent
     pages.each do |page|
       begin
         parse_single_page(page)
+      rescue ex : Hwaro::HwaroError
+        # Classified frontmatter errors (HWARO_E_CONTENT) must abort the
+        # build so scripts and CI see a stable exit code, rather than
+        # silently skipping the offending page.
+        raise ex
       rescue ex
         page.parse_failed = true
         Logger.warn "Failed to parse #{page.path}: #{ex.message}"
@@ -209,12 +214,22 @@ module Hwaro::Core::Build::Phases::ParseContent
     pages.each { |page| work_queue.send(page) }
     work_queue.close
 
+    # Track the first classified frontmatter error seen by any worker so
+    # the build can abort deterministically after draining the queue.
+    classified_error : Hwaro::HwaroError? = nil
+    error_mutex = Mutex.new
+
     # Spawn workers
     worker_count.times do
       spawn do
         while page = work_queue.receive?
           begin
             parse_single_page(page)
+          rescue ex : Hwaro::HwaroError
+            error_mutex.synchronize do
+              classified_error ||= ex
+            end
+            page.parse_failed = true
           rescue ex
             page.parse_failed = true
             Logger.warn "Failed to parse #{page.path}: #{ex.message}"
@@ -226,6 +241,13 @@ module Hwaro::Core::Build::Phases::ParseContent
 
     # Wait for all pages to finish
     pages.size.times { done.receive }
+
+    # Surface the first classified frontmatter error now that all workers
+    # have drained. We prefer this over re-raising inside the worker fiber
+    # so the build aborts predictably after the parallel phase completes.
+    if err = classified_error
+      raise err
+    end
   end
 
   private def calculate_page_url(page : Models::Page)

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -154,6 +154,11 @@ module Hwaro::Core::Build::Phases::Render
     pages.each_with_index { |page, idx| work_queue.send({page, idx}) }
     work_queue.close
 
+    # Track the first classified error seen by any worker so the build
+    # can abort deterministically after draining the result channel.
+    classified_error : Hwaro::HwaroError? = nil
+    error_mutex = Mutex.new
+
     # Spawn workers, each with its own Crinja env and template cache
     worker_count.times do |worker_id|
       env = worker_envs[worker_id]
@@ -174,6 +179,12 @@ module Hwaro::Core::Build::Phases::Render
             output_path = get_output_path(page, output_dir)
             cache.update(source_path, output_path)
             results.send(true)
+          rescue ex : Hwaro::HwaroError
+            error_mutex.synchronize do
+              classified_error ||= ex
+            end
+            Logger.error "Parallel render failed for #{page.path}: #{ex.message}"
+            results.send(false)
           rescue ex
             Logger.error "Parallel render failed for #{page.path}: #{ex.message}"
             Logger.debug "  Template: #{determine_template(page, templates)}, Section: #{page.section}"
@@ -189,6 +200,14 @@ module Hwaro::Core::Build::Phases::Render
     pages.size.times do
       count += 1 if results.receive
     end
+
+    # Surface the first classified error now that all workers have drained
+    # so the CLI sees the documented exit code / JSON payload instead of
+    # a silent `status=ok, pages_generated=0`.
+    if err = classified_error
+      raise err
+    end
+
     count
   end
 
@@ -565,16 +584,15 @@ module Hwaro::Core::Build::Phases::Render
                           compiled
                         end
       crinja_template.render(vars)
-    rescue ex : Crinja::TemplateNotFoundError
-      msg = "Template error for #{page.path}: #{ex.message}"
-      Logger.warn "#{msg}"
-      page.build_warnings << msg unless page.build_warnings.includes?(msg)
-      content
     rescue ex : Crinja::Error
-      msg = "Template error for #{page.path}: #{ex.message}"
-      Logger.warn "#{msg}"
-      page.build_warnings << msg unless page.build_warnings.includes?(msg)
-      content
+      # Classify as a template error so `hwaro build --json` surfaces a
+      # stable HWARO_E_TEMPLATE code (exit 4). Previously these errors
+      # were downgraded to build warnings, which hid misconfigured
+      # templates from scripts and CI.
+      raise Hwaro::HwaroError.new(
+        code: Hwaro::Errors::HWARO_E_TEMPLATE,
+        message: "Template error for #{page.path}: #{ex.message}",
+      )
     end
   end
 

--- a/src/core/lifecycle/manager.cr
+++ b/src/core/lifecycle/manager.cr
@@ -82,6 +82,10 @@ module Hwaro
                 Logger.error "  ✖ Build aborted by hook: #{hook.name}"
                 return result
               end
+            rescue ex : Hwaro::HwaroError
+              # Classified errors propagate unchanged so the CLI can surface
+              # them with their documented exit code / JSON payload.
+              raise ex
             rescue ex
               Logger.error "  Hook '#{hook.name}' failed at #{point}: #{ex.message}"
               Logger.debug "  Backtrace: #{ex.backtrace?.try(&.first(5).join("\n    ")) || "unavailable"}"
@@ -105,6 +109,10 @@ module Hwaro
           # Phase action
           begin
             yield
+          rescue ex : Hwaro::HwaroError
+            # Classified phase-action errors propagate to the CLI so exit
+            # code + JSON payload stay stable; don't downgrade to Abort.
+            raise ex
           rescue ex
             Logger.error "Phase #{phase} failed: #{ex.message}"
             Logger.debug "  Backtrace: #{ex.backtrace?.try(&.first(5).join("\n    ")) || "unavailable"}"

--- a/src/services/content_validator.cr
+++ b/src/services/content_validator.cr
@@ -8,6 +8,7 @@ require "json"
 require "yaml"
 require "toml"
 require "./doctor"
+require "../utils/errors"
 require "../utils/logger"
 
 module Hwaro
@@ -24,9 +25,19 @@ module Hwaro
       end
 
       def run : Array(Issue)
-        issues = [] of Issue
-        return issues unless Dir.exists?(@content_dir)
+        # Inability to validate at all (e.g. the content directory does
+        # not exist) is classified as HWARO_E_CONTENT — the validator
+        # cannot produce findings, so the caller needs a distinct failure
+        # signal rather than an empty "looks good" result.
+        unless Dir.exists?(@content_dir)
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONTENT,
+            message: "Content directory '#{@content_dir}' does not exist",
+            hint: "Create it or pass --content-dir DIR to point at your content root.",
+          )
+        end
 
+        issues = [] of Issue
         find_content_files.each do |file_path|
           validate_file(file_path, issues)
         end


### PR DESCRIPTION
## Summary

First chunk of #375 — replaces the fragile `classify_build_error`
Crinja-name heuristic with real `rescue` points that wrap
template-render and top-level frontmatter parse failures as
`HwaroError` so `hwaro build --json` emits stable, structured error
payloads:

- Broken template (`{{ unclosed`, unclosed blocks, …) -> `HWARO_E_TEMPLATE` / exit 4
- Malformed TOML/YAML frontmatter in a content file -> `HWARO_E_CONTENT` / exit 5
- Missing content directory in `tool validate` -> `HWARO_E_CONTENT` / exit 5

Sites classified in this PR:
- `TemplateEngine#render` / `render_template` (`src/content/processors/template.cr`) — wrap `Crinja::Error`
- `Render` phase's `apply_template` (`src/core/build/phases/render.cr`) — wrap `Crinja::Error` (previously downgraded to a build warning)
- `Markdown#extract_from_toml` / `extract_from_yaml` (`src/content/processors/markdown.cr`) — raise when a file path is supplied; library-style calls without a path keep the previous graceful-nil fallback
- `ParseContent` phase (`src/core/build/phases/parse_content.cr`) — let `HwaroError` propagate out of the per-page rescues (sequential + parallel); workers record the first classified error and the phase re-raises after the queue drains
- `ContentValidator#run` (`src/services/content_validator.cr`) — raise when the content directory is missing

The `classify_build_error` string-match fallback for config-load
messages stays intact for now; it will be retired when config loading
raises `HwaroError` directly (separate PR).

**Scope note:** this PR is explicitly template + content only. IO and
network error classification, per the issue plan, are deferred to
follow-up PRs so this stays reviewable.

### Taxonomy (unchanged)
No new codes, no exit-code changes, no payload-shape changes.

## Test plan
- [x] `crystal spec` — 4418 examples, 0 failures
- [x] Unit spec: broken template string -> `HwaroError` with `code == HWARO_E_TEMPLATE` (exit 4)
- [x] Unit spec: malformed TOML frontmatter with a file path -> `HwaroError(HWARO_E_CONTENT)` (exit 5)
- [x] Unit spec: malformed YAML frontmatter with a file path -> `HwaroError(HWARO_E_CONTENT)` (exit 5)
- [x] Unit spec: `ContentValidator` with a missing directory -> `HwaroError(HWARO_E_CONTENT)` (exit 5)
- [x] Unit spec: library-style `Markdown#parse` with no file path keeps the graceful fallback
- [x] `just build` succeeds

---

한 줄 메모: #375의 첫 조각으로 템플릿/콘텐츠 에러를 `HwaroError`로 분류하도록 실제 rescue 지점을 추가했고, 휴리스틱은 제거했습니다 (IO/네트워크는 후속 PR).