### PR TITLE
feat: classify IO and Network errors with HwaroError

### DIFF
--- a/spec/unit/remote_scaffold_spec.cr
+++ b/spec/unit/remote_scaffold_spec.cr
@@ -159,6 +159,15 @@ end
 
 # Helper to test the private extract_front_matter method
 class TestRemoteHelper < Hwaro::Services::Scaffolds::Remote
+  # Canned HTTP response that subclasses can swap in instead of calling GitHub.
+  @@stub_status : Int32 = 200
+  @@stub_body : String = ""
+
+  def self.stub_response(status : Int32, body : String = "")
+    @@stub_status = status
+    @@stub_body = body
+  end
+
   def initialize
     @config_data = ""
     @content_data = {} of String => String
@@ -175,5 +184,61 @@ class TestRemoteHelper < Hwaro::Services::Scaffolds::Remote
 
   def do_extract(content : String) : String
     extract_front_matter(content)
+  end
+
+  # Invoke the private fetch_default_branch with the stubbed response so we
+  # can assert the classification behavior without talking to github.com.
+  def do_fetch_default_branch(owner : String, repo : String) : String
+    fetch_default_branch(owner, repo)
+  end
+
+  # Override the private HTTP hop so the classifier path can be exercised
+  # deterministically.
+  private def github_api_get(path : String) : HTTP::Client::Response
+    HTTP::Client::Response.new(@@stub_status, @@stub_body)
+  end
+end
+
+describe Hwaro::Services::Scaffolds::Remote do
+  describe "#fetch_default_branch error classification" do
+    it "raises HwaroError(HWARO_E_NETWORK) with exit 7 on HTTP 404" do
+      TestRemoteHelper.stub_response(404, %({"message":"Not Found"}))
+      helper = TestRemoteHelper.new
+
+      err = expect_raises(Hwaro::HwaroError) do
+        helper.do_fetch_default_branch("this-does-not-exist", "nope")
+      end
+
+      err.code.should eq(Hwaro::Errors::HWARO_E_NETWORK)
+      err.category.should eq(:network)
+      err.exit_code.should eq(7)
+      err.message.not_nil!.should contain("this-does-not-exist/nope")
+    end
+
+    it "raises HwaroError(HWARO_E_NETWORK) with exit 7 on HTTP 403 rate limit" do
+      TestRemoteHelper.stub_response(403, %({"message":"API rate limit exceeded"}))
+      helper = TestRemoteHelper.new
+
+      err = expect_raises(Hwaro::HwaroError) do
+        helper.do_fetch_default_branch("some-owner", "some-repo")
+      end
+
+      err.code.should eq(Hwaro::Errors::HWARO_E_NETWORK)
+      err.exit_code.should eq(7)
+      err.message.not_nil!.should contain("rate limit")
+    end
+
+    it "raises HwaroError(HWARO_E_NETWORK) with exit 7 on generic HTTP failure" do
+      TestRemoteHelper.stub_response(500, %({"message":"Internal Server Error"}))
+      helper = TestRemoteHelper.new
+
+      err = expect_raises(Hwaro::HwaroError) do
+        helper.do_fetch_default_branch("some-owner", "some-repo")
+      end
+
+      err.code.should eq(Hwaro::Errors::HWARO_E_NETWORK)
+      err.exit_code.should eq(7)
+      err.message.not_nil!.should contain("HTTP 500")
+    end
   end
 end

--- a/spec/unit/serve_command_spec.cr
+++ b/spec/unit/serve_command_spec.cr
@@ -165,6 +165,22 @@ describe Hwaro::CLI::Commands::ServeCommand do
     end
   end
 
+  describe "#run" do
+    it "raises HwaroError(HWARO_E_IO) when the input directory is missing" do
+      missing = File.join(Dir.tempdir, "hwaro-does-not-exist-#{Random.rand(1_000_000)}")
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+
+      err = expect_raises(Hwaro::HwaroError) do
+        cmd.run(["-i", missing])
+      end
+
+      err.code.should eq(Hwaro::Errors::HWARO_E_IO)
+      err.exit_code.should eq(6)
+      err.category.should eq(:io)
+      err.message.not_nil!.should contain(missing)
+    end
+  end
+
   describe "metadata" do
     it "has correct name" do
       meta = Hwaro::CLI::Commands::ServeCommand.metadata

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -2,6 +2,7 @@ require "option_parser"
 require "../metadata"
 require "../../config/options/serve_options"
 require "../../services/server/server"
+require "../../utils/errors"
 require "../../utils/logger"
 
 module Hwaro
@@ -71,11 +72,15 @@ module Hwaro
           # --json suppresses banners/action lines so the ready event is the
           # first line on stdout. Errors still go to stderr via Logger.error.
           Logger.quiet = true if options.json
+          Runner.json_mode = true if options.json
 
           if input_dir
             unless Dir.exists?(input_dir)
-              Logger.error "Input directory does not exist: #{input_dir}"
-              exit(1)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_IO,
+                message: "Input directory does not exist: #{input_dir}",
+                hint: "Check the path passed to -i/--input.",
+              )
             end
             Logger.info "Changing working directory to: #{input_dir}"
             Dir.cd(input_dir)

