### PR TITLE
fix(config): validate base_url scheme and host at load/CLI time

### DIFF
--- a/spec/unit/build_command_spec.cr
+++ b/spec/unit/build_command_spec.cr
@@ -44,6 +44,23 @@ describe Hwaro::CLI::Commands::BuildCommand do
       options.base_url.should eq("https://example.com")
     end
 
+    it "rejects an invalid --base-url with HWARO_E_USAGE" do
+      cmd = Hwaro::CLI::Commands::BuildCommand.new
+      err = expect_raises(Hwaro::HwaroError) do
+        cmd.parse_options(["--base-url", "not a valid url"])
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      err.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+    end
+
+    it "rejects a --base-url without a scheme" do
+      cmd = Hwaro::CLI::Commands::BuildCommand.new
+      err = expect_raises(Hwaro::HwaroError) do
+        cmd.parse_options(["--base-url", "example.com"])
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+    end
+
     it "parses boolean flags" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
       result, _ = cmd.parse_options([

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -57,6 +57,73 @@ describe Hwaro::Models::Config do
         (err.message || "").should contain(env_path)
       end
     end
+
+    it "raises HwaroError(HWARO_E_CONFIG) for an invalid base_url in config.toml" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.toml")
+        File.write(path, %(base_url = "not a valid url"))
+        err = expect_raises(Hwaro::HwaroError) do
+          Hwaro::Models::Config.load(path)
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        err.exit_code.should eq(Hwaro::Errors::EXIT_CONFIG)
+        (err.message || "").should contain("Invalid base_url")
+      end
+    end
+
+    it "raises HwaroError(HWARO_E_CONFIG) for a base_url with no scheme" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.toml")
+        File.write(path, %(base_url = "example.com"))
+        err = expect_raises(Hwaro::HwaroError) do
+          Hwaro::Models::Config.load(path)
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+      end
+    end
+  end
+
+  describe ".validate_base_url!" do
+    it "accepts the empty string (default — no base URL)" do
+      Hwaro::Models::Config.validate_base_url!("")
+    end
+
+    it "accepts http(s) URLs with host" do
+      [
+        "http://example.com",
+        "https://example.com",
+        "https://example.com/subpath",
+        "https://example.com/deep/subpath/",
+        "http://localhost:3000",
+        "http://127.0.0.1:8080",
+      ].each do |value|
+        Hwaro::Models::Config.validate_base_url!(value)
+      end
+    end
+
+    it "rejects values without a scheme" do
+      expect_raises(ArgumentError, /Invalid base_url/) do
+        Hwaro::Models::Config.validate_base_url!("example.com")
+      end
+      expect_raises(ArgumentError, /Invalid base_url/) do
+        Hwaro::Models::Config.validate_base_url!("/subpath")
+      end
+    end
+
+    it "rejects non-http schemes" do
+      expect_raises(ArgumentError, /Invalid base_url/) do
+        Hwaro::Models::Config.validate_base_url!("ftp://example.com")
+      end
+      expect_raises(ArgumentError, /Invalid base_url/) do
+        Hwaro::Models::Config.validate_base_url!("file:///local/path")
+      end
+    end
+
+    it "rejects garbage strings" do
+      expect_raises(ArgumentError, /Invalid base_url/) do
+        Hwaro::Models::Config.validate_base_url!("not a valid url")
+      end
+    end
   end
 
   describe "#initialize" do

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -104,9 +104,14 @@ describe Hwaro::Services::Doctor do
     end
 
     describe "config — base_url format" do
-      it "warns when base_url has no protocol" do
+      # Scheme/host validity is enforced at `Config.load`, so bad URLs
+      # surface as a `config-parse-error` rather than a style advisory
+      # here. The doctor retains advisory checks for empty and
+      # trailing-slash variants only.
+
+      it "reports the load-time base_url error when scheme is missing" do
         issues = run_doctor(%(title = "My Site"\nbase_url = "example.com"\n))
-        issues.any?(&.message.includes?("http://")).should be_true
+        issues.any? { |i| i.id == "config-parse-error" && (i.message || "").includes?("Invalid base_url") }.should be_true
       end
 
       it "warns when base_url has trailing slash" do
@@ -117,7 +122,7 @@ describe Hwaro::Services::Doctor do
       it "does not warn on proper base_url" do
         issues = run_doctor(base_config)
         issues.any?(&.message.includes?("trailing slash")).should be_false
-        issues.any? { |i| i.message.includes?("http://") && i.message.includes?("https://") }.should be_false
+        issues.any?(&.message.includes?("Invalid base_url")).should be_false
       end
     end
 

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -188,7 +188,18 @@ module Hwaro
             # Path & URL
             CLI.register_flag(parser, INPUT_DIR_FLAG) { |v| input_dir = v }
             parser.on("-o DIR", "--output DIR", "Output directory (default: public)") { |dir| output_dir = dir; output_dir_explicit = true }
-            CLI.register_flag(parser, BASE_URL_FLAG) { |v| base_url = v }
+            CLI.register_flag(parser, BASE_URL_FLAG) do |v|
+              begin
+                Models::Config.validate_base_url!(v)
+              rescue ex : ArgumentError
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: ex.message || "Invalid --base-url",
+                  hint: "Examples: https://example.com, https://example.com/subpath, http://localhost:3000.",
+                )
+              end
+              base_url = v
+            end
             CLI.register_flag(parser, ENV_FLAG) { |v| env_name = v }
 
             # Content filtering

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -130,7 +130,18 @@ module Hwaro
 
             # Path & URL
             CLI.register_flag(parser, INPUT_DIR_FLAG) { |v| input_dir = v }
-            CLI.register_flag(parser, BASE_URL_FLAG) { |v| base_url = v }
+            CLI.register_flag(parser, BASE_URL_FLAG) do |v|
+              begin
+                Models::Config.validate_base_url!(v)
+              rescue ex : ArgumentError
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: ex.message || "Invalid --base-url",
+                  hint: "Examples: https://example.com, https://example.com/subpath, http://localhost:3000.",
+                )
+              end
+              base_url = v
+            end
             CLI.register_flag(parser, ENV_FLAG) { |v| env_name = v }
 
             # Content filtering

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1,4 +1,5 @@
 require "toml"
