### PR TITLE
fix(shortcode): warn on unknown direct-call shortcodes, dedupe per build

### DIFF
--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -74,6 +74,56 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
       # Block path returns the original block as fallback, byte-for-byte
       result.should eq(content)
     end
+
+    it "warns when a direct-call shortcode name is not a registered template or Crinja function" do
+      builder = Hwaro::Core::Build::Builder.new
+      sink = IO::Memory.new
+      previous_io = Hwaro::Logger.io
+      Hwaro::Logger.io = sink
+      begin
+        builder.test_sc_process(%(text {{ typo_sc(arg="x") }} more), {} of String => String)
+      ensure
+        Hwaro::Logger.io = previous_io
+      end
+      sink.to_s.should contain("Shortcode template 'shortcodes/typo_sc' not found.")
+    end
+
+    it "does not warn when a direct call matches a registered Crinja function name" do
+      # `env`, `asset`, `url_for`, `get_url`, `resize_image`, … are
+      # registered on the shared Crinja env by the template processor.
+      # Direct-call syntax in content ({{ env(\"X\") }}) is a legitimate
+      # template-function reference, not a typo'd shortcode, so the
+      # shortcode processor must silent-pass-through.
+      builder = Hwaro::Core::Build::Builder.new
+      sink = IO::Memory.new
+      previous_io = Hwaro::Logger.io
+      Hwaro::Logger.io = sink
+      begin
+        builder.test_sc_process(%({{ env("FOO") }} {{ asset(name="x.css") }}), {} of String => String)
+      ensure
+        Hwaro::Logger.io = previous_io
+      end
+      sink.to_s.should_not contain("Shortcode template")
+    end
+
+    it "dedupes missing-template warnings across multiple invocations" do
+      builder = Hwaro::Core::Build::Builder.new
+      sink = IO::Memory.new
+      previous_io = Hwaro::Logger.io
+      Hwaro::Logger.io = sink
+      begin
+        # Same missing shortcode used three times, in two syntaxes.
+        builder.test_sc_process(
+          %({{ missing_sc(a="1") }} {{ missing_sc(a="2") }} {% missing_sc %}b{% end %}),
+          {} of String => String,
+        )
+      ensure
+        Hwaro::Logger.io = previous_io
+      end
+      # Exactly one warning line per unique missing template key.
+      output = sink.to_s
+      output.scan("Shortcode template 'shortcodes/missing_sc' not found.").size.should eq(1)
+    end
   end
 
   describe "malformed shortcodes" do

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -91,6 +91,9 @@ module Hwaro
         @profiler : Profiler?
         @crinja_env : Crinja?
         @compiled_templates_cache : Hash(UInt64, Crinja::Template) = {} of UInt64 => Crinja::Template
+        # Tracks shortcode template keys we've already warned about, so a
+        # single typo used across many pages emits just one warning line.
+        @shortcode_warnings_seen : Set(String)? = nil
         @pages_by_path : Hash(String, Models::Page)?
         @i18n_translations : Content::I18n::TranslationData = Content::I18n::TranslationData.new
         # Per-section cache of Crinja::Value arrays, keyed by "section_name:language"

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -76,8 +76,13 @@ module Hwaro
           end
 
           # 3. Direct call: {{ name(args) }}
+          # Direct calls are also valid Crinja/Jinja function-call syntax
+          # ({{ env("FOO") }}, {{ asset(name="x") }}, …), so we warn only when
+          # the name resolves to neither a shortcode template nor a registered
+          # Crinja function — that way real typos surface while legitimate
+          # template-function calls in content pass through silently.
           processed.gsub(/\{\{\s*([a-zA-Z_][\w\-]*)\s*\((.*?)\)\s*\}\}/) do |match|
-            render_shortcode_result($1, $2, templates, context, shortcode_results, match, warn_missing: false, crinja_env_override: crinja_env_override)
+            render_shortcode_result($1, $2, templates, context, shortcode_results, match, warn_missing: true, crinja_env_override: crinja_env_override)
           end
         end
 
@@ -192,7 +197,9 @@ module Hwaro
           template = templates[template_key]? || BuiltinShortcodes.templates[template_key]?
 
           unless template
-            Logger.warn "Shortcode template '#{template_key}' not found." if warn_missing
+            if warn_missing && !crinja_function?(name, crinja_env_override)
+              warn_missing_shortcode(template_key)
+            end
             return fallback
           end
 
