### PR TITLE
fix(deploy): classify every failure under HwaroError taxonomy

### DIFF
--- a/spec/unit/deployer_service_spec.cr
+++ b/spec/unit/deployer_service_spec.cr
@@ -5,30 +5,43 @@ require "../../src/config/options/deploy_options"
 
 describe Hwaro::Services::Deployer do
   describe "#run" do
-    it "fails if no targets configured" do
-      config = Hwaro::Models::Config.new
-      deployer = Hwaro::Services::Deployer.new
-      options = Hwaro::Config::Options::DeployOptions.new(targets: [] of String)
+    it "raises HwaroError(HWARO_E_CONFIG) if no targets configured" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        deployer = Hwaro::Services::Deployer.new
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: dir,
+          targets: [] of String,
+        )
 
-      result = deployer.run(options, config)
-      result.should be_false
+        err = expect_raises(Hwaro::HwaroError) { deployer.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain("No deployment targets")
+      end
     end
 
-    it "fails if unknown target specified" do
-      config = Hwaro::Models::Config.new
-      target = Hwaro::Models::DeploymentTarget.new
-      target.name = "production"
-      target.url = "file:///tmp/prod"
-      config.deployment.targets << target
+    it "raises HwaroError(HWARO_E_USAGE) if an unknown target is specified" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "production"
+        target.url = "file:///tmp/prod"
+        config.deployment.targets << target
 
-      deployer = Hwaro::Services::Deployer.new
-      options = Hwaro::Config::Options::DeployOptions.new(targets: ["staging"])
+        deployer = Hwaro::Services::Deployer.new
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: dir,
+          targets: ["staging"],
+        )
 
-      result = deployer.run(options, config)
-      result.should be_false
+        err = expect_raises(Hwaro::HwaroError) { deployer.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        (err.message || "").should contain("Unknown deploy target: staging")
+        (err.hint || "").should contain("production")
+      end
     end
 
-    it "fails if source directory missing" do
+    it "raises HwaroError(HWARO_E_CONFIG) if the source directory is missing" do
       Dir.mktmpdir do |dir|
         config = Hwaro::Models::Config.new
         target = Hwaro::Models::DeploymentTarget.new
@@ -42,8 +55,9 @@ describe Hwaro::Services::Deployer do
           targets: ["production"]
         )
 
-        result = deployer.run(options, config)
-        result.should be_false
+        err = expect_raises(Hwaro::HwaroError) { deployer.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain("Source directory not found")
       end
     end
 
@@ -528,6 +542,120 @@ describe "Deployer private helpers" do
       # After normalization, "assets\style.css" becomes "assets/style.css"
       # which should NOT match the exclude (exclude is also a literal pattern)
       deployer.test_included_by_target?("assets\\style.css", target).should be_true
+    end
+  end
+
+  describe "classified error surface" do
+    it "raises HwaroError(HWARO_E_CONFIG) when target has neither url nor command" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "bare"
+        target.url = ""
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: dir, targets: ["bare"])
+        err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain("missing 'url'")
+      end
+    end
+
+    it "raises HwaroError(HWARO_E_CONFIG) on an unsupported URL scheme with no command override" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "unknown"
+        target.url = "gopher://example.com"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: dir, targets: ["unknown"])
+        err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain("Unsupported deploy target URL scheme")
+      end
+    end
+
+    it "raises HwaroError(HWARO_E_USAGE) when --max-deletes limit is exceeded" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(src_dir)
+        File.write(File.join(src_dir, "keep.html"), "x")
+        FileUtils.mkdir_p(dest_dir)
+        # Seed the destination with more files than the limit.
+        10.times { |i| File.write(File.join(dest_dir, "extra-#{i}.html"), "y") }
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{dest_dir}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: src_dir, targets: ["local"], max_deletes: 5,
+        )
+        err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        (err.message || "").should contain("Refusing to delete")
+        (err.message || "").should contain("max_deletes: 5")
+        # The existing "extra-*" files must remain on disk — the safety
+        # limit aborted the plan before any deletion happened.
+        Dir.children(dest_dir).count(&.starts_with?("extra-")).should eq(10)
+      end
+    end
+
+    it "raises HwaroError(HWARO_E_USAGE) when source and destination overlap" do
+      Dir.mktmpdir do |dir|
+        # Deploy INTO a subdirectory of the source — classic overlap that
+        # could wipe the source files during a delete pass.
+        src_dir = dir
+        dest_dir = File.join(dir, "nested")
+        File.write(File.join(src_dir, "keep.html"), "x")
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "nested"
+        target.url = "file://#{dest_dir}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: src_dir, targets: ["nested"])
+        err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        (err.message || "").should contain("source and destination overlap")
+      end
+    end
+
+    it "propagates HwaroError from deploy_structured as per-target payload with the correct code" do
+      # Regression: a `--max-deletes` refusal used to surface in --json as
+      # HWARO_E_NETWORK with the generic "Deploy target '<name>' failed"
+      # message; now it carries the classified HWARO_E_USAGE code and the
+      # real "Refusing to delete N files" text.
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(src_dir)
+        File.write(File.join(src_dir, "keep.html"), "x")
+        FileUtils.mkdir_p(dest_dir)
+        10.times { |i| File.write(File.join(dest_dir, "extra-#{i}.html"), "y") }
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{dest_dir}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: src_dir, targets: ["local"], max_deletes: 5,
+        )
+        results = Hwaro::Services::Deployer.new.deploy_structured(options, config)
+        results.size.should eq(1)
+        result = results.first
+        result.status.should eq("error")
+        err = result.error.not_nil!
+        err["code"].should eq(Hwaro::Errors::HWARO_E_USAGE)
+        (err["message"] || "").should contain("Refusing to delete")
+      end
     end
   end
 end

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -98,8 +98,11 @@ module Hwaro
             exit(overall == "ok" ? 0 : worst_exit_for(results))
           end
 
