### PR TITLE
fix(init): validate languages, warn on ignored scaffold, fail on empty remote

### DIFF
--- a/spec/unit/init_command_spec.cr
+++ b/spec/unit/init_command_spec.cr
@@ -88,6 +88,21 @@ describe Hwaro::CLI::Commands::InitCommand do
       # With spaces
       options = cmd.parse_options(["--include-multilingual", "en, ko, fr"])
       options.multilingual_languages.should eq(["en", "ko", "fr"])
+
+      # Region subtags
+      options = cmd.parse_options(["--include-multilingual", "en-US,pt-BR,zh-Hant"])
+      options.multilingual_languages.should eq(["en-US", "pt-BR", "zh-Hant"])
+    end
+
+    it "rejects invalid language codes in --include-multilingual" do
+      cmd = Hwaro::CLI::Commands::InitCommand.new
+      expect_raises(Hwaro::HwaroError, /Invalid language code: '@@@'/) do
+        cmd.parse_options(["--include-multilingual", "en,@@@"])
+      end
+
+      expect_raises(Hwaro::HwaroError, /Invalid language code/) do
+        cmd.parse_options(["--include-multilingual", "123"])
+      end
     end
 
     it "parses mixed flags and arguments" do

--- a/spec/unit/init_options_spec.cr
+++ b/spec/unit/init_options_spec.cr
@@ -151,4 +151,48 @@ describe Hwaro::Config::Options::InitOptions do
       opts.multilingual?.should be_true
     end
   end
+
+  describe ".validate_language_code!" do
+    it "accepts ISO 639 primary subtags" do
+      %w[en ko ja fr de EN Ko].each do |code|
+        Hwaro::Config::Options::InitOptions.validate_language_code!(code)
+      end
+    end
+
+    it "accepts language-region tags" do
+      %w[en-US pt-BR zh-CN].each do |code|
+        Hwaro::Config::Options::InitOptions.validate_language_code!(code)
+      end
+    end
+
+    it "accepts language-script and language-script-region tags" do
+      %w[zh-Hant sr-Latn zh-Hant-TW].each do |code|
+        Hwaro::Config::Options::InitOptions.validate_language_code!(code)
+      end
+    end
+
+    it "rejects non-alphabetic primary subtag" do
+      expect_raises(ArgumentError, /Invalid language code/) do
+        Hwaro::Config::Options::InitOptions.validate_language_code!("@@@")
+      end
+      expect_raises(ArgumentError, /Invalid language code/) do
+        Hwaro::Config::Options::InitOptions.validate_language_code!("123")
+      end
+    end
+
+    it "rejects empty string" do
+      expect_raises(ArgumentError, /Invalid language code/) do
+        Hwaro::Config::Options::InitOptions.validate_language_code!("")
+      end
+    end
+
+    it "rejects tags with spaces or punctuation" do
+      expect_raises(ArgumentError, /Invalid language code/) do
+        Hwaro::Config::Options::InitOptions.validate_language_code!("en_US")
+      end
+      expect_raises(ArgumentError, /Invalid language code/) do
+        Hwaro::Config::Options::InitOptions.validate_language_code!("en US")
+      end
+    end
+  end
 end

--- a/spec/unit/initializer_spec.cr
+++ b/spec/unit/initializer_spec.cr
@@ -242,6 +242,55 @@ describe Hwaro::Services::Initializer do
         end
       end
 
