### PR TITLE
fix(new): classify Creator error raises under the HwaroError taxonomy

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -205,7 +205,7 @@ describe Hwaro::Services::Creator do
       end
     end
 
-    it "raises an error if file already exists" do
+    it "raises HwaroError(HWARO_E_IO) when the file already exists" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do
           FileUtils.mkdir_p("content/drafts")
@@ -214,14 +214,17 @@ describe Hwaro::Services::Creator do
           options = Hwaro::Config::Options::NewOptions.new(path: "existing.md", title: "Existing Post")
           creator = Hwaro::Services::Creator.new
 
-          expect_raises(Exception, "File already exists: content/drafts/existing.md") do
+          err = expect_raises(Hwaro::HwaroError) do
             creator.run(options)
           end
+          err.code.should eq(Hwaro::Errors::HWARO_E_IO)
+          err.exit_code.should eq(Hwaro::Errors::EXIT_IO)
+          (err.message || "").should contain("File already exists: content/drafts/existing.md")
         end
       end
     end
 
-    it "raises an error if explicit archetype is missing" do
+    it "raises HwaroError(HWARO_E_USAGE) when an explicit archetype is missing" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do
           FileUtils.mkdir_p("content/drafts")
@@ -230,14 +233,17 @@ describe Hwaro::Services::Creator do
           options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Post", archetype: "missing")
           creator = Hwaro::Services::Creator.new
 
-          expect_raises(Exception, "Archetype not found: archetypes/missing.md") do
+          err = expect_raises(Hwaro::HwaroError) do
             creator.run(options)
           end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+          err.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+          (err.message || "").should contain("Archetype not found: archetypes/missing.md")
         end
       end
     end
 
-    it "fails fast when title cannot be inferred (flag-only, no prompt)" do
+    it "fails fast with HwaroError(HWARO_E_USAGE) when title cannot be inferred (flag-only, no prompt)" do
       # `hwaro new` is flag-only: the Creator must raise a clear usage error
       # rather than falling back to an interactive `gets` prompt. This holds
       # in both TTY and non-TTY environments.
@@ -248,14 +254,16 @@ describe Hwaro::Services::Creator do
           options = Hwaro::Config::Options::NewOptions.new
           creator = Hwaro::Services::Creator.new
 
-          expect_raises(Exception, /missing --title/) do
+          err = expect_raises(Hwaro::HwaroError) do
             creator.run(options)
           end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+          (err.message || "").should match(/missing --title/)
         end
       end
     end
 
-    it "fails fast when path is a directory and title is missing" do
+    it "fails fast with HwaroError(HWARO_E_USAGE) when path is a directory and title is missing" do
       # Regression: `hwaro new posts/` (directory, no --title) should raise
       # the same usage error since no title can be inferred from a directory.
       Dir.mktmpdir do |dir|
@@ -265,9 +273,10 @@ describe Hwaro::Services::Creator do
           options = Hwaro::Config::Options::NewOptions.new(path: "blog")
           creator = Hwaro::Services::Creator.new
 
-          expect_raises(Exception, /missing --title/) do
+          err = expect_raises(Hwaro::HwaroError) do
             creator.run(options)
           end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
         end
       end
     end
@@ -501,7 +510,7 @@ describe Hwaro::Services::Creator do
         end
       end
 
-      it "refuses bundle creation when a single-file sibling already exists" do
+      it "refuses bundle creation with HwaroError(HWARO_E_IO) when a single-file sibling already exists" do
         # Both `posts/hello.md` (sibling) and `posts/hello/index.md`
         # (bundle) would render to the same URL — we'd rather fail loudly
         # than silently duplicate the page.
@@ -512,9 +521,11 @@ describe Hwaro::Services::Creator do
 
             options = Hwaro::Config::Options::NewOptions.new(
               path: "posts/hello.md", title: "Hello", bundle: true)
-            expect_raises(Exception, /sibling already exists/) do
+            err = expect_raises(Hwaro::HwaroError) do
               Hwaro::Services::Creator.new.run(options)
             end
+            err.code.should eq(Hwaro::Errors::HWARO_E_IO)
+            (err.message || "").should contain("single-file sibling")
 
             # Existing file left untouched, bundle not created.
             File.read("content/posts/hello.md").should contain("Existing")

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -2,6 +2,7 @@ require "file_utils"
 require "time"
 require "../config/options/new_options"
 require "../models/config"
+require "../utils/errors"
 require "../utils/logger"
 
 module Hwaro
@@ -120,12 +121,20 @@ module Hwaro
         # cannot be inferred. The `new` command is flag-only: no interactive
         # prompts, so behavior is predictable in TTY, CI, and agent runs.
         if !full_path && title.empty?
-          raise "missing --title (or <path>.md) argument\nUsage: hwaro new <path> [options]\nRun 'hwaro new --help' for details."
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "missing --title (or <path>.md) argument",
+            hint: "Pass --title, or give a path ending in .md (e.g. 'posts/my-post.md').",
+          )
         end
 
         if !full_path
           if title.empty?