-          ok = Services::Deployer.new.run(options)
-          exit(1) unless ok
+          # Deployer#run raises Hwaro::HwaroError on failure; the Runner
+          # catches it and emits the classified `Error [HWARO_E_XXX]: …`
+          # line with the right exit code. A successful return is a
+          # no-op — the Runner exits 0 at the end of `run` automatically.
+          Services::Deployer.new.run(options)
         end
 
         # Pick the most severe exit code across failing targets so CI can

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -176,23 +176,31 @@ module Hwaro
             [] of String
           end
 
-        return results if target_names.empty?
+        if target_names.empty?
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONFIG,
+            message: "No deployment targets configured.",
+            hint: "Add '[[deployment.targets]]' to config.toml, or pass target names: hwaro deploy <targets>",
+          )
+        end
 
         targets = target_names.compact_map do |name|
           target = deployment.target_named(name)
           if target
             target
           else
+            available = deployment.targets.map(&.name).join(", ")
+            hint = available.empty? ? nil.as(String?) : "Configured targets: #{available}."
             results << DeployResult.new(
               name: name,
               status: "error",
               created: 0, updated: 0, deleted: 0,
               duration_ms: 0.0,
               error: {
-                "code"     => Hwaro::Errors::HWARO_E_CONFIG,
-                "category" => Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_CONFIG).to_s,
+                "code"     => Hwaro::Errors::HWARO_E_USAGE,
+                "category" => Hwaro::Errors.category_for(Hwaro::Errors::HWARO_E_USAGE).to_s,
                 "message"  => "Unknown deploy target: #{name}",
-                "hint"     => nil.as(String?),
+                "hint"     => hint,
               } of String => String?,
             )
             nil
@@ -227,9 +235,14 @@ module Hwaro
         rescue ex : Hwaro::HwaroError
           error = ex
         rescue ex
+          # Any non-`HwaroError` reaching here is an unexpected defect,
+          # not a network problem. Classifying as HWARO_E_INTERNAL avoids
+          # the older blanket-`HWARO_E_NETWORK` that made bugs masquerade
+          # as connectivity issues and hid the original message behind a
+          # generic "Deploy target 'X' failed" line.
           error = Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_NETWORK,
-            message: ex.message || "Deploy target '#{target.name}' failed",
+            code: Hwaro::Errors::HWARO_E_INTERNAL,
+            message: ex.message || "Deploy target '#{target.name}' failed with #{ex.class}",
           )
         end
 
