### PR TITLE
feat(doctor): detect malformed front matter in content files

### DIFF
--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -447,6 +447,90 @@ describe Hwaro::Services::Doctor do
         end
       end
     end
+
+    describe "content front matter diagnostics" do
+      # Scans each `.md` / `.markdown` file with the same parser the
+      # builder uses so doctor catches `HWARO_E_CONTENT`-class issues
+      # before `hwaro build` runs.
+
+      it "reports malformed TOML front matter as a content error" do
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, base_config)
+          content_dir = File.join(dir, "content")
+          FileUtils.mkdir_p(content_dir)
+          File.write(File.join(content_dir, "bad.md"), "+++\ntitle = \"Unclosed\n+++\nbody\n")
+
+          doctor = Hwaro::Services::Doctor.new(content_dir: content_dir, config_path: config_path, templates_dir: File.join(dir, "templates"))
+          issues = doctor.run
+          matching = issues.select do |i|
+            i.category == "content" &&
+              i.id == "content-frontmatter-invalid" &&
+              i.level == :error
+          end
+          matching.should_not be_empty
+          (matching.first.file || "").should contain("bad.md")
+        end
+      end
+
+      it "reports malformed YAML front matter as a content error" do
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, base_config)
+          content_dir = File.join(dir, "content")
+          FileUtils.mkdir_p(content_dir)
+          File.write(File.join(content_dir, "bad-yaml.md"), "---\ntitle: \"Unclosed\n---\nbody\n")
+
+          doctor = Hwaro::Services::Doctor.new(content_dir: content_dir, config_path: config_path, templates_dir: File.join(dir, "templates"))
+          issues = doctor.run
+          issues.any? do |i|
+            i.category == "content" && i.level == :error && (i.file || "").includes?("bad-yaml.md")
+          end.should be_true
+        end
+      end
+
+      it "does not report anything for a clean scaffold" do
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, base_config)
+          content_dir = File.join(dir, "content")
+          FileUtils.mkdir_p(content_dir)
+          File.write(File.join(content_dir, "index.md"), "+++\ntitle = \"Home\"\n+++\nbody\n")
+          File.write(File.join(content_dir, "about.md"), "---\ntitle: About\n---\nbody\n")
+
+          doctor = Hwaro::Services::Doctor.new(content_dir: content_dir, config_path: config_path, templates_dir: File.join(dir, "templates"))
+          issues = doctor.run
+          issues.any? { |i| i.category == "content" }.should be_false
+        end
+      end
+
+      it "skips silently when the content directory doesn't exist" do
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, base_config)
+          # No content dir at all.
+          doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path, templates_dir: File.join(dir, "templates"))
+          issues = doctor.run
+          issues.any? { |i| i.category == "content" }.should be_false
+        end
+      end
+
+      it "also scans nested directories and .markdown extension" do
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, base_config)
+          content_dir = File.join(dir, "content")
+          FileUtils.mkdir_p(File.join(content_dir, "posts", "deep"))
+          File.write(File.join(content_dir, "posts", "deep", "bad.markdown"), "+++\ntitle = \"Broken\n+++\n")
+
+          doctor = Hwaro::Services::Doctor.new(content_dir: content_dir, config_path: config_path, templates_dir: File.join(dir, "templates"))
+          issues = doctor.run
+          issues.any? do |i|
+            i.category == "content" && (i.file || "").ends_with?("bad.markdown")
+          end.should be_true
+        end
+      end
+    end
   end
 
   describe "ConfigSnippets drift guard" do

--- a/src/cli/commands/tool/doctor_command.cr
+++ b/src/cli/commands/tool/doctor_command.cr
@@ -53,6 +53,11 @@ module Hwaro
               ["template-unclosed-block", "template-mismatched-vars", "template-read-error"]),
           ]
 
