### PR TITLE
fix(doctor): exit non-zero on errors and reclassify build-blocking diagnostics

### DIFF
--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -348,6 +348,20 @@ hwaro doctor               # Diagnose config, template, and structure issues
 hwaro doctor --fix         # Add missing config sections to config.toml
 ```
 
+**Exit codes.** `doctor` returns a classified exit code based on the most
+severe issue reported, so CI pipelines can gate on it directly:
+
+| Outcome | Exit |
+|---|---|
+| No issues, warnings only, or info-level findings | `0` |
+| Config errors (missing/broken `config.toml`) | `3` (`HWARO_E_CONFIG`) |
+| Template errors (missing required file, unclosed tags) | `4` (`HWARO_E_TEMPLATE`) |
+| Content errors (malformed front matter, when the check lands) | `5` (`HWARO_E_CONTENT`) |
+| Other error-level issues | `1` |
+
+Warnings (empty `base_url`, trailing slash, duplicate taxonomy names, etc.)
+are advisory and never change the exit code.
+
 For content validation, use `hwaro tool validate`. See [doctor](/start/tools/doctor/) for details.
 
 ### tool

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -32,9 +32,13 @@ end
 describe Hwaro::Services::Doctor do
   describe "#run" do
     describe "config diagnostics" do
-      it "warns when config file is missing" do
+      it "reports missing config file as an error (build-blocking)" do
         issues = run_doctor_no_config
-        issues.any? { |i| i.category == "config" && i.message.includes?("not found") }.should be_true
+        issues.any? do |i|
+          i.category == "config" &&
+            i.message.includes?("not found") &&
+            i.level == :error
+        end.should be_true
       end
 
       it "warns when base_url is empty" do
@@ -127,7 +131,7 @@ describe Hwaro::Services::Doctor do
     end
 
     describe "template diagnostics" do
-      it "warns when templates directory is missing" do
+      it "reports missing templates directory as an error (build-blocking)" do
         Dir.mktmpdir do |dir|
           config_path = File.join(dir, "config.toml")
           File.write(config_path, base_config)
@@ -135,11 +139,13 @@ describe Hwaro::Services::Doctor do
 
           doctor = Hwaro::Services::Doctor.new(content_dir: content_dir, config_path: config_path, templates_dir: File.join(dir, "templates"))
           issues = doctor.run
-          issues.any? { |i| i.category == "template" && i.message.includes?("not found") }.should be_true
+          issues.any? do |i|
+            i.category == "template" && i.message.includes?("not found") && i.level == :error
+          end.should be_true
         end
       end
 
-      it "warns when required template files are missing" do
+      it "reports missing required template files as errors (build-blocking)" do
         Dir.mktmpdir do |dir|
           config_path = File.join(dir, "config.toml")
           File.write(config_path, base_config)
@@ -151,12 +157,12 @@ describe Hwaro::Services::Doctor do
           doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path, templates_dir: templates_dir)
           issues = doctor.run
           tpl_issues = issues.select { |i| i.category == "template" }
-          tpl_issues.any?(&.message.includes?("section.html")).should be_true
+          tpl_issues.any? { |i| i.message.includes?("section.html") && i.level == :error }.should be_true
           tpl_issues.any?(&.message.includes?("page.html")).should be_false
         end
       end
 
-      it "warns on unclosed template block tags" do
+      it "reports unclosed template block tags as errors (build-blocking)" do
         Dir.mktmpdir do |dir|
           config_path = File.join(dir, "config.toml")
           File.write(config_path, base_config)
@@ -167,7 +173,9 @@ describe Hwaro::Services::Doctor do
 
           doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path, templates_dir: templates_dir)
           issues = doctor.run
-          issues.any? { |i| i.message.includes?("unclosed template block") }.should be_true
+          issues.any? do |i|
+            i.message.includes?("unclosed template block") && i.level == :error
+          end.should be_true
         end
       end
 

--- a/spec/unit/tool_commands_spec.cr
+++ b/spec/unit/tool_commands_spec.cr
@@ -221,6 +221,66 @@ describe Hwaro::CLI::Commands::Tool::DoctorCommand do
       flag.not_nil!.value_hint.should eq("DIR")
     end
   end
+
+  # Pin the exit-code contract so CI pipelines can rely on
+  # `hwaro doctor` failing non-zero when it reports errors.
+  describe "#exit_code_for (classified exit)" do
+    it "returns EXIT_SUCCESS when no issues are reported" do
+      doctor_exit_code_for([] of Hwaro::Services::Issue).should eq(Hwaro::Errors::EXIT_SUCCESS)
+    end
+
+    it "returns EXIT_SUCCESS when only warnings and infos are reported" do
+      issues = [
+        Hwaro::Services::Issue.new(id: "base-url-missing", level: :warning, category: "config", file: nil, message: "w"),
+        Hwaro::Services::Issue.new(id: "missing-config-pwa", level: :info, category: "config_missing", file: nil, message: "i"),
+      ]
+      doctor_exit_code_for(issues).should eq(Hwaro::Errors::EXIT_SUCCESS)
+    end
+
+    it "returns EXIT_CONFIG on a config-category error" do
+      issues = [
+        Hwaro::Services::Issue.new(id: "config-not-found", level: :error, category: "config", file: nil, message: "missing"),
+      ]
+      doctor_exit_code_for(issues).should eq(Hwaro::Errors::EXIT_CONFIG)
+    end
+
+    it "returns EXIT_TEMPLATE on a template-category error" do
+      issues = [
+        Hwaro::Services::Issue.new(id: "template-unclosed-block", level: :error, category: "template", file: nil, message: "unclosed"),
+      ]
+      doctor_exit_code_for(issues).should eq(Hwaro::Errors::EXIT_TEMPLATE)
+    end
+
+    it "picks the worst (numerically highest) exit when multiple categories error out" do
+      # EXIT_TEMPLATE (4) beats EXIT_CONFIG (3); both of those beat
+      # EXIT_GENERIC (1). Mirrors deploy_command.cr#worst_exit_for.
+      issues = [
+        Hwaro::Services::Issue.new(id: "config-not-found", level: :error, category: "config", file: nil, message: "c"),
+        Hwaro::Services::Issue.new(id: "template-unclosed-block", level: :error, category: "template", file: nil, message: "t"),
+      ]
+      doctor_exit_code_for(issues).should eq(Hwaro::Errors::EXIT_TEMPLATE)
+    end
+
+    it "ignores warnings when any error is present" do
+      issues = [
+        Hwaro::Services::Issue.new(id: "base-url-missing", level: :warning, category: "config", file: nil, message: "w"),
+        Hwaro::Services::Issue.new(id: "template-unclosed-block", level: :error, category: "template", file: nil, message: "t"),
+      ]
+      doctor_exit_code_for(issues).should eq(Hwaro::Errors::EXIT_TEMPLATE)
+    end
+  end
+end
+
+# Reopen the command to expose the private exit-code helper for the
+# spec above without actually invoking `exit(n)` via `run`.
+class Hwaro::CLI::Commands::Tool::DoctorCommand
+  def test_exit_code_for(issues)
+    exit_code_for(issues)
+  end
+end
+
+private def doctor_exit_code_for(issues : Array(Hwaro::Services::Issue)) : Int32
+  Hwaro::CLI::Commands::Tool::DoctorCommand.new.test_exit_code_for(issues)
 end
 
 describe Hwaro::CLI::Commands::Tool::PlatformCommand do

--- a/src/cli/commands/tool/doctor_command.cr
+++ b/src/cli/commands/tool/doctor_command.cr
@@ -2,6 +2,7 @@ require "json"
 require "colorize"
 require "option_parser"
 require "../../metadata"
+require "../../../utils/errors"
 require "../../../utils/logger"
 require "../../../services/doctor"
 
@@ -103,10 +104,40 @@ module Hwaro
                 },
               }
               puts result.to_json
-              return
+              exit(exit_code_for(issues))
             end
 
             render_human(issues, config_path)
+            exit(exit_code_for(issues))
+          end
+
+          # Map any `:error`-level issues to an appropriate exit code so
+          # CI pipelines can gate on `hwaro doctor` directly. Warnings
+          # and infos don't change the exit code — only real errors do.
+          # Picks the highest-numeric exit across reported errors so
+          # mixed categories surface the most severe failure class
+          # (mirrors `deploy_command.cr#worst_exit_for`).
+          private def exit_code_for(issues : Array(Services::Issue)) : Int32
+            worst = Hwaro::Errors::EXIT_SUCCESS
+            issues.each do |issue|
+              next unless issue.level == :error
+              code = exit_code_for_category(issue.category)
+              worst = code if code > worst
+            end
+            worst
+          end
+
+          private def exit_code_for_category(category : String) : Int32
+            case category
+            when "config", "config_missing"
+              Hwaro::Errors::EXIT_CONFIG
+            when "template"
+              Hwaro::Errors::EXIT_TEMPLATE
+            when "content"
+              Hwaro::Errors::EXIT_CONTENT
+            else
+              Hwaro::Errors::EXIT_GENERIC
+            end
           end
 
           # Render human-readable diagnostics with inline status glyphs per check.

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -143,7 +143,10 @@ module Hwaro
 
       private def check_config(issues : Array(Issue)) : Models::Config?
         unless File.exists?(@config_path)