-            raise "Title cannot be empty."
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "Title cannot be empty.",
+              hint: "Pass a non-empty --title.",
+            )
           end
           filename = title.downcase.gsub(/[^\p{L}\p{N}]+/, "-").strip("-") + ".md"
           full_path = File.join(base_dir, filename)
@@ -165,7 +174,12 @@ module Hwaro
         if bundle_mode && !bundle_path?(full_path)
           candidate = bundle_path_for(full_path)
           if bundle_collides_with_sibling?(candidate)
-            raise "Cannot create bundle at #{candidate}: single-file sibling already exists. Remove the existing file or omit --bundle."
+            sibling = candidate.rchop("/index.md") + ".md"
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_IO,
+              message: "Cannot create bundle at #{candidate}: single-file sibling already exists.",
+              hint: "Remove #{sibling}, or omit --bundle to append to the existing file location.",
+            )
           end
           full_path = candidate
           base_dir = File.dirname(full_path)
@@ -179,7 +193,11 @@ module Hwaro
                   end
 
         if File.exists?(full_path)
-          raise "File already exists: #{full_path}"
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_IO,
+            message: "File already exists: #{full_path}",
+            hint: "Pass a different <path>, or edit the existing file directly.",
+          )
         end
 
         File.write(full_path, content)
@@ -242,7 +260,11 @@ module Hwaro
             Logger.debug "Using archetype: #{archetype_path}"
             return File.read(archetype_path)
           else
-            raise "Archetype not found: #{archetype_path}"
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "Archetype not found: #{archetype_path}",
+              hint: "Run 'hwaro new --list-archetypes' to see archetypes available in this project.",
+            )
           end
         end
 


### PR DESCRIPTION
Closes #421.

## Summary

\`Services::Creator\` had five \`raise "string message"\` call sites that bypassed the \`HwaroError\` taxonomy the rest of the CLI uses:

- missing \`--title\` (or \`<path>.md\`)
- empty title
- bundle collision with single-file sibling
- file already exists
- archetype not found

Consequences before this change:
- Exit code was always 1 (generic) rather than the per-code documented exit (\`HWARO_E_IO\` → 6, \`HWARO_E_USAGE\` → 2).
- \`--json\` emitted plain text \`Error: …\` instead of the structured \`{"status":"error","error":{"code":…}}\` payload every other command produces.
- Error line prefix was \`Error:\` not \`Error [HWARO_E_XXX]:\`, breaking the documented grep pattern.

## Mapping

| Site | Code | Exit |
|---|---|---|
| missing \`--title\` / \`<path>.md\` | \`HWARO_E_USAGE\` | 2 |
| empty title | \`HWARO_E_USAGE\` | 2 |
| archetype not found | \`HWARO_E_USAGE\` | 2 |
| file already exists | \`HWARO_E_IO\` | 6 |
| bundle sibling collision | \`HWARO_E_IO\` | 6 |

Each raise carries a concrete \`hint:\` — file-exists points at editing the existing file, archetype-missing points at \`--list-archetypes\`, bundle-collision names the sibling path the user has to remove.

## Before / after

Before:
\`\`\`console
\$ hwaro new posts/hello-world.md --title Again --json
Error: File already exists: content/posts/hello-world.md
\$ echo \$?
1
\`\`\`

After:
\`\`\`console
\$ hwaro new posts/hello-world.md --title Again
Error [HWARO_E_IO]: File already exists: content/posts/hello-world.md
Pass a different <path>, or edit the existing file directly.
\$ echo \$?
6

\$ hwaro new posts/hello-world.md --title Again --json
{"status":"error","error":{"code":"HWARO_E_IO","category":"io","message":"File already exists: content/posts/hello-world.md","hint":"Pass a different <path>, or edit the existing file directly."}}
\$ echo \$?
6

\$ hwaro new posts/x.md --title X -a nosuch
Error [HWARO_E_USAGE]: Archetype not found: archetypes/nosuch.md
Run 'hwaro new --list-archetypes' to see archetypes available in this project.
\$ echo \$?
2
\`\`\`

## Diff footprint

\`\`\`
 spec/unit/creator_spec.cr | 31 +++++++++++++++++++++----------
 src/services/creator.cr   | 32 +++++++++++++++++++++++++++-----
 2 files changed, 48 insertions(+), 15 deletions(-)
\`\`\`

The Runner plumbing handles text / JSON / quiet rendering without per-command changes — same pattern that fixed \`build\`, \`deploy\`, and the tool subcommands in #373/#378/#380. \`new\` was apparently missed in that sweep; this closes the gap.

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4549 examples, 0 failures (upgrades 5 existing specs from \`expect_raises(Exception, ...)\` to the classified \`expect_raises(Hwaro::HwaroError)\` + assert code + exit_code + message; adds message-substring checks for each path)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual verification of all 5 sites with both text and \`--json\` output.