### PR TITLE
feat(init): add --clean flag to wipe target before scaffolding

### DIFF
--- a/spec/unit/init_command_spec.cr
+++ b/spec/unit/init_command_spec.cr
@@ -32,6 +32,15 @@ describe Hwaro::CLI::Commands::InitCommand do
       options.force.should be_true
     end
 
+    it "parses clean flag" do
+      cmd = Hwaro::CLI::Commands::InitCommand.new
+      options = cmd.parse_options([] of String)
+      options.clean.should be_false
+
+      options = cmd.parse_options(["--clean"])
+      options.clean.should be_true
+    end
+
     it "parses scaffold flag" do
       cmd = Hwaro::CLI::Commands::InitCommand.new
 

--- a/spec/unit/init_options_spec.cr
+++ b/spec/unit/init_options_spec.cr
@@ -125,6 +125,7 @@ describe Hwaro::Config::Options::InitOptions do
       opts = Hwaro::Config::Options::InitOptions.new
       opts.path.should eq(".")
       opts.force.should be_false
+      opts.clean.should be_false
       opts.skip_agents_md.should be_false
       opts.skip_sample_content.should be_false
       opts.skip_taxonomies.should be_false

--- a/spec/unit/initializer_spec.cr
+++ b/spec/unit/initializer_spec.cr
@@ -46,6 +46,86 @@ describe Hwaro::Services::Initializer do
       end
     end
 