@@ -297,8 +310,11 @@ module Hwaro
 
         url = target.url
         if url.empty?
-          Logger.error "Target '#{target.name}' is missing 'url' (or 'command')."
-          return {false, TargetCounts.new}
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONFIG,
+            message: "Target '#{target.name}' is missing 'url' (or 'command').",
+            hint: "Set either 'url' or 'command' in [[deployment.targets]].",
+          )
         end
 
         if directory_destination = local_directory_destination(url)
@@ -311,8 +327,12 @@ module Hwaro
           return {ok, TargetCounts.new}
         end
 
-        Logger.error "Unsupported deploy target URL scheme for '#{target.name}': #{url}"
-        {false, TargetCounts.new}
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          message: "Unsupported deploy target URL scheme for '#{target.name}': #{url}",
+          hint: "Set 'command' for this target to use external tools (rsync/aws/gsutil/etc). " \
+                "Example: command = \"aws s3 sync {source}/ {url} --delete\"",
+        )
       end
 
       def run(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Bool
@@ -323,9 +343,11 @@ module Hwaro
         source_dir = File.expand_path(source_dir)
 
         unless Dir.exists?(source_dir)
-          Logger.error "Source directory not found: #{source_dir}"
-          Logger.info "Run 'hwaro build' first, or pass '--source DIR'."
-          return false
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONFIG,
+            message: "Source directory not found: #{source_dir}",
+            hint: "Run 'hwaro build' first, or pass '--source DIR'.",
+          )
         end
 
         target_names =
@@ -340,28 +362,40 @@ module Hwaro
           end
 
         if target_names.empty?
-          Logger.error "No deployment targets configured."
-          Logger.info "Add '[[deployment.targets]]' to config.toml, or pass target names: hwaro deploy <targets>"
-          return false
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONFIG,
+            message: "No deployment targets configured.",
+            hint: "Add '[[deployment.targets]]' to config.toml, or pass target names: hwaro deploy <targets>",
+          )
         end
 
-        targets = target_names.compact_map do |name|
+        targets = target_names.map do |name|
           target = deployment.target_named(name)
-          if target
-            target
-          else
-            Logger.error "Unknown deploy target: #{name}"
-            nil
+          unless target
+            available = deployment.targets.map(&.name).join(", ")
+            hint = if available.empty?
+                     "No targets are configured. Add '[[deployment.targets]]' to config.toml."
+                   else
+                     "Configured targets: #{available}."
+                   end
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "Unknown deploy target: #{name}",
+              hint: hint,
+            )
           end
+          target
         end
-
-        return false if targets.empty?
 
         effective = EffectiveOptions.new(deployment, options)
 
+        # All failure paths inside deploy_target now raise HwaroError, so
+        # the loop body either completes or the error propagates up to
+        # the Runner which renders the classified error + exit code. The
+        # Bool return is kept for backwards compatibility with callers
+        # that only care about success/skip.
         targets.each do |target|
-          ok = deploy_target(target, source_dir, effective, deployment)
-          return false unless ok
+          deploy_target(target, source_dir, effective, deployment)
         end
 
         true
@@ -395,8 +429,11 @@ module Hwaro
 
         url = target.url
         if url.empty?
-          Logger.error "Target '#{target.name}' is missing 'url' (or 'command')."
-          return false
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONFIG,
+            message: "Target '#{target.name}' is missing 'url' (or 'command').",
+            hint: "Set either 'url' or 'command' in [[deployment.targets]].",
+          )
         end
 
         if directory_destination = local_directory_destination(url)
@@ -408,14 +445,12 @@ module Hwaro
           return deploy_via_command(target, source_dir, auto_command, effective)
         end
 
