### PR TITLE
feat: leaf-bundle layout for `hwaro new` (--bundle / archetype / config)

### DIFF
--- a/docs/content/writing/archetypes.md
+++ b/docs/content/writing/archetypes.md
@@ -105,10 +105,32 @@ default fields of that template are controlled by `[content.new]` in
 [content.new]
 front_matter_format = "toml"         # "toml" (default) or "yaml"
 default_fields = ["description"]      # extra keys to scaffold with empty values
+bundle = false                        # true: scaffold foo/index.md instead of foo.md
 ```
 
 Fields that overlap with the built-ins (`title`, `date`, `draft`, `tags`)
 are ignored so they aren't duplicated with empty values.
+
+### Leaf-bundle (directory) layout
+
+When you plan to add multilingual siblings (`index.ko.md`) or colocated
+images next to a page, you want the directory-per-page layout:
+
+```
+content/abcd/
+└── index.md
+```
+
+Pick the layout per invocation, per archetype, or per site:
+
+- **CLI:** `hwaro new posts/hello.md --bundle` (or `--no-bundle` to force
+  the single-file form).
+- **Archetype:** put `<!-- hwaro: bundle -->` as the first line of the
+  archetype so any `hwaro new` using it defaults to bundle mode. The
+  directive is stripped from the generated content.
+- **Config:** `bundle = true` under `[content.new]` sets the house style.
+
+Priority is CLI > archetype > config > single-file (the default).
 
 ## Usage Examples
 

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -753,6 +753,16 @@ describe Hwaro::Models::Config do
       config.content_new.default_fields = ["title", "description", "date", "author"]
       config.content_new.extra_fields.should eq(["description", "author"])
     end
+
+    it "defaults bundle to false and loads it from [content.new]" do
+      Hwaro::Models::Config.new.content_new.bundle.should be_false
+
+      config = load_config(<<-TOML)
+      [content.new]
+      bundle = true
+      TOML
+      config.content_new.bundle.should be_true
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -483,6 +483,82 @@ describe Hwaro::Services::Creator do
           end
         end
       end
+
+      it "does not wrap `_index.md` section indices" do
+        # Section indices look like bundles shape-wise but mean something
+        # different; wrapping to `_index/index.md` would create a phantom
+        # section.
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "posts/_index.md", title: "Posts", bundle: true)
+            Hwaro::Services::Creator.new.run(options)
+
+            File.exists?("content/posts/_index.md").should be_true
+            File.exists?("content/posts/_index/index.md").should be_false
+          end
+        end
+      end
+
+      it "refuses bundle creation when a single-file sibling already exists" do
+        # Both `posts/hello.md` (sibling) and `posts/hello/index.md`
+        # (bundle) would render to the same URL — we'd rather fail loudly
+        # than silently duplicate the page.
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            File.write("content/posts/hello.md", "+++\ntitle = \"Existing\"\n+++\n")
+
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "posts/hello.md", title: "Hello", bundle: true)
+            expect_raises(Exception, /sibling already exists/) do
+              Hwaro::Services::Creator.new.run(options)
+            end
+
+            # Existing file left untouched, bundle not created.
+            File.read("content/posts/hello.md").should contain("Existing")
+            File.exists?("content/posts/hello/index.md").should be_false
+          end
+        end
+      end
+
+      it "warns and ignores unknown hwaro directives" do
+        # Typos like `<!-- hwaro: bundlr=true -->` used to silently no-op.
+        # Now they warn and bundle mode is not activated (behaviour check
+        # substitutes for asserting on Logger output).
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/tools")
+            FileUtils.mkdir_p("archetypes")
+            File.write(
+              "archetypes/tools.md",
+              "<!-- hwaro: bundlr=true -->\n+++\ntitle = \"{{ title }}\"\n+++\n"
+            )
+
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "tools/saw.md", title: "Saw")
+            Hwaro::Services::Creator.new.run(options)
+
+            # Unknown key → no bundle reshape; single file wins.
+            File.exists?("content/tools/saw.md").should be_true
+            Dir.exists?("content/tools/saw").should be_false
+          end
+        end
+      end
+
+      it "works with --section + --bundle together" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "hello.md", title: "Hello", section: "blog", bundle: true)
+            Hwaro::Services::Creator.new.run(options)
+
+            File.exists?("content/blog/hello/index.md").should be_true
+            File.exists?("content/blog/hello.md").should be_false
+          end
+        end
+      end
     end
   end
 end

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -371,5 +371,118 @@ describe Hwaro::Services::Creator do
         end
       end
     end
+
+    # Precedence: CLI --bundle > archetype directive > config > single.
+    # These tests each isolate a single layer so regressions in the
+    # resolver show up independently.
+    describe "bundle (leaf-bundle) layout" do
+      it "creates foo/index.md when --bundle is passed on the CLI" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "posts/hello.md", title: "Hello", bundle: true)
+            Hwaro::Services::Creator.new.run(options)
+
+            File.exists?("content/posts/hello/index.md").should be_true
+            File.exists?("content/posts/hello.md").should be_false
+          end
+        end
+      end
+
+      it "--no-bundle (bundle=false) forces a single file even when config defaults to bundle" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            config = Hwaro::Models::Config.new
+            config.content_new.bundle = true
+
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "posts/solo.md", title: "Solo", bundle: false)
+            Hwaro::Services::Creator.new.run(options, config)
+
+            File.exists?("content/posts/solo.md").should be_true
+            Dir.exists?("content/posts/solo").should be_false
+          end
+        end
+      end
+
+      it "falls back to the config default when --bundle is unspecified" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            config = Hwaro::Models::Config.new
+            config.content_new.bundle = true
+
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "posts/defaulted.md", title: "Defaulted")
+            Hwaro::Services::Creator.new.run(options, config)
+
+            File.exists?("content/posts/defaulted/index.md").should be_true
+          end
+        end
+      end
+
+      it "honours `<!-- hwaro: bundle -->` directive in an archetype and strips it" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/tools")
+            FileUtils.mkdir_p("archetypes")
+            File.write(
+              "archetypes/tools.md",
+              "<!-- hwaro: bundle -->\n+++\ntitle = \"{{ title }}\"\nkind = \"tool\"\n+++\n\n# {{ title }}\n"
+            )
+
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "tools/drill.md", title: "Drill")
+            Hwaro::Services::Creator.new.run(options)
+
+            bundle_path = "content/tools/drill/index.md"
+            File.exists?(bundle_path).should be_true
+            content = File.read(bundle_path)
+            # Directive must not leak into generated content.
+            content.should_not contain("hwaro:")
+            content.should contain("title = \"Drill\"")
+            content.should contain("kind = \"tool\"")
+          end
+        end
+      end
+
+      it "lets CLI --no-bundle override an archetype directive" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/tools")
+            FileUtils.mkdir_p("archetypes")
+            File.write(
+              "archetypes/tools.md",
+              "<!-- hwaro: bundle=true -->\n+++\ntitle = \"{{ title }}\"\n+++\n"
+            )
+
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "tools/saw.md", title: "Saw", bundle: false)
+            Hwaro::Services::Creator.new.run(options)
+
+            File.exists?("content/tools/saw.md").should be_true
+            Dir.exists?("content/tools/saw").should be_false
+          end
+        end
+      end
+
+      it "is idempotent when the path already ends in index.md" do
+        # Guards against double-wrapping: `hwaro new foo/index.md --bundle`
+        # must not produce `foo/index/index.md`.
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/foo")
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "foo/index.md", title: "Foo", bundle: true)
+            Hwaro::Services::Creator.new.run(options)
+
+            File.exists?("content/foo/index.md").should be_true
+            File.exists?("content/foo/index/index.md").should be_false
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/new_command_spec.cr
+++ b/spec/unit/new_command_spec.cr
@@ -100,6 +100,21 @@ describe Hwaro::CLI::Commands::NewCommand do
         cmd.parse_options(["--unknown"])
       end
     end
+
+    it "defaults bundle to nil (fall back to archetype/config)" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      options, _ = cmd.parse_options(["post.md"])
+      options.bundle.should be_nil
+    end
+
+    it "parses --bundle as true and --no-bundle as false" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      options, _ = cmd.parse_options(["post.md", "--bundle"])
+      options.bundle.should be_true
+
+      options, _ = cmd.parse_options(["post.md", "--no-bundle"])
+      options.bundle.should be_false
+    end
   end
 
   # A malformed `config.toml` must surface as the same classified

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -26,6 +26,8 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--tags", description: "Comma-separated tags", takes_value: true, value_hint: "TAGS"),
           FlagInfo.new(short: "-s", long: "--section", description: "Section directory (e.g. blog, docs)", takes_value: true, value_hint: "NAME"),
           FlagInfo.new(short: "-a", long: "--archetype", description: "Archetype to use", takes_value: true, value_hint: "NAME"),
+          FlagInfo.new(short: nil, long: "--bundle", description: "Create a leaf-bundle directory (foo/index.md) instead of a single file"),
+          FlagInfo.new(short: nil, long: "--no-bundle", description: "Create a single file (foo.md); overrides config default"),
 
           # Introspection
           FlagInfo.new(short: nil, long: "--list-archetypes", description: "List archetypes available in the current project and exit"),
@@ -131,6 +133,7 @@ module Hwaro
           draft = nil.as(Bool?)
           tags = [] of String
           section = nil.as(String?)
+          bundle = nil.as(Bool?)
           json_output = args.includes?("--json")
 
           OptionParser.parse(args) do |parser|
@@ -143,6 +146,11 @@ module Hwaro
             parser.on("--tags TAGS", "Comma-separated tags") { |t| tags = t.split(",").map(&.strip).reject(&.empty?) }
             parser.on("-s NAME", "--section NAME", "Section directory (e.g. blog, docs)") { |s| section = s }
             parser.on("-a NAME", "--archetype NAME", "Archetype to use") { |a| archetype = a }
+            # `--bundle` / `--no-bundle` are mutually exclusive in intent but
+            # OptionParser doesn't enforce that — last one wins, which matches
+            # typical Unix convention.
+            parser.on("--bundle", "Create a leaf-bundle directory (foo/index.md)") { bundle = true }
+            parser.on("--no-bundle", "Create a single file (foo.md)") { bundle = false }
             parser.on("--json", "Emit machine-readable JSON output") { json_output = true }
             CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
@@ -159,6 +167,7 @@ module Hwaro
             draft: draft,
             tags: tags,
             section: section,
+            bundle: bundle,
           ), json_output}
         end
       end

--- a/src/config/options/new_options.cr
+++ b/src/config/options/new_options.cr
@@ -9,6 +9,10 @@ module Hwaro
         property draft : Bool?
         property tags : Array(String)
         property section : String?
+        # `--bundle` / `--no-bundle`. `nil` means "user didn't specify";
+        # Creator then consults the archetype directive and the config
+        # default in that order (CLI > archetype > config > single).
+        property bundle : Bool?
 
         def initialize(
           @path : String? = nil,
@@ -18,6 +22,7 @@ module Hwaro
           @draft : Bool? = nil,
           @tags : Array(String) = [] of String,
           @section : String? = nil,
+          @bundle : Bool? = nil,
         )
         end
       end

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -199,6 +199,12 @@ module Hwaro
     #   - `default_fields`      — extra front matter keys (e.g. "description")
     #     emitted with empty values so users can fill them in without having
     #     to remember them.
+    #   - `bundle`              — when true, new pages default to the
+    #     leaf-bundle layout (`foo/index.md`) instead of a single file
+    #     (`foo.md`), which is the shape needed for multilingual siblings
+    #     and colocated page assets. Overridden by an archetype's own
+    #     `<!-- hwaro: bundle -->` directive, and by `--bundle`/`--no-bundle`
+    #     on the CLI (CLI > archetype > config).
     #
     # Fields listed in `default_fields` that overlap with built-ins
     # (`title`, `date`, `draft`, `tags`) are ignored because those have
@@ -211,10 +217,12 @@ module Hwaro
 
       property front_matter_format : String
       property default_fields : Array(String)
+      property bundle : Bool
 
       def initialize
         @front_matter_format = FORMAT_TOML
         @default_fields = ["description"]
+        @bundle = false
       end
 
       def toml? : Bool
@@ -1006,6 +1014,7 @@ module Hwaro
         nested = content_section["new"]?.try(&.as_h?)
         format_any = nested.try(&.[]?("front_matter_format")) || content_section["front_matter_format"]?
         fields_any = nested.try(&.[]?("default_fields")) || content_section["default_fields"]?
+        bundle_any = nested.try(&.[]?("bundle")) || content_section["bundle"]?
 
         if format = format_any.try(&.as_s?)
           normalized = format.downcase
@@ -1018,6 +1027,10 @@ module Hwaro
 
         if fields = fields_any.try(&.as_a?)
           config.content_new.default_fields = fields.compact_map(&.as_s?)
+        end
+
+        if bundle = bundle_any.try(&.as_bool?)
+          config.content_new.bundle = bundle
         end
       end
 

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -9,6 +9,14 @@ module Hwaro
     class Creator
       ARCHETYPES_DIR = "archetypes"
 
+      # `<!-- hwaro: KEY[=VALUE], KEY[=VALUE] -->` directive that an
+      # archetype can put on its very first line to declare metadata
+      # hwaro should honour (and strip) before applying the template.
+      # Currently recognises `bundle` (bool). Keeping it an HTML comment
+      # means the archetype still parses cleanly if hwaro isn't the one
+      # reading it.
+      HWARO_DIRECTIVE_RE = /\A<!--\s*hwaro:\s*(.*?)\s*-->\s*\n?/
+
       def run(options : Config::Options::NewOptions, config : Models::Config? = nil)
         path = options.path
         title = options.title || ""
@@ -91,10 +99,30 @@ module Hwaro
         date = options.date || Time.local.to_s("%Y-%m-%d %H:%M:%S")
         tags = options.tags
 
-        # Find archetype
-        archetype_content = find_archetype(options.archetype, full_path)
+        # Find archetype, extracting any hwaro directives (e.g. bundle=true)
+        # before substitution so they don't end up in generated content.
+        raw_archetype_content = find_archetype(options.archetype, full_path)
+        archetype_content, archetype_directives =
+          extract_directives(raw_archetype_content)
 
         content_new = (config || Models::Config.new).content_new
+
+        # Resolve bundle mode: CLI > archetype directive > config default.
+        # The CLI form is an explicit tri-state (`Bool?`) so `--no-bundle`
+        # really overrides rather than defaulting back.
+        bundle_mode = options.bundle
+        bundle_mode = archetype_directives["bundle"]?.try { |v| v == "true" } if bundle_mode.nil?
+        bundle_mode = content_new.bundle if bundle_mode.nil?
+
+        # Reshape `<dir>/<name>.md` → `<dir>/<name>/index.md` when bundle
+        # mode is active. Skipped if the path is already an `index.md`
+        # so repeated invocations don't create `foo/index/index.md`.
+        if bundle_mode && !bundle_path?(full_path)
+          full_path = bundle_path_for(full_path)
+          base_dir = File.dirname(full_path)
+          FileUtils.mkdir_p(base_dir) unless Dir.exists?(base_dir)
+        end
+
         content = if archetype_content
                     process_archetype(archetype_content, title, date, is_draft, tags)
                   else
@@ -107,6 +135,35 @@ module Hwaro
 
         File.write(full_path, content)
         Logger.info "Created new content: #{full_path}"
+      end
+
+      # Returns `{stripped_content, directives}`. When the archetype's first
+      # line is `<!-- hwaro: k=v, k2=v2 -->`, that line is removed from the
+      # content and the directives are returned as a hash. Shorthand keys
+      # without `=VALUE` are treated as `k = "true"`.
+      private def extract_directives(content : String?) : {String?, Hash(String, String)}
+        directives = {} of String => String
+        return {nil, directives} unless content
+
+        match = HWARO_DIRECTIVE_RE.match(content)
+        return {content, directives} unless match
+
+        match[1].split(",").each do |pair|
+          k, _, v = pair.strip.partition("=")
+          key = k.strip
+          next if key.empty?
+          directives[key] = v.strip.empty? ? "true" : v.strip
+        end
+        {content.sub(HWARO_DIRECTIVE_RE, ""), directives}
+      end
+
+      private def bundle_path?(path : String) : Bool
+        File.basename(path) == "index.md"
+      end
+
+      private def bundle_path_for(path : String) : String
+        base = File.basename(path, ".md")
+        File.join(File.dirname(path), base, "index.md")
       end
 
       private def find_archetype(explicit_archetype : String?, path : String) : String?

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -12,10 +12,14 @@ module Hwaro
       # `<!-- hwaro: KEY[=VALUE], KEY[=VALUE] -->` directive that an
       # archetype can put on its very first line to declare metadata
       # hwaro should honour (and strip) before applying the template.
-      # Currently recognises `bundle` (bool). Keeping it an HTML comment
-      # means the archetype still parses cleanly if hwaro isn't the one
-      # reading it.
+      # Keeping it an HTML comment means the archetype still parses
+      # cleanly if hwaro isn't the one reading it.
       HWARO_DIRECTIVE_RE = /\A<!--\s*hwaro:\s*(.*?)\s*-->\s*\n?/
+
+      # Keys accepted inside `<!-- hwaro: ... -->`. Anything else is
+      # logged as a warning so typos (`bundlr=true`) surface instead of
+      # silently becoming no-ops.
+      KNOWN_DIRECTIVES = {"bundle"}
 
       def run(options : Config::Options::NewOptions, config : Models::Config? = nil)
         path = options.path
@@ -116,9 +120,14 @@ module Hwaro
 
         # Reshape `<dir>/<name>.md` → `<dir>/<name>/index.md` when bundle
         # mode is active. Skipped if the path is already an `index.md`
-        # so repeated invocations don't create `foo/index/index.md`.
+        # or `_index.md` so repeated invocations (and accidental bundle
+        # mode on section indices) don't create `foo/index/index.md`.
         if bundle_mode && !bundle_path?(full_path)
-          full_path = bundle_path_for(full_path)
+          candidate = bundle_path_for(full_path)
+          if bundle_collides_with_sibling?(candidate)
+            raise "Cannot create bundle at #{candidate}: single-file sibling already exists. Remove the existing file or omit --bundle."
+          end
+          full_path = candidate
           base_dir = File.dirname(full_path)
           FileUtils.mkdir_p(base_dir) unless Dir.exists?(base_dir)
         end
@@ -140,7 +149,8 @@ module Hwaro
       # Returns `{stripped_content, directives}`. When the archetype's first
       # line is `<!-- hwaro: k=v, k2=v2 -->`, that line is removed from the
       # content and the directives are returned as a hash. Shorthand keys
-      # without `=VALUE` are treated as `k = "true"`.
+      # without `=VALUE` are treated as `k = "true"`. Unknown keys warn
+      # (but don't fail) so typos surface instead of silently no-oping.
       private def extract_directives(content : String?) : {String?, Hash(String, String)}
         directives = {} of String => String
         return {nil, directives} unless content
@@ -152,18 +162,36 @@ module Hwaro
           k, _, v = pair.strip.partition("=")
           key = k.strip
           next if key.empty?
+          unless KNOWN_DIRECTIVES.includes?(key)
+            Logger.warn "Unknown hwaro directive '#{key}' in archetype; ignoring. Known keys: #{KNOWN_DIRECTIVES.to_a.sort.join(", ")}."
+            next
+          end
           directives[key] = v.strip.empty? ? "true" : v.strip
         end
         {content.sub(HWARO_DIRECTIVE_RE, ""), directives}
       end
 
+      # `index.md` and `_index.md` are already "in bundle shape" — the
+      # former is a page bundle's leaf file and the latter is a section
+      # index. Wrapping either into `<name>/index.md` would be nonsense
+      # (`posts/_index/index.md` creates a phantom section).
       private def bundle_path?(path : String) : Bool
-        File.basename(path) == "index.md"
+        basename = File.basename(path)
+        basename == "index.md" || basename == "_index.md"
       end
 
       private def bundle_path_for(path : String) : String
         base = File.basename(path, ".md")
         File.join(File.dirname(path), base, "index.md")
+      end
+
+      # True when switching `<name>.md` to `<name>/index.md` would
+      # collide with an existing single-file sibling on disk. Both would
+      # render to the same URL, so we refuse rather than silently create
+      # a duplicate.
+      private def bundle_collides_with_sibling?(full_path : String) : Bool
+        sibling_md = full_path.rchop("/index.md") + ".md"
+        File.exists?(sibling_md) && File.file?(sibling_md)
       end
 
       private def find_archetype(explicit_archetype : String?, path : String) : String?


### PR DESCRIPTION
## Summary

`hwaro new posts/hello.md --bundle` now creates `content/posts/hello/index.md` (the leaf-bundle shape multilingual siblings and colocated assets need) instead of `content/posts/hello.md`. The layout can be set three ways, with CLI > archetype > config precedence:

- **CLI:** `--bundle` / `--no-bundle` (tri-state, so `--no-bundle` really overrides)
- **Archetype:** `<!-- hwaro: bundle -->` as the first line of the archetype (HTML comment keeps it parseable by other tools; stripped before substitution so it never leaks into content)
- **Config:** `[content.new] bundle = true` for a house default

Default remains single-file. Repeated invocations on a path already ending in `index.md` are idempotent — no `foo/index/index.md` double-wrap.

The archetype directive uses `<!-- hwaro: KEY[=VALUE], ... -->` syntax so additional keys can be added without coining another convention.

Closes #386

## Test plan

- [x] `crystal spec spec/unit/` — 4147 examples, 0 failures
- [x] `crystal spec spec/functional/` — 263 examples, 0 failures
- [x] 6 new creator cases: CLI on, CLI off overrides config, config default applies, archetype directive honored and stripped, CLI overrides archetype, idempotent index.md
- [x] Config + CLI parse tests for the new field/flags
- [x] Manual: verified all four precedence layers on a freshly-scaffolded blog site