+    describe "--clean option" do
+      it "removes all existing files before scaffolding" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "existing")
+          Dir.mkdir_p(File.join(target, "stale-subdir"))
+          File.write(File.join(target, "stale-file.txt"), "old")
+          File.write(File.join(target, "stale-subdir", "nested.txt"), "deep")
+
+          Hwaro::Services::Initializer.new.run(target, clean: true)
+
+          File.exists?(File.join(target, "stale-file.txt")).should be_false
+          Dir.exists?(File.join(target, "stale-subdir")).should be_false
+          File.exists?(File.join(target, "config.toml")).should be_true
+        end
+      end
+
+      it "wipes stale files when switching scaffolds" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+
+          # First init with blog scaffold leaves posts/, archives.md etc.
+          Hwaro::Services::Initializer.new.run(
+            target,
+            scaffold_type: Hwaro::Config::Options::ScaffoldType::Blog,
+          )
+          Dir.exists?(File.join(target, "content", "posts")).should be_true
+          File.exists?(File.join(target, "content", "archives.md")).should be_true
+
+          # Re-init with simple scaffold + --clean should leave only the
+          # simple scaffold's files behind.
+          Hwaro::Services::Initializer.new.run(
+            target,
+            clean: true,
+            scaffold_type: Hwaro::Config::Options::ScaffoldType::Simple,
+          )
+
+          Dir.exists?(File.join(target, "content", "posts")).should be_false
+          File.exists?(File.join(target, "content", "archives.md")).should be_false
+          File.exists?(File.join(target, "content", "index.md")).should be_true
+          File.exists?(File.join(target, "content", "about.md")).should be_true
+        end
+      end
+
+      it "refuses to clean a directory containing .git/" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "repo")
+          Dir.mkdir_p(File.join(target, ".git"))
+          File.write(File.join(target, ".git", "HEAD"), "ref: refs/heads/main")
+          File.write(File.join(target, "README.md"), "# repo")
+
+          expect_raises(Hwaro::HwaroError, /contains a \.git directory/) do
+            Hwaro::Services::Initializer.new.run(target, clean: true)
+          end
+
+          # Original files stay in place.
+          File.exists?(File.join(target, ".git", "HEAD")).should be_true
+          File.exists?(File.join(target, "README.md")).should be_true
+        end
+      end
+
+      it "is a no-op on a non-existent target" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "fresh")
+          Hwaro::Services::Initializer.new.run(target, clean: true)
+
+          File.exists?(File.join(target, "config.toml")).should be_true
+        end
+      end
+
+      it "is a no-op on an empty target" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "empty")
+          Dir.mkdir_p(target)
+          Hwaro::Services::Initializer.new.run(target, clean: true)
+
+          File.exists?(File.join(target, "config.toml")).should be_true
+        end
+      end
+    end
+
     describe "--skip-agents-md option" do
       it "does not create AGENTS.md when skip_agents_md=true" do
         Dir.mktmpdir do |dir|

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -22,6 +22,7 @@ module Hwaro
         FLAGS = [
           # Project setup
           FlagInfo.new(short: "-f", long: "--force", description: "Force creation even if directory is not empty"),
+          FlagInfo.new(short: nil, long: "--clean", description: "Remove existing files in target before scaffolding (implies --force; refuses if target contains .git/)"),
           FlagInfo.new(short: nil, long: "--scaffold", description: "Scaffold type or remote source (e.g., blog, github:user/repo)", takes_value: true, value_hint: "TYPE"),
           FlagInfo.new(short: nil, long: "--include-multilingual", description: "Enable multilingual support (e.g., en,ko)", takes_value: true, value_hint: "LANGS"),
           FlagInfo.new(short: nil, long: "--minimal-config", description: "Generate minimal config.toml without comments and optional sections"),
@@ -88,6 +89,7 @@ module Hwaro
           # Project setup
           path = "."
           force = false
+          clean = false
           scaffold = Config::Options::ScaffoldType::Simple
           scaffold_remote : String? = nil
           multilingual_languages = [] of String
@@ -104,6 +106,7 @@ module Hwaro
 
             # Project setup
             parser.on("-f", "--force", "Force creation even if directory is not empty") { force = true }
+            parser.on("--clean", "Remove existing files in target before scaffolding (implies --force; refuses if target contains .git/)") { clean = true }
             parser.on("--scaffold TYPE", "Scaffold type or remote source (e.g., blog, github:user/repo)") do |type|
               if Services::Scaffolds::Remote.remote?(type)
                 scaffold_remote = type
@@ -188,6 +191,7 @@ module Hwaro
           Config::Options::InitOptions.new(
             path: path,
             force: force,
+            clean: clean,
             skip_agents_md: skip_agents_md,
             skip_sample_content: skip_sample_content,
             skip_taxonomies: skip_taxonomies,

--- a/src/config/options/init_options.cr
+++ b/src/config/options/init_options.cr
@@ -92,6 +92,7 @@ module Hwaro
 
         property path : String
         property force : Bool
+        property clean : Bool
         property skip_agents_md : Bool
         property skip_sample_content : Bool
         property skip_taxonomies : Bool
@@ -104,6 +105,7 @@ module Hwaro
         def initialize(
           @path : String = ".",
           @force : Bool = false,
+          @clean : Bool = false,
           @skip_agents_md : Bool = false,
           @skip_sample_content : Bool = false,
           @skip_taxonomies : Bool = false,

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -3,7 +3,9 @@
 # Creates the initial project structure with sample content,
 # templates, and configuration based on the selected scaffold.
 
+require "file_utils"
 require "../config/options/init_options"
+require "../utils/errors"
 require "../utils/logger"
 require "../services/scaffolds/registry"
 require "../services/scaffolds/remote"
@@ -29,7 +31,8 @@ module Hwaro
           options.multilingual_languages,
           scaffold,
           options.agents_mode,
-          options.minimal_config
+          options.minimal_config,
+          options.clean
         )
       end
 
@@ -42,9 +45,10 @@ module Hwaro
         multilingual_languages : Array(String) = [] of String,
         scaffold_type : Config::Options::ScaffoldType = Config::Options::ScaffoldType::Simple,
         agents_mode : Config::Options::AgentsMode = Config::Options::AgentsMode::Remote,
+        clean : Bool = false,
       )
         scaffold = Scaffolds::Registry.get(scaffold_type)
-        run_with_scaffold(target_path, force, skip_agents_md, skip_sample_content, skip_taxonomies, multilingual_languages, scaffold, agents_mode)
+        run_with_scaffold(target_path, force, skip_agents_md, skip_sample_content, skip_taxonomies, multilingual_languages, scaffold, agents_mode, false, clean)
       end
 
       private def run_with_scaffold(
@@ -57,14 +61,21 @@ module Hwaro
         scaffold : Scaffolds::Base,
         agents_mode : Config::Options::AgentsMode = Config::Options::AgentsMode::Remote,
         minimal_config : Bool = false,
+        clean : Bool = false,
       )
+        if clean && Dir.exists?(target_path) && !Dir.empty?(target_path)
+          clean_target(target_path)
+        end
+
         unless Dir.exists?(target_path)
           Dir.mkdir_p(target_path)
         end
 
-        unless force || Dir.empty?(target_path)
+        # --clean wipes the dir up front; --force keeps existing files in
+        # place and writes on top. Either one allows a non-empty target.
+        unless force || clean || Dir.empty?(target_path)
           Logger.error "Directory '#{target_path}' is not empty."
-          Logger.error "Use --force to overwrite."
+          Logger.error "Use --force to overwrite, or --clean to remove existing files first."
           exit(1)
         end
 
@@ -507,6 +518,30 @@ module Hwaro
         when "ar" then "العربية"
         when "hi" then "हिन्दी"
         else           code.upcase
+        end
+      end
+
+      # Remove every entry inside `target_path`, keeping the directory
+      # itself. Refuses to touch a target that contains `.git/` so a
+      # typo'd path or an accidental `--clean .` in a real repo can't
+      # wipe the user's work.
+      private def clean_target(target_path : String)
+        if Dir.exists?(File.join(target_path, ".git"))
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "Refusing to --clean '#{target_path}': target contains a .git directory.",
+            hint: "Delete .git manually if you really want to wipe this directory.",
+          )
+        end
+
+        entries = Dir.children(target_path)
+        return if entries.empty?
+
+        Logger.info "Cleaning #{entries.size} existing entr#{entries.size == 1 ? "y" : "ies"} from '#{target_path}'..."
+        entries.each do |entry|
+          full = File.join(target_path, entry)
+          FileUtils.rm_rf(full)
+          Logger.action :remove, full, :yellow
         end
       end
 


