### PR TITLE
perf: top-k related posts and combined CSS structural-char pass

### DIFF
--- a/spec/unit/related_posts_spec.cr
+++ b/spec/unit/related_posts_spec.cr
@@ -166,6 +166,145 @@ describe "Related posts" do
     p1.related_posts[0].title.should eq("Post B")
   end
 
+  it "only relates pages of the same language" do
+    builder = Hwaro::Core::Build::Builder.new
+    config = Hwaro::Models::Config.new
+    config.related.enabled = true
+    config.related.taxonomies = ["tags"]
+
+    site = Hwaro::Models::Site.new(config)
+
+    p_en = Hwaro::Models::Page.new("posts/a.md")
+    p_en.title = "Post A"
+    p_en.tags = ["crystal", "web"]
+    p_en.language = "en"
+    p_en.url = "/en/posts/a/"
+
+    p_en2 = Hwaro::Models::Page.new("posts/b.md")
+    p_en2.title = "Post B"
+    p_en2.tags = ["crystal"]
+    p_en2.language = "en"
+    p_en2.url = "/en/posts/b/"
+
+    p_ko = Hwaro::Models::Page.new("posts/c.md")
+    p_ko.title = "Post C"
+    p_ko.tags = ["crystal", "web"]
+    p_ko.language = "ko"
+    p_ko.url = "/ko/posts/c/"
+
+    p_nil = Hwaro::Models::Page.new("posts/d.md")
+    p_nil.title = "Post D"
+    p_nil.tags = ["crystal", "web"]
+    p_nil.url = "/posts/d/"
+
+    site.pages = [p_en, p_en2, p_ko, p_nil]
+
+    builder.test_compute_related_posts(site)
+
+    p_en.related_posts.map(&.title).should eq(["Post B"])
+    p_ko.related_posts.should be_empty
+    p_nil.related_posts.should be_empty
+  end
+
+  it "preserves tie-break order at the limit boundary" do
+    builder = Hwaro::Core::Build::Builder.new
+    config = Hwaro::Models::Config.new
+    config.related.enabled = true
+    config.related.limit = 2
+    config.related.taxonomies = ["tags"]
+
+    site = Hwaro::Models::Site.new(config)
+
+    # Three candidates with identical scores relative to p1; top-k must return
+    # the first two encountered (matching a stable descending sort).
+    p1 = Hwaro::Models::Page.new("posts/a.md")
+    p1.title = "Post A"
+    p1.tags = ["crystal"]
+    p1.url = "/posts/a/"
+
+    p2 = Hwaro::Models::Page.new("posts/b.md")
+    p2.title = "Post B"
+    p2.tags = ["crystal"]
+    p2.url = "/posts/b/"
+
+    p3 = Hwaro::Models::Page.new("posts/c.md")
+    p3.title = "Post C"
+    p3.tags = ["crystal"]
+    p3.url = "/posts/c/"
+
+    p4 = Hwaro::Models::Page.new("posts/d.md")
+    p4.title = "Post D"
+    p4.tags = ["crystal"]
+    p4.url = "/posts/d/"
+
+    site.pages = [p1, p2, p3, p4]
+
+    builder.test_compute_related_posts(site)
+
+    p1.related_posts.map(&.title).should eq(["Post B", "Post C"])
+  end
+
+  it "returns empty when limit is zero" do
+    builder = Hwaro::Core::Build::Builder.new
+    config = Hwaro::Models::Config.new
+    config.related.enabled = true
+    config.related.limit = 0
+    config.related.taxonomies = ["tags"]
+
+    site = Hwaro::Models::Site.new(config)
+
+    p1 = Hwaro::Models::Page.new("posts/a.md")
+    p1.title = "Post A"
+    p1.tags = ["crystal"]
+    p1.url = "/posts/a/"
+
+    p2 = Hwaro::Models::Page.new("posts/b.md")
+    p2.title = "Post B"
+    p2.tags = ["crystal"]
+    p2.url = "/posts/b/"
+
+    site.pages = [p1, p2]
+
+    builder.test_compute_related_posts(site)
+
+    p1.related_posts.should be_empty
+  end
+
+  it "returns top-k in score-descending order with many candidates" do
+    builder = Hwaro::Core::Build::Builder.new
+    config = Hwaro::Models::Config.new
+    config.related.enabled = true
+    config.related.limit = 3
+    config.related.taxonomies = ["tags"]
+
+    site = Hwaro::Models::Site.new(config)
+
+    target = Hwaro::Models::Page.new("posts/target.md")
+    target.title = "Target"
+    target.tags = ["a", "b", "c", "d"]
+    target.url = "/posts/target/"
+
+    # Build 20 candidates with varying overlap.
+    pages = [target] of Hwaro::Models::Page
+    20.times do |i|
+      p = Hwaro::Models::Page.new("posts/p#{i}.md")
+      p.title = "P#{i}"
+      # Cycle through overlap counts 1..4
+      overlap = (i % 4) + 1
+      p.tags = ["a", "b", "c", "d"].first(overlap)
+      p.url = "/posts/p#{i}/"
+      pages << p
+    end
+
+    site.pages = pages
+
+    builder.test_compute_related_posts(site)
+
+    # Scores descending; top 3 should all have score 4 (overlap=4 items).
+    # In insertion order those are P3, P7, P11 (i % 4 == 3).
+    target.related_posts.map(&.title).should eq(["P3", "P7", "P11"])
+  end
+
   it "scores across multiple taxonomies" do
     builder = Hwaro::Core::Build::Builder.new
     config = Hwaro::Models::Config.new

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -549,6 +549,7 @@ module Hwaro::Core::Build::Phases::Transform
     config = site.config.related
     taxonomy_names = config.taxonomies
     limit = config.limit