+require "uri"
 require "./deployment"
 require "../utils/errors"
 require "../utils/text_utils"
@@ -755,6 +756,27 @@ module Hwaro
       # File-not-found is classified as HWARO_E_CONFIG rather than HWARO_E_IO
       # because a missing `config.toml` is a config-level user error, not an
       # arbitrary IO failure.
+      # Accepts an absolute `http(s)://host[:port][/path]` URL or the empty
+      # string (which means "no absolute URL is configured"). Raises
+      # ArgumentError on anything else so callers can wrap the failure in
+      # whichever classified `HwaroError` code suits their context
+      # (`HWARO_E_CONFIG` for config.toml, `HWARO_E_USAGE` for CLI flags).
+      def self.validate_base_url!(value : String) : Nil
+        return if value.empty?
+
+        uri = begin
+          URI.parse(value)
+        rescue
+          raise ArgumentError.new("Invalid base_url: '#{value}'. Expected http(s)://host[/path].")
+        end
+
+        scheme = uri.scheme
+        host = uri.host
+        if scheme.nil? || !%w[http https].includes?(scheme.downcase) || host.nil? || host.empty?
+          raise ArgumentError.new("Invalid base_url: '#{value}'. Expected http(s)://host[/path].")
+        end
+      end
+
       def self.load(config_path : String = "config.toml", env : String? = nil) : Config
         config = new
 
@@ -787,7 +809,18 @@ module Hwaro
 
         config.title = config.raw["title"]?.try(&.as_s?) || config.title
         config.description = config.raw["description"]?.try(&.as_s?) || config.description
-        config.base_url = config.raw["base_url"]?.try(&.as_s?) || config.base_url
+        if raw_base_url = config.raw["base_url"]?.try(&.as_s?)
+          begin
+            validate_base_url!(raw_base_url)
+          rescue ex : ArgumentError
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_CONFIG,
+              message: ex.message || "Invalid base_url in #{config_path}",
+              hint: "Set base_url to an absolute URL such as \"https://example.com\" or \"http://localhost:3000\".",
+            )
+          end
+          config.base_url = raw_base_url
+        end
         config.default_language = config.raw["default_language"]?.try(&.as_s?) || config.default_language
 
         load_sitemap(config)

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -155,17 +155,16 @@ module Hwaro
         end
 
         # base_url check
+        #
+        # Scheme/host validity is enforced at `Models::Config.load` time via
+        # `validate_base_url!`, so any base_url reaching this point is either
+        # empty or a well-formed http(s) URL. We only cover the remaining
+        # style advisories here.
         if config.base_url.empty?
           issues << Issue.new(id: "base-url-missing", level: :warning, category: "config", file: @config_path, message: "base_url is not set")
