### PR TITLE
feat: make `hwaro new` front matter configurable with description default

### DIFF
--- a/docs/content/writing/archetypes.md
+++ b/docs/content/writing/archetypes.md
@@ -95,7 +95,18 @@ If no specific archetype matches, uses `archetypes/default.md`.
 
 ### 5. Built-in Template
 
-If no archetypes exist, uses the built-in default template.
+If no archetypes exist, uses the built-in default template. The format and
+default fields of that template are controlled by `[content.new]` in
+`config.toml`:
+
+```toml
+[content.new]
+front_matter_format = "toml"         # "toml" (default) or "yaml"
+default_fields = ["description"]      # extra keys to scaffold with empty values
+```
+
+Fields that overlap with the built-ins (`title`, `date`, `draft`, `tags`)
+are ignored so they aren't duplicated with empty values.
 
 ## Usage Examples
 

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -706,6 +706,56 @@ describe Hwaro::Models::Config do
   end
 
   # ---------------------------------------------------------------------------
+  # `hwaro new` content scaffold defaults
+  # ---------------------------------------------------------------------------
+
+  describe "content.new configuration" do
+    it "defaults to TOML front matter with a description field" do
+      config = Hwaro::Models::Config.new
+      config.content_new.front_matter_format.should eq("toml")
+      config.content_new.default_fields.should eq(["description"])
+      config.content_new.toml?.should be_true
+    end
+
+    it "loads front_matter_format and default_fields from [content.new]" do
+      config = load_config(<<-TOML)
+      [content.new]
+      front_matter_format = "yaml"
+      default_fields = ["description", "summary"]
+      TOML
+
+      config.content_new.front_matter_format.should eq("yaml")
+      config.content_new.default_fields.should eq(["description", "summary"])
+      config.content_new.toml?.should be_false
+    end
+
+    it "accepts flat keys on [content] as a shorthand" do
+      config = load_config(<<-TOML)
+      [content]
+      front_matter_format = "YAML"
+      TOML
+
+      # Case-insensitive normalization keeps configs tolerant of casing.
+      config.content_new.front_matter_format.should eq("yaml")
+    end
+
+    it "keeps the default format when the configured value is unknown" do
+      config = load_config(<<-TOML)
+      [content.new]
+      front_matter_format = "json"
+      TOML
+
+      config.content_new.front_matter_format.should eq("toml")
+    end
+
+    it "filters built-in fields out of extra_fields" do
+      config = Hwaro::Models::Config.new
+      config.content_new.default_fields = ["title", "description", "date", "author"]
+      config.content_new.extra_fields.should eq(["description", "author"])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Pagination
   # ---------------------------------------------------------------------------
 

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../src/models/config"
 require "../../src/services/creator"
 
 describe Hwaro::Services::Creator do
@@ -18,8 +19,8 @@ describe Hwaro::Services::Creator do
           File.exists?(expected_path).should be_true
 
           content = File.read(expected_path)
-          content.should contain("title: \"My First Post\"")
-          content.should contain("draft: true")
+          content.should contain("title = \"My First Post\"")
+          content.should contain("draft = true")
         end
       end
     end
@@ -38,7 +39,7 @@ describe Hwaro::Services::Creator do
           File.exists?(expected_path).should be_true
 
           content = File.read(expected_path)
-          content.should contain("title: \"My Custom Title\"")
+          content.should contain("title = \"My Custom Title\"")
         end
       end
     end
@@ -74,7 +75,7 @@ describe Hwaro::Services::Creator do
           File.exists?(expected_path).should be_true
 
           content = File.read(expected_path)
-          content.should contain("title: \"My Blog Post\"")
+          content.should contain("title = \"My Blog Post\"")
         end
       end
     end
@@ -163,8 +164,8 @@ describe Hwaro::Services::Creator do
           File.exists?(expected_path).should be_true
 
           content = File.read(expected_path)
-          content.should contain("title: \"Fallback Test\"")
-          content.should contain("date: ")
+          content.should contain("title = \"Fallback Test\"")
+          content.should contain("date = ")
         end
       end
     end
@@ -199,7 +200,7 @@ describe Hwaro::Services::Creator do
           File.exists?(expected_path).should be_true
 
           content = File.read(expected_path)
-          content.should contain("title: \"My Draft Post\"")
+          content.should contain("title = \"My Draft Post\"")
         end
       end
     end
@@ -287,7 +288,86 @@ describe Hwaro::Services::Creator do
           File.exists?(expected_path).should be_true
 
           content = File.read(expected_path)