+    return if limit <= 0
     pages = site.pages.reject { |p| p.draft || p.is_index || p.generated || !p.render }
 
     # Build inverted index: {taxonomy_name => {term => Array(page_path)}}
@@ -569,8 +570,6 @@ module Hwaro::Core::Build::Phases::Transform
     end
 
     pages.each do |page|
-      next if limit <= 0
-
       # Count co-occurrences via inverted index: O(terms * avg_pages_per_term).
       # Filter by language during accumulation — cross-language candidates are
       # discarded from the final output anyway, so skipping them here produces
@@ -585,6 +584,8 @@ module Hwaro::Core::Build::Phases::Transform
           if candidates = inv_tax[term]?
             candidates.each do |other_path|
               next if other_path == page.path
+              # page_lookup[other_path] is guaranteed present: the inverted
+              # index is populated from the same `pages` iteration above.
               next unless page_lookup[other_path].language == page_lang
               scores[other_path] += 1
             end
@@ -597,7 +598,8 @@ module Hwaro::Core::Build::Phases::Transform
       # Bounded top-k selection — equivalent to `.sort_by { -s }.first(limit)`
       # but O(n*k) instead of O(n log n) with fewer allocations. Ties break by
       # scores-hash insertion order (which mirrors pages/taxonomy iteration),
-      # matching a stable descending sort.
+      # matching a stable descending sort. Optimal when limit is small
+      # (default 5); parity with sort near limit ≈ log₂(n).
       top = [] of {String, Int32}
       scores.each do |path, score|
         idx = 0

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -569,8 +569,14 @@ module Hwaro::Core::Build::Phases::Transform
     end
 
     pages.each do |page|
-      # Count co-occurrences via inverted index: O(terms * avg_pages_per_term)
+      next if limit <= 0
+
+      # Count co-occurrences via inverted index: O(terms * avg_pages_per_term).
+      # Filter by language during accumulation — cross-language candidates are
+      # discarded from the final output anyway, so skipping them here produces
+      # identical results while reducing work for multilingual sites.
       scores = Hash(String, Int32).new(0)
+      page_lang = page.language
       taxonomy_names.each do |tax_name|
         values = page.taxonomies[tax_name]? || (tax_name == "tags" ? page.tags : [] of String)
         inv_tax = inverted[tax_name]?
@@ -579,6 +585,7 @@ module Hwaro::Core::Build::Phases::Transform
           if candidates = inv_tax[term]?
             candidates.each do |other_path|
               next if other_path == page.path
+              next unless page_lookup[other_path].language == page_lang
               scores[other_path] += 1
             end
           end
@@ -587,12 +594,22 @@ module Hwaro::Core::Build::Phases::Transform
 
       next if scores.empty?
 
-      # Filter by language and build result
-      page.related_posts = scores.to_a
-        .select { |path, _| page_lookup[path]?.try(&.language) == page.language }
-        .sort_by! { |_, s| -s }
-        .first(limit)
-        .map { |path, _| page_lookup[path] }
+      # Bounded top-k selection — equivalent to `.sort_by { -s }.first(limit)`
+      # but O(n*k) instead of O(n log n) with fewer allocations. Ties break by
+      # scores-hash insertion order (which mirrors pages/taxonomy iteration),
+      # matching a stable descending sort.
+      top = [] of {String, Int32}
+      scores.each do |path, score|
+        idx = 0
+        while idx < top.size && score <= top[idx][1]
+          idx += 1
+        end
+        next if idx >= limit
+        top.insert(idx, {path, score})
+        top.pop if top.size > limit
+      end
+
+      page.related_posts = top.map { |path, _| page_lookup[path] }
     end
   end
 end

