### PR TITLE
fix(doctor): narrow missing_config_sections rescue; atomic write in --fix

### DIFF
--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -376,14 +376,81 @@ describe Hwaro::Services::Doctor do
         end
       end
 
+      it "raises HwaroError(HWARO_E_CONFIG) when config.toml is missing" do
+        Dir.mktmpdir do |dir|
+          # No config.toml at all.
+          doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: File.join(dir, "config.toml"))
+          err = expect_raises(Hwaro::HwaroError) { doctor.fix_config }
+          err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+          (err.message || "").should contain("not found")
+        end
+      end
+
+      it "raises HwaroError(HWARO_E_CONFIG) when config.toml has TOML parse errors" do
+        # Refuses to --fix a broken config rather than silently saying
+        # "up to date" (the old behaviour from the bare-rescue return).
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, %(title = "Ok"\nbroken = = \n))
+
+          doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path)
+          err = expect_raises(Hwaro::HwaroError) { doctor.fix_config }
+          err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+          (err.message || "").downcase.should contain("parse error")
+          (err.hint || "").should contain("'hwaro doctor'")
+
+          # And the broken input is NOT modified — no half-append.
+          File.read(config_path).should eq(%(title = "Ok"\nbroken = = \n))
+        end
+      end
+
+      it "writes atomically via a temp file so a concurrent reader never sees a partial config" do
+        # End-to-end sanity for the temp-file + rename approach: the
+        # temp file lives at `<config>.hwaro-tmp` during the write and
+        # is renamed into place in one step, so there is no leftover
+        # temp file after a successful fix.
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, %(title = "My Site"\nbase_url = "https://example.com"\n))
+
+          doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path)
+          added = doctor.fix_config
+          added.should_not be_empty
+
+          File.exists?("#{config_path}.hwaro-tmp").should be_false
+          # Config now contains the original pre-existing content plus
+          # at least one appended section, end-to-end.
+          text = File.read(config_path)
+          text.should contain(%(title = "My Site"))
+          text.should contain("[pwa]")
+        end
+      end
+
       it "returns empty when nothing is missing" do
         Dir.mktmpdir do |dir|
           config_path = File.join(dir, "config.toml")
-          # Write a config with all known sections
-          sections = Hwaro::Services::Doctor::KNOWN_CONFIG_SECTIONS.keys.map { |k|
-            "[#{k}]"
-          }.join("\n")
-          File.write(config_path, %(title = "My Site"\nbase_url = "https://example.com"\n#{sections}\n[og]\ndefault_image = "/img.png"\n[og.auto_image]\nenabled = false\n[image_processing.lqip]\nenabled = false\n))
+          # Synthesize a config that lists every known top-level section
+          # and each known sub-section exactly once, in an order that's
+          # valid TOML (sub-sections right after their parents). Previous
+          # versions of this spec duplicated `[og]` which happened to
+          # parse under a bare `rescue` that swallowed errors — now
+          # `fix_config` surfaces parse errors as HwaroError.
+          sub_children_by_parent = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
+          Hwaro::Services::Doctor::KNOWN_SUB_SECTIONS.each_key do |parent, child|
+            sub_children_by_parent[parent] << child
+          end
+
+          body = String.build do |str|
+            str << %(title = "My Site"\n)
+            str << %(base_url = "https://example.com"\n)
+            Hwaro::Services::Doctor::KNOWN_CONFIG_SECTIONS.each_key do |key|
+              str << "[#{key}]\n"
+              sub_children_by_parent[key]?.try &.each do |child|
+                str << "[#{key}.#{child}]\n"
+              end
+            end
+          end
+          File.write(config_path, body)
 
           doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path)
           added = doctor.fix_config

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -57,22 +57,18 @@ module Hwaro
         issues.reject { |i| ignore.includes?(i.id) }
       end
 
-      # Returns the list of config section keys missing from the user's config.toml
+      # Returns the list of config section keys missing from the user's config.toml.
+      # On I/O or TOML parse failure, returns an empty array — those paths are
+      # already reported by `check_config` as classified issues, so silent-empty
+      # here lets the main run loop carry on without double-reporting. Callers
+      # that need a clearer signal (e.g. `fix_config`) should probe the file
+      # directly via `readable_config_toml` / `parse_config_toml`.
       def missing_config_sections : Array(String)
-        return [] of String unless File.exists?(@config_path)
+        raw_text = readable_config_toml
+        return [] of String unless raw_text
 
-        raw_text = begin
-          File.read(@config_path)
-        rescue ex : IO::Error | File::Error
-          Logger.debug "Doctor: cannot read #{@config_path}: #{ex.message}"
-          return [] of String
-        end
-
-        begin
-          raw = TOML.parse(raw_text)
-        rescue
-          return [] of String
-        end
+        raw = parse_config_toml(raw_text)
+        return [] of String unless raw
 
         # Collect commented section headers (e.g. "# [pwa]", "# [og.auto_image]")
         commented_sections = Set(String).new
@@ -110,8 +106,37 @@ module Hwaro
       # Append missing config sections to config.toml.
       # When minimal is true, skip advanced optional sections (pwa, amp, assets, etc.)
       # Returns the list of sections that were added.
+      #
+      # Raises `HwaroError` when the config cannot be read or parsed so
+      # `--fix` refuses to append to a broken file (prior behaviour was
+      # to silently say "Config is up to date"), and when the atomic
+      # write fails (temp file + rename; see below).
       def fix_config(minimal : Bool = false) : Array(String)
-        return [] of String unless File.exists?(@config_path)
+        unless File.exists?(@config_path)
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONFIG,
+            message: "Config file not found: #{@config_path}",
+            hint: "Run 'hwaro init' to scaffold a project, or cd into a directory containing config.toml.",
+          )
+        end
+
+        raw_text = readable_config_toml
+        unless raw_text
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_IO,
+            message: "Cannot read #{@config_path}",
+            hint: "Check file permissions and retry.",
+          )
+        end
+
+        raw = parse_config_toml(raw_text)
+        unless raw
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONFIG,
+            message: "#{@config_path} has TOML parse errors; refusing to --fix.",
+            hint: "Fix the TOML syntax first (run 'hwaro doctor' to see the parse error), then re-run 'hwaro doctor --fix'.",
+          )
+        end
 
         missing = missing_config_sections
         return [] of String if missing.empty?