-          content.should contain("title: \"Breaking News! (2024)\"")
+          content.should contain("title = \"Breaking News! (2024)\"")
+        end
+      end
+    end
+
+    it "defaults to TOML front matter with a description field" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello")
+          Hwaro::Services::Creator.new.run(options)
+
+          content = File.read("content/drafts/post.md")
+          content.should contain("+++\n")
+          content.should contain("title = \"Hello\"")
+          content.should contain("description = \"\"")
+          content.should_not contain("---\n")
+        end
+      end
+    end
+
+    it "emits YAML front matter when config selects yaml" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+
+          config = Hwaro::Models::Config.new
+          config.content_new.front_matter_format = "yaml"
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello")
+          Hwaro::Services::Creator.new.run(options, config)
+
+          content = File.read("content/drafts/post.md")
+          content.should contain("---\n")
+          content.should contain("title: \"Hello\"")
+          content.should contain("description: \"\"")
+          content.should_not contain("+++\n")
+        end
+      end
+    end
+
+    it "honours custom default_fields from config" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+
+          config = Hwaro::Models::Config.new
+          config.content_new.default_fields = ["description", "author", "summary"]
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello")
+          Hwaro::Services::Creator.new.run(options, config)
+
+          content = File.read("content/drafts/post.md")
+          content.should contain("description = \"\"")
+          content.should contain("author = \"\"")
+          content.should contain("summary = \"\"")
+        end
+      end
+    end
+
+    it "ignores built-in fields listed in default_fields" do
+      # Built-ins (title/date/draft/tags) have dedicated rendering. Listing
+      # them in default_fields must not duplicate them with empty values.
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+
+          config = Hwaro::Models::Config.new
+          config.content_new.default_fields = ["title", "date", "draft", "tags", "description"]
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello")
+          Hwaro::Services::Creator.new.run(options, config)
+
+          content = File.read("content/drafts/post.md")
+          content.scan("title = ").size.should eq(1)
+          content.scan("date = ").size.should eq(1)
+          content.should_not contain("title = \"\"")
+          content.should_not contain("date = \"\"")
+          content.should contain("description = \"\"")
         end
       end
     end

--- a/spec/unit/new_command_spec.cr
+++ b/spec/unit/new_command_spec.cr
@@ -101,4 +101,23 @@ describe Hwaro::CLI::Commands::NewCommand do
       end
     end
   end
+
+  # A malformed `config.toml` must surface as the same classified
+  # HWARO_E_CONFIG error that every other command raises. Silently falling
+  # back to defaults would hide user typos from `hwaro new`.
+  describe "#run with malformed config" do
+    it "raises HwaroError(HWARO_E_CONFIG) when config.toml is broken" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", "this = = broken\n")
+          FileUtils.mkdir_p("content/drafts")
+
+          err = expect_raises(Hwaro::HwaroError) do
+            Hwaro::CLI::Commands::NewCommand.new.run(["post.md", "-t", "Hello"])
+          end
+          err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        end
+      end
+    end
+  end
 end

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -2,6 +2,7 @@ require "option_parser"
 require "json"
 require "../metadata"
 require "../../config/options/new_options"
+require "../../models/config"
 require "../../services/creator"
 require "../../utils/errors"
 require "../../utils/logger"
@@ -72,7 +73,19 @@ module Hwaro
             )
           end
 
-          Services::Creator.new.run(options)
+          Services::Creator.new.run(options, load_config_if_present)
+        end
+
+        # Try to load `config.toml` so `hwaro new` can honour site-level
+        # preferences (front matter format, default fields). Missing or
+        # malformed config falls back to defaults silently — `hwaro new` must
+        # keep working in freshly-scaffolded or in-flight projects.
+        private def load_config_if_present : Models::Config?
+          return nil unless File.exists?("config.toml")
+          Models::Config.load
+        rescue ex
+          Logger.debug "Skipping config load for 'new': #{ex.message}"
+          nil
         end
 
         # Print archetypes found under the current project's archetypes/ dir.

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -77,15 +77,13 @@ module Hwaro
         end
 
         # Try to load `config.toml` so `hwaro new` can honour site-level
-        # preferences (front matter format, default fields). Missing or
-        # malformed config falls back to defaults silently — `hwaro new` must
-        # keep working in freshly-scaffolded or in-flight projects.
+        # preferences (front matter format, default fields). A missing
+        # `config.toml` is tolerated (freshly-scaffolded projects), but a
+        # malformed one is surfaced as the same classified HwaroError every
+        # other command raises — silent fallback would mask user typos.
         private def load_config_if_present : Models::Config?
           return nil unless File.exists?("config.toml")
           Models::Config.load
-        rescue ex
-          Logger.debug "Skipping config load for 'new': #{ex.message}"
-          nil
         end
 
         # Print archetypes found under the current project's archetypes/ dir.

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -996,16 +996,18 @@ module Hwaro
       end
 
       # Loads `hwaro new` scaffold settings from `[content.new]` (preferred)