-        else
-          unless config.base_url.starts_with?("http://") || config.base_url.starts_with?("https://")
-            issues << Issue.new(id: "base-url-scheme", level: :warning, category: "config", file: @config_path,
-              message: "base_url should start with http:// or https://")
-          end
-          if config.base_url.ends_with?("/")
-            issues << Issue.new(id: "base-url-trailing-slash", level: :warning, category: "config", file: @config_path,
-              message: "base_url should not end with a trailing slash")
-          end
+        elsif config.base_url.ends_with?("/")
+          issues << Issue.new(id: "base-url-trailing-slash", level: :warning, category: "config", file: @config_path,
+            message: "base_url should not end with a trailing slash")
         end
 
         # title check


### PR DESCRIPTION
Closes #405.

## Summary

`hwaro build --base-url \"not a valid url\"` (or `\"example.com\"` without a scheme) was accepted silently and baked directly into sitemap, RSS feed, and OG meta URLs, producing dead links with no warning. The same silent failure also applied to bad `base_url` values in `config.toml`.

## Before

```console
$ hwaro build --base-url \"not a valid url\"
Build complete! Generated 7 pages.
$ grep -oE '<loc>[^<]*</loc>' public/sitemap.xml | head -2
<loc>not a valid url/posts/hello-world/</loc>
<loc>not a valid url/posts/getting-started-with-hwaro/</loc>
```

## After

```console
$ hwaro build --base-url \"not a valid url\"
Error [HWARO_E_USAGE]: Invalid base_url: 'not a valid url'. Expected http(s)://host[/path].
Examples: https://example.com, https://example.com/subpath, http://localhost:3000.
$ echo $?
2

$ hwaro build --base-url \"example.com\"
Error [HWARO_E_USAGE]: Invalid base_url: 'example.com'. Expected http(s)://host[/path].
# exit 2

$ cat > config.toml <<'TOML'
base_url = \"not a url\"
TOML
$ hwaro build
Error [HWARO_E_CONFIG]: Invalid base_url: 'not a url'. Expected http(s)://host[/path].
Set base_url to an absolute URL such as \"https://example.com\" or \"http://localhost:3000\".
# exit 3
```

Valid values still pass through unchanged:

```console
$ hwaro build --base-url \"https://example.com\"        # ok
$ hwaro build --base-url \"http://localhost:3000\"      # ok
$ hwaro build --base-url \"https://example.com/subpath\" # ok
```

## Changes

- **`Models::Config.validate_base_url!`** — shared validator. Accepts the empty string (no base URL configured) and any well-formed `http(s)://host[:port][/path]` URL; raises `ArgumentError` on anything else so callers can wrap failures in whichever classified `HwaroError` code suits their context.
- **`Models::Config.load`** — runs the validator on `base_url` read from `config.toml` (and any env-specific override); wraps failures in `HwaroError(HWARO_E_CONFIG)` → exit 3.
- **`BuildCommand#parse_options` / `ServeCommand#parse_options`** — run the validator on `--base-url` CLI overrides; wrap failures in `HwaroError(HWARO_E_USAGE)` → exit 2.
- **`Services::Doctor`** — the old `base-url-scheme` advisory (\"should start with http:// or https://\") is now unreachable for any config that loaded, so it's removed. Empty-base_url and trailing-slash advisories stay. Bad URLs in `config.toml` now surface via doctor's existing `config-parse-error` with the load-time message.

## Diff footprint

```
 spec/unit/build_command_spec.cr   | 17 ++++++++++
 spec/unit/config_spec.cr          | 67 +++++++++++++++++++++++++++++++++++++++
 spec/unit/doctor_spec.cr          | 11 +++++--
 src/cli/commands/build_command.cr | 13 +++++++-
 src/cli/commands/serve_command.cr | 13 +++++++-
 src/models/config.cr              | 35 +++++++++++++++++++-
 src/services/doctor.cr            | 17 +++++-----
 7 files changed, 158 insertions(+), 15 deletions(-)
```

## Test plan

- [x] `just build`
- [x] `just test` → 4517 examples, 0 failures (adds 9 new specs: validator class method for empty/valid/no-scheme/non-http/garbage; 2 config.toml invalid-base_url load errors; 2 CLI `--base-url` rejections; doctor spec updated to assert the load-time error surface)
- [x] `just fix` (format) + `bin/ameba` → 340 inspected, 0 failures
- [x] Manual: all pre-existing valid values (`https://example.com`, `http://localhost:3000`, subpath URLs) keep working; all invalid values now error out with the correct exit code (2 for CLI, 3 for config.toml).