### PR TITLE
fix(build): log a summary line when drafts are excluded

### DIFF
--- a/spec/unit/markdown_hooks_spec.cr
+++ b/spec/unit/markdown_hooks_spec.cr
@@ -98,6 +98,70 @@ describe Hwaro::Content::Hooks::MarkdownHooks do
       end
     end
 
+    it "logs a draft-skip summary when drafts are excluded" do
+      Dir.mktmpdir do |tmpdir|
+        content_dir = File.join(tmpdir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "d1.md"), "---\ntitle: D1\ndraft: true\n---\nBody")
+        File.write(File.join(content_dir, "d2.md"), "---\ntitle: D2\ndraft: true\n---\nBody")
+        File.write(File.join(content_dir, "ok.md"), "---\ntitle: Published\n---\nBody")
+
+        buffer = IO::Memory.new
+        previous_io = Hwaro::Logger.io
+        Hwaro::Logger.io = buffer
+        begin
+          Dir.cd(tmpdir) do
+            manager = Hwaro::Core::Lifecycle::Manager.new
+            hooks = Hwaro::Content::Hooks::MarkdownHooks.new
+            hooks.register_hooks(manager)
+
+            config = Hwaro::Config::Options::BuildOptions.new(drafts: false)
+            ctx = Hwaro::Core::Lifecycle::BuildContext.new(config)
+            ctx.config = Hwaro::Models::Config.new
+            ctx.pages << Hwaro::Models::Page.new("d1.md")
+            ctx.pages << Hwaro::Models::Page.new("d2.md")
+            ctx.pages << Hwaro::Models::Page.new("ok.md")
+
+            manager.trigger(Hwaro::Core::Lifecycle::HookPoint::AfterReadContent, ctx)
+          end
+        ensure
+          Hwaro::Logger.io = previous_io
+        end
+
+        buffer.to_s.should contain("2 page(s) skipped (draft).")
+      end
+    end
+
+    it "does not log a draft-skip summary when no drafts are filtered" do
+      Dir.mktmpdir do |tmpdir|
+        content_dir = File.join(tmpdir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "ok.md"), "---\ntitle: Published\n---\nBody")
+
+        buffer = IO::Memory.new
+        previous_io = Hwaro::Logger.io
+        Hwaro::Logger.io = buffer
+        begin
+          Dir.cd(tmpdir) do
+            manager = Hwaro::Core::Lifecycle::Manager.new
+            hooks = Hwaro::Content::Hooks::MarkdownHooks.new
+            hooks.register_hooks(manager)
+
+            config = Hwaro::Config::Options::BuildOptions.new(drafts: false)
+            ctx = Hwaro::Core::Lifecycle::BuildContext.new(config)
+            ctx.config = Hwaro::Models::Config.new
+            ctx.pages << Hwaro::Models::Page.new("ok.md")
+
+            manager.trigger(Hwaro::Core::Lifecycle::HookPoint::AfterReadContent, ctx)
+          end
+        ensure
+          Hwaro::Logger.io = previous_io
+        end
+
+        buffer.to_s.should_not contain("skipped (draft)")
+      end
+    end
+
     it "parses sections" do
       Dir.mktmpdir do |tmpdir|
         content_dir = File.join(tmpdir, "content")

--- a/src/content/hooks/markdown_hooks.cr
+++ b/src/content/hooks/markdown_hooks.cr
@@ -103,11 +103,36 @@ module Hwaro
           filter_expired = !ctx.options.include_expired
           filter_future = !ctx.options.include_future
           now = Time.utc
+          soon = now + 7.days
+
+          # Warn about pages expiring soon (before filtering them out)
+          if filter_expired
+            ctx.pages.each do |p|
+              if exp = p.expires
+                if exp > now && exp <= soon
+                  Logger.warn "Page '#{p.path}' expires on #{exp.to_s("%Y-%m-%d")} (within 7 days)"
+                end
+              end
+            end
+          end
+
+          draft_count = 0
+          expired_count = 0
+          future_count = 0
 
           filter = ->(p : Models::Page) do
-            (!include_drafts && p.draft) ||
-            (filter_expired && (p.expires.try { |e| e <= now } || false)) ||
-            (filter_future && (p.date.try { |d| d > now } || false))
+            if !include_drafts && p.draft
+              draft_count += 1
+              true
+            elsif filter_expired && (p.expires.try { |e| e <= now } || false)
+              expired_count += 1
+              true
+            elsif filter_future && (p.date.try { |d| d > now } || false)
+              future_count += 1
+              true
+            else
+              false
+            end
           end
 
           before = ctx.pages.size + ctx.sections.size
