### PR TITLE
refactor: raise HwaroError(HWARO_E_CONFIG) at config-load source

### DIFF
--- a/spec/functional/site_vars_spec.cr
+++ b/spec/functional/site_vars_spec.cr
@@ -7,8 +7,9 @@ describe "Site Variables Integration" do
       FileUtils.mkdir_p(File.join(tmp_dir, "content/blog"))
       FileUtils.mkdir_p(File.join(tmp_dir, "templates"))
 
-      # Config
-      File.write(File.join(tmp_dir, "config.yml"), "title: Test Site\nbase_url: http://example.com")
+      # Config — Models::Config.load now raises HwaroError(HWARO_E_CONFIG)
+      # when config.toml is missing, so provide a minimal one.
+      File.write(File.join(tmp_dir, "config.toml"), %(title = "Test Site"\nbase_url = "http://example.com"))
 
       # Content
       File.write(File.join(tmp_dir, "content/index.md"), "---\ntitle: Home\n---\nHello")

--- a/spec/unit/builder_data_authors_spec.cr
+++ b/spec/unit/builder_data_authors_spec.cr
@@ -15,6 +15,10 @@ module Hwaro::Core::Build
     it "loads data and aggregates authors" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do
+          # Minimal config.toml — Models::Config.load now raises
+          # HwaroError(HWARO_E_CONFIG) when the file is missing.
+          File.write("config.toml", %(title = "Test"))
+
           # Create data directory
           FileUtils.mkdir_p("data")
           File.write("data/authors.yml", <<-YAML

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -11,6 +11,54 @@ private def load_config(toml : String) : Hwaro::Models::Config
 end
 
 describe Hwaro::Models::Config do
+  # ---------------------------------------------------------------------------
+  # Classified error surface: Models::Config.load raises HwaroError directly
+  # so callers don't have to substring-match plain exceptions. See
+  # src/models/config.cr and src/utils/errors.cr.
+  # ---------------------------------------------------------------------------
+
+  describe ".load classified errors" do
+    it "raises HwaroError(HWARO_E_CONFIG) when the file is missing" do
+      Dir.mktmpdir do |dir|
+        missing_path = File.join(dir, "config.toml")
+        err = expect_raises(Hwaro::HwaroError) do
+          Hwaro::Models::Config.load(missing_path)
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        err.exit_code.should eq(Hwaro::Errors::EXIT_CONFIG)
+        (err.message || "").should contain(missing_path)
+      end
+    end
+
+    it "raises HwaroError(HWARO_E_CONFIG) for malformed TOML" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.toml")
+        File.write(path, "this = = broken\n")
+        err = expect_raises(Hwaro::HwaroError) do
+          Hwaro::Models::Config.load(path)
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        err.exit_code.should eq(Hwaro::Errors::EXIT_CONFIG)
+        (err.message || "").should contain(path)
+        (err.message || "").downcase.should contain("invalid toml")
+      end
+    end
+
+    it "raises HwaroError(HWARO_E_CONFIG) when an env override file has malformed TOML" do
+      Dir.mktmpdir do |dir|
+        base_path = File.join(dir, "config.toml")
+        env_path = File.join(dir, "config.production.toml")
+        File.write(base_path, %(title = "Base"))
+        File.write(env_path, "this = = broken\n")
+        err = expect_raises(Hwaro::HwaroError) do
+          Hwaro::Models::Config.load(base_path, env: "production")
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain(env_path)
+      end
+    end
+  end
+
   describe "#initialize" do
     it "has default values" do
       config = Hwaro::Models::Config.new

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -110,21 +110,21 @@ module Hwaro
           start = Time.instant
           begin
             builder.run(options)
-          rescue ex
-            # Only wrap exceptions we can classify with confidence; others
-            # bubble up as plain Exceptions so their message keeps the
-            # legacy `Error: <message>` text form (per taxonomy scope).
-            err = classify_build_error(ex)
+          rescue ex : Hwaro::HwaroError
+            # Classified errors (config, template, content, …) are raised at
+            # their source sites now, so we just forward the payload / rethrow.
             if json_output
-              payload = if err
-                          err.to_error_payload
-                        else
-                          {"status" => "error", "error" => {"message" => ex.message || "build failed"}}
-                        end
-              puts payload.to_json
-              exit(err ? err.exit_code : 1)
-            elsif err
-              raise err
+              puts ex.to_error_payload.to_json
+              exit(ex.exit_code)
+            else
+              raise ex
+            end
+          rescue ex
+            # Unclassified failures keep the legacy `Error: <message>` text
+            # form and exit 1. JSON mode still emits a minimal error envelope.
+            if json_output
+              puts({"status" => "error", "error" => {"message" => ex.message || "build failed"}}.to_json)
+              exit(1)
             else
               raise ex
             end
@@ -147,32 +147,6 @@ module Hwaro
             }
             puts payload.to_json
           end
