### PR TITLE
fix(render): dedupe identical template errors across pages

### DIFF
--- a/spec/unit/phases_render_spec.cr
+++ b/spec/unit/phases_render_spec.cr
@@ -19,6 +19,14 @@ module Hwaro::Core::Build
     def test_build_pages_by_path(site : Models::Site)
       build_pages_by_path(site)
     end
+
+    def test_render_error_signature(message : String)
+      render_error_signature(message)
+    end
+
+    def test_report_render_failures(failures, verbose)
+      report_render_failures(failures, verbose)
+    end
   end
 end
 
@@ -154,6 +162,108 @@ describe Hwaro::Core::Build::Phases::Render do
       result = builder.test_build_pages_by_path(site)
       result["blog/post.md"].should eq(page)
       result["blog/_index.md"].should eq(section)
+    end
+  end
+
+  describe "#render_error_signature" do
+    it "strips the page-specific 'Template error for <path>' prefix" do
+      builder = Hwaro::Core::Build::Builder.new
+      msg = "Template error for posts/hello-world.md: Unterminated tag\ntemplate: <string>:1:20 .. 1:20"
+      builder.test_render_error_signature(msg).should eq("Unterminated tag")
+    end
+
+    it "normalizes the same underlying error across different pages" do
+      builder = Hwaro::Core::Build::Builder.new
+      a = "Template error for about.md: Unterminated tag\nmore context"
+      b = "Template error for posts/hello-world.md: Unterminated tag\nother context"
+      builder.test_render_error_signature(a).should eq(builder.test_render_error_signature(b))
+    end
+
+    it "falls back to the first line when there is no 'Template error for' prefix" do
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_render_error_signature("Missing filter 'foo'\n  at line 3").should eq("Missing filter 'foo'")
+    end
+  end
+
+  describe "#report_render_failures" do
+    it "groups identical failures into a single summary line" do
+      buffer = IO::Memory.new
+      previous_io = Hwaro::Logger.io
+      Hwaro::Logger.io = buffer
+      begin
+        builder = Hwaro::Core::Build::Builder.new
+        failures = [
+          {page_path: "index.md", message: "Template error for index.md: Unterminated tag"},
+          {page_path: "about.md", message: "Template error for about.md: Unterminated tag"},
+          {page_path: "posts/hello.md", message: "Template error for posts/hello.md: Unterminated tag"},
+        ]
+        builder.test_report_render_failures(failures, verbose: false)
+      ensure
+        Hwaro::Logger.io = previous_io
+      end
+      output = buffer.to_s
+      output.should contain("Render failed for 3 pages: Unterminated tag")
+      output.should contain("  - index.md")
+      output.should contain("  - about.md")
+      output.should contain("  - posts/hello.md")
+      output.should contain("--verbose")
+      output.scan("Unterminated tag").size.should eq(1)
+    end
+
+    it "shows per-page detail under --verbose" do
+      buffer = IO::Memory.new
+      previous_io = Hwaro::Logger.io
+      Hwaro::Logger.io = buffer
+      begin
+        builder = Hwaro::Core::Build::Builder.new
+        failures = [
+          {page_path: "index.md", message: "Template error for index.md: Unterminated tag"},
+          {page_path: "about.md", message: "Template error for about.md: Unterminated tag"},
+        ]
+        builder.test_report_render_failures(failures, verbose: true)
+      ensure
+        Hwaro::Logger.io = previous_io
+      end
+      output = buffer.to_s
+      output.scan("Parallel render failed for").size.should eq(2)
+      output.should contain("index.md")
+      output.should contain("about.md")
+    end
+
+    it "uses the single-page format when only one page fails with a given error" do
+      buffer = IO::Memory.new
+      previous_io = Hwaro::Logger.io
+      Hwaro::Logger.io = buffer
+      begin
+        builder = Hwaro::Core::Build::Builder.new
+        failures = [
+          {page_path: "index.md", message: "Template error for index.md: something unique"},
+        ]
+        builder.test_report_render_failures(failures, verbose: false)
+      ensure
+        Hwaro::Logger.io = previous_io
+      end
+      output = buffer.to_s
+      output.should contain("Render failed for index.md:")
+      output.should_not contain("Run with --verbose")
+    end
+
+    it "truncates large affected-page lists with an '… and N more' tail" do
+      buffer = IO::Memory.new
+      previous_io = Hwaro::Logger.io
+      Hwaro::Logger.io = buffer
+      begin
+        builder = Hwaro::Core::Build::Builder.new
+        failures = (1..8).map do |i|
+          {page_path: "posts/p#{i}.md", message: "Template error for posts/p#{i}.md: Unterminated tag"}
+        end.to_a
+        builder.test_report_render_failures(failures, verbose: false)
+      ensure
+        Hwaro::Logger.io = previous_io
+      end
+      output = buffer.to_s
+      output.should contain("Render failed for 8 pages: Unterminated tag")
+      output.should contain("… and 3 more")
     end
   end
 end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -159,6 +159,13 @@ module Hwaro::Core::Build::Phases::Render
     classified_error : Hwaro::HwaroError? = nil
     error_mutex = Mutex.new
 
