### PR TITLE
fix(new): warn and keep path when -s section conflicts with path's directory

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -666,6 +666,127 @@ describe Hwaro::Services::Creator do
         end
       end
     end
+
+    describe "--section vs path directory conflict" do
+      # Regression: `hwaro new posts/foo.md -s docs` used to silently drop
+      # the path's leading directory and create the file under the section
+      # instead. The path is authoritative now (the user wrote the dir),
+      # and --section is ignored after a one-line warning.
+
+      it "prefers the path and warns when the leading directory and --section disagree" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+
+            buffer = IO::Memory.new
+            previous_io = Hwaro::Logger.io
+            Hwaro::Logger.io = buffer
+            begin
+              options = Hwaro::Config::Options::NewOptions.new(
+                path: "posts/conflict.md", title: "C", section: "docs")
+              Hwaro::Services::Creator.new.run(options)
+            ensure
+              Hwaro::Logger.io = previous_io
+            end
+
+            # Path wins.
+            File.exists?("content/posts/conflict.md").should be_true
+            File.exists?("content/docs/conflict.md").should be_false
+
+            log = buffer.to_s
+            log.should contain("--section 'docs'")
+            log.should contain("posts/")
+            log.should contain("ignoring --section")
+          end
+        end
+      end
+
+      it "warns when the path is dir-ish and leading-segment differs from --section" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+
+            buffer = IO::Memory.new
+            previous_io = Hwaro::Logger.io
+            Hwaro::Logger.io = buffer
+            begin
+              options = Hwaro::Config::Options::NewOptions.new(
+                path: "posts/nope", title: "Nope", section: "docs")
+              Hwaro::Services::Creator.new.run(options)
+            ensure
+              Hwaro::Logger.io = previous_io
+            end
+
+            # Section branch discarded; directory fallback takes over and
+            # produces <path>/<slug>.md under the path's own leading dir.
+            File.exists?("content/posts/nope/nope.md").should be_true
+            File.exists?("content/docs/posts/nope.md").should be_false
+            File.exists?("content/docs/nope.md").should be_false
+
+            buffer.to_s.should contain("ignoring --section")
+          end
+        end
+      end
+
+      it "preserves deeper nesting in the path when dropping --section" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "tools/deep/note.md", title: "Note", section: "docs")
+            Hwaro::Services::Creator.new.run(options)
+
+            File.exists?("content/tools/deep/note.md").should be_true
+            File.exists?("content/docs/tools/deep/note.md").should be_false
+            File.exists?("content/docs/note.md").should be_false
+          end
+        end
+      end
+
+      it "does not warn when --section matches the path's leading directory" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+
+            buffer = IO::Memory.new
+            previous_io = Hwaro::Logger.io
+            Hwaro::Logger.io = buffer
+            begin
+              options = Hwaro::Config::Options::NewOptions.new(
+                path: "posts/post.md", title: "P", section: "posts")
+              Hwaro::Services::Creator.new.run(options)
+            ensure
+              Hwaro::Logger.io = previous_io
+            end
+
+            File.exists?("content/posts/post.md").should be_true
+            buffer.to_s.should_not contain("--section")
+          end
+        end
+      end
+
+      it "does not warn when the path has no leading directory (section provides it)" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+
+            buffer = IO::Memory.new
+            previous_io = Hwaro::Logger.io
+            Hwaro::Logger.io = buffer
+            begin
+              options = Hwaro::Config::Options::NewOptions.new(
+                path: "intro.md", title: "Intro", section: "docs")
+              Hwaro::Services::Creator.new.run(options)
+            ensure
+              Hwaro::Logger.io = previous_io
+            end
+
+            File.exists?("content/docs/intro.md").should be_true
+            buffer.to_s.should_not contain("--section")
+          end
+        end
+      end
+    end
   end
 
   describe ".validate_and_normalize_path!" do

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -67,7 +67,7 @@ module Hwaro
         title = options.title || ""
 
         # --section overrides the base directory
-        if section = options.section
+        if section = resolve_section(options.section, path)
           if path && path.ends_with?(".md")
             filename = File.basename(path)
             full_path = File.join("content", section, filename)
