### PR TITLE
fix(links): prepend base_url path to internal @/ links

### DIFF
--- a/spec/unit/internal_link_resolver_spec.cr
+++ b/spec/unit/internal_link_resolver_spec.cr
@@ -67,5 +67,50 @@ describe Hwaro::Content::Processors::InternalLinkResolver do
       result = Hwaro::Content::Processors::InternalLinkResolver.resolve(html, pages, "index.md")
       result.should eq html
     end
+
+    it "prepends base_url path component when site is served from a subpath" do
+      pages = {"blog/post.md" => make_page("blog/post.md", "/blog/post/")}
+      html = %(<a href="@/blog/post.md">link</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.resolve(
+        html, pages, "index.md", "https://example.github.io/project"
+      )
+      result.should eq %(<a href="/project/blog/post/">link</a>)
+    end
+
+    it "prepends base_url path to links with anchors" do
+      pages = {"blog/post.md" => make_page("blog/post.md", "/blog/post/")}
+      html = %(<a href="@/blog/post.md#section">link</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.resolve(
+        html, pages, "index.md", "https://example.github.io/project"
+      )
+      result.should eq %(<a href="/project/blog/post/#section">link</a>)
+    end
+
+    it "does not add prefix when base_url has no path component" do
+      pages = {"blog/post.md" => make_page("blog/post.md", "/blog/post/")}
+      html = %(<a href="@/blog/post.md">link</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.resolve(
+        html, pages, "index.md", "https://example.com"
+      )
+      result.should eq %(<a href="/blog/post/">link</a>)
+    end
+
+    it "handles trailing slash in base_url" do
+      pages = {"blog/post.md" => make_page("blog/post.md", "/blog/post/")}
+      html = %(<a href="@/blog/post.md">link</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.resolve(
+        html, pages, "index.md", "https://example.github.io/project/"
+      )
+      result.should eq %(<a href="/project/blog/post/">link</a>)
+    end
+
+    it "handles nested base path" do
+      pages = {"docs/_index.md" => make_page("docs/_index.md", "/docs/")}
+      html = %(<a href="@/docs/_index.md">docs</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.resolve(
+        html, pages, "index.md", "https://example.com/a/b"
+      )
+      result.should eq %(<a href="/a/b/docs/">docs</a>)
+    end
   end
 end

--- a/src/content/processors/internal_link_resolver.cr
+++ b/src/content/processors/internal_link_resolver.cr
@@ -1,4 +1,5 @@
 require "html"
+require "uri"
 
 # Internal Link Resolver
 #
@@ -25,8 +26,18 @@ module Hwaro
         # - `html` — rendered HTML string
         # - `pages_by_path` — map from content path (e.g. "blog/post.md") to Page
         # - `source_path` — path of the page being rendered (for warning messages)
-        def resolve(html : String, pages_by_path : Hash(String, Models::Page), source_path : String) : String
+        # - `base_url` — site base_url, used to prepend the path component (e.g. "/noir")
+        #   so links work when the site is served from a subpath. When empty or root,
+        #   no prefix is added and behavior matches the previous output.
+        def resolve(
+          html : String,
+          pages_by_path : Hash(String, Models::Page),
+          source_path : String,
+          base_url : String = "",
+        ) : String
           return html unless html.includes?("@/")
+
+          base_path = base_url.empty? ? "" : URI.parse(base_url).path.rstrip("/")
 
           html.gsub(INTERNAL_LINK_REGEX) do |match|
             content_path = $1
@@ -38,7 +49,8 @@ module Hwaro
             end
 
             if page = pages_by_path[content_path]?
-              url = HTML.escape(page.url)
+              page_url = page.url.starts_with?("/") ? page.url : "/#{page.url}"
+              url = HTML.escape("#{base_path}#{page_url}")
               if anchor && !anchor.empty?
                 "href=\"#{url}##{HTML.escape(anchor)}\""
               else

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -301,7 +301,7 @@ module Hwaro::Core::Build::Phases::Render
 
     # Resolve internal @/ links to actual page URLs
     if pages_by_path = @pages_by_path
-      html_content = Content::Processors::InternalLinkResolver.resolve(html_content, pages_by_path, page.path)
+      html_content = Content::Processors::InternalLinkResolver.resolve(html_content, pages_by_path, page.path, site.config.base_url)
     end
 
     # Store rendered HTML in page.content for reuse by Feed/Search generators


### PR DESCRIPTION
## Summary

Fixes #396. `InternalLinkResolver` inserted `page.url` (a domain-root-relative path like `/blog/post/`) directly as the href value. When `base_url` included a path component (e.g. `https://example.github.io/project`), browsers resolved the href against the domain root and dropped the `/project` prefix, producing 404s on deployed sites served from a subpath.

This fix extracts the path component from `config.base_url` via `URI.parse` and prepends it to the emitted href. Templates using `{{ base_url }}` and `generate_permalink` were unaffected because they already combined `base_url` with the relative path explicitly, so no change there.

The `base_url` parameter on `InternalLinkResolver.resolve` defaults to `""` for backwards compatibility — existing spec calls keep working, and when `base_url` is empty or has no path component the output is unchanged.

Real-world repro: https://github.com/owasp-noir/noir/issues/1234 (OWASP Noir docs deployed to `/noir` subpath).

## Test plan

- [x] New specs in `spec/unit/internal_link_resolver_spec.cr` covering: subpath base_url, subpath + anchor, no-path base_url, trailing slash in base_url, nested base path
- [x] `crystal spec spec/unit/internal_link_resolver_spec.cr` → 13 examples, 0 failures
- [x] `crystal spec spec/unit/` → 4156 examples, 0 failures (no regressions)
- [x] Manual check: rebuild OWASP Noir docs with patched hwaro and verify internal links resolve to `/noir/...`