### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v0.12.0
+
+### Added
+- Leaf-bundle layout for `hwaro new` with `--bundle`, archetype, and config support (#391)
+- Scaffold `archetypes/default.md` on `hwaro init` (#388)
+- Configurable front matter with description default for `hwaro new` (#387)
+- `--json` output for `build`, `serve`, `deploy`, and `tool` subcommands (#372)
+- Per-target summary in `hwaro deploy --json` (#377)
+- JSON introspection for scaffolds, archetypes, and deploy targets (#368)
+- Stable error taxonomy with consistent exit codes (#373)
+- `HwaroError` classification for IO, network, template, and content errors (#378, #380)
+- Global `--quiet` flag and `NO_COLOR` support (#371)
+- Live reload enabled by default for `hwaro serve` (#370)
+- Deterministic ready signal from `hwaro serve` (#367)
+- Closest-match suggestion on unknown command/subcommand (#366)
+- Configured deploy targets shown in `deploy --help` (#364)
+- Inline status glyphs in doctor output (#365)
+- Crystal 1.20 support (#342)
+- Docs coverage for remaining CLI flags, config keys, template helpers, `tool import`, `serve --no-error-overlay`, and `check-links` filename (#392, #393)
+
+### Changed
+- `hwaro new` is flag-only; dropped interactive title prompt (#369)
+- Skip image reprocessing for unchanged sources on serve rebuilds (#390)
+- Top-k related posts and combined CSS structural-char pass (#382)
+- Raise `HwaroError(HWARO_E_CONFIG)` at config-load source (#379)
+- Switch CI to official `crystallang/crystal` image
+- Expanded unit and functional specs across scaffolds, build phases, lifecycle, pagination, content processors, image hooks, live reload, and tool subcommands (#338, #339, #340, #341, #343, #344, #345, #346, #347)
+
+### Fixed
+- Broken check-links URL and missing OG image alt text in docs (#394)
+- Scaffold sample dates and broken docs links (#383)
+- Always emit `date` field in `tool list --json` (#376)
+- Spurious `feeds.filename` doctor warning (#363)
+- Interactive prompt hang in non-TTY environments for `hwaro new` (#362)
+- Stray dots in `init` output for current directory (#361)
+- IPv6 loopback allowlist in `LiveReloadHandler`
+
 ## v0.11.1
 
 ### Added

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         hwaro = pkgs.crystal.buildCrystalPackage rec {
           pname = "hwaro";
-          version = "0.11.1";
+          version = "0.12.0";
 
           src = ./.;
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: hwaro
-version: 0.11.1
+version: 0.12.0
 
 authors:
   - HAHWUL <hahwul@gmail.com>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: hwaro
 base: core24
-version: 0.11.1
+version: 0.12.0
 summary: Hwaro (화로) is a lightweight and fast static site generator written in Crystal.
 description: Hwaro (화로) is a lightweight and fast static site generator written in Crystal. It provides a flexible, extensible architecture for building static websites with support for markdown content, templates, SEO features, and lifecycle hooks.
 

--- a/spec/hwaro_spec.cr
+++ b/spec/hwaro_spec.cr
@@ -4,7 +4,7 @@ describe Hwaro do
   describe "VERSION" do
     it "has a version number" do
       Hwaro::VERSION.should_not be_nil
-      Hwaro::VERSION.should eq("0.11.1")
+      Hwaro::VERSION.should eq("0.12.0")
     end
   end
 

--- a/src/hwaro.cr
+++ b/src/hwaro.cr
@@ -98,5 +98,5 @@ require "./content/hooks"
 require "./cli/runner"
 
 module Hwaro
-  VERSION = "0.11.1"
+  VERSION = "0.12.0"
 end

--- a/src/utils/logger.cr
+++ b/src/utils/logger.cr
@@ -76,7 +76,7 @@ module Hwaro
     # Auto-detect unless explicitly set. Disabled when `NO_COLOR` env var
     # is set to any non-empty value, or when STDOUT is not a TTY.
     def self.color_enabled? : Bool
-      if override = @@color_enabled
+      unless (override = @@color_enabled).nil?
         return override
       end
       return false if ENV.has_key?("NO_COLOR") && !ENV["NO_COLOR"].empty?


### PR DESCRIPTION
## Summary
- Bump version to v0.12.0 across `shard.yml`, `flake.nix`, `snapcraft.yaml`, and source
- Add v0.12.0 section to `CHANGELOG.md` summarizing changes since v0.11.1

## Highlights since v0.11.1
- Leaf-bundle layout for `hwaro new` and configurable front matter (#387, #391)
- Global `--json` output, `--quiet` flag, and `NO_COLOR` support (#371, #372, #377)
- Stable error taxonomy with `HwaroError` classification and consistent exit codes (#373, #378, #379, #380)
- Live reload enabled by default and deterministic ready signal for `hwaro serve` (#367, #370)
- Crystal 1.20 support and expanded unit/functional spec coverage (#342 and others)
- Docs gap fills, scaffold date refreshes, and misc fixes (#361, #362, #363, #376, #383, #392, #393, #394)

## Test plan
- [x] `shards build --release`
- [ ] `crystal spec`
- [x] Verify `hwaro --version` reports v0.12.0