@@ -115,6 +140,10 @@ module Hwaro
           ctx.sections.reject!(&filter)
           after = ctx.pages.size + ctx.sections.size
           ctx.invalidate_all_pages_cache if before != after
+
+          Logger.info "  #{draft_count} page(s) skipped (draft)." if draft_count > 0
+          Logger.info "  #{future_count} page(s) skipped (future-dated)." if future_count > 0
+          Logger.info "  Excluded #{expired_count} expired page#{"s" if expired_count > 1}" if expired_count > 0
         end
 
         private def calculate_urls(ctx : Core::Lifecycle::BuildContext)

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -69,6 +69,7 @@ module Hwaro::Core::Build::Phases::ParseContent
     pages_before = ctx.pages.size
     sections_before = ctx.sections.size
     failed_count = 0
+    draft_count = 0
     expired_count = 0
     future_count = 0
 
@@ -77,6 +78,7 @@ module Hwaro::Core::Build::Phases::ParseContent
         failed_count += 1
         true
       elsif !include_drafts && p.draft
+        draft_count += 1
         true
       elsif filter_expired && (p.expires.try { |e| e <= now } || false)
         expired_count += 1
@@ -98,6 +100,7 @@ module Hwaro::Core::Build::Phases::ParseContent
     end
 
     Logger.warn "  #{failed_count} page(s) skipped due to parse errors." if failed_count > 0
+    Logger.info "  #{draft_count} page(s) skipped (draft)." if draft_count > 0
     Logger.info "  #{future_count} page(s) skipped (future-dated)." if future_count > 0
     Logger.info "  Excluded #{expired_count} expired page#{"s" if expired_count > 1}" if expired_count > 0
 


### PR DESCRIPTION
Closes #407.

## Summary

The build pipeline summarized pages filtered out for parse errors, future dates, and expiry, but drafts disappeared silently. The input count on the preceding line (\`Found 9 pages.\`) would drop to \`Generated 7 pages\` with no explanation in between.

The active filter actually lives in \`content/hooks/markdown_hooks.cr#filter_drafts\` and has no logging at all. The parallel fallback in \`core/build/phases/parse_content.cr\` had counters + summary lines for three of the four categories but was missing the draft one. Both paths are now aligned.

## Before

```console
$ hwaro build
Building site...
  Found 9 pages.
  Generated sitemap with 7 URLs.
  …
Build complete! Generated 7 pages in 15.59ms.
```

## After

```console
$ hwaro build
Building site...
  Found 9 pages.
  2 page(s) skipped (draft).
  Generated sitemap with 7 URLs.
  …
Build complete! Generated 7 pages in 17.08ms.
```

All three filter categories triggered together:

```console
$ hwaro build
  Found 11 pages.
  2 page(s) skipped (draft).
  1 page(s) skipped (future-dated).
  Excluded 1 expired page
  …
Build complete! Generated 7 pages in 16.45ms.
```

## Changes

- **\`markdown_hooks.cr#filter_drafts\`** (active hook path): add \`draft_count\` / \`future_count\` / \`expired_count\` counters, emit one summary line per category when > 0, and mirror the \"expires within 7 days\" advisory that the fallback code already had. The log wording matches the existing parse-content strings so output stays uniform regardless of which code path fires.
- **\`parse_content.cr\`** (fallback, used when no hooks register for \`BeforeParseContent\`): add the missing \`draft_count\` counter alongside the existing future/expired ones so the fallback stays feature-parity with the hook path.

## Diff footprint

```
 spec/unit/markdown_hooks_spec.cr       | 64 ++++++++++++++++++++++++++++++++++
 src/content/hooks/markdown_hooks.cr    | 35 +++++++++++++++++--
 src/core/build/phases/parse_content.cr |  3 ++
 3 files changed, 99 insertions(+), 3 deletions(-)
```

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4526 examples, 0 failures (adds 2 new specs: one asserting the draft summary is emitted when drafts are filtered, one asserting no spurious line is emitted when no drafts are present)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual verification on blog scaffold with 2 drafts, 1 future-dated, 1 expired — all three summary lines present and counts correct
- [x] \`hwaro build --drafts\` (drafts kept) does NOT emit the skip line — existing \"Including N draft(s):\" listing path still fires instead