--- a/src/utils/css_minifier.cr
+++ b/src/utils/css_minifier.cr
@@ -52,8 +52,10 @@ module Hwaro
         result = result.gsub(/\s+/, " ")
 
         # ── Step 5: Remove space around structural characters ─────────────
-        result = result.gsub(/\s*\{\s*/, "{")
-        result = result.gsub(/\s*\}\s*/, "}")
+        # Combined single-pass for `{`, `}`, `;`, `,` — these targets are
+        # disjoint (none can appear inside another's match) so one scan is
+        # equivalent to four sequential gsubs but allocates only one string.
+        result = result.gsub(/\s*([{};,])\s*/) { $1 }
         # Only remove spaces around `:` inside declaration blocks (after `{`)
         # and parenthesized expressions (e.g. media queries `(max-width: 600px)`)
         # to preserve descendant combinator spaces in selectors (e.g. `div :hover`)
@@ -68,8 +70,6 @@ module Hwaro
             "(" + $1.gsub(/\s*:\s*/, ":") + ")"
           end
         end
-        result = result.gsub(/\s*;\s*/, ";")
-        result = result.gsub(/\s*,\s*/, ",")
 
         # ── Step 6: Strip trailing semicolons before } ────────────────────
         result = result.gsub(/;\}/, "}")

--- a/src/utils/css_minifier.cr
+++ b/src/utils/css_minifier.cr
@@ -55,6 +55,8 @@ module Hwaro
         # Combined single-pass for `{`, `}`, `;`, `,` — these targets are
         # disjoint (none can appear inside another's match) so one scan is
         # equivalent to four sequential gsubs but allocates only one string.
+        # Running this before the `:` trims below is safe because `:` trimming
+        # operates on `:` context only and never interacts with `;` or `,`.
         result = result.gsub(/\s*([{};,])\s*/) { $1 }
         # Only remove spaces around `:` inside declaration blocks (after `{`)
         # and parenthesized expressions (e.g. media queries `(max-width: 600px)`)


### PR DESCRIPTION
## Summary

Two safe, output-equivalent performance tweaks on hot paths in the build pipeline.

### 1. Related posts — `src/core/build/phases/transform.cr`

- **Filter language during score accumulation** instead of after sorting. Cross-language candidates would be discarded from the final output anyway, so skipping them during accumulation produces identical results while reducing work (meaningful for multilingual sites).
- **Bounded top-k selection** replaces `.sort_by { -s }.first(limit)`. `O(n·k)` instead of `O(n log n)` with fewer allocations. Tie-break preserves scores-hash insertion order — equivalent to a stable descending sort.

### 2. CSS minifier — `src/utils/css_minifier.cr`

Merge the four separate `gsub` passes for ``{`` / ``}`` / ``;`` / ``,`` surrounding whitespace into a single pass:

```crystal
# before: 4 gsubs, 4 intermediate strings
result = result.gsub(/\s*\{\s*/, "{")
result = result.gsub(/\s*\}\s*/, "}")
# …
result = result.gsub(/\s*;\s*/, ";")
result = result.gsub(/\s*,\s*/, ",")

# after: 1 gsub, 1 intermediate string
result = result.gsub(/\s*([{};,])\s*/) { $1 }
```

Targets are disjoint (none can appear inside another's match region) so the single scan is mathematically equivalent to four sequential passes.

## Correctness

- Output of both changes is provably equivalent to the prior code.
- Related-posts language filter: cross-language entries don't contribute to other candidates' scores, so removing them early is a pure reduction of filtered-later items.
- Top-k insertion uses strict `>` comparison (`score <= top[idx][1]` to skip), so ties retain the order in which the scores hash was populated — the same order Crystal's stable sort would yield.
- CSS combined pass verified against nested blocks, empty `{}`, `{;}`, `@media` with paren-scoped `:`, and multi-space variants.

## Test plan

- [x] `crystal spec spec/unit/related_posts_spec.cr` — 10 / 10 pass (6 existing + 4 new)
  - language filter across `en` / `ko` / `nil`
  - tie-break order at the limit boundary
  - `limit = 0` yields empty
  - 20-candidate top-3 with mixed overlap counts
- [x] `crystal spec spec/unit/css_minifier_spec.cr` — 102 / 102 pass
- [x] `crystal spec` (full suite) — 4432 / 4432 pass
- [x] `crystal tool format --check` on both files