+          CONTENT_CHECKS = [
+            CheckSpec.new("front matter (TOML/YAML parse)",
+              ["content-frontmatter-invalid", "content-read-error"]),
+          ]
+
           def self.metadata : CommandInfo
             CommandInfo.new(
               name: NAME,
@@ -156,6 +161,11 @@ module Hwaro
               Logger.info "    #{render_check_line(spec, issues, plain)}"
             end
             Logger.info ""
+            Logger.info "  content/"
+            CONTENT_CHECKS.each do |spec|
+              Logger.info "    #{render_check_line(spec, issues, plain)}"
+            end
+            Logger.info ""
 
             if issues.empty?
               Logger.info "#{ok_glyph(plain)} No issues found. Your site looks great!"
@@ -166,6 +176,7 @@ module Hwaro
             config_issues = issues.select { |i| i.category == "config" }
             config_missing = issues.select { |i| i.category == "config_missing" }
             template_issues = issues.select { |i| i.category == "template" }
+            content_issues = issues.select { |i| i.category == "content" }
             structure_issues = issues.select { |i| i.category == "structure" }
 
             unless config_issues.empty?
@@ -183,6 +194,12 @@ module Hwaro
             unless template_issues.empty?
               Logger.info "Templates:"
               template_issues.each { |issue| print_issue(issue, plain) }
+              Logger.info ""
+            end
+
+            unless content_issues.empty?
+              Logger.info "Content:"
+              content_issues.each { |issue| print_issue(issue, plain) }
               Logger.info ""
             end
 

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -7,7 +7,9 @@ require "json"
 require "yaml"
 require "toml"
 require "../models/config"
+require "../utils/errors"
 require "../utils/logger"
+require "../content/processors/markdown"
 require "./config_snippets"
 
 module Hwaro
@@ -50,6 +52,7 @@ module Hwaro
         config = check_config(issues)
         check_templates(issues)
         check_directory_structure(issues)
+        check_content_frontmatter(issues)
         ignore = config.try(&.doctor.ignore) || [] of String
         issues.reject { |i| ignore.includes?(i.id) }
       end
@@ -298,6 +301,38 @@ module Hwaro
           unless has_index
             issues << Issue.new(id: "structure-missing-index", level: :info, category: "structure", file: child,
               message: "Section directory missing _index.md: #{entry}/")
+          end
+        end
+      end
+
+      # Parse every markdown file's front matter so doctor flags what
+      # would otherwise only surface at `hwaro build` time. Reuses the
+      # canonical `Processor::Markdown.parse` so the check stays in
+      # sync with the parser used by the build pipeline — any
+      # front-matter shape the builder rejects as `HWARO_E_CONTENT`
+      # appears here as an `:error` issue.
+      private def check_content_frontmatter(issues : Array(Issue))
+        return unless Dir.exists?(@content_dir)
+
+        Dir.glob(File.join(@content_dir, "**", "*.{md,markdown}")) do |path|
+          # Skip things that aren't regular files (symlink to nowhere,
+          # directory matching the glob, etc.).
+          next unless File.file?(path)
+
+          raw = begin
+            File.read(path)
+          rescue ex : IO::Error | File::Error
+            issues << Issue.new(id: "content-read-error", level: :error, category: "content", file: path,
+              message: "Failed to read content file: #{ex.message}")
+            next
+          end
+
+          begin
+            Processor::Markdown.parse(raw, path)
+          rescue ex : Hwaro::HwaroError
+            first_line = (ex.message || "Invalid front matter").lines.first?.to_s.strip
+            issues << Issue.new(id: "content-frontmatter-invalid", level: :error, category: "content", file: path,
+              message: first_line.empty? ? "Invalid front matter" : first_line)
           end
         end
       end


### PR DESCRIPTION
Closes #437.

## Summary

\`hwaro doctor\` covered config, templates, and directory structure but didn't look inside content files — so a \`.md\` with malformed TOML/YAML front matter passed doctor's "No issues found" check and then failed \`hwaro build\` with \`HWARO_E_CONTENT\` (exit 5). Once #436 made doctor usable as a CI gate, this blind spot meant the gate still wouldn't catch authorship mistakes.

## Fix

Add a \`check_content_frontmatter\` pass in \`Services::Doctor\` that globs \`content/**/*.{md,markdown}\` and parses each through \`Processor::Markdown.parse\` — the same parser the build pipeline uses — so any shape rejected as \`HWARO_E_CONTENT\` at build time surfaces here as an \`:error\` issue:

- id: \`content-frontmatter-invalid\` (or \`content-read-error\` for unreadable files)
- category: \`content\`
- level: \`:error\`

The category-to-exit mapping added in #440 already routes \`"content"\` errors to \`EXIT_CONTENT\` (5), so \`hwaro doctor\` exits non-zero — same class that \`hwaro build\` would use — when a bad front matter file is present.

## Human output

CLI display gains a matching "content/" inline check line with a "front matter (TOML/YAML parse)" label and a grouped "Content:" section for per-file detail.

### Before

\`\`\`console
\$ cat > content/bad.md <<'MD'
+++
title = "Unclosed
+++
MD
\$ hwaro doctor
Running diagnostics...
  config.toml
    [ok]   file present & parseable
    …
  templates/
    [ok]   required files (page.html, section.html)
    [ok]   template syntax
[ok] No issues found. Your site looks great!
\$ echo \$?
0                           # silent blind spot

\$ hwaro build
Error [HWARO_E_CONTENT]: Invalid TOML frontmatter in content/bad.md: …
\$ echo \$?
5
\`\`\`

### After

\`\`\`console
\$ hwaro doctor
Running diagnostics...
  config.toml
    [ok]   …
  templates/
    [ok]   …
  content/
    [err]  front matter (TOML/YAML parse)

Content:
  [err]  content/bad.md: Invalid TOML frontmatter in content/bad.md: newline is not allowed in basic string at 1:13

Found 1 error(s), 0 warning(s), 0 info(s)
\$ echo \$?
5                           # classified EXIT_CONTENT — CI can gate on this
\`\`\`

## Scope notes

- **Parser reuse**: doctor's verdict stays in sync with \`build\` automatically. When the parser's error message changes, doctor picks up the new wording for free.
- Skips silently when \`content/\` doesn't exist (same graceful degrade as the existing directory-structure check).
- Handles both \`.md\` and \`.markdown\` extensions; recurses into subdirs.
- IO errors (broken symlink, permission denied) surface via a separate \`content-read-error\` id at \`:error\` level so the exit-code path still triggers.
- Orthogonal to \`hwaro tool validate\`, which covers different checks (dead links, empty alt text, etc.).

## Diff footprint

\`\`\`
 spec/unit/doctor_spec.cr                | 84 +++++++++++++++++++++++++++++++++
 src/cli/commands/tool/doctor_command.cr | 17 +++++++
 src/services/doctor.cr                  | 35 ++++++++++++++
 3 files changed, 136 insertions(+)
\`\`\`

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4578 examples, 0 failures (adds 5 new specs: bad TOML detected, bad YAML detected, clean scaffold passes, missing content dir skipped silently, nested subdirs + \`.markdown\` extension both scanned)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual on simple scaffold: clean → no content issues; bad TOML → err + exit 5; bad YAML → err + exit 5; \`--json\` payload classifies correctly.