### PR TITLE
fix(serve): reorder banners behind successful bind

### DIFF
--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -15,6 +15,10 @@ module Hwaro
       def test_ready_signal_line(host : String, port : Int32) : String
         ready_signal_line(host, port)
       end
+
+      def test_run_with_options(host, port, open_browser, access_log, live_reload, build_options, json_output)
+        run_with_options(host, port, open_browser, access_log, live_reload, build_options, json_output)
+      end
     end
   end
 end
@@ -1869,6 +1873,54 @@ describe Hwaro::Services::LiveReloadInjectHandler, "path sanitization" do
       handler.call(context)
 
       dummy.called.should be_true
+    end
+  end
+end
+
+# Regression: when bind_tcp fails (port conflict), `hwaro serve` used
+# to print "Serving site at …", "Live reload enabled", and the watcher
+# fiber would emit "Watching for changes …" — all *before* the final
+# "Could not bind" error surfaced, suggesting the server was up when
+# it wasn't. The fix reorders bind to happen before any banner, and
+# spawns the watcher fiber only after bind succeeds.
+describe "bind failure handling" do
+  it "raises HwaroError(HWARO_E_IO) when the port is already in use" do
+    Dir.mktmpdir do |project_dir|
+      Dir.cd(project_dir) do
+        File.write("config.toml", "title = \"Test\"\nbase_url = \"http://localhost:3000\"\n")
+        FileUtils.mkdir_p("content")
+        File.write("content/index.md", "---\ntitle: Home\n---\nHello")
+
+        # Grab a free port, then hold it so the Server tries to bind onto it.
+        occupied = TCPServer.new("127.0.0.1", 0)
+        port = occupied.local_address.port
+
+        build_options = Hwaro::Config::Options::BuildOptions.new
+
+        buffer = IO::Memory.new
+        previous_io = Hwaro::Logger.io
+        Hwaro::Logger.io = buffer
+
+        begin
+          err = expect_raises(Hwaro::HwaroError) do
+            Hwaro::Services::Server.new.test_run_with_options(
+              "127.0.0.1", port, false, false, true, build_options, false,
+            )
+          end
+
+          err.code.should eq(Hwaro::Errors::HWARO_E_IO)
+          err.exit_code.should eq(Hwaro::Errors::EXIT_IO)
+          (err.message || "").downcase.should contain("bind")
+
+          output = buffer.to_s
+          output.should_not contain("Serving site at")
+          output.should_not contain("Live reload enabled")
+          output.should_not contain("Watching for changes")
+        ensure
+          Hwaro::Logger.io = previous_io
+          occupied.close
+        end
+      end
     end
   end
 end

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -11,8 +11,10 @@
 
 require "http/server"
 require "json"
+require "socket"
 require "../../core/build/builder"
 require "../../content/hooks"
+require "../../utils/errors"
 require "../../utils/logger"
 require "../../utils/path_utils"
 require "../../config/options/serve_options"
@@ -267,21 +269,6 @@ module Hwaro
         watch_options = build_options.dup
         watch_options.preserve_output = true
 
-        spawn do
-          watch_for_changes(watch_options)
-        end
-
-        url = "http://#{host}:#{port}"
-        Logger.success "Serving site at #{url}"
-        Logger.info "Press Ctrl+C to stop."
-
-        if open_browser
-          spawn do
-            sleep 0.5.seconds
-            open_browser_url(url)
-          end
-        end
-
         output_dir = sanitize_output_dir(build_options.output_dir)
 
         handlers = [] of HTTP::Handler
@@ -292,7 +279,6 @@ module Hwaro
           handlers << lr_handler
           handlers << IndexRewriteHandler.new(output_dir)
           handlers << LiveReloadInjectHandler.new(output_dir)
-          Logger.info "Live reload enabled"
         else
           handlers << IndexRewriteHandler.new(output_dir)
         end
@@ -301,7 +287,40 @@ module Hwaro
 
         server = HTTP::Server.new(handlers)
 