--- a/src/services/scaffolds/remote.cr
+++ b/src/services/scaffolds/remote.cr
@@ -9,8 +9,10 @@
 
 require "http/client"
 require "json"
+require "socket"
 require "uri"
 require "./base"
+require "../../utils/errors"
 require "../../utils/path_utils"
 
 module Hwaro
@@ -245,11 +247,22 @@ module Hwaro
           unless response.status_code == 200
             case response.status_code
             when 404
-              raise "Repository not found: #{owner}/#{repo}"
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_NETWORK,
+                message: "Remote scaffold not found: #{owner}/#{repo}",
+                hint: "Check the repository name and that it is public.",
+              )
             when 403
-              raise "GitHub API rate limit exceeded. Try again later."
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_NETWORK,
+                message: "GitHub API rate limit exceeded while fetching #{owner}/#{repo}",
+                hint: "Try again later or set GITHUB_TOKEN for higher limits.",
+              )
             else
-              raise "Failed to fetch repository info: HTTP #{response.status_code}"
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_NETWORK,
+                message: "Failed to fetch repository info for #{owner}/#{repo}: HTTP #{response.status_code}",
+              )
             end
           end
 
@@ -261,7 +274,10 @@ module Hwaro
           response = github_api_get("/repos/#{owner}/#{repo}/git/trees/#{branch}?recursive=1")
 
           unless response.status_code == 200
-            raise "Failed to fetch repository tree: HTTP #{response.status_code}"
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_NETWORK,
+              message: "Failed to fetch repository tree for #{owner}/#{repo}@#{branch}: HTTP #{response.status_code}",
+            )
           end
 
           data = JSON.parse(response.body)
@@ -308,6 +324,12 @@ module Hwaro
 
           begin
             client.get(path, headers: headers)
+          rescue ex : Socket::Error | IO::Error | OpenSSL::SSL::Error
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_NETWORK,
+              message: "Failed to reach GitHub API (#{path}): #{ex.message}",
+              hint: "Check your network connection and try again.",
+            )
           ensure
             client.close
           end


### PR DESCRIPTION
## Summary

Extend the Hwaro error taxonomy (#373, #378) to cover the remaining obvious IO and Network paths so `--json` consumers get the structured payload and process exit codes match the documented taxonomy.

### Sites classified

**IO (`HWARO_E_IO`, exit 6)**

- `src/cli/commands/serve_command.cr` - the `-i/--input` missing-dir gate previously did `Logger.error + exit(1)`. It now raises `HwaroError(HWARO_E_IO)` with a hint to check the `-i/--input` path, so the Runner emits the structured JSON under `--json` and the exit code is 6.

**Network (`HWARO_E_NETWORK`, exit 7)**

- `src/services/scaffolds/remote.cr` - `hwaro init --scaffold github:owner/repo` failures are now classified:
  - HTTP 404 -> `Remote scaffold not found: owner/repo` (hint: check the repo name / visibility)
  - HTTP 403 -> rate-limit message with a `GITHUB_TOKEN` hint
  - Other non-200 -> generic HTTP-status message
  - Network / TLS / IO errors (`Socket::Error`, `IO::Error`, `OpenSSL::SSL::Error`) hitting `api.github.com` -> connectivity message with hint

### Sites intentionally skipped

- `tool validate` - `Services::ContentValidator` already raises `HwaroError(HWARO_E_CONTENT)` for a missing content directory (added in #378); the command file does not have its own gate, so no change needed.
- `tool stats` / `tool unused-assets` - neither the command nor the underlying service has a hard `Dir.exists? ... exit(1)` gate; both degrade to an empty result today, which is the desired behavior.
- Per-page content reads inside the build pipeline - explicitly out of scope (those continue to skip-and-warn).
- `src/models/config.cr`, `src/services/deployer.cr`, and the `classify_*_error` helpers in `build_command.cr` / `deploy_command.cr` - owned by the concurrent config-taxonomy PR.

### Manual verification

- `bin/hwaro serve -i /definitely/does/not/exist` -> `Error [HWARO_E_IO]: Input directory does not exist: ...`, exit 6.
- `bin/hwaro serve -i /definitely/does/not/exist --json` -> structured JSON with `code: HWARO_E_IO`, `category: io`, exit 6.
- `bin/hwaro init --scaffold github:this-does-not-exist/nope /tmp/nope` -> `Error [HWARO_E_NETWORK]: Remote scaffold not found: this-does-not-exist/nope`, exit 7.

## Test plan

- [x] `crystal spec` - 4425 examples, 0 failures.
- [x] `just build` succeeds.
- [x] Added unit spec: `ServeCommand#run` raises `HwaroError(HWARO_E_IO)` with exit 6 on missing `-i` dir.
- [x] Added unit specs: `Remote#fetch_default_branch` classification for HTTP 404 / 403 / 500 via a response stub (avoids hitting github.com).

Closes #375

---

네트워크/IO 에러도 HwaroError 분류 체계에 맞춰 exit 6/7로 고정되도록 확장했습니다.