+    # Accumulate per-page failures rather than logging immediately.
+    # A broken shared template used to print the same "Parallel render
+    # failed" line once per page (7 identical 4-line blocks on a 7-page
+    # blog); deduping by normalized error signature collapses that into
+    # one summary with the list of affected pages.
+    failures = [] of NamedTuple(page_path: String, message: String)
+
     # Spawn workers, each with its own Crinja env and template cache
     worker_count.times do |worker_id|
       env = worker_envs[worker_id]
@@ -182,11 +189,13 @@ module Hwaro::Core::Build::Phases::Render
           rescue ex : Hwaro::HwaroError
             error_mutex.synchronize do
               classified_error ||= ex
+              failures << {page_path: page.path, message: ex.message.to_s}
             end
-            Logger.error "Parallel render failed for #{page.path}: #{ex.message}"
             results.send(false)
           rescue ex
-            Logger.error "Parallel render failed for #{page.path}: #{ex.message}"
+            error_mutex.synchronize do
+              failures << {page_path: page.path, message: ex.message.to_s}
+            end
             Logger.debug "  Template: #{determine_template(page, templates)}, Section: #{page.section}"
             Logger.debug "  Backtrace: #{ex.backtrace?.try(&.first(3).join("\n    ")) || "unavailable"}"
             results.send(false)
@@ -201,6 +210,11 @@ module Hwaro::Core::Build::Phases::Render
       count += 1 if results.receive
     end
 
+    # Emit the (deduped) failure summary before surfacing the classified
+    # error, so users see both the list of affected pages and the final
+    # `Error [HWARO_E_TEMPLATE]: …` line.
+    report_render_failures(failures, verbose) unless failures.empty?
+
     # Surface the first classified error now that all workers have drained
     # so the CLI sees the documented exit code / JSON payload instead of
     # a silent `status=ok, pages_generated=0`.
@@ -209,6 +223,44 @@ module Hwaro::Core::Build::Phases::Render
     end
 
     count