@@ -127,16 +152,54 @@ module Hwaro
           end
         end
 
-        unless snippets.empty?
-          # Ensure existing file ends with a newline before appending
-          existing = File.read(@config_path)
-          File.open(@config_path, "a") do |f|
-            f.print("\n") unless existing.ends_with?("\n")
+        return added if snippets.empty?
+
+        # Write atomically: compose the final file contents in a temp
+        # file beside `config.toml`, then `File.rename` into place so a
+        # mid-write interruption (SIGINT, disk full) can't leave a
+        # partially-appended config behind.
+        tmp_path = "#{@config_path}.hwaro-tmp"
+        begin
+          File.open(tmp_path, "w") do |f|
+            f.print(raw_text)
+            f.print("\n") unless raw_text.ends_with?("\n")
             snippets.each { |s| f.print(s) }
           end
+          File.rename(tmp_path, @config_path)
+        rescue ex : IO::Error | File::Error
+          # Clean the half-written temp file so re-running isn't blocked.
+          File.delete(tmp_path) if File.exists?(tmp_path)
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_IO,
+            message: "Failed to update #{@config_path}: #{ex.message}",
+            hint: "Check file permissions and available disk space, then retry.",
+          )
         end
 
         added
+      end
+
+      # Read `config.toml` as text. Returns nil on I/O failure
+      # (permission denied, missing file, etc.) so callers can branch
+      # without nesting another begin/rescue.
+      private def readable_config_toml : String?
+        return unless File.exists?(@config_path)
+        File.read(@config_path)
+      rescue ex : IO::Error | File::Error
+        Logger.debug "Doctor: cannot read #{@config_path}: #{ex.message}"
+        nil
+      end
+
+      # Parse the raw `config.toml` text. Returns nil on TOML parse
+      # failure; callers already downstream of `check_config` have seen
+      # the classified error so silent-nil here avoids double-reporting.
+      # The rescue is narrowed to `TOML::ParseException` so any other
+      # unexpected error propagates rather than being silently swallowed.
+      private def parse_config_toml(raw_text : String) : TOML::Table?
+        TOML.parse(raw_text)
+      rescue ex : TOML::ParseException
+        Logger.debug "Doctor: TOML parse error in #{@config_path}: #{ex.message}"
+        nil
       end
 
       # Get the TOML snippet for a missing config section


### PR DESCRIPTION
Closes #438, closes #439.

