### PR TITLE
fix(serve): ignore editor backup/swap files in the watcher

### DIFF
--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -19,6 +19,14 @@ module Hwaro
       def test_run_with_options(host, port, open_browser, access_log, live_reload, build_options, json_output)
         run_with_options(host, port, open_browser, access_log, live_reload, build_options, json_output)
       end
+
+      def test_scan_mtimes
+        scan_mtimes
+      end
+
+      def self.test_watcher_ignored?(path : String) : Bool
+        watcher_ignored?(path)
+      end
     end
   end
 end
@@ -1883,6 +1891,66 @@ end
 # "Could not bind" error surfaced, suggesting the server was up when
 # it wasn't. The fix reorders bind to happen before any banner, and
 # spawns the watcher fiber only after bind succeeds.
+describe "watcher ignore patterns" do
+  # Regression: `sed -i.bak`, vim's default `.swp` files, emacs
+  # lock/autosave files, and `.DS_Store` used to show up as watcher
+  # events — each one counted as an added/removed file and forced a
+  # `:full` rebuild. Now the watcher drops them before scan_mtimes
+  # records anything.
+
+  {
+    ".bak backup"           => "note.md.bak",
+    "vim swap"              => ".note.md.swp",
+    "trailing-tilde backup" => "note.md~",
+    "emacs lock file"       => ".#note.md",
+    "emacs autosave"        => "#note.md#",
+    ".DS_Store"             => ".DS_Store",
+  }.each do |label, name|
+    it "ignores #{label} (#{name})" do
+      Hwaro::Services::Server.test_watcher_ignored?(name).should be_true
+      Hwaro::Services::Server.test_watcher_ignored?(File.join("content", "posts", name)).should be_true
+    end
+  end
+
+  it "does NOT ignore regular content files" do
+    [
+      "index.md",
+      "about.md",
+      "posts/hello-world.md",
+      "templates/page.html",
+      "static/css/style.css",
+    ].each do |path|
+      Hwaro::Services::Server.test_watcher_ignored?(path).should be_false
+    end
+  end
+
+  it "does NOT ignore files that merely contain a tilde or hash inside" do
+    # Bare tildes/hashes inside the basename are fine — only the
+    # specific editor-byproduct shapes (trailing ~, wrapping #…#,
+    # leading .#) should be dropped.
+    Hwaro::Services::Server.test_watcher_ignored?("notes-for-~user.md").should be_false
+    Hwaro::Services::Server.test_watcher_ignored?("tag-#python.md").should be_false
+  end
+
+  it "excludes matched files from scan_mtimes" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        FileUtils.mkdir_p("content/posts")
+        File.write("content/posts/hello.md", "real")
+        File.write("content/posts/hello.md.bak", "backup")
+        File.write("content/posts/.hello.md.swp", "swap")
+        File.write("content/posts/.DS_Store", "apple")
+
+        mtimes = Hwaro::Services::Server.new.test_scan_mtimes
+        mtimes.keys.should contain("content/posts/hello.md")
+        mtimes.keys.should_not contain("content/posts/hello.md.bak")
+        mtimes.keys.should_not contain("content/posts/.hello.md.swp")
+        mtimes.keys.should_not contain("content/posts/.DS_Store")
+      end
+    end
+  end
+end
+
 describe "bind failure handling" do
   it "raises HwaroError(HWARO_E_IO) when the port is already in use" do
     Dir.mktmpdir do |project_dir|

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -547,6 +547,29 @@ module Hwaro
         Logger.debug "Failed to open browser: #{ex.message}"
       end
 