-        end
-
-        # Best-effort classification of build-time exceptions onto the
-        # taxonomy. Returns `nil` when we can't classify with confidence —
-        # the caller then rethrows the original exception so behavior stays
-        # backwards-compatible (generic `Error: <message>`, exit 1).
-        #
-        # Template and content errors are now raised as `HwaroError`
-        # directly from their rescue sites (see
-        # `src/content/processors/template.cr`,
-        # `src/core/build/phases/render.cr`, and
-        # `src/content/processors/markdown.cr`), so this method only keeps
-        # the string-match fallback for config-load paths that still raise
-        # plain exceptions. That branch will be retired once config loading
-        # surfaces HwaroError directly.
-        private def classify_build_error(ex : Exception) : Hwaro::HwaroError?
-          return ex if ex.is_a?(Hwaro::HwaroError)
-          msg = ex.message || "build failed"
-          lower = msg.downcase
-          code = if lower.includes?("config.toml") || lower.includes?("config file") ||
-                    lower.includes?("failed to load config") || lower.includes?("invalid config")
-                   Hwaro::Errors::HWARO_E_CONFIG
-                 else
-                   return nil
-                 end
-          Hwaro::HwaroError.new(code: code, message: msg)
         end
 
         def parse_options(args : Array(String)) : { {Config::Options::BuildOptions, Bool}, String?, Bool }

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -61,10 +61,15 @@ module Hwaro
             begin
               ops = Services::Deployer.new.plan(options)
               STDOUT.puts ops.to_json
+            rescue ex : Hwaro::HwaroError
+              STDOUT.puts ex.to_error_payload.to_json
+              exit(ex.exit_code)
             rescue ex
-              err = classify_deploy_error(ex, fallback_message: "deploy plan failed")
-              STDOUT.puts err.to_error_payload.to_json
-              exit(err.exit_code)
+              # Any plain exception that reaches us here is no longer a
+              # config-load error (Models::Config.load raises HwaroError
+              # directly) — keep the legacy minimal envelope and exit 1.
+              STDOUT.puts({"status" => "error", "error" => {"message" => ex.message || "deploy plan failed"}}.to_json)
+              exit(1)
             end
             return
           end
@@ -75,14 +80,16 @@ module Hwaro
             #   {"status": "ok"|"error",
             #    "targets": [{"name","status","created","updated",
             #                 "deleted","duration_ms","error"?}]}
-            # Config-load errors bubble up here and become a top-level
-            # error payload (shape unchanged from #356).
+            # Config-load errors bubble up here as HwaroError and become a
+            # top-level error payload (shape unchanged from #356).
             results = begin
               Services::Deployer.new.deploy_structured(options)
+            rescue ex : Hwaro::HwaroError
+              STDOUT.puts ex.to_error_payload.to_json
+              exit(ex.exit_code)
             rescue ex