+  end
+
+  # Collapse identical errors raised across many pages (typical of a
+  # broken shared template) into a single summary line, preserving the
+  # full page list. `--verbose` opts back into per-page detail.
+  private def report_render_failures(
+    failures : Array(NamedTuple(page_path: String, message: String)),
+    verbose : Bool,
+  )
+    if verbose
+      failures.each do |f|
+        Logger.error "Parallel render failed for #{f[:page_path]}: #{f[:message]}"
+      end
+      return
+    end
+
+    grouped = failures.group_by { |f| render_error_signature(f[:message]) }
+    grouped.each do |signature, group|
+      if group.size == 1
+        Logger.error "Render failed for #{group.first[:page_path]}: #{group.first[:message]}"
+      else
+        Logger.error "Render failed for #{group.size} pages: #{signature}"
+        group.first(5).each { |f| Logger.error "  - #{f[:page_path]}" }
+        if group.size > 5
+          Logger.error "  … and #{group.size - 5} more"
+        end
+        Logger.error "  Run with --verbose to see each failure individually."
+      end
+    end
+  end
+
+  # Strip the page-specific prefix that Crinja adds to template errors
+  # ("Template error for posts/hello-world.md: Unterminated tag …") so
+  # identical failures on different pages collapse to the same key.
+  private def render_error_signature(message : String) : String
+    normalized = message.sub(/^Template error for [^:]+:\s*/, "")
+    first_line = normalized.lines.first?.try(&.strip) || normalized.strip
+    first_line.empty? ? normalized.strip : first_line
   end
 
   private def process_files_sequential(


### PR DESCRIPTION
Closes #406.

## Summary

A broken shared template used to emit the same \`Parallel render failed for X: Template error … Unterminated tag\` block once per page. On a 7-page blog scaffold with a busted \`templates/page.html\` that was ~30 lines of repeated output (six identical four-line error blocks + the final classified error). On larger sites it easily reached 100+ lines.

## Before / after

### Before

```
Parallel render failed for posts/hello-world.md: Template error for posts/hello-world.md: Unterminated tag
template: <string>:1:20 .. 1:20

 1 | {% if broken syntax
 X |                    ^
Parallel render failed for posts/getting-started-with-hwaro.md: Template error ...
template: <string>:1:20 .. 1:20

 1 | {% if broken syntax
 X |                    ^
…  # same four-line block, 4 more times
Error [HWARO_E_TEMPLATE]: Template error for posts/hello-world.md: Unterminated tag
template: <string>:1:20 .. 1:20

 1 | {% if broken syntax
 X |                    ^
```

### After

```
Render failed for 6 pages: Unterminated tag
  - posts/hello-world.md
  - posts/getting-started-with-hwaro.md
  - posts/markdown-tips.md
  - index.md
  - about.md
  … and 1 more
  Run with --verbose to see each failure individually.
Error [HWARO_E_TEMPLATE]: Template error for posts/hello-world.md: Unterminated tag
template: <string>:1:20 .. 1:20

 1 | {% if broken syntax
 X |                    ^
```

## Changes

- **Accumulate instead of logging live.** `process_files_parallel` now stores each per-page failure in an array under the existing mutex. Immediate \`Logger.error\` calls for the failure line are gone.
- **Summarize after workers drain.** New private helper \`report_render_failures(failures, verbose)\` groups entries by an error signature and prints one summary line per unique signature, with the list of affected pages (first 5 + \"… and N more\" tail when longer) and a \"Run with --verbose …\" hint.
- **\`--verbose\` preserves per-page detail.** When the flag is on the helper falls back to the previous output format so detailed triage stays available.
- **\`render_error_signature\` normalizes messages.** Strips Crinja's page-specific \`Template error for <path>:\` prefix so identical failures across pages collapse to the same key.
- **Classified errors still surface correctly.** A classified \`HwaroError\` is captured by the first worker to see it, added to the accumulator, and re-raised after summary emission. Exit codes (\`HWARO_E_TEMPLATE\` → 4, etc.) and \`--json\` payloads are unchanged.

Sequential path (\`--no-parallel\`) is intentionally untouched — it fails fast on the first exception, which matches its existing \"raise on first error\" semantics.

## Diff footprint

```
 spec/unit/phases_render_spec.cr | 110 ++++++++++++++++++++++++++++++++++++++++
 src/core/build/phases/render.cr |  56 +++++++++++++++++++-
 2 files changed, 164 insertions(+), 2 deletions(-)
```

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4524 examples, 0 failures (adds 7 new specs: signature extractor across 3 message shapes, 4 \`report_render_failures\` cases covering deduped multi-page, verbose pass-through, single-failure format, and the \"… and N more\" tail)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual: broken \`templates/page.html\` on blog scaffold
  - default: 1 summary + 5 listed pages + \"… and 1 more\" + verbose hint + classified error
  - \`--verbose\`: 6 per-page \`Parallel render failed …\` lines + classified error
  - exit 4 in both cases (\`HWARO_E_TEMPLATE\`)