### PR TITLE
docs: fix broken check-links URL and add OG image alt text

### DIFF
--- a/docs/content/features/og-images.md
+++ b/docs/content/features/og-images.md
@@ -7,7 +7,7 @@ toc = true
 
 Hwaro can automatically generate Open Graph (OG) preview images for pages that don't have a custom image set. These images are used by social media platforms when your content is shared.
 
-![](/og-images/features-og-images.png)
+![Auto-generated OG image for the Auto OG Images page](/og-images/features-og-images.png)
 *Example: This is the og image of this page.*
 
 ## How It Works

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -388,7 +388,7 @@ hwaro tool check-links --json
 |----------|------------|-------------|
 | Content | [list](/start/tools/list/) | List content files by status (all, drafts, published) |
 | Content | [convert](/start/tools/convert/) | Convert frontmatter between YAML and TOML formats |
-| Content | [check-links](/start/tools/deadlink/) | Check for dead links in content files |
+| Content | [check-links](/start/tools/check-links/) | Check for dead links in content files |
 | Content | [stats](/start/tools/stats/) | Show content statistics |
 | Content | [validate](/start/tools/validate/) | Validate content frontmatter and markup |
 | Content | [unused-assets](/start/tools/unused-assets/) | Find unreferenced static files |


### PR DESCRIPTION
## Summary
Two small doc-quality fixes surfaced while auditing recent changes.

- **`start/cli.md`** — The tool-commands table still pointed at `/start/tools/deadlink/`, left behind by the `deadlink.md` → `check-links.md` rename in #392. The URL now 404'd. Updated to `/start/tools/check-links/`.
- **`features/og-images.md`** — The hero example image had empty alt text, which was the only warning emitted by `hwaro tool validate`. Added descriptive alt text.

## Test plan
- [x] `hwaro build` succeeds (63 pages).
- [x] `hwaro tool validate` reports **no issues** (previously: 1 warning).
- [x] Internal-link scan over every built page: no remaining broken `/start/...` / `/features/...` / `/writing/...` / `/templates/...` / `/deploy/...` links.