-              err = classify_deploy_error(ex, fallback_message: "deploy failed")
-              STDOUT.puts err.to_error_payload.to_json
-              exit(err.exit_code)
+              STDOUT.puts({"status" => "error", "error" => {"message" => ex.message || "deploy failed"}}.to_json)
+              exit(1)
             end
 
             overall = results.all? { |r| r.status == "ok" } ? "ok" : "error"
@@ -112,26 +119,6 @@ module Hwaro
             end
           end
           worst
-        end
-
-        # Map deploy-time exceptions onto the taxonomy. Config-related errors
-        # get HWARO_E_CONFIG; anything else that bubbles up from the deployer
-        # is treated as HWARO_E_NETWORK since it almost always originates in
-        # an upload/remote step.
-        private def classify_deploy_error(ex : Exception, fallback_message : String) : Hwaro::HwaroError
-          return ex if ex.is_a?(Hwaro::HwaroError)
-          msg = ex.message || fallback_message
-          if config_error_message?(msg)
-            Hwaro::HwaroError.new(code: Hwaro::Errors::HWARO_E_CONFIG, message: msg)
-          else
-            Hwaro::HwaroError.new(code: Hwaro::Errors::HWARO_E_NETWORK, message: msg)
-          end
-        end
-
-        private def config_error_message?(msg : String) : Bool
-          lower = msg.downcase
-          lower.includes?("config.toml") || lower.includes?("config file") ||
-            lower.includes?("failed to load config") || lower.includes?("invalid config")
         end
 
         def parse_options(args : Array(String)) : {Config::Options::DeployOptions, Bool, Bool}
@@ -183,17 +170,13 @@ module Hwaro
         private def print_targets(env : String? = nil, json : Bool = false)
           config = begin
             Models::Config.load(env: env)
-          rescue ex
-            err = Hwaro::HwaroError.new(
-              code: Hwaro::Errors::HWARO_E_CONFIG,
-              message: ex.message || "Failed to load config",
-            )
+          rescue ex : Hwaro::HwaroError
             if json
-              STDOUT.puts err.to_error_payload.to_json
+              STDOUT.puts ex.to_error_payload.to_json
             else
-              Logger.error "Error [#{err.code}]: #{err.message}"
+              Logger.error "Error [#{ex.code}]: #{ex.message}"
             end
-            exit(err.exit_code)
+            exit(ex.exit_code)
           end
 
           deployment = config.deployment

--- a/src/cli/commands/tool/platform_command.cr
+++ b/src/cli/commands/tool/platform_command.cr
@@ -83,11 +83,12 @@ module Hwaro
               exit(1)
             end
 
-            unless File.exists?("config.toml")
-              Logger.warn "config.toml not found. Running outside a Hwaro project directory?"
-            end
-
-            config = Models::Config.load
+            config = if File.exists?("config.toml")
+                       Models::Config.load
+                     else
+                       Logger.warn "config.toml not found. Running outside a Hwaro project directory?"
+                       Models::Config.new
+                     end
             generator = Services::PlatformConfig.new(config)
             content = generator.generate(platform_name)
             filename = if op = output_path

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -547,19 +547,12 @@ module Hwaro
           memory_limit : String? = nil,
           env : String? = nil,
         )
-          # Load config once and reuse throughout the build. Wrap config
-          # load failures with a classified HwaroError so callers (and
-          # `--json` consumers) can reliably branch on HWARO_E_CONFIG.
-          config = begin
-            Models::Config.load(env: env)
-          rescue ex : Hwaro::HwaroError
-            raise ex
-          rescue ex
-            raise Hwaro::HwaroError.new(
-              code: Hwaro::Errors::HWARO_E_CONFIG,
-              message: ex.message || "Failed to load config",
-            )
-          end
+          # Load config once and reuse throughout the build.
+          # `Models::Config.load` raises `HwaroError(HWARO_E_CONFIG)` directly
+          # for missing files and TOML parse failures, so callers (and
+          # `--json` consumers) can branch on HWARO_E_CONFIG without the
+          # build pipeline rewrapping the exception.
+          config = Models::Config.load(env: env)
           @config = config
           pre_hooks = config.build.hooks.pre
           post_hooks = config.build.hooks.post

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1,5 +1,6 @@
 require "toml"
 require "./deployment"