-          issues << Issue.new(id: "config-not-found", level: :warning, category: "config", file: @config_path, message: "Config file not found")
+          # Missing config.toml blocks every build path (`Config.load`
+          # raises `HWARO_E_CONFIG`), so surface it as an error — not an
+          # advisory — so CI can gate on `doctor`'s exit code.
+          issues << Issue.new(id: "config-not-found", level: :error, category: "config", file: @config_path, message: "Config file not found")
           return
         end
 
@@ -223,10 +226,15 @@ module Hwaro
         end
       end
 
-      # Check templates directory for required files
+      # Check templates directory for required files.
+      #
+      # All template-level problems here are build-blocking — Crinja
+      # refuses to render if templates are missing or have syntax
+      # errors — so they're emitted at `:error` level so CI gates on
+      # `doctor`'s exit code catch them before `hwaro build` runs.
       private def check_templates(issues : Array(Issue))
         unless Dir.exists?(@templates_dir)
-          issues << Issue.new(id: "template-dir-missing", level: :warning, category: "template", file: nil,
+          issues << Issue.new(id: "template-dir-missing", level: :error, category: "template", file: nil,
             message: "Templates directory not found: #{@templates_dir}")
           return
         end
@@ -234,7 +242,7 @@ module Hwaro
         %w[page.html section.html].each do |required|
           path = File.join(@templates_dir, required)
           unless File.exists?(path)
-            issues << Issue.new(id: "template-required-missing", level: :warning, category: "template", file: path,
+            issues << Issue.new(id: "template-required-missing", level: :error, category: "template", file: path,
               message: "Required template file missing: #{required}")
           end
         end
@@ -245,7 +253,9 @@ module Hwaro
         end
       end
 
-      # Basic template syntax check — unclosed tags
+      # Basic template syntax check — unclosed tags.
+      # Unclosed tags raise `HWARO_E_TEMPLATE` during render, so flag
+      # them at :error level rather than :warning.
       private def check_template_syntax(file_path : String, issues : Array(Issue))
         content = File.read(file_path)
 
@@ -257,7 +267,7 @@ module Hwaro
         opens = stripped.scan(/\{%[-\s]*\b(if|for|block|macro)\b/).size
         closes = stripped.scan(/\{%[-\s]*\bend(if|for|block|macro)\b/).size
         if opens != closes
-          issues << Issue.new(id: "template-unclosed-block", level: :warning, category: "template", file: file_path,
+          issues << Issue.new(id: "template-unclosed-block", level: :error, category: "template", file: file_path,
             message: "Possible unclosed template block tag (#{opens} opened, #{closes} closed)")
         end
 
@@ -265,7 +275,7 @@ module Hwaro
         open_vars = stripped.scan(/\{\{/).size
         close_vars = stripped.scan(/\}\}/).size
         if open_vars != close_vars
-          issues << Issue.new(id: "template-mismatched-vars", level: :warning, category: "template", file: file_path,
+          issues << Issue.new(id: "template-mismatched-vars", level: :error, category: "template", file: file_path,
             message: "Mismatched {{ }} variable tags (#{open_vars} opened, #{close_vars} closed)")
         end
       rescue ex


### PR DESCRIPTION
Closes #436.

## Summary

\`hwaro doctor\` never exited non-zero, so CI pipelines couldn't use it as a pre-build gate. Compounding that, three diagnostics that should have been errors (the site literally can't build) were emitted as warnings, which would have been treated as passing anyway once the exit-code contract landed.

## Severity reclassification

| Diagnostic | Before | After |
|---|---|---|
| Missing \`config.toml\` | \`:warning\` | \`:error\` |
| Missing \`templates/\` directory | \`:warning\` | \`:error\` |
| Missing required template file | \`:warning\` | \`:error\` |
| Unclosed template block tag | \`:warning\` | \`:error\` |
| Mismatched \`{{ }}\` variable tags | \`:warning\` | \`:error\` |
| Broken TOML in \`config.toml\` | \`:error\` | \`:error\` (unchanged) |

Advisories that **stay** at \`:warning\`: empty \`base_url\`, trailing slash, default title, duplicate taxonomies/languages, invalid sitemap changefreq/priority, invalid search format. \`missing-config-*\` sections remain \`:info\` since they're optional.

## Exit code policy

Mirrors \`deploy_command.cr#worst_exit_for\` — pick the highest numeric exit across \`:error\`-level issues:

| Outcome | Exit |
|---|---|
| No errors (regardless of warnings/infos) | \`EXIT_SUCCESS\` (0) |
| Config-category errors | \`EXIT_CONFIG\` (3) |
| Template-category errors | \`EXIT_TEMPLATE\` (4) |
| Content-category errors (reserved for #437) | \`EXIT_CONTENT\` (5) |
| Other \`:error\` issues | \`EXIT_GENERIC\` (1) |
| Mixed categories | most severe wins |

Works identically for text and \`--json\` modes — the JSON payload already carried \`level\` per issue, so consumers who parsed the summary already had the data; they just got the wrong exit.

## Before / after

Before:
\`\`\`console
\$ rm config.toml && hwaro doctor
Running diagnostics...
  config.toml
    [warn] file present & parseable
    …
\$ echo \$?
0
\`\`\`

After:
\`\`\`console
\$ rm config.toml && hwaro doctor
Running diagnostics...
  config.toml
    [err]  file present & parseable
    …
\$ echo \$?
3

\$ hwaro doctor           # broken template + broken config
…
    [err]  file present & parseable   # config
    [err]  template syntax            # template
\$ echo \$?
4    # EXIT_TEMPLATE wins over EXIT_CONFIG
\`\`\`

Docs \`docs/content/start/cli.md\` now document the classified exit codes so users know what to expect.

## Diff footprint

\`\`\`
 docs/content/start/cli.md               | 14 ++++++++
 spec/unit/doctor_spec.cr                | 24 ++++++++-----
 spec/unit/tool_commands_spec.cr         | 60 +++++++++++++++++++++++++++++++++
 src/cli/commands/tool/doctor_command.cr | 33 +++++++++++++++++-
 src/services/doctor.cr                  | 24 +++++++++----
 5 files changed, 139 insertions(+), 16 deletions(-)
\`\`\`

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4573 examples, 0 failures (upgrades 4 existing severity specs from generic level checks to classified \`level == :error\`; adds 6 new specs for the exit-code mapping: success, warnings-only, config-error, template-error, mixed-categories-worst-wins, warnings-mixed-with-errors)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual verification on simple scaffold across 7 scenarios: clean (exit 0), missing config (3), broken TOML (3), broken template (4), missing required template (4), mixed config+template (4 — worst wins), warnings-only base_url empty (0).