-        Logger.error "Unsupported deploy target URL scheme for '#{target.name}': #{url}"
-        Logger.info "Set 'command' for this target to use external tools (rsync/aws/gsutil/etc)."
-        Logger.info "Example:"
-        Logger.info "  [[deployment.targets]]"
-        Logger.info "  name = \"prod\""
-        Logger.info "  url = \"s3://my-bucket\""
-        Logger.info "  command = \"aws s3 sync {source}/ {url} --delete\""
-        false
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          message: "Unsupported deploy target URL scheme for '#{target.name}': #{url}",
+          hint: "Set 'command' for this target to use external tools (rsync/aws/gsutil/etc). " \
+                "Example: command = \"aws s3 sync {source}/ {url} --delete\"",
+        )
       end
 
       # Shell metacharacters that indicate potentially dangerous commands.
@@ -462,11 +497,17 @@ module Hwaro
           result.output.each_line { |line| Logger.info "  #{line}" }
         end
         unless result.success
-          Logger.error "Deploy command failed (exit #{result.exit_code})."
+          # Surface stderr from the subprocess before raising so the user
+          # sees the tool-specific failure detail; the classified error
+          # itself carries only the summary exit-code info.
           unless result.error.empty?
             result.error.each_line { |line| Logger.error "  #{line}" }
           end
-          return false
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_IO,
+            message: "Deploy command failed (exit #{result.exit_code}): #{expanded}",
+            hint: "Inspect the stderr above for details from the deploy tool.",
+          )
         end
 
         Logger.success "Deploy command completed."
@@ -485,8 +526,11 @@ module Hwaro
         dest_dir_expanded = File.expand_path(dest_dir)
 
         if nested_path?(source_dir, dest_dir_expanded) || nested_path?(dest_dir_expanded, source_dir)
-          Logger.error "Refusing to deploy: source and destination overlap."
-          return {false, counts}
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "Refusing to deploy: source and destination overlap.",
+            hint: "source: #{source_dir} / dest: #{dest_dir_expanded}",
+          )
         end
 
         FileUtils.mkdir_p(dest_dir_expanded)
@@ -494,13 +538,16 @@ module Hwaro
         desired = build_desired_map(source_dir, target)
         existing = list_existing_files(dest_dir_expanded)
 
-        return {false, counts} unless validate_strip_index_html_for_filesystem(target, desired.keys)
-        return {false, counts} unless validate_destination_paths(dest_dir_expanded, desired.keys)
+        validate_strip_index_html_for_filesystem(target, desired.keys)
+        validate_destination_paths(dest_dir_expanded, desired.keys)
 
         to_delete = compute_deletes(existing, desired.keys, target)
         if effective.max_deletes != -1 && to_delete.size > effective.max_deletes
-          Logger.error "Refusing to delete #{to_delete.size} files (max_deletes: #{effective.max_deletes})."
-          return {false, counts}
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "Refusing to delete #{to_delete.size} files (max_deletes: #{effective.max_deletes}).",
+            hint: "Set deployment.maxDeletes = -1 (or pass --max-deletes -1) to disable the limit.",
+          )
         end
 
         to_copy, _skipped = compute_copies(desired, dest_dir_expanded, effective.force)
@@ -547,10 +594,11 @@ module Hwaro
         dest_dir = File.expand_path(dest_dir)
 
         if nested_path?(source_dir, dest_dir) || nested_path?(dest_dir, source_dir)
-          Logger.error "Refusing to deploy: source and destination overlap."
-          Logger.info "source: #{source_dir}"
-          Logger.info "dest:   #{dest_dir}"
-          return false
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "Refusing to deploy: source and destination overlap.",
+            hint: "source: #{source_dir} / dest: #{dest_dir}",
+          )
         end
 
         FileUtils.mkdir_p(dest_dir)
@@ -558,14 +606,16 @@ module Hwaro
         desired = build_desired_map(source_dir, target)
         existing = list_existing_files(dest_dir)
 
-        return false unless validate_strip_index_html_for_filesystem(target, desired.keys)
-        return false unless validate_destination_paths(dest_dir, desired.keys)
+        validate_strip_index_html_for_filesystem(target, desired.keys)
+        validate_destination_paths(dest_dir, desired.keys)
 
         to_delete = compute_deletes(existing, desired.keys, target)
         if effective.max_deletes != -1 && to_delete.size > effective.max_deletes