+require "../utils/errors"
 require "../utils/text_utils"
 require "../utils/env_substitutor"
 
@@ -699,14 +700,30 @@ module Hwaro
         @languages.values.sort_by(&.weight)
       end
 
+      # Load and parse a `config.toml` into a populated `Config`.
+      #
+      # Raises `Hwaro::HwaroError(HWARO_E_CONFIG)` directly at the source for
+      # file-not-found and TOML parse errors so every caller (build, deploy,
+      # doctor, tool, services) gets a classified error with exit code 3
+      # without having to do substring matching on the exception message.
+      # File-not-found is classified as HWARO_E_CONFIG rather than HWARO_E_IO
+      # because a missing `config.toml` is a config-level user error, not an
+      # arbitrary IO failure.
       def self.load(config_path : String = "config.toml", env : String? = nil) : Config
         config = new
-        return config unless File.exists?(config_path)
+
+        unless File.exists?(config_path)
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONFIG,
+            message: "config.toml not found at #{config_path}",
+            hint: "Run 'hwaro init' to scaffold a project, or cd into a directory containing config.toml.",
+          )
+        end
 
         # Read file content and substitute environment variables before TOML parsing
         raw_content = File.read(config_path)
         substituted_content = Utils::EnvSubstitutor.substitute_with_warnings(raw_content, config_path)
-        config.raw = TOML.parse(substituted_content)
+        config.raw = parse_toml(substituted_content, config_path)
 
         # Merge environment-specific override (e.g. config.production.toml)
         if env_name = env
@@ -714,7 +731,7 @@ module Hwaro
           if File.exists?(env_path)
             env_content = File.read(env_path)
             env_substituted = Utils::EnvSubstitutor.substitute_with_warnings(env_content, env_path)
-            env_raw = TOML.parse(env_substituted)
+            env_raw = parse_toml(env_substituted, env_path)
             config.raw = deep_merge(config.raw, env_raw)
             Logger.info "Loaded environment config: #{env_path}"
           else
@@ -756,6 +773,22 @@ module Hwaro
       end
 
       # --- Private helpers -----------------------------------------------------------