@@ -267,6 +267,28 @@ module Hwaro
       private def bundle_collides_with_sibling?(full_path : String) : Bool
         sibling_md = full_path.rchop("/index.md") + ".md"
         File.exists?(sibling_md) && File.file?(sibling_md)
+      end
+
+      # Reconcile `-s section` with a path argument that already carries
+      # a directory. Prior behaviour silently dropped the path's leading
+      # directory and used the section — so `hwaro new posts/foo.md -s
+      # docs` landed the file at `content/docs/foo.md` with no warning,
+      # which made scripted flows and shell-completion surprise users.
+      #
+      # New behaviour: if the path's leading segment and the section
+      # disagree, the path is authoritative (the user wrote the dir, so
+      # respect it) and `--section` is dropped with a one-line warning.
+      # When they match, or when the path lacks a directory entirely
+      # (`-s docs foo.md`), the section is returned as-is.
+      private def resolve_section(section : String?, path : String?) : String?
+        return unless section
+        return section unless path && path.includes?("/")
+
+        first_segment = path.split("/").first
+        return section if first_segment == section
+
+        Logger.warn "  --section '#{section}' conflicts with directory '#{first_segment}/' in path '#{path}'; using the path and ignoring --section."
+        nil
       end
 
       private def find_archetype(explicit_archetype : String?, path : String) : String?


### PR DESCRIPTION
Closes #419.

## Summary

\`hwaro new posts/foo.md -s docs\` silently dropped the \`posts/\` part of the path and wrote \`content/docs/foo.md\`. The user wrote both pieces of information and the tool picked one without saying so; scripted flows and shell-completion setups landed files in a surprising location.

## Fix

A new private \`resolve_section(section, path)\` helper detects the conflict (path's leading segment differs from \`--section\`) and:

- Emits a single warning line naming both the section and the path's directory, and declaring that \`--section\` is being ignored.
- Returns \`nil\` so the rest of Creator's pipeline runs through its no-section branch, which preserves the path as authoritative.

No-conflict invocations (\`-s\` matches the leading dir, or path has no leading dir) still flow through the section branch unchanged — no noise.

## Matrix

| Input | Before | After |
|---|---|---|
| \`posts/foo.md -s docs\` | \`content/docs/foo.md\` (silent) | warn + \`content/posts/foo.md\` |
| \`posts/foo -s docs\` (no .md) | \`content/docs/posts/foo.md\` (silent) | warn + \`content/posts/foo/foo.md\` |
| \`tools/deep/note.md -s docs\` | \`content/docs/note.md\` (silent, even middle segment dropped) | warn + \`content/tools/deep/note.md\` |
| \`foo.md -s docs\` (path has no dir) | \`content/docs/foo.md\` | same (silent) |
| \`posts/post.md -s posts\` (matching) | \`content/posts/post.md\` | same (silent) |
| \`posts/post.md\` (no \`-s\`) | \`content/posts/post.md\` | same (silent) |

## Rationale for "warn + path wins" over "error out"

- Most CLIs treat redundant-but-derivable flags as overrideable; the path is the more specific input and deserves priority.
- Error-out forces every conflicting invocation to be fixed up even when the user's intent is obvious from the path.
- The warning still surfaces the issue to anyone auditing output, without breaking scripts that happen to set \`--section\` as a default and pass through explicit paths occasionally.

Option 1 (error out) remains on the table if a future case demands strictness — switching the helper's \`nil\` return to a raised \`HwaroError(HWARO_E_USAGE)\` is a one-line change.

## Diff footprint

\`\`\`
 spec/unit/creator_spec.cr | 121 ++++++++++++++++++++++++++++++++++++++++++++++
 src/services/creator.cr   |  24 ++++++++-
 2 files changed, 144 insertions(+), 1 deletion(-)
\`\`\`

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4559 examples, 0 failures (adds 5 new specs: conflict + .md path, conflict + dir-ish path, deeper-nesting preserved, matching section silent, no-dir path silent)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual verification on blog scaffold of all 6 matrix rows, including verifying that the warning line appears exactly once on conflict and never on non-conflict invocations.