-        server.bind_tcp host, port
+        # Bind BEFORE emitting any "Serving site at …" / "Live reload
+        # enabled" / "Watching for changes …" banners. Previously those
+        # lines printed first and the watcher fiber was already spawned,
+        # so a port-conflict error produced misleading output that looked
+        # like the server was running before the final `Error: Could not
+        # bind …` line.
+        begin
+          server.bind_tcp host, port
+        rescue ex : Socket::BindError
+          # Socket::BindError#message already includes the address, so
+          # use it verbatim rather than re-prefixing.
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_IO,
+            message: ex.message || "Could not bind to '#{host}:#{port}'",
+            hint: "Is another process already listening on this port? Try -p/--port with a different value.",
+          )
+        end
+
+        url = "http://#{host}:#{port}"
+        Logger.success "Serving site at #{url}"
+        Logger.info "Press Ctrl+C to stop."
+        Logger.info "Live reload enabled" if live_reload
+
+        if open_browser
+          spawn do
+            sleep 0.5.seconds
+            open_browser_url(url)
+          end
+        end
+
+        spawn do
+          watch_for_changes(watch_options)
+        end
+
         emit_ready_signal(host, port, json_output)
         server.listen
       end


### PR DESCRIPTION
Closes #408.

## Summary

\`hwaro serve\` used to print its \"Serving site at …\" / \"Press Ctrl+C to stop.\" / \"Live reload enabled\" lines — and start the watcher fiber that emits \"Watching for changes …\" — *before* the TCP bind attempt. On a port conflict the output order was:

```
Serving site at http://127.0.0.1:3555       ← lie
Press Ctrl+C to stop.                       ← lie
Live reload enabled                         ← lie
Error: Could not bind to '127.0.0.1:3555': Address already in use
Watching for changes in …                   ← printed AFTER the error
                                              by the already-spawned
                                              watcher fiber
```

Three misleading \"server is up\" lines, the real error, then more misleading watcher chatter. Users who copied the first URL got connection-refused or landed on whichever other process was holding the port.

## After

```console
$ hwaro serve -p 3559           # port held by another process
Changing working directory to: …
Performing initial build...
Building site...
  …
Build complete! Generated 7 pages in 29ms.
Error [HWARO_E_IO]: Could not bind to '127.0.0.1:3559': Address already in use
Is another process already listening on this port? Try -p/--port with a different value.
$ echo $?
6
```

No misleading banners. The \`HWARO_E_IO\` classification gives scripts a stable exit code (6) and, under \`--json\`, a structured payload.

## Changes

- **Move \`bind_tcp\` ahead of every banner/fiber** in \`Server#run_with_options\`. The bind is now the gate — everything past it assumes the listener is live.
- **Wrap the bind in \`begin/rescue Socket::BindError\`** and re-raise as \`Hwaro::HwaroError(HWARO_E_IO)\` so it flows through the Runner's classified-error surface: \`Error [HWARO_E_IO]: …\`, exit code 6, \`--json\` payload. Includes a hint pointing at \`-p/--port\`.
- **Emit \"Serving site at …\" / \"Press Ctrl+C to stop.\" / \"Live reload enabled\" only after bind succeeds.**
- **Spawn the watch-for-changes fiber only after bind succeeds**, so \"Watching for changes …\" never prints on a failed start.

## Diff footprint

```
 spec/unit/server_spec.cr      | 52 +++++++++++++++++++++++++++++++++++++++++
 src/services/server/server.cr | 53 ++++++++++++++++++++++++++++-------------
 2 files changed, 88 insertions(+), 17 deletions(-)
```

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4527 examples, 0 failures (adds a regression spec that occupies a port with \`TCPServer\`, calls \`Server#run_with_options\` on the same port, asserts the classified \`HwaroError(HWARO_E_IO)\` surface, and asserts the captured Logger buffer contains **none** of \"Serving site at\", \"Live reload enabled\", or \"Watching for changes\")
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual: two concurrent \`hwaro serve -p 3559\` — second instance now prints only the build output + single classified error + hint, exits with code 6. Kill the first → second can start cleanly on the same port.