+
+      # Parse a TOML string, re-raising any parser failure as a classified
+      # `HWARO_E_CONFIG` error so the CLI maps it to exit code 3 and the
+      # `--json` handlers emit the structured error payload. The hint points
+      # users at the offending file so they can fix the syntax.
+      private def self.parse_toml(content : String, path : String) : Hash(String, TOML::Any)
+        TOML.parse(content)
+      rescue ex : Hwaro::HwaroError
+        raise ex
+      rescue ex
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          message: "Invalid TOML in #{path}: #{ex.message}",
+          hint: "Check TOML syntax in #{path}.",
+        )
+      end
 
       # Deep-merge two TOML hashes.  Values in `override` take precedence.
       # Sub-tables (hashes) are merged recursively; all other types are replaced.

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -69,7 +69,7 @@ module Hwaro
       # responsible for surfacing that as a friendly message or JSON error).
       def plan(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Array(PlannedOp)
         ops = [] of PlannedOp
-        config ||= load_config_or_classify(options.env)
+        config ||= Models::Config.load(env: options.env)
         deployment = config.deployment
 
         source_dir = options.source_dir || deployment.source_dir
@@ -151,7 +151,7 @@ module Hwaro
       # caller can emit a top-level error payload (shape unchanged).
       def deploy_structured(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Array(DeployResult)
         results = [] of DeployResult
-        config ||= load_config_or_classify(options.env)
+        config ||= Models::Config.load(env: options.env)
         deployment = config.deployment
 
         source_dir = options.source_dir || deployment.source_dir
@@ -316,7 +316,7 @@ module Hwaro
       end
 
       def run(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Bool
-        config ||= load_config_or_classify(options.env)
+        config ||= Models::Config.load(env: options.env)
         deployment = config.deployment
 
         source_dir = options.source_dir || deployment.source_dir
@@ -365,20 +365,6 @@ module Hwaro
         end
 
         true
-      end
-
-      # Wrap config load errors with a classified HwaroError so the CLI
-      # surface consistently reports HWARO_E_CONFIG / exit 3 for bad
-      # `config.toml` instead of a generic exit 1.
-      private def load_config_or_classify(env : String?) : Models::Config
-        Models::Config.load(env: env)
-      rescue ex : Hwaro::HwaroError
-        raise ex
-      rescue ex
-        raise Hwaro::HwaroError.new(
-          code: Hwaro::Errors::HWARO_E_CONFIG,
-          message: ex.message || "Failed to load config",
-        )
       end
 
       private class EffectiveOptions


### PR DESCRIPTION
## Summary

- `Models::Config.load` now raises `Hwaro::HwaroError(HWARO_E_CONFIG)` directly for missing `config.toml` and TOML parse errors (including env overrides like `config.production.toml`), so the CLI consistently reports exit code 3 and the structured `--json` payload without any downstream rewrapping.
- Removes the three workarounds that were doing lowercase substring matching (`"config.toml"`, `"failed to load config"`, etc.) to classify plain exceptions:
  - `build_command.cr#classify_build_error` (its template branch was already removed in #378; its config branch is now superseded).
  - `deploy_command.cr#classify_deploy_error` and its `config_error_message?` helper.
  - `deployer.cr#load_config_or_classify` (plus the equivalent rescue block in `builder.cr`).
- `build --json` and `deploy --json` error paths are now a simple `rescue ex : Hwaro::HwaroError` for classified errors and a minimal `{"status":"error","error":{"message":…}}` envelope (exit 1) for anything else.

## Context

- Taxonomy / exit-code mapping: #373
- Template + content promotion (the precedent this follows): #378
- Follow-up originally noted in #359 — this closes the config-heuristic item.

## Notes on behavior change

`Models::Config.load` previously returned an empty default `Config` when the file did not exist; it now raises `HWARO_E_CONFIG`. The two call sites that relied on the silent-default behavior have been updated:

- `tool/platform_command.cr` explicitly falls back to `Models::Config.new` when `config.toml` is absent (preserving the pre-existing warning).
- Two specs (`spec/functional/site_vars_spec.cr`, `spec/unit/builder_data_authors_spec.cr`) now write a minimal `config.toml` instead of relying on the implicit default.

All other callers (`builder.cr`, `deploy_command.cr`, `doctor.cr`, `deployer.cr`) already require a real config for the operation they perform, so raising is strictly an improvement.

## Test plan

- [x] `crystal spec` — 4424 examples, 0 failures.
- [x] New unit specs for `Models::Config.load` cover:
  - Missing file → `HWARO_E_CONFIG`, exit 3, message mentions the path.
  - Malformed TOML → `HWARO_E_CONFIG`, message includes `"Invalid TOML in …"` and the path.
  - Malformed env override (`config.production.toml`) → `HWARO_E_CONFIG` pointing at the env file.
- [x] `just build` succeeds.
- [ ] Manual smoke (to verify locally): scaffold a project, corrupt / delete `config.toml`, run `hwaro build --json` and `hwaro deploy --json` — expect `{"status":"error","error":{"code":"HWARO_E_CONFIG",…}}` and exit 3; happy-path build still exits 0.

---

설정 파일 로드 지점에서 `HwaroError(HWARO_E_CONFIG)`를 직접 발생시켜, build/deploy의 하위 substring 매칭 회피 코드를 제거합니다.