### PR DESCRIPTION
## Summary

`--force` lets `hwaro init` write into a non-empty directory but keeps every existing file in place. Re-running init with a different scaffold therefore leaves stale files from the previous scaffold behind, which is the last rough edge surfaced during the init UX pass (follow-up to #399 / #401).

### Before (on main)

```console
$ hwaro init site --scaffold blog --quiet
$ hwaro init site --scaffold simple --force --quiet
$ ls site/content/
posts  about.md  archives.md  index.md
# posts/ and archives.md are leftovers from the blog scaffold.
```

### After

```console
$ hwaro init site --scaffold blog --quiet
$ hwaro init site --scaffold simple --clean
Cleaning 6 existing entries from 'site'...
      remove  site/archetypes
      remove  site/content
      remove  site/static
      remove  site/templates
      remove  site/config.toml
      remove  site/AGENTS.md
Initializing new Hwaro project in 'site'...
$ ls site/content/
about.md  index.md
```

### Safety

The most dangerous footgun is `hwaro init . --clean` inside an actual repository. That's gated behind an explicit check:

```console
$ cd my-real-repo && hwaro init . --clean
Error [HWARO_E_USAGE]: Refusing to --clean '.': target contains a .git directory.
Delete .git manually if you really want to wipe this directory.
# exit 2
```

No-op on missing or empty targets. Each removed entry is logged via `Logger.action :remove` so the user sees exactly what disappears.

## Changes

- `--clean` flag on `hwaro init` (new `InitOptions#clean` property, new CLI flag, new `Initializer#clean_target` private method).
- `.git/` guard raises `HwaroError(HWARO_E_USAGE)` → exit 2 → caught by the Runner and surfaced as the usual classified error.
- The \"Directory … is not empty\" message now also mentions `--clean` as an alternative to `--force`.
- `--clean` and `--force` remain independent — passing just `--clean` is enough; you don't need both.

## Diff footprint

```
 spec/unit/init_command_spec.cr     |  9 +++++
 spec/unit/init_options_spec.cr     |  1 +
 spec/unit/initializer_spec.cr      | 80 +++++++++++++++++++++++++++++++++++++
 src/cli/commands/init_command.cr   |  4 ++
 src/config/options/init_options.cr |  2 +
 src/services/initializer.cr        | 43 +++++++++++++++++--
 6 files changed, 135 insertions(+), 4 deletions(-)
```

## Test plan

- [x] `just build`
- [x] `just test` → 4498 examples, 0 failures (6 new specs: stale-file cleanup, scaffold-switch scenario, `.git/` guard, no-op on missing dir, no-op on empty dir, CLI flag parsing)
- [x] `just fix` (format) + `bin/ameba` → 340 inspected, 0 failures
- [x] Manual: `init blog` → `init simple --clean` leaves only the simple scaffold's files; `init blog` → `init simple --force` keeps `posts/`/`archives.md` as expected (unchanged behavior)
- [x] Manual: `--clean` on a fresh dir still scaffolds normally
- [x] Manual: `--clean` on a `.git/`-containing target aborts with HWARO_E_USAGE (exit 2), leaves all files intact