### PR TITLE
fix(deploy): reject unknown placeholders in command templates

### DIFF
--- a/spec/unit/deployer_service_spec.cr
+++ b/spec/unit/deployer_service_spec.cr
@@ -626,6 +626,68 @@ describe "Deployer private helpers" do
       end
     end
 
+    it "raises HwaroError(HWARO_E_CONFIG) on unknown command placeholders" do
+      # Typos like `{srouce}` and forward-looking tokens like `{bucket}`
+      # used to reach the shell as literals and cause confusing
+      # downstream errors. The validator now rejects anything that still
+      # matches `\{name\}` after expansion.
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "typo"
+        target.url = "custom://"
+        target.command = "echo src={srouce} bucket={bucket}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: dir, targets: ["typo"])
+        err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain("Unknown placeholder(s)")
+        (err.message || "").should contain("{srouce}")
+        (err.message || "").should contain("{bucket}")
+        # Supported-placeholder list in the hint for discoverability.
+        (err.hint || "").should contain("{source}")
+        (err.hint || "").should contain("{url}")
+        (err.hint || "").should contain("{target}")
+      end
+    end
+
+    it "leaves commands with only supported placeholders alone" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "good"
+        target.url = "custom://"
+        # {target} inside a comment-style literal string should also pass
+        target.command = "true # {source} {url} {target}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: dir, targets: ["good"])
+        # Does not raise — `true` exits 0, no HwaroError surfaces.
+        Hwaro::Services::Deployer.new.run(options, config).should be_true
+      end
+    end
+
+    it "catches unknown placeholders even during --dry-run" do
+      # Dry-run still needs to expand + validate the template so typos
+      # are caught without waiting for the user to trigger a real deploy.
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "typo"
+        target.url = "custom://"
+        target.command = "echo {unknown}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: dir, targets: ["typo"], dry_run: true,
+        )
+        err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain("{unknown}")
+      end
+    end
+
     it "propagates HwaroError from deploy_structured as per-target payload with the correct code" do
       # Regression: a `--max-deletes` refusal used to surface in --json as
       # HWARO_E_NETWORK with the generic "Deploy target '<name>' failed"

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -909,11 +909,49 @@ module Hwaro
         (input.try(&.strip.downcase) == "y")
       end
 
+      # Supported placeholders in `command = "..."` templates. Listed
+      # here so `expand_placeholders` can produce a helpful error message
+      # when an unknown `{foo}` slips through (typo, forward-looking
+      # name, etc.) instead of sending the literal to the shell.
+      COMMAND_PLACEHOLDERS = {"source", "url", "target"}
+
+      # Pattern used to detect *remaining* placeholders after expansion.
+      # Anything that still matches is unknown and rejected.
+      private COMMAND_PLACEHOLDER_RE = /\{([a-zA-Z_][\w-]*)\}/
+
       private def expand_placeholders(command : String, source_dir : String, target : Models::DeploymentTarget) : String
-        command
+        expanded = command
           .gsub("{source}", shell_escape(source_dir))
           .gsub("{url}", shell_escape(target.url))
           .gsub("{target}", shell_escape(target.name))
+
+        validate_no_unexpanded_placeholders!(command, expanded, target)
+        expanded
+      end
+
+      # Raise HWARO_E_CONFIG if the expanded command still contains any
+      # `{name}` tokens — catches typos like `{srouce}` and forward-
+      # looking placeholders (`{bucket}`, `{region}`) before the literal
+      # reaches the underlying deploy tool and produces a confusing
+      # downstream error.
+      private def validate_no_unexpanded_placeholders!(
+        original : String,
+        expanded : String,
+        target : Models::DeploymentTarget,
+      ) : Nil
+        unresolved = expanded.scan(COMMAND_PLACEHOLDER_RE)
+          .map { |m| m[1] }
+          .uniq!
+          .reject { |name| COMMAND_PLACEHOLDERS.includes?(name) }
+
+        return if unresolved.empty?
+
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          message: "Unknown placeholder(s) in 'command' for target '#{target.name}': " \
+                   "#{unresolved.map { |n| "{#{n}}" }.join(", ")}",
+          hint: "Supported placeholders: #{COMMAND_PLACEHOLDERS.to_a.sort.map { |n| "{#{n}}" }.join(", ")}.",
+        )
       end
 
       # Escape a string for safe interpolation into a shell command.


### PR DESCRIPTION
Closes #432.

Companion note: #431 was closed separately as resolved-in-#433 — PR #433's classified-error migration collapsed the stderr/stdout stream contamination that #431 described.

## Summary

\`command = "{srouce}"\` (typo) or a forward-looking \`{bucket}\` slipped through \`expand_placeholders\` as literal text and reached the shell, where downstream tools produced confusing errors like \`file not found: {srouce}\`. Users had no signal that their placeholder name didn't match what hwaro supports.

## Before / after

### Before

\`\`\`console
\$ hwaro deploy typo --dry-run
      Deploy  Target: typo
Dry run: would run command:
  echo src={srouce} url='custom://' bucket={bucket}
# (runs with literals; user discovers typo only when AWS/gsutil complains)
\`\`\`

### After

\`\`\`console
\$ hwaro deploy typo --dry-run
      Deploy  Target: typo
Error [HWARO_E_CONFIG]: Unknown placeholder(s) in 'command' for target 'typo': {srouce}, {bucket}
Supported placeholders: {source}, {target}, {url}.
\$ echo \$?
3
\`\`\`

Also works under \`--json\` (structured payload with \`HWARO_E_CONFIG\`) and catches the issue during \`--dry-run\` so no subprocess is ever invoked with a busted template.

## Changes

- New \`COMMAND_PLACEHOLDERS\` constant lists the supported names in one place so future additions stay in sync with the error hint.
- \`expand_placeholders\` now calls \`validate_no_unexpanded_placeholders!\` after substitution; anything still matching \`\\{name\\}\` surfaces as \`HwaroError(HWARO_E_CONFIG)\` with the unresolved names + the supported set.
- Works uniformly across: regular deploy, \`--dry-run\`, \`--json\` (both paths since both call \`expand_placeholders\`), and auto-generated commands for known URL schemes (\`s3\`, \`gs\`, \`az\`) — those templates only use supported placeholders today, so they remain quiet.

## Diff footprint

\`\`\`
 spec/unit/deployer_service_spec.cr | 62 +++++++++++++++++++++++++++++++++++++
 src/services/deployer.cr           | 40 +++++++++++++++++++++++-
 2 files changed, 101 insertions(+), 1 deletion(-)
\`\`\`

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4567 examples, 0 failures (adds 3 new specs: rejects unknown placeholders with correct code + message + hint, leaves valid-placeholder commands alone, catches typos during \`--dry-run\` before any subprocess runs)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual: typo + regular deploy, typo + \`--dry-run\`, typo + \`--json\`, valid placeholders happy path all behave as expected.