### PR TITLE
feat: scaffold `archetypes/default.md` on `hwaro init`

### DIFF
--- a/docs/content/writing/archetypes.md
+++ b/docs/content/writing/archetypes.md
@@ -7,6 +7,8 @@ toc = true
 
 Archetypes are content templates that define default front matter and content structure for new pages. When you create content with `hwaro new`, archetypes provide consistent starting points.
 
+`hwaro init` ships a starter `archetypes/default.md` (and scaffold-specific archetypes like `posts.md` for the blog scaffold) so `hwaro new` picks up TOML front matter with a `description` field out of the box. Edit or extend them to match your site's conventions.
+
 ## Overview
 
 Archetypes live in the `archetypes/` directory at your project root:

--- a/spec/unit/initializer_spec.cr
+++ b/spec/unit/initializer_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../../src/services/initializer"
+require "../../src/services/creator"
 require "file_utils"
 
 describe Hwaro::Services::Initializer do
@@ -129,6 +130,79 @@ describe Hwaro::Services::Initializer do
           File.exists?(File.join(target, "config.toml")).should be_true
           Dir.exists?(File.join(target, "content")).should be_true
           Dir.exists?(File.join(target, "templates")).should be_true
+        end
+      end
+    end
+
+    describe "archetypes" do
+      it "creates archetypes/default.md for built-in scaffolds" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+          Hwaro::Services::Initializer.new.run(target)
+
+          archetype_path = File.join(target, "archetypes", "default.md")
+          File.exists?(archetype_path).should be_true
+
+          content = File.read(archetype_path)
+          content.should contain("+++")
+          content.should contain("title = \"{{ title }}\"")
+          content.should contain("description = \"\"")
+        end
+      end
+
+      it "ships a posts archetype with the blog scaffold" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+          Hwaro::Services::Initializer.new.run(
+            target,
+            scaffold_type: Hwaro::Config::Options::ScaffoldType::Blog,
+          )
+
+          posts_path = File.join(target, "archetypes", "posts.md")
+          File.exists?(posts_path).should be_true
+
+          content = File.read(posts_path)
+          content.should contain("authors = []")
+          content.should contain("categories = []")
+        end
+      end
+
+      it "ships section archetypes with the docs scaffold" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+          Hwaro::Services::Initializer.new.run(
+            target,
+            scaffold_type: Hwaro::Config::Options::ScaffoldType::Docs,
+          )
+
+          %w[getting-started guide reference].each do |name|
+            File.exists?(File.join(target, "archetypes", "#{name}.md")).should be_true
+          end
+          content = File.read(File.join(target, "archetypes", "guide.md"))
+          content.should contain("weight = 10")
+          content.should contain("toc = true")
+        end
+      end
+
+      it "makes `hwaro new` pick up the scaffolded default archetype" do
+        # Regression: the whole point of shipping `archetypes/default.md`
+        # is that `Services::Creator#find_archetype` should match it for
+        # fresh sites, producing TOML front matter with `description`
+        # instead of the hardcoded built-in template.
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+          Hwaro::Services::Initializer.new.run(target)
+
+          Dir.cd(target) do
+            FileUtils.mkdir_p("content/drafts")
+            options = Hwaro::Config::Options::NewOptions.new(path: "hello.md", title: "Hello")
+            Hwaro::Services::Creator.new.run(options)
+
+            content = File.read("content/drafts/hello.md")
+            content.should contain("+++")
+            content.should contain("title = \"Hello\"")
+            content.should contain("description = \"\"")
+          end
         end
       end
     end

--- a/spec/unit/initializer_spec.cr
+++ b/spec/unit/initializer_spec.cr
@@ -179,7 +179,10 @@ describe Hwaro::Services::Initializer do
             File.exists?(File.join(target, "archetypes", "#{name}.md")).should be_true
           end
           content = File.read(File.join(target, "archetypes", "guide.md"))
-          content.should contain("weight = 10")
+          # `weight` is commented out so every new docs page doesn't
+          # default to the same weight and collide on ordering.
+          content.should contain("# weight = 10")
+          content.should_not match(/^weight = /m)
           content.should contain("toc = true")
         end
       end

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -98,6 +98,10 @@ module Hwaro
         # Create static files
         create_scaffold_static_files(target_path, scaffold)
 
+        # Create archetype files so `hwaro new` has templates to match
+        # against and the archetype convention is discoverable.
+        create_scaffold_archetypes(target_path, scaffold)
+
         # Create config.toml
         config_content = if minimal_config
                            scaffold.minimal_config_content(skip_taxonomies)
@@ -170,6 +174,31 @@ module Hwaro
         shortcode_files = scaffold.shortcode_files
         shortcode_files.each do |relative_path, content|
           full_path = File.join(templates_dir, relative_path)
+          create_file(full_path, content)
+        end
+      end
+
+      # Writes the scaffold's archetype files under `archetypes/` so
+      # `hwaro new` can match them via `Services::Creator#find_archetype`.
+      # Creating the directory — even for scaffolds that ship no archetype
+      # files (e.g. remote) — would leave a confusing empty folder, so we
+      # skip both directory creation and file writes when the scaffold
+      # returns no archetypes.
+      private def create_scaffold_archetypes(target_path : String, scaffold : Scaffolds::Base)
+        archetype_files = scaffold.archetype_files
+        return if archetype_files.empty?
+
+        archetypes_dir = File.join(target_path, "archetypes")
+        create_directory(archetypes_dir)
+
+        archetype_files.each do |relative_path, content|
+          full_path = File.join(archetypes_dir, relative_path)
+          dir_path = File.dirname(full_path)
+
+          unless Dir.exists?(dir_path)
+            create_directory(dir_path)
+          end
+
           create_file(full_path, content)
         end
       end

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -43,6 +43,39 @@ module Hwaro
           }
         end
 