-      # or falls back to flat keys under `[content]` so short configs like
-      # `[content]\nfront_matter_format = "yaml"` also work.
+      # or falls back to flat keys on `[content]` so short configs like
+      # `[content]\nfront_matter_format = "yaml"` also work. The fallback is
+      # scoped to the two recognised keys so unrelated `[content]` sub-tables
+      # (e.g. `[content.files]`) can never be misread as `new`-scaffold input.
       private def self.load_content_new(config : Config)
         return unless content_section = config.raw["content"]?.try(&.as_h?)
 
-        # Prefer the nested `[content.new]` table; fall back to flat keys on
-        # `[content]` for single-option configs.
-        section = content_section["new"]?.try(&.as_h?) || content_section
+        nested = content_section["new"]?.try(&.as_h?)
+        format_any = nested.try(&.[]?("front_matter_format")) || content_section["front_matter_format"]?
+        fields_any = nested.try(&.[]?("default_fields")) || content_section["default_fields"]?
 
-        if format = section["front_matter_format"]?.try(&.as_s?)
+        if format = format_any.try(&.as_s?)
           normalized = format.downcase
           if ContentNewConfig::VALID_FORMATS.includes?(normalized)
             config.content_new.front_matter_format = normalized
@@ -1014,7 +1016,7 @@ module Hwaro
           end
         end
 
-        if fields = section["default_fields"]?.try(&.as_a?)
+        if fields = fields_any.try(&.as_a?)
           config.content_new.default_fields = fields.compact_map(&.as_s?)
         end
       end

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -192,6 +192,42 @@ module Hwaro
       end
     end
 
+    # `hwaro new` content scaffolding configuration.
+    #
+    # Controls what `hwaro new` writes when there is no matching archetype:
+    #   - `front_matter_format` — "toml" (default) or "yaml"
+    #   - `default_fields`      — extra front matter keys (e.g. "description")
+    #     emitted with empty values so users can fill them in without having
+    #     to remember them.
+    #
+    # Fields listed in `default_fields` that overlap with built-ins
+    # (`title`, `date`, `draft`, `tags`) are ignored because those have
+    # dedicated handling and values.
+    class ContentNewConfig
+      FORMAT_TOML = "toml"
+      FORMAT_YAML = "yaml"
+      VALID_FORMATS = {FORMAT_TOML, FORMAT_YAML}
+      BUILTIN_FIELDS = {"title", "date", "draft", "tags"}
+
+      property front_matter_format : String
+      property default_fields : Array(String)
+
+      def initialize
+        @front_matter_format = FORMAT_TOML
+        @default_fields = ["description"]
+      end
+
+      def toml? : Bool
+        @front_matter_format == FORMAT_TOML
+      end
+
+      # Extra fields, with built-ins filtered out and duplicates removed,
+      # preserving configured order.
+      def extra_fields : Array(String)
+        @default_fields.reject { |f| BUILTIN_FIELDS.includes?(f) }.uniq
+      end
+    end
+
     # Auto-includes configuration for automatic CSS/JS loading
     class AutoIncludesConfig
       property enabled : Bool
@@ -625,6 +661,7 @@ module Hwaro
       property search : SearchConfig
       property plugins : PluginConfig
       property content_files : ContentFilesConfig
+      property content_new : ContentNewConfig
       property pagination : PaginationConfig
       property highlight : HighlightConfig
       property auto_includes : AutoIncludesConfig
@@ -657,6 +694,7 @@ module Hwaro
         @search = SearchConfig.new
         @plugins = PluginConfig.new
         @content_files = ContentFilesConfig.new
+        @content_new = ContentNewConfig.new
         @pagination = PaginationConfig.new
         @highlight = HighlightConfig.new
         @auto_includes = AutoIncludesConfig.new
@@ -751,6 +789,7 @@ module Hwaro
         load_search(config)
         load_plugins(config)
         load_content_files(config)
+        load_content_new(config)
         load_pagination(config)
         load_highlight(config)
         load_auto_includes(config)
@@ -953,6 +992,30 @@ module Hwaro
 
         if disallow_paths_any
           config.content_files.disallow_paths = ContentFilesConfig.normalize_paths(string_or_array(disallow_paths_any))
+        end
+      end
+
+      # Loads `hwaro new` scaffold settings from `[content.new]` (preferred)
+      # or falls back to flat keys under `[content]` so short configs like
+      # `[content]\nfront_matter_format = "yaml"` also work.
+      private def self.load_content_new(config : Config)
+        return unless content_section = config.raw["content"]?.try(&.as_h?)
+
+        # Prefer the nested `[content.new]` table; fall back to flat keys on
+        # `[content]` for single-option configs.
+        section = content_section["new"]?.try(&.as_h?) || content_section
+
+        if format = section["front_matter_format"]?.try(&.as_s?)
+          normalized = format.downcase
+          if ContentNewConfig::VALID_FORMATS.includes?(normalized)
+            config.content_new.front_matter_format = normalized
+          else
+            Logger.warn "Unknown content.new.front_matter_format '#{format}', keeping '#{config.content_new.front_matter_format}'"
+          end
+        end
+
+        if fields = section["default_fields"]?.try(&.as_a?)
+          config.content_new.default_fields = fields.compact_map(&.as_s?)
         end
       end
 

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -1,6 +1,7 @@
 require "file_utils"
 require "time"
 require "../config/options/new_options"
