### PR TITLE
fix(new): validate and normalize <path> before creating content

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -561,4 +561,64 @@ describe Hwaro::Services::Creator do
       end
     end
   end
+
+  describe ".validate_and_normalize_path!" do
+    it "accepts a plain relative path unchanged" do
+      Hwaro::Services::Creator.validate_and_normalize_path!("posts/hello.md").should eq("posts/hello.md")
+      Hwaro::Services::Creator.validate_and_normalize_path!("index.md").should eq("index.md")
+    end
+
+    it "collapses double slashes" do
+      Hwaro::Services::Creator.validate_and_normalize_path!("posts//foo.md").should eq("posts/foo.md")
+      Hwaro::Services::Creator.validate_and_normalize_path!("a//b///c.md").should eq("a/b/c.md")
+    end
+
+    it "strips leading ./ segments" do
+      Hwaro::Services::Creator.validate_and_normalize_path!("./posts/foo.md").should eq("posts/foo.md")
+    end
+
+    it "accepts non-markdown-extension paths" do
+      # The validator is about path shape, not extension — Creator decides
+      # bundle vs single-file downstream.
+      Hwaro::Services::Creator.validate_and_normalize_path!("posts/foo").should eq("posts/foo")
+    end
+
+    it "rejects an empty or whitespace-only path" do
+      expect_raises(ArgumentError, /missing <path>/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!("")
+      end
+      expect_raises(ArgumentError, /missing <path>/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!("   ")
+      end
+    end
+
+    it "rejects an absolute path" do
+      expect_raises(ArgumentError, /Absolute path/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!("/tmp/evil.md")
+      end
+      expect_raises(ArgumentError, /Absolute path/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!("/etc/passwd")
+      end
+    end
+
+    it "rejects paths that escape content/ via ..;" do
+      expect_raises(ArgumentError, /escapes the content\/ directory/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!("../escaped.md")
+      end
+      expect_raises(ArgumentError, /escapes the content\/ directory/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!("../../../etc/passwd")
+      end
+    end
+
+    it "rejects paths that reduce to content/ itself (no filename)" do
+      expect_raises(ArgumentError, /escapes/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!(".")
+      end
+    end
+
+    it "accepts paths that reference .. internally but stay under content/" do
+      # foo/../bar.md resolves to bar.md which is still inside content/.
+      Hwaro::Services::Creator.validate_and_normalize_path!("foo/../bar.md").should eq("bar.md")
+    end
+  end
 end

--- a/spec/unit/new_command_spec.cr
+++ b/spec/unit/new_command_spec.cr
@@ -135,4 +135,71 @@ describe Hwaro::CLI::Commands::NewCommand do
       end
     end
   end
+
+  # Path-shape validation happens at the CLI boundary so each bad path
+  # surfaces as a classified usage error (exit 2, JSON payload if --json).
+  # The Creator class itself is tested more thoroughly in creator_spec.cr.
+  describe "#run path validation" do
+    it "rejects `..`-escaping paths with HWARO_E_USAGE" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          err = expect_raises(Hwaro::HwaroError) do
+            Hwaro::CLI::Commands::NewCommand.new.run(["../escaped.md", "-t", "X"])
+          end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+          err.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+          (err.message || "").should contain("escapes the content/ directory")
+
+          # Nothing should have been written anywhere.
+          File.exists?(File.join(dir, "escaped.md")).should be_false
+          File.exists?("escaped.md").should be_false
+        end
+      end
+    end
+
+    it "rejects absolute paths with HWARO_E_USAGE" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          err = expect_raises(Hwaro::HwaroError) do
+            Hwaro::CLI::Commands::NewCommand.new.run(["/tmp/hwaro-evil.md", "-t", "X"])
+          end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+          (err.message || "").should contain("Absolute path")
+
+          File.exists?("/tmp/hwaro-evil.md").should be_false
+          File.exists?("content/tmp/hwaro-evil.md").should be_false
+        end
+      end
+    end
+
+    it "rejects empty path with HWARO_E_USAGE" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          err = expect_raises(Hwaro::HwaroError) do
+            Hwaro::CLI::Commands::NewCommand.new.run(["", "-t", "X"])
+          end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+          (err.message || "").should contain("missing <path>")
+        end
+      end
+    end
+
+    it "normalizes double slashes in the input path" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          Hwaro::CLI::Commands::NewCommand.new.run(["posts//slashy.md", "-t", "Slashy"])
+
+          # Canonical path on disk.
+          File.exists?("content/posts/slashy.md").should be_true
+          # No phantom dir from the stray slash.
+          Dir.exists?("content/posts/").should be_true
+          Dir.children("content/posts").includes?("").should be_false
+        end
+      end
+    end
+  end
 end

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -67,13 +67,35 @@ module Hwaro
           # missing <path> always fails fast with a classified usage error.
           # Keeping this a HwaroError lets both text and --json consumers see
           # the same taxonomy (code/category/exit).
-          if options.path.nil?
+          raw_path = options.path
+          if raw_path.nil?
             raise Hwaro::HwaroError.new(
               code: Hwaro::Errors::HWARO_E_USAGE,
               message: "missing <path> argument",
               hint: "Usage: hwaro new <path> [options] — run 'hwaro new --help' for details.",
             )
           end
+
+          # Canonicalize early so the rest of the pipeline (and the
+          # `Created new content: …` log line) works with a path that
+          # has no `..`, no absolute-root leak, and no double slashes.
+          # Empty / absolute / content-escaping paths fail here with a
+          # classified usage error instead of silently landing at an
+          # unexpected filesystem location.
+          begin
+            normalized = Services::Creator.validate_and_normalize_path!(raw_path)
+          rescue ex : ArgumentError
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: ex.message || "Invalid <path> argument",
+              hint: "Usage: hwaro new <path> [options] — run 'hwaro new --help' for details.",
+            )
+          end
+          # Feed the normalized path back into the Creator. The stored
+          # path keeps the `content/` prefix so downstream branches that
+          # check `starts_with?("content/")` take the already-rooted
+          # path as-is (see Creator#run).
+          options.path = normalized
 
           Services::Creator.new.run(options, load_config_if_present)
         end

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -7,6 +7,7 @@ require "../utils/logger"
 module Hwaro
   module Services
     class Creator
+      CONTENT_DIR    = "content"
       ARCHETYPES_DIR = "archetypes"
 
       # `<!-- hwaro: KEY[=VALUE], KEY[=VALUE] -->` directive that an
@@ -20,6 +21,45 @@ module Hwaro
       # logged as a warning so typos (`bundlr=true`) surface instead of
       # silently becoming no-ops.
       KNOWN_DIRECTIVES = {"bundle"}
+
+      # Validate a user-supplied `<path>` argument to `hwaro new` and
+      # return a normalized form relative to `content/` (no prefix),
+      # with `./`, `..`, and double-slash segments already collapsed.
+      # The result is safe to pass straight into the existing Creator
+      # resolution logic, which re-adds the `content/` prefix as needed.
+      #
+      # Raises `ArgumentError` when the input is empty, absolute, or
+      # would resolve outside `content/`. Callers (the CLI) wrap the
+      # failure in `HwaroError(HWARO_E_USAGE)` so the classified exit
+      # code and `--json` payload match the rest of the tool.
+      def self.validate_and_normalize_path!(raw : String) : String
+        stripped = raw.strip
+        if stripped.empty?
+          raise ArgumentError.new("missing <path> argument")
+        end
+
+        if Path[stripped].absolute?
+          raise ArgumentError.new(
+            "Absolute path '#{raw}' is not allowed. " \
+            "Paths are relative to #{CONTENT_DIR}/, e.g. 'posts/my-article.md'."
+          )
+        end
+
+        full = Path[File.join(CONTENT_DIR, stripped)].normalize.to_s
+        root_prefix = "#{CONTENT_DIR}#{File::SEPARATOR}"
+
+        # The normalized path must sit strictly below content/ — equal
+        # to the root is also a reject (no filename) and anything that
+        # doesn't start with "content/" means `..` escaped the tree.
+        unless full.starts_with?(root_prefix)
+          raise ArgumentError.new(
+            "Path '#{raw}' escapes the #{CONTENT_DIR}/ directory. " \
+            "Use a path inside #{CONTENT_DIR}/, e.g. 'posts/my-article.md'."
+          )
+        end
+
+        full[root_prefix.size..]
+      end
 
       def run(options : Config::Options::NewOptions, config : Models::Config? = nil)
         path = options.path


### PR DESCRIPTION
Closes #418, #422, #423, #424.

## Summary

\`hwaro new <path>\` passed the raw path straight to the filesystem after joining with \`content/\`. Four related symptoms:

| Input | Before | After |
|---|---|---|
| \`../escaped.md\` | Wrote \`content/../escaped.md\` (i.e. project root, outside \`content/\`). Exit 0. | \`Error [HWARO_E_USAGE]: Path '../escaped.md' escapes the content/ directory.\` Exit 2. |
| \`/tmp/evil.md\` | Leading \`/\` stripped; landed at \`content/tmp/evil.md\`. Exit 0. | \`Error [HWARO_E_USAGE]: Absolute path '/tmp/evil.md' is not allowed.\` Exit 2. |
| \`""\` (empty) | Fell through to title-slug at \`content/\` root. | \`Error [HWARO_E_USAGE]: missing <path> argument\`. Exit 2. |
| \`posts//slashy.md\` | File at \`content/posts/slashy.md\` but log said \`content/posts//slashy.md\`. | Log says \`content/posts/slashy.md\`. |

All four are in the same code path (raw \`File.join("content", path)\` + \`File.write\`), so one normalization step closes all of them.

## Changes

- **New class method** \`Services::Creator.validate_and_normalize_path!(raw : String) : String\`. Canonicalizes via \`Path[...].normalize\`, rejects empty / whitespace-only / absolute / content-escaping input, and returns the normalized form **relative to \`content/\`** (no prefix) so the existing Creator resolution branches stay untouched.
- **\`NewCommand#run\`** calls the validator right after parsing options, wraps any \`ArgumentError\` in \`HwaroError(HWARO_E_USAGE)\`, and feeds the normalized path back onto \`options.path\`. Classified exit code (2), classified text output (\`Error [HWARO_E_USAGE]: …\`), and JSON payload under \`--json\` all come for free via the existing Runner plumbing.

## Out of scope (follow-up PRs already filed)

- #419 — \`-s section\` silently overrides path directory (separate fix in Creator resolution)
- #420 — \`--bundle\` double-wraps when path lacks \`.md\`
- #421 — remaining \`raise "string"\` call sites in Creator that bypass the error taxonomy on non-path failures (file-exists, archetype-missing, etc.)

The file-exists / archetype-missing rescues still raise plain strings; the path-validation surface is the only one this PR touches.

## Diff footprint

\`\`\`
 spec/unit/creator_spec.cr       | 60 +++++++++++++++++++++++++++++++++++
 spec/unit/new_command_spec.cr   | 67 ++++++++++++++++++++++++++++++++++++++++
 src/cli/commands/new_command.cr | 24 +++++++++++++-
 src/services/creator.cr         | 40 +++++++++++++++++++++++
 4 files changed, 190 insertions(+), 1 deletion(-)
\`\`\`

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4549 examples, 0 failures (adds 11 new specs: validator accepts plain/normalized cases, collapses double slashes, strips \`./\`, rejects empty/whitespace/absolute/traversal, accepts internal \`..\` that stays under \`content/\`; plus CLI specs asserting classified \`HWARO_E_USAGE\` surface + no stray files written on rejection + normalized disk path on double-slash input)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual on blog scaffold:
  - \`hwaro new ../escaped.md --title X\` → exit 2, no file anywhere
  - \`hwaro new /tmp/evil.md --title X\` → exit 2, no file anywhere
  - \`hwaro new "" --title X\` → exit 2, "missing <path> argument"
  - \`hwaro new posts//slashy.md --title X\` → clean log + disk path
  - \`hwaro new posts/foo.md --title X\` (happy path) → unchanged
  - \`hwaro new --json /abs --title X\` → JSON payload with \`HWARO_E_USAGE\` on stdout, exit 2