-          Logger.error "Refusing to delete #{to_delete.size} files (max_deletes: #{effective.max_deletes})."
-          Logger.info "Set deployment.maxDeletes = -1 (or pass --max-deletes -1) to disable the limit."
-          return false
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "Refusing to delete #{to_delete.size} files (max_deletes: #{effective.max_deletes}).",
+            hint: "Set deployment.maxDeletes = -1 (or pass --max-deletes -1) to disable the limit.",
+          )
         end
 
         to_copy, skipped = compute_copies(desired, dest_dir, effective.force)
@@ -697,21 +747,22 @@ module Hwaro
         normalized
       end
 
-      private def validate_strip_index_html_for_filesystem(target : Models::DeploymentTarget, dest_paths : Array(String)) : Bool
-        return true unless target.strip_index_html
+      private def validate_strip_index_html_for_filesystem(target : Models::DeploymentTarget, dest_paths : Array(String)) : Nil
+        return unless target.strip_index_html
         dest_paths.each do |path|
           next if path.empty?
           prefix = "#{path}/"
           if dest_paths.any?(&.starts_with?(prefix))
-            Logger.error "stripIndexHTML cannot be used with file:// deployments when both '#{path}' and '#{prefix}...' exist."
-            Logger.info "Disable stripIndexHTML for target '#{target.name}', or deploy via an object store."
-            return false
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_CONFIG,
+              message: "stripIndexHTML cannot be used with file:// deployments when both '#{path}' and '#{prefix}...' exist.",
+              hint: "Disable stripIndexHTML for target '#{target.name}', or deploy via an object store.",
+            )
           end
         end
-        true
       end
 
-      private def validate_destination_paths(dest_dir : String, dest_paths : Array(String)) : Bool
+      private def validate_destination_paths(dest_dir : String, dest_paths : Array(String)) : Nil
         dest_set = dest_paths.to_set
 
         dest_paths.each do |rel|
@@ -722,29 +773,36 @@ module Hwaro
             parts[0...-1].each do |part|
               prefix = prefix.empty? ? part : "#{prefix}/#{part}"
               if dest_set.includes?(prefix)
-                Logger.error "Filesystem deploy conflict: both file '#{prefix}' and path '#{rel}' exist."
-                return false
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_IO,
+                  message: "Filesystem deploy conflict: both file '#{prefix}' and path '#{rel}' exist.",
+                  hint: "Remove one or the other before deploying.",
+                )
               end
             end
           end
 
           full_path = File.join(dest_dir, rel)
           if Dir.exists?(full_path)
-            Logger.error "Destination path is a directory but needs a file: #{rel}"
-            return false
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_IO,
+              message: "Destination path is a directory but needs a file: #{rel}",
+              hint: "Remove the existing directory at #{full_path} or rename the source file.",
+            )
           end
 
           current = dest_dir
           parts[0...-1].each do |part|
             current = File.join(current, part)
             if File.file?(current)
-              Logger.error "Destination path is a file but needs a directory: #{current}"
-              return false
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_IO,
+                message: "Destination path is a file but needs a directory: #{current}",
+                hint: "Remove the existing file at #{current} or rename the source.",
+              )
             end
           end
         end
-
-        true
       end
 
       # Compare two files for identical content. Uses size check first,
@@ -839,7 +897,13 @@ module Hwaro
       end
 
       private def confirm?(prompt : String) : Bool
-        raise "Cannot prompt for confirmation (stdin is not a TTY)." unless STDIN.tty?
+        unless STDIN.tty?
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "Cannot prompt for confirmation: stdin is not a TTY.",
+            hint: "Pass --force to skip confirmation prompts in non-interactive environments.",
+          )
+        end
         Logger.warn "#{prompt} [y/N]"
         input = STDIN.gets
         (input.try(&.strip.downcase) == "y")


### PR DESCRIPTION
Closes #429, closes #430.

## Summary

