### PR TITLE
docs: cover remaining CLI flags, config keys, and template helpers

### DIFF
--- a/docs/content/features/og-images.md
+++ b/docs/content/features/og-images.md
@@ -36,6 +36,7 @@ pattern_scale = 1.0
 background_image = "static/og-bg.jpg"
 overlay_opacity = 0.5
 format = "svg"
+font_path = "static/fonts/Inter-Bold.ttf"
 ```
 
 | Key | Type | Default | Description |
@@ -55,6 +56,7 @@ format = "svg"
 | background_image | string | — | Background image file path. Embedded as base64 data URI |
 | overlay_opacity | float | `0.5` | Opacity of the color overlay on background images (0.0–1.0) |
 | format | string | `"svg"` | Output format: `"svg"` or `"png"` |
+| font_path | string | — | Path to a custom `.ttf` / `.otf` font file for PNG output. Falls back to system fonts, then the bundled DejaVu Sans Bold |
 
 ## Style Presets
 

--- a/docs/content/features/pwa.md
+++ b/docs/content/features/pwa.md
@@ -28,6 +28,7 @@ start_url = "/"
 icons = ["static/icon-192.png", "static/icon-512.png"]
 offline_page = "/offline.html"
 precache_urls = ["/", "/about/", "/css/main.css"]
+cache_strategy = "cache-first"
 ```
 
 | Key | Type | Default | Description |
@@ -42,6 +43,7 @@ precache_urls = ["/", "/about/", "/css/main.css"]
 | icons | array | [] | Icon file paths |
 | offline_page | string | — | Fallback page when offline |
 | precache_urls | array | [] | URLs to cache during service worker install |
+| cache_strategy | string | `"cache-first"` | Asset fetch strategy: `cache-first`, `network-first`, or `stale-while-revalidate` |
 
 ## Icon Sizing
 
@@ -79,9 +81,19 @@ Add the manifest link and service worker registration to your base template:
 The generated service worker uses:
 
 - **Precache on install** — URLs listed in `precache_urls` plus `start_url` are cached immediately
-- **Cache-first for assets** — Subsequent requests serve from cache, falling back to network
-- **Network-first for navigation** — Page navigations try the network first, falling back to the offline page
+- **Asset fetching** — Controlled by `cache_strategy` (see below)
+- **Network-first for navigation** — Page navigations always try the network first, falling back to the offline page
 - **Automatic cache versioning** — Old caches are cleaned up on service worker activation
+
+Set `cache_strategy` to pick how assets (non-navigation requests) are served:
+
+| Value | Behavior |
+|-------|----------|
+| `cache-first` (default) | Serve from cache if present, otherwise fetch from network and cache the response. Fastest for static sites. |
+| `network-first` | Try the network first; fall back to cache on failure. Use when you want fresh content but offline resilience. |
+| `stale-while-revalidate` | Serve the cached copy immediately and refresh the cache in the background. Balances speed and freshness. |
+
+Unknown values log a warning and fall back to `cache-first`.
 
 ## Offline Page
 

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -111,6 +111,7 @@ Remote scaffolds fetch `config.toml`, `templates/`, `static/`, and content struc
 | --skip-sample-content | Skip creating sample content files |
 | --skip-taxonomies | Skip taxonomies configuration and templates |
 | --include-multilingual LANGS | Enable multilingual support (e.g., `en,ko,ja`) |
+| --minimal-config | Generate minimal `config.toml` without comments or optional sections |
 | --list-scaffolds | List available built-in scaffolds and exit |
 | --json | Emit machine-readable JSON output (with --list-scaffolds) |
 
@@ -138,6 +139,8 @@ Creates a Markdown file with front matter template. Supports **archetypes** for 
 | --tags TAGS | Comma-separated tags |
 | -s, --section NAME | Section directory (e.g. `blog`, `docs`) |
 | -a, --archetype NAME | Archetype to use |
+| --bundle | Create a leaf-bundle directory (`foo/index.md`) instead of a single file |
+| --no-bundle | Force a single file (`foo.md`); overrides `[content.new].bundle = true` |
 | --list-archetypes | List archetypes in the current project and exit |
 | --json | Emit machine-readable JSON output (archetypes listing and classified errors) |
 

--- a/docs/content/templates/functions.md
+++ b/docs/content/templates/functions.md
@@ -313,6 +313,31 @@ Alias for `url_for()`. You can use either name:
 
 ---
 
+### asset()
+
+Resolve a bundled or fingerprinted asset to its final URL. When the [asset pipeline](/features/asset-pipeline/) is enabled, the input name is looked up in the build manifest so you always get the hashed filename.
+
+```jinja
+<link rel="stylesheet" href="{{ asset(name='main.css') }}">
+<script src="{{ asset(name='app.js') }}"></script>
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| name | String | Bundle or asset name (e.g. `main.css`, `app.js`) |
+
+**Returns:** String — absolute URL under `base_url`. When no manifest entry is found, the name is returned as a path under `base_url` unchanged, so templates keep working before you turn the pipeline on.
+
+---
+
+### asset_url()
+
+Alias for `asset()`. Use whichever reads better in your templates.
+
+---
+
 ### now()
 
 Get current datetime:


### PR DESCRIPTION
## Summary
Second pass at closing doc/code gaps after #392. Each addition was verified against the source.

- **CLI reference** (`start/cli.md`)
  - Document `hwaro init --minimal-config` (src/cli/commands/init_command.cr:26) — generates a minimal `config.toml` without comments or optional sections.
  - Document `hwaro new --bundle` / `--no-bundle` (src/cli/commands/new_command.cr:29-30) — leaf-bundle layout switches from the CLI. Previously only mentioned in `writing/archetypes.md`, so users reading the CLI reference couldn't find them.
- **OG images** (`features/og-images.md`)
  - Document `[og.auto_image].font_path` (src/models/config.cr:316, src/content/seo/og_png_renderer.cr:162) — custom TTF/OTF font for PNG output, with fallback chain to system fonts and the bundled DejaVu Sans Bold.
- **PWA** (`features/pwa.md`)
  - Document `[pwa].cache_strategy` (src/models/config.cr:634, src/content/seo/pwa.cr:82) — three validated values (`cache-first`, `network-first`, `stale-while-revalidate`) plus the corresponding service worker fetch handler behavior. The old copy said "cache-first for assets" as if hard-coded, but it's actually configurable.
- **Template functions** (`templates/functions.md`)
  - Add `asset()` and `asset_url()` (src/content/processors/template.cr:547, 562). Already covered in `features/asset-pipeline.md`, but the template-functions catalog is the canonical index and should list every registered function.

## Test plan
- [x] `hwaro build` in `docs/` succeeds (63 pages, no new warnings).
- [x] Each added flag/key confirmed present in source via grep before documenting.