+      it "warns when --include-multilingual is given a single language" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+          buffer = IO::Memory.new
+          prev_io = Hwaro::Logger.io
+          Hwaro::Logger.io = buffer
+          begin
+            Hwaro::Services::Initializer.new.run(target, multilingual_languages: ["en"])
+          ensure
+            Hwaro::Logger.io = prev_io
+          end
+          buffer.to_s.should contain("needs 2+ languages")
+        end
+      end
+
+      it "warns when a non-default scaffold is used with multilingual" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+          buffer = IO::Memory.new
+          prev_io = Hwaro::Logger.io
+          Hwaro::Logger.io = buffer
+          begin
+            Hwaro::Services::Initializer.new.run(
+              target,
+              multilingual_languages: ["en", "ko"],
+              scaffold_type: Hwaro::Config::Options::ScaffoldType::Docs,
+            )
+          ensure
+            Hwaro::Logger.io = prev_io
+          end
+          buffer.to_s.should contain("sample content is not used in multilingual mode")
+        end
+      end
+
+      it "does not emit scaffold-override warning for default simple scaffold" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+          buffer = IO::Memory.new
+          prev_io = Hwaro::Logger.io
+          Hwaro::Logger.io = buffer
+          begin
+            Hwaro::Services::Initializer.new.run(target, multilingual_languages: ["en", "ko"])
+          ensure
+            Hwaro::Logger.io = prev_io
+          end
+          buffer.to_s.should_not contain("sample content is not used in multilingual mode")
+        end
+      end
+
       it "creates multilingual blog content" do
         Dir.mktmpdir do |dir|
           target = File.join(dir, "site")

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -5,6 +5,7 @@ require "../../config/options/init_options"
 require "../../services/initializer"
 require "../../services/scaffolds/registry"
 require "../../services/scaffolds/remote"
+require "../../utils/errors"
 require "../../utils/logger"
 
 module Hwaro
@@ -128,7 +129,19 @@ module Hwaro
               end
             end
             parser.on("--include-multilingual LANGS", "Enable multilingual support (e.g., en,ko)") do |langs|
-              multilingual_languages = langs.split(",").map(&.strip).reject(&.empty?)
+              parsed = langs.split(",").map(&.strip).reject(&.empty?)
+              begin
+                parsed.each { |code| Config::Options::InitOptions.validate_language_code!(code) }
+              rescue ex : ArgumentError
+                # Classify so the Runner emits `Error [HWARO_E_USAGE]: …`
+                # and exits with the documented usage code (2).
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: ex.message || "Invalid language code",
+                  hint: "Examples: 'en', 'ko', 'en,ko', 'pt-BR', 'zh-Hant'.",
+                )
+              end
+              multilingual_languages = parsed
             end
             parser.on("--minimal-config", "Generate minimal config.toml without comments and optional sections") { minimal_config = true }
             parser.on("--agents MODE", "AGENTS.md content mode: remote (default) or local") do |mode|

--- a/src/config/options/init_options.cr
+++ b/src/config/options/init_options.cr
@@ -76,6 +76,20 @@ module Hwaro
       end
 
       struct InitOptions
+        # BCP 47 subset: primary subtag (2-3 letters) plus optional
+        # script/region subtags (2-8 alphanumerics each). Covers "en",
+        # "pt-BR", "zh-Hant", "zh-Hant-TW".
+        LANGUAGE_CODE_REGEX = /\A[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*\z/
+
+        def self.validate_language_code!(code : String) : Nil
+          unless LANGUAGE_CODE_REGEX.matches?(code)
+            raise ArgumentError.new(
+              "Invalid language code: '#{code}'. " \
+              "Use BCP 47 codes like 'en', 'ko', 'pt-BR', 'zh-Hant'."
+            )
+          end
+        end
+
         property path : String
         property force : Bool
         property skip_agents_md : Bool

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -74,8 +74,19 @@ module Hwaro
 
         is_multilingual = multilingual_languages.size > 1
 
+        if multilingual_languages.size == 1
+          Logger.warn "  --include-multilingual needs 2+ languages; '#{multilingual_languages.first}' alone is treated as non-multilingual."
+        end
+
         if minimal_config && is_multilingual
           Logger.warn "  --minimal-config does not include multilingual settings; ignoring --include-multilingual"
+        end
+
+        # Multilingual content uses a fixed layout rather than per-scaffold
+        # sample files, so surface that as a warning when the user chose a
+        # non-default scaffold.
+        if is_multilingual && !scaffold.is_a?(Scaffolds::Remote) && scaffold.type != Config::Options::ScaffoldType::Simple
+          Logger.warn "  --scaffold '#{scaffold.type}' sample content is not used in multilingual mode; a generic index/about/blog layout is created instead."
         end
 
         # Create content structure

--- a/src/services/scaffolds/remote.cr
+++ b/src/services/scaffolds/remote.cr
@@ -160,9 +160,11 @@ module Hwaro
           end
 
           if targets.empty?
-            Logger.warn "No scaffold files found in #{label}."
-            Logger.warn "Expected: config.toml, templates/, or static/ directories."
-            return
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_CONTENT,
+              message: "No scaffold files found in #{label}.",
+              hint: "Remote scaffolds must contain a config.toml, templates/, static/, or content/ directory.",
+            )
           end
 
           # Download files in parallel using fibers