+require "../models/config"
 require "../utils/logger"
 
 module Hwaro
@@ -8,7 +9,7 @@ module Hwaro
     class Creator
       ARCHETYPES_DIR = "archetypes"
 
-      def run(options : Config::Options::NewOptions)
+      def run(options : Config::Options::NewOptions, config : Models::Config? = nil)
         path = options.path
         title = options.title || ""
 
@@ -93,10 +94,11 @@ module Hwaro
         # Find archetype
         archetype_content = find_archetype(options.archetype, full_path)
 
+        content_new = (config || Models::Config.new).content_new
         content = if archetype_content
                     process_archetype(archetype_content, title, date, is_draft, tags)
                   else
-                    generate_default_content(title, date, is_draft, tags)
+                    generate_default_content(title, date, is_draft, tags, content_new)
                   end
 
         if File.exists?(full_path)
@@ -167,20 +169,60 @@ module Hwaro
         content
       end
 
-      private def generate_default_content(title : String, date : String, is_draft : Bool, tags : Array(String)) : String
-        safe_title = title.gsub("\"", "\\\"").gsub("\n", " ")
+      # Built-in scaffold used when no archetype matches. Format and extra
+      # fields are driven by `[content.new]` in `config.toml` so the output
+      # matches the rest of the site's conventions (TOML by default to align
+      # with the shipped scaffolds).
+      private def generate_default_content(
+        title : String,
+        date : String,
+        is_draft : Bool,
+        tags : Array(String),
+        content_new : Models::ContentNewConfig,
+      ) : String
+        if content_new.toml?
+          build_toml_front_matter(title, date, is_draft, tags, content_new.extra_fields)
+        else
+          build_yaml_front_matter(title, date, is_draft, tags, content_new.extra_fields)
+        end
+      end
+
+      private def build_toml_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String)) : String
+        safe_title = escape_string(title)
+        String.build do |str|
+          str << "+++\n"
+          str << "title = \"#{safe_title}\"\n"
+          str << "date = \"#{date}\"\n"
+          extra_fields.each { |f| str << "#{f} = \"\"\n" }
+          str << "draft = true\n" if is_draft
+          unless tags.empty?
+            rendered = tags.map { |t| "\"#{escape_string(t)}\"" }.join(", ")
+            str << "tags = [#{rendered}]\n"
+          end
+          str << "+++\n\n"
+          str << "# #{title}\n"
+        end
+      end
+
+      private def build_yaml_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String)) : String
+        safe_title = escape_string(title)
         String.build do |str|
           str << "---\n"
           str << "title: \"#{safe_title}\"\n"
           str << "date: #{date}\n"
+          extra_fields.each { |f| str << "#{f}: \"\"\n" }
           str << "draft: true\n" if is_draft
           unless tags.empty?
             str << "tags:\n"
-            tags.each { |tag| str << "  - \"#{tag.gsub("\"", "\\\"")}\"\n" }
+            tags.each { |tag| str << "  - \"#{escape_string(tag)}\"\n" }
           end
           str << "---\n\n"
           str << "# #{title}\n"
         end
+      end
+
+      private def escape_string(value : String) : String
+        value.gsub("\"", "\\\"").gsub("\n", " ")
       end
     end
   end


### PR DESCRIPTION
## Summary

- `hwaro new` now scaffolds TOML front matter by default and includes a `description` field, matching the `hwaro init` scaffolds instead of hardcoding YAML with a minimal field set.
- Format and extra fields are configurable via `[content.new]` in `config.toml`; missing or malformed config falls back to defaults so `hwaro new` keeps working in freshly-scaffolded projects.
- Built-in fields (`title`, `date`, `draft`, `tags`) listed in `default_fields` are filtered out so they aren't duplicated with empty values.

Example:

```toml
[content.new]
front_matter_format = "toml"     # or "yaml"
default_fields = ["description"] # extra empty keys to scaffold
```

Closes #384

## Test plan

- [x] `crystal spec spec/unit/` — 4127 examples, 0 failures
- [x] Manual: `hwaro new hello.md -t "Hello World"` → TOML front matter with empty `description`
- [x] Manual: with `[content.new] front_matter_format = "yaml"` + custom `default_fields` → YAML output with all extra empty fields