## Summary

Two \`--fix\` safety issues in \`Services::Doctor\`, sharing the same code path.

### #438: bare \`rescue\` swallowed TOML parse errors

\`missing_config_sections\` caught **any** exception from \`TOML.parse\` with a bare \`rescue\` and returned an empty list. \`fix_config\` used that helper to decide what to append, so on a broken config it reported \"Config is up to date — no missing sections\" while \`check_config\` had already flagged the same file as \`[err] file present & parseable\`. Those two lines contradicted each other.

### #439: \`--fix\` had no atomic write or backup

\`fix_config\` opened \`config.toml\` in append mode and wrote each snippet one at a time. A SIGINT, disk-full, or mid-write I/O error could leave the config partially appended with no recovery path.

## Fix

### Narrowed rescues + probe helpers

Extract two small helpers:

- \`readable_config_toml\` → returns \`String?\`, rescue narrowed to \`IO::Error | File::Error\`.
- \`parse_config_toml\` → returns \`TOML::Table?\`, rescue narrowed to \`TOML::ParseException\`.

Both return \`nil\` on failure so the main \`run\` loop (which already reports the classified issue via \`check_config\`) continues without double-reporting. \`fix_config\` probes the same helpers directly and raises \`HwaroError\` on failure so the CLI refuses to append to a broken file.

### Atomic write

Write the composed output (existing content + trailing newline if needed + snippets) to \`<config_path>.hwaro-tmp\`, then \`File.rename\` into place. I/O failures rescue, delete the partial temp file, and re-raise as classified \`HwaroError\`.

## Error mapping

| Condition | Code | Exit |
|---|---|---|
| \`config.toml\` absent | \`HWARO_E_CONFIG\` | 3 |
| \`config.toml\` unreadable (perms, etc.) | \`HWARO_E_IO\` | 6 |
| \`config.toml\` has TOML parse errors | \`HWARO_E_CONFIG\` | 3 |
| Atomic rename / temp-file write fails | \`HWARO_E_IO\` | 6 |

Each carries a concrete \`hint:\` pointing at the next action (run \`hwaro init\`, fix TOML, check perms / disk space).

## Before / after

Before:
\`\`\`console
\$ echo 'broken = = ' >> config.toml
\$ hwaro doctor --fix 2>&1 | tail -2
    [err]  file present & parseable   # from check_config
  …
[ok] Config is up to date — no missing sections.   # from fix_config — contradicts itself
\$ echo \$?
0
\`\`\`

After:
\`\`\`console
\$ hwaro doctor --fix
Error [HWARO_E_CONFIG]: config.toml has TOML parse errors; refusing to --fix.
Fix the TOML syntax first (run 'hwaro doctor' to see the parse error), then re-run 'hwaro doctor --fix'.
\$ echo \$?
3

\$ hwaro doctor --fix   # same run after fixing the TOML
Added 20 missing config section(s) to config.toml:
  + [plugins]
  …
\$ ls config.toml.hwaro-tmp       # no leftover temp file after success
ls: config.toml.hwaro-tmp: No such file or directory
\`\`\`

## Spec note

One existing spec (\`fix_config returns empty when nothing is missing\`) relied on the bare-rescue behaviour to pass despite constructing invalid TOML (duplicate \`[og]\` tables from the synthesized section list plus an explicit \`[og]\` block below). The spec now builds valid TOML that lists every known section exactly once, with sub-sections nested after their parents. Same intent, valid input.

## Diff footprint

\`\`\`
 spec/unit/doctor_spec.cr |  77 ++++++++++++++++++++++++++++++++---
 src/services/doctor.cr   | 103 ++++++++++++++++++++++++++++++++++++++---------
 2 files changed, 155 insertions(+), 25 deletions(-)
\`\`\`

## Test plan

- [x] \`just build\`
- [x] \`just test\` → 4581 examples, 0 failures (adds 3 new specs: \`--fix\` raises on missing config, \`--fix\` raises on parse errors without modifying the input, atomic write leaves no \`.hwaro-tmp\` after success; updates the existing \`returns empty when nothing is missing\` spec to use valid TOML)
- [x] \`just fix\` (format) + \`bin/ameba\` → 340 inspected, 0 failures
- [x] Manual on simple scaffold: 4 scenarios — broken config refused (exit 3), complete config idempotent, missing config refused (exit 3), minimal config expanded atomically with no leftover temp file.