@@ -280,6 +287,29 @@ module Hwaro
           html.gsub(/HWARO-SHORTCODE-PLACEHOLDER-\d+/) do |match|
             shortcode_results[match]? || match
           end
+        end
+
+        # True when `name` is a registered Crinja function in the env used
+        # for template rendering. Direct shortcode calls ({{ name(args) }})
+        # and template function calls share syntax, so this check lets the
+        # shortcode processor silent-pass-through legitimate function calls
+        # like `env`, `asset`, `url_for`, `get_url`, … while still warning
+        # on names that aren't registered anywhere.
+        private def crinja_function?(name : String, crinja_env_override : Crinja?) : Bool
+          env = crinja_env_override || crinja_env
+          env.functions.has_key?(name)
+        rescue
+          false
+        end
+
+        # Emit a "shortcode template not found" warning at most once per
+        # template key per build to avoid spamming the log when the same
+        # typo appears on many pages.
+        private def warn_missing_shortcode(template_key : String) : Nil
+          seen = (@shortcode_warnings_seen ||= Set(String).new)
+          return if seen.includes?(template_key)
+          seen << template_key
+          Logger.warn "Shortcode template '#{template_key}' not found."
         end
       end
     end


### PR DESCRIPTION
Closes #404.

## Summary

Before this change, typo'd direct-call shortcodes (`{{ nonexistent() }}` in content) were silently rendered as literal text. The shortcode processor deliberately set `warn_missing: false` on the direct-call path because the `{{ name(args) }}` regex also matches legitimate Crinja function calls in content (`{{ env(\"FOO\") }}`, `{{ asset(name=\"x\") }}`, `{{ url_for(path=\"y\") }}`, …), and a naive warning would fire for every such call. The cost was that real typos shipped to production with no feedback.

## Fix

- When a direct-call name doesn't resolve to a shortcode template, consult the shared Crinja environment's function registry. If the name is a registered function, silent-pass-through as before — the later template-rendering pass resolves it. Only warn when the name is registered nowhere.
- Flip the direct-call `warn_missing` flag from `false` to `true`. The Crinja-function probe is the guard against the false-positive class the old default was avoiding.
- **Dedupe** missing-template warnings per build via a `Set(String)` on `Builder` keyed by template path. A single typo used across 100 pages now emits one warning line instead of 100, and the block path no longer double-warns when the recursive body pass hits the same name.

## Repro before / after

```console
$ hwaro init site --scaffold blog --quiet && cd site
$ cat >> content/posts/hello-world.md <<'MD'

Before {{ nonexistent(arg=\"x\") }} after.
MD

# Before
$ hwaro build 2>&1 | grep -i shortcode
# (nothing — silent)

# After
$ hwaro build 2>&1 | grep -i shortcode
[WARN] Shortcode template 'shortcodes/nonexistent' not found.
```

Legitimate template-function calls in content stay silent:

```console
$ cat > content/posts/env.md <<'MD'
+++
title = \"Env\"
date = \"2025-01-01\"
+++
API: {{ env(\"API_URL\") }}
MD
$ hwaro build 2>&1 | grep -i shortcode
# (no output — 'env' is a registered Crinja function)
```

Dedupe across pages:

```console
# Three pages each using {{ typo_sc() }}
$ hwaro build 2>&1 | grep -c typo_sc
1
```

Live check on the hwaro docs site (63 pages, many inline-backtick `\`{{ asset(name=\"...\") }}\`` / `\`{{ env(\"X\") }}\`` examples): clean build, no warnings.

## Diff footprint

```
 spec/unit/shortcode_processor_edge_cases_spec.cr | 50 ++++++++++++++++++++++++
 src/core/build/builder.cr                        |  3 ++
 src/core/build/shortcode_processor.cr            | 34 +++++++++++++++-
 3 files changed, 85 insertions(+), 2 deletions(-)
```

## Test plan

- [x] `just build`
- [x] `just test` → 4508 examples, 0 failures (adds 3 new specs: warn-on-typo, no-warn-for-registered-crinja-function, dedupe across invocations)
- [x] `just fix` (format) + `bin/ameba` → 340 inspected, 0 failures
- [x] Existing \"unknown shortcodes\" edge-case specs (direct/explicit/block fallback returns original text byte-for-byte) still pass
- [x] `hwaro build -i docs` → 63 pages, no warnings (docs use inline template-function examples extensively)
- [x] Blog scaffold with a typo'd direct call: exactly one warning; same typo on 3 pages: still exactly one warning