### PR DESCRIPTION
## Summary

Surfaces four silent-failure paths hit while exploring `hwaro init` with various scaffold + flag combinations. Each was reproducible on `main`; see *Reproductions* below.

- **Validate `--include-multilingual` language codes** against a BCP 47 subset (primary subtag of 2–3 letters plus optional script/region subtags of 2–8 alphanumerics). Values like `@@@` or `123` previously became filename suffixes (`content/index.@@@.md`). Now rejected with `HWARO_E_USAGE` (exit 2).
- **Warn on single-language `--include-multilingual en`.** Previously a silent no-op because `is_multilingual = size > 1`; the user thinks they enabled i18n, but nothing happens.
- **Warn when `--scaffold` + `--include-multilingual` are combined** with a non-default scaffold. Multilingual mode always produces a fixed `index`/`about`/`blog` layout regardless of `--scaffold`, so `--scaffold docs --include-multilingual en,ko` drops the `guide/`, `reference/`, `getting-started/` sections without saying so. A structural rewrite to make each scaffold multilingual-aware is out of scope for this PR; a warning at least sets expectations.
- **Raise `HWARO_E_CONTENT` (exit 5) when a remote scaffold has no usable files.** `--scaffold github:hahwul/hwaro` previously printed a `[WARN]` and exited 0 with an empty boilerplate project, which is worse than failing loudly.

### Reproductions (on `main`, before this PR)

```console
$ hwaro init /tmp/a --include-multilingual "en,@@@"
# succeeds; creates content/index.@@@.md  ← bug

$ hwaro init /tmp/b --include-multilingual "en"
# succeeds silently as non-multilingual  ← confusing

$ hwaro init /tmp/c --scaffold docs --include-multilingual "en,ko"
# ls /tmp/c/content → blog/ index.md about.md (docs' guide/reference gone)  ← bug

$ hwaro init /tmp/d --scaffold github:hahwul/hwaro
[WARN] No scaffold files found in hahwul/hwaro.
$ echo $?
0  ← bug; should fail
```

### After this PR

```console
$ hwaro init /tmp/a --include-multilingual "en,@@@"
Error [HWARO_E_USAGE]: Invalid language code: '@@@'. Use BCP 47 codes like 'en', 'ko', 'pt-BR', 'zh-Hant'.
Examples: 'en', 'ko', 'en,ko', 'pt-BR', 'zh-Hant'.
# exit 2

$ hwaro init /tmp/b --include-multilingual "en"
[WARN]   --include-multilingual needs 2+ languages; 'en' alone is treated as non-multilingual.
# exit 0

$ hwaro init /tmp/c --scaffold docs --include-multilingual "en,ko"
[WARN]   --scaffold 'docs' sample content is not used in multilingual mode; a generic index/about/blog layout is created instead.
# exit 0

$ hwaro init /tmp/d --scaffold github:hahwul/hwaro
Error [HWARO_E_CONTENT]: No scaffold files found in hahwul/hwaro.
Remote scaffolds must contain a config.toml, templates/, static/, or content/ directory.
# exit 5
```

### Out of scope

- Making each scaffold multilingual-aware (so `--scaffold docs --include-multilingual` actually produces a localized docs tree). That's an `initializer.cr` + per-scaffold refactor; filed as a follow-up consideration.
- Changing `--force` semantics. Today `--force` allows writing into a non-empty directory but doesn't clean stale files from a previous scaffold. That's a separate design question (arguably `--clean` is the better additive flag).

## Test plan

- [x] `just build`
- [x] `just test` → 4488 examples, 0 failures (adds 8 new specs across `init_options_spec`, `init_command_spec`, `initializer_spec`)
- [x] `just fix` (format) + `bin/ameba` → 340 inspected, 0 failures
- [x] Manual reproduction of all four paths before and after
- [x] Valid codes `en`, `en,ko`, `en-US,pt-BR,zh-Hant`, `zh-Hant-TW` continue to work
- [x] Existing non-multilingual scaffold init + build unaffected (rebuilt each of the 7 built-in scaffolds end-to-end)