Every deploy failure in \`Services::Deployer\` used to \`Logger.error\` + \`return false\`; the outer rescue at \`deployer.cr:229\` then wrapped any escaping exception as \`HwaroError(HWARO_E_NETWORK)\` with a generic \`"Deploy target 'X' failed"\` message. Three symptoms:

- Text-mode output was \`Error: <message>\` with exit 1, not the documented \`Error [HWARO_E_XXX]: …\` form + per-code exit (2/3/5/6/7).
- \`--json\` classified everything as network, stripping the real reason (\`--max-deletes\` refusal, config error, etc.) behind a bland "Deploy target 'X' failed" line.
- Actual bugs in the deployer looked like network errors — hard to distinguish from legitimate connectivity issues.

## Mapping

Each failure site now raises a classified \`HwaroError\` with the right code + a concrete \`hint:\`.

| Site | Code | Exit |
|---|---|---|
| Source dir not found | \`HWARO_E_CONFIG\` | 3 |
| No deployment targets | \`HWARO_E_CONFIG\` | 3 |
| Unknown deploy target | \`HWARO_E_USAGE\` | 2 |
| Target missing url/command | \`HWARO_E_CONFIG\` | 3 |
| Unsupported URL scheme | \`HWARO_E_CONFIG\` | 3 |
| Deploy command nonzero exit | \`HWARO_E_IO\` | 6 |
| Source/dest overlap | \`HWARO_E_USAGE\` | 2 |
| \`--max-deletes\` refusal | \`HWARO_E_USAGE\` | 2 |
| stripIndexHTML conflict | \`HWARO_E_CONFIG\` | 3 |
| Filesystem file↔dir conflict | \`HWARO_E_IO\` | 6 |
| Confirm prompt in non-TTY | \`HWARO_E_USAGE\` | 2 |

The outer \`rescue ex\` at line 229 now classifies non-\`HwaroError\` leftovers as \`HWARO_E_INTERNAL\` instead of \`HWARO_E_NETWORK\` so genuine bugs stop masquerading as connectivity issues.

The "unknown deploy target" error in both text and \`--json\` paths now lists available target names in the hint, which is what the old text output documented but never surfaced in the classified payload.

## Before / after

Before (\`--json\` on a \`--max-deletes\` refusal):
\`\`\`json
{"status":"error","targets":[{"name":"local","status":"error","error":{"code":"HWARO_E_NETWORK","category":"network","message":"Deploy target 'local' failed","hint":null}}]}
\`\`\`

After:
\`\`\`json
{"status":"error","targets":[{"name":"local","status":"error","error":{"code":"HWARO_E_USAGE","category":"usage","message":"Refusing to delete 10 files (max_deletes: 5).","hint":"Set deployment.maxDeletes = -1 (or pass --max-deletes -1) to disable the limit."}}]}
\`\`\`

Before (text, unknown target):
\`\`\`
Unknown deploy target: nosuch
# exit 1
\`\`\`

After:
\`\`\`
Error [HWARO_E_USAGE]: Unknown deploy target: nosuch
Configured targets: local, staging, prod.
# exit 2
\`\`\`

## Mechanics

- \`deploy_target\` / \`deploy_target_with_counts\` still return \`Bool\` for backwards compatibility but the \`false\` branch is now unreachable — every failure raises instead.
- \`Services::Deployer#run\` no longer short-circuits on \`ok == false\`; the loop body raises and the error propagates to the Runner, which renders the classified form.
- \`deploy_structured\`'s per-target rescue at line 227 is kept so a single failed target still produces a structured error row (rather than aborting the whole run mid-way in JSON mode). Its no-targets path now raises consistently with \`run\`.

## Diff footprint

\`\`\`
 spec/unit/deployer_service_spec.cr | 166 ++++++++++++++++++++++++++----
 src/cli/commands/deploy_command.cr |   7 +-
 src/services/deployer.cr           | 202 ++++++++++++++++++++++++-------------
 3 files changed, 285 insertions(+), 90 deletions(-)
\`\`\`

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4564 examples, 0 failures (adds 5 new specs covering missing-url, unsupported-scheme, max-deletes, source/dest overlap, and the structured-payload classification regression; upgrades 3 existing "fails with …" specs to assert classified codes)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual on blog scaffold + local file:// target: unknown target, missing URL, unsupported scheme, max-deletes refusal, missing source dir all emit \`Error [HWARO_E_XXX]: …\` in text mode and the structured payload under \`--json\`, with correct per-code exit codes (2/3/2/2/3 respectively)
- [x] Happy path deploys continue to work unchanged.