+        # Returns archetype files (path relative to `archetypes/`) as a
+        # hash of path => content. The default set ships a `default.md`
+        # that `hwaro new` picks up automatically (see
+        # `Services::Creator#find_archetype`), which both makes the
+        # archetype slot discoverable and ensures scaffolded content gets
+        # reasonable default front matter (TOML + `description`) without
+        # relying on the built-in template. Subclasses can extend this to
+        # add section-specific archetypes (e.g. `posts.md`).
+        def archetype_files : Hash(String, String)
+          {
+            "default.md" => default_archetype,
+          }
+        end
+
+        # Built-in default archetype content (TOML front matter).
+        # `Services::Creator` substitutes `{{ title }}`, `{{ date }}`,
+        # `{{ draft }}`, and `{{ tags }}`; other fields (description) ship
+        # with empty values for users to fill in.
+        protected def default_archetype : String
+          <<-MD
+          +++
+          title = "{{ title }}"
+          date = "{{ date }}"
+          draft = {{ draft }}
+          description = ""
+          tags = {{ tags }}
+          +++
+
+          # {{ title }}
+
+          MD
+        end
+
         # Returns the config.toml content
         abstract def config_content(skip_taxonomies : Bool = false) : String
 

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -156,6 +156,34 @@ module Hwaro
           }
         end
 
+        # Blog ships a `posts.md` archetype in addition to `default.md` so
+        # `hwaro new posts/<slug>.md` auto-matches it (see
+        # `Services::Creator#find_archetype`) and scaffolds blog-shaped
+        # front matter (authors/categories) without the user having to
+        # write the archetype themselves.
+        def archetype_files : Hash(String, String)
+          super.merge({
+            "posts.md" => posts_archetype,
+          })
+        end
+
+        protected def posts_archetype : String
+          <<-MD
+          +++
+          title = "{{ title }}"
+          date = "{{ date }}"
+          draft = {{ draft }}
+          description = ""
+          authors = []
+          categories = []
+          tags = {{ tags }}
+          +++
+
+          # {{ title }}
+
+          MD
+        end
+
         private def css_content : String
           <<-CSS
           :root {

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -65,13 +65,17 @@ module Hwaro
         end
 
         protected def docs_archetype : String
+          # `weight` is commented out intentionally: every docs section
+          # page shouldn't default to the same weight or ordering becomes
+          # non-deterministic. Users who care about ordering should set
+          # it explicitly per page.
           <<-MD
           +++
           title = "{{ title }}"
           date = "{{ date }}"
           draft = {{ draft }}
           description = ""
-          weight = 10
+          # weight = 10
           toc = true
           tags = {{ tags }}
           +++

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -51,6 +51,36 @@ module Hwaro
           files
         end
 
+        # Docs ships section-specific archetypes so `hwaro new
+        # getting-started/foo.md`, `guide/foo.md`, and `reference/foo.md`
+        # each auto-match (see `Services::Creator#find_archetype`) with
+        # docs-shaped front matter (weight/toc) that a generic
+        # `default.md` would miss.
+        def archetype_files : Hash(String, String)
+          super.merge({
+            "getting-started.md" => docs_archetype,
+            "guide.md"           => docs_archetype,
+            "reference.md"       => docs_archetype,
+          })
+        end
+
+        protected def docs_archetype : String
+          <<-MD
+          +++
+          title = "{{ title }}"
+          date = "{{ date }}"
+          draft = {{ draft }}
+          description = ""
+          weight = 10
+          toc = true
+          tags = {{ tags }}
+          +++
+
+          # {{ title }}
+
+          MD
+        end
+
         def template_files(skip_taxonomies : Bool = false) : Hash(String, String)
           files = {
             "header.html"  => header_template,

--- a/src/services/scaffolds/remote.cr
+++ b/src/services/scaffolds/remote.cr
@@ -62,6 +62,13 @@ module Hwaro
           @shortcode_data
         end
 
+        # Remote scaffolds mirror the upstream repo verbatim; we don't
+        # inject a built-in `default.md` because the remote might deliberately
+        # not use archetypes, or already ship its own under `archetypes/`.
+        def archetype_files : Hash(String, String)
+          {} of String => String
+        end
+
         def config_content(skip_taxonomies : Bool = false) : String
           @config_data
         end


### PR DESCRIPTION
## Summary

- `hwaro init` now writes an `archetypes/` directory so the convention is discoverable and fresh projects get TOML front matter with a `description` field by default (instead of falling through to `Creator`'s hardcoded built-in template).
- Base scaffolds ship `default.md`; the blog scaffold additionally ships `posts.md` (`authors`/`categories`); the docs scaffold ships `getting-started.md`/`guide.md`/`reference.md` (`weight`/`toc`). Remote scaffolds stay verbatim with no injected archetypes. Scaffolds returning an empty archetype set don't create an empty `archetypes/` directory.

Closes #385

## Test plan

- [x] `crystal spec spec/unit/` — 4132 examples, 0 failures
- [x] `hwaro init simple-site` → `archetypes/default.md` created with TOML + `description`
- [x] `hwaro init blog-site --scaffold blog` → additionally creates `archetypes/posts.md`
- [x] `hwaro init docs-site --scaffold docs` → creates `getting-started.md`/`guide.md`/`reference.md`
- [x] In a fresh blog scaffold: `hwaro new posts/hello.md -t Test` picks up `posts.md` → `authors`/`categories` present
- [x] `hwaro build` of scaffolded site with the new archetype-generated content parses cleanly