+      # Paths matching these regexes are treated as editor byproducts
+      # (backups, swap files, autosaves, OS metadata) and are excluded
+      # from the watcher. Editors using `rename`-based atomic save or
+      # keep-a-backup patterns (vim's default, `sed -i.bak`, emacs,
+      # JetBrains, …) used to double-trigger rebuilds — once for the
+      # real edit and once for the byproduct — and each event forced a
+      # full rebuild (see server.cr `:full` strategy fallback).
+      WATCHER_IGNORE_PATTERNS = [
+        /\.bak$/,
+        /~$/,
+        /\.swp$/, /\.swo$/, /\.swx$/,
+        /\.DS_Store$/,
+        # emacs lock file:   .#filename
+        # emacs autosave:    #filename#
+        /(?:\A|\/)\.#[^\/]+$/,
+        /(?:\A|\/)#[^\/]+#$/,
+      ]
+
+      protected def self.watcher_ignored?(path : String) : Bool
+        basename = File.basename(path)
+        WATCHER_IGNORE_PATTERNS.any? { |re| re.matches?(path) || re.matches?(basename) }
+      end
+
       private def scan_mtimes : Hash(String, Time)
         mtimes = {} of String => Time
         dirs_to_watch = ["content", "templates", "static"]
@@ -555,6 +578,7 @@ module Hwaro
           next unless Dir.exists?(dir)
           Dir.glob(File.join(dir, "**", "*")) do |file|
             next if File.directory?(file)
+            next if Server.watcher_ignored?(file)
             begin
               mtimes[file] = File.info(file).modification_time
             rescue ex


### PR DESCRIPTION
Closes #409.

## Summary

\`hwaro serve\`'s file watcher treated editor byproducts as content changes: \`sed -i.bak 's/…/…/' content/posts/hello.md\` produced a rebuild for the real edit AND a second rebuild when the \`.bak\` was created (and another round when it got removed). Both events also flipped the rebuild strategy from \`:incremental\` to \`:full\` because the debounce layer categorises added/removed paths as a full-rebuild trigger — so a single-file edit forced every page to re-render.

Vim's default \`.swp\` file, emacs lock/autosave shapes (\`.#foo\`, \`#foo#\`), and macOS \`.DS_Store\` hit the same path.

## Before / after

### Before (\`sed -i.bak\` on a single .md file)

```
[Watch] Change detected (1 content, 1 added file(s)). Strategy: full...
Building site...
  Found 7 pages.
  …
Build complete! Generated 7 pages in 15ms.

[Watch] Change detected (1 content, 1 removed file(s)). Strategy: full...
Building site...
  …
Build complete! Generated 7 pages in 15ms.
```

Two \`:full\` rebuilds, both re-render every page, browser live-reloads twice.

### After

```
[Watch] Change detected (1 content file(s)). Strategy: incremental...
Incremental build for 1 changed file(s)...
Incremental build complete! Rendered 4/7 pages in 21ms.
```

One \`:incremental\` rebuild, 4/7 pages re-rendered, one live-reload event.

## Changes

- **\`WATCHER_IGNORE_PATTERNS\`** covers the common editor-byproduct shapes:
  - \`*.bak\` (\`sed -i.bak\`, generic backup)
  - \`*~\` (trailing-tilde backup)
  - \`.*.swp\` / \`.swo\` / \`.swx\` (vim swap)
  - \`.#foo\` (emacs lock file)
  - \`#foo#\` (emacs autosave)
  - \`.DS_Store\` (macOS Finder metadata)
- **\`Server.watcher_ignored?(path)\`** applies the patterns to both the full path and the basename.
- **\`scan_mtimes\`** filters each glob result through \`watcher_ignored?\` so those files never enter the mtime map. No mtime entry → no diff entry → no added/removed event → no \`:full\` strategy bump.
- Regular content stays watched — the patterns only match the specific editor-byproduct shapes, not any path that merely contains \`~\` or \`#\` inside (e.g. \`notes-for-~user.md\`, \`tag-#python.md\`).

## Diff footprint

```
 spec/unit/server_spec.cr      | 68 ++++++++++++++++++++++++++++++++++++++
 src/services/server/server.cr | 24 ++++++++++++++
 2 files changed, 92 insertions(+)
```

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4536 examples, 0 failures (adds 9 new specs: one per editor-byproduct shape, a negative case for regular content paths, a tilde/hash-in-middle negative case, and an end-to-end check that \`scan_mtimes\` drops the matched files on disk)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual: \`sed -i.bak 's/Hello/MODIFIED/' content/posts/hello-world.md\` now produces a single \`:incremental\` rebuild instead of two \`:full\` rebuilds; confirmed 4/7 pages re-rendered.