### PR TITLE
fix(import): classify errors, warn on collisions, add --force

### DIFF
--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -283,29 +283,47 @@ describe "hwaro tool agents-md" do
 end
 
 describe "hwaro tool import" do
-  it "exits 1 and reports missing source-type" do
+  it "exits with HWARO_E_USAGE when source-type is missing" do
     with_initialized_project do |project_dir|
       status, _, err = run_hwaro(["tool", "import"], chdir: project_dir)
-      status.success?.should be_false
-      err.should contain("Missing source")
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+      err.should contain("<source-type>")
     end
   end
 
-  it "exits 1 and reports missing path when only source-type is given" do
+  it "exits with HWARO_E_USAGE when path is missing" do
     with_initialized_project do |project_dir|
       status, _, err = run_hwaro(["tool", "import", "hugo"], chdir: project_dir)
-      status.success?.should be_false
-      err.should contain("Missing path")
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+      err.should contain("<path>")
     end
   end
 
-  it "exits 1 and reports an unknown source-type" do
+  it "exits with HWARO_E_USAGE on unknown source-type" do
     with_initialized_project do |project_dir|
       status, _, err = run_hwaro(
         ["tool", "import", "definitely-not-real", "/tmp"], chdir: project_dir
       )
-      status.success?.should be_false
-      err.should contain("Unknown source type")
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+      err.should contain("unknown source type")
+    end
+  end
+
+  it "exits with HWARO_E_USAGE when source directory yields no importable content" do
+    with_initialized_project do |project_dir|
+      Dir.mktmpdir do |empty|
+        FileUtils.mkdir_p(File.join(empty, "content"))
+        status, _, err = run_hwaro(
+          ["tool", "import", "hugo", empty, "-o", File.join(project_dir, "out")],
+          chdir: project_dir
+        )
+        status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+        err.should contain("HWARO_E_USAGE")
+        err.should contain("no importable content")
+      end
     end
   end
 end

--- a/spec/unit/importers/base_spec.cr
+++ b/spec/unit/importers/base_spec.cr
@@ -23,8 +23,8 @@ class TestImporter < Hwaro::Services::Importers::Base
     format_date(time)
   end
 
-  def test_write_content_file(output_dir, section, slug, frontmatter, body, verbose = false)
-    write_content_file(output_dir, section, slug, frontmatter, body, verbose)
+  def test_write_content_file(output_dir, section, slug, frontmatter, body, verbose = false, force = false)
+    write_content_file(output_dir, section, slug, frontmatter, body, verbose, force)
   end
 end
 
@@ -125,6 +125,19 @@ describe Hwaro::Services::Importers::Base do
         content = File.read(File.join(dir, "existing.md"))
         content.should contain("First")
         content.should_not contain("Second")
+      end
+    end
+
+    it "overwrites existing files when force is true" do
+      Dir.mktmpdir do |dir|
+        importer = TestImporter.new
+        importer.test_write_content_file(dir, "", "existing", "+++\n+++", "First")
+        result = importer.test_write_content_file(dir, "", "existing", "+++\n+++", "Second", false, true)
+        result.should be_true
+
+        content = File.read(File.join(dir, "existing.md"))
+        content.should contain("Second")
+        content.should_not contain("First")
       end
     end
   end

--- a/spec/unit/importers/jekyll_importer_spec.cr
+++ b/spec/unit/importers/jekyll_importer_spec.cr
@@ -408,6 +408,42 @@ describe Hwaro::Services::Importers::JekyllImporter do
       end
     end
 
+    it "overwrites existing output file when force is true" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "_posts")
+        FileUtils.mkdir_p(posts_dir)
+
+        File.write(File.join(posts_dir, "2024-01-01-existing.md"), <<-JEKYLL
+          ---
+          title: "Existing"
+          ---
+          Fresh content.
+          JEKYLL
+        )
+
+        output_dir = File.join(dir, "output")
+        FileUtils.mkdir_p(File.join(output_dir, "posts"))
+        File.write(File.join(output_dir, "posts", "existing.md"), "stale")
+
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "jekyll",
+          path: dir,
+          output_dir: output_dir,
+          force: true,
+        )
+
+        importer = Hwaro::Services::Importers::JekyllImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(1)
+        result.skipped_count.should eq(0)
+
+        content = File.read(File.join(output_dir, "posts", "existing.md"))
+        content.should contain("Fresh content.")
+        content.should_not contain("stale")
+      end
+    end
+
     it "imports multiple posts" do
       Dir.mktmpdir do |dir|
         posts_dir = File.join(dir, "_posts")

--- a/src/cli/commands/tool/import_command.cr
+++ b/src/cli/commands/tool/import_command.cr
@@ -11,6 +11,7 @@ require "../../../services/importers/obsidian_importer"
 require "../../../services/importers/hexo_importer"
 require "../../../services/importers/astro_importer"
 require "../../../services/importers/eleventy_importer"
+require "../../../utils/errors"
 require "../../../utils/logger"
 
 module Hwaro
@@ -23,9 +24,12 @@ module Hwaro
           POSITIONAL_ARGS    = ["source-type", "path"]
           POSITIONAL_CHOICES = ["wordpress", "jekyll", "hugo", "notion", "obsidian", "hexo", "astro", "eleventy"]
 
+          FORCE_FLAG = FlagInfo.new(short: nil, long: "--force", description: "Overwrite existing files instead of skipping")
+
           FLAGS = [
             FlagInfo.new(short: "-o", long: "--output", description: "Output content directory (default: content)", takes_value: true, value_hint: "DIR"),
             DRAFTS_FLAG,
+            FORCE_FLAG,
             VERBOSE_FLAG,
             HELP_FLAG,
           ]
@@ -46,14 +50,27 @@ module Hwaro
             supported = POSITIONAL_CHOICES.join(", ")
 
             if options.source_type.empty?
-              Logger.error "Missing source type. Usage: hwaro tool import <source-type> <path>"
-              Logger.info "Supported: #{supported}"
-              exit(1)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "missing <source-type> argument",
+                hint: "Usage: hwaro tool import <source-type> <path> — supported: #{supported}.",
+              )
+            end
+
+            unless POSITIONAL_CHOICES.includes?(options.source_type)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "unknown source type: #{options.source_type}",
+                hint: "Supported: #{supported}.",
+              )
             end
 
             if options.path.empty?
-              Logger.error "Missing path. Usage: hwaro tool import #{options.source_type} <path>"
-              exit(1)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "missing <path> argument",
+                hint: "Usage: hwaro tool import #{options.source_type} <path> — run 'hwaro tool import --help' for details.",
+              )
             end
 
             importer = case options.source_type
@@ -74,9 +91,11 @@ module Hwaro
                        when "eleventy"
                          Services::Importers::EleventyImporter.new
                        else
-                         Logger.error "Unknown source type: #{options.source_type}"
-                         Logger.info "Supported: #{supported}"
-                         exit(1)
+                         # Unreachable: POSITIONAL_CHOICES check above covers this.
+                         raise Hwaro::HwaroError.new(
+                           code: Hwaro::Errors::HWARO_E_INTERNAL,
+                           message: "unhandled source type: #{options.source_type}",
+                         )
                        end
 
             Logger.info "Importing from #{options.source_type}: #{options.path}"
@@ -84,11 +103,53 @@ module Hwaro
 
             result = importer.run(options)
 
-            if result.success
-              Logger.success "Import complete: #{result.imported_count} imported, #{result.skipped_count} skipped, #{result.error_count} errors"
+            unless result.success
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_IO,
+                message: result.message,
+                hint: importer_hint(options.source_type),
+              )
+            end
+
+            total = result.imported_count + result.skipped_count + result.error_count
+            if total == 0
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "no importable content found at: #{options.path}",
+                hint: importer_hint(options.source_type),
+              )
+            end
+
+            Logger.success "Import complete: #{result.imported_count} imported, #{result.skipped_count} skipped, #{result.error_count} errors"
+
+            if result.skipped_count > 0 && !options.force
+              Logger.warn "#{result.skipped_count} file(s) skipped because the destination already exists. Re-run with --force to overwrite."
+            end
+          end
+
+          # Source-type-specific hint describing where/what the importer
+          # expects to find. Used for both "empty source" and "importer
+          # failed" paths so the user gets a concrete next step.
+          private def importer_hint(source_type : String) : String
+            case source_type
+            when "wordpress"
+              "Expected a WXR XML file (WordPress Tools → Export → All content)."
+            when "jekyll"
+              "Expected a Jekyll site root containing _posts/ (and optionally _drafts/)."
+            when "hugo"
+              "Expected a Hugo site root containing content/."
+            when "notion"
+              "Expected an unzipped Notion Markdown export directory."
+            when "obsidian"
+              "Expected an Obsidian vault directory containing .md files."
+            when "hexo"
+              "Expected a Hexo site root containing source/_posts/ (and optionally source/_drafts/)."
+            when "astro"
+              "Expected an Astro project root containing src/content/."
+            when "eleventy"
+              "Expected an Eleventy project root containing .md files."
             else
-              Logger.error "Import failed: #{result.message}"
-              exit(1)
+              "Run 'hwaro tool import --help' for supported source types."
             end
           end
 
@@ -96,12 +157,14 @@ module Hwaro
             output_dir = "content"
             drafts = false
             verbose = false
+            force = false
             positional = [] of String
 
             OptionParser.parse(args) do |parser|
               parser.banner = "Usage: hwaro tool import <source-type> <path> [options]"
               parser.on("-o DIR", "--output DIR", "Output content directory (default: content)") { |dir| output_dir = dir }
               CLI.register_flag(parser, DRAFTS_FLAG) { |_| drafts = true }
+              CLI.register_flag(parser, FORCE_FLAG) { |_| force = true }
               CLI.register_flag(parser, VERBOSE_FLAG) { |_| verbose = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
               parser.unknown_args do |remaining|
@@ -118,6 +181,7 @@ module Hwaro
               output_dir: output_dir,
               drafts: drafts,
               verbose: verbose,
+              force: force,
             )
           end
         end

--- a/src/config/options/import_options.cr
+++ b/src/config/options/import_options.cr
@@ -7,6 +7,7 @@ module Hwaro
         property output_dir : String
         property drafts : Bool
         property verbose : Bool
+        property force : Bool
 
         def initialize(
           @source_type : String = "",
@@ -14,6 +15,7 @@ module Hwaro
           @output_dir : String = "content",
           @drafts : Bool = false,
           @verbose : Bool = false,
+          @force : Bool = false,
         )
         end
       end

--- a/src/services/importers/astro_importer.cr
+++ b/src/services/importers/astro_importer.cr
@@ -42,7 +42,7 @@ module Hwaro
 
           files.each do |file_path|
             begin
-              result = import_file(file_path, content_dir, output_dir, options.drafts, options.verbose)
+              result = import_file(file_path, content_dir, output_dir, options.drafts, options.verbose, options.force)
               case result
               when :imported
                 imported += 1
@@ -87,6 +87,7 @@ module Hwaro
           output_dir : String,
           include_drafts : Bool,
           verbose : Bool,
+          force : Bool,
         ) : Symbol
           raw = File.read(file_path)
           frontmatter_yaml, body = parse_astro_file(raw)
@@ -206,7 +207,7 @@ module Hwaro
           slug = slugify(File.basename(file_path, File.extname(file_path)))
 
           frontmatter = generate_frontmatter(fields)
-          written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose)
+          written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
           written ? :imported : :skipped
         end
 

--- a/src/services/importers/base.cr
+++ b/src/services/importers/base.cr
@@ -56,7 +56,9 @@ module Hwaro
           Utils::TextUtils.slugify(title)
         end
 
-        # Write a content file, skipping if it already exists
+        # Write a content file. Skips if it already exists unless `force`
+        # is true, in which case the existing file is overwritten. Returns
+        # true when a file was written, false when it was skipped.
         protected def write_content_file(
           output_dir : String,
           section : String,
@@ -64,6 +66,7 @@ module Hwaro
           frontmatter : String,
           body : String,
           verbose : Bool = false,
+          force : Bool = false,
         ) : Bool
           dir = section.empty? ? output_dir : File.join(output_dir, section)
           FileUtils.mkdir_p(dir) unless Dir.exists?(dir)
@@ -71,14 +74,16 @@ module Hwaro
           filename = slug.ends_with?(".md") ? slug : "#{slug}.md"
           path = File.join(dir, filename)
 
-          if File.exists?(path)
+          if File.exists?(path) && !force
             Logger.warn "Skipped (already exists): #{path}" if verbose
             return false
           end
 
           content = "#{frontmatter}\n\n#{body}\n"
           File.write(path, content)
-          Logger.debug "Imported: #{path}" if verbose
+          if verbose
+            Logger.debug(force ? "Overwrote: #{path}" : "Imported: #{path}")
+          end
           true
         end
 

--- a/src/services/importers/eleventy_importer.cr
+++ b/src/services/importers/eleventy_importer.cr
@@ -41,7 +41,7 @@ module Hwaro
 
           files.each do |file_path|
             begin
-              result = import_file(file_path, path, output_dir, dir_data, options.drafts, options.verbose)
+              result = import_file(file_path, path, output_dir, dir_data, options.drafts, options.verbose, options.force)
               case result
               when :imported
                 imported += 1
@@ -166,6 +166,7 @@ module Hwaro
           dir_data : Hash(String, Hash(String, YAML::Any)),
           include_drafts : Bool,
           verbose : Bool,
+          force : Bool,
         ) : Symbol
           raw = File.read(file_path)
           frontmatter_yaml, body = parse_eleventy_file(raw)
@@ -283,7 +284,7 @@ module Hwaro
           slug = slugify(File.basename(file_path, File.extname(file_path)))
 
           frontmatter = generate_frontmatter(fields)
-          written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose)
+          written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
           written ? :imported : :skipped
         end
 

--- a/src/services/importers/hexo_importer.cr
+++ b/src/services/importers/hexo_importer.cr
@@ -36,7 +36,7 @@ module Hwaro
 
           files.each do |file_info|
             begin
-              result = import_file(file_info, output_dir, options.verbose)
+              result = import_file(file_info, output_dir, options.verbose, options.force)
               case result
               when :imported
                 imported += 1
@@ -98,6 +98,7 @@ module Hwaro
           file_info : NamedTuple(path: String, draft: Bool),
           output_dir : String,
           verbose : Bool,
+          force : Bool,
         ) : Symbol
           raw = File.read(file_info[:path])
           frontmatter_yaml, body = parse_hexo_file(raw)
@@ -226,7 +227,7 @@ module Hwaro
           end
 
           frontmatter = generate_frontmatter(fields)
-          written = write_content_file(output_dir, "posts", slug, frontmatter, body.strip, verbose)
+          written = write_content_file(output_dir, "posts", slug, frontmatter, body.strip, verbose, force)
           written ? :imported : :skipped
         end
 

--- a/src/services/importers/hugo_importer.cr
+++ b/src/services/importers/hugo_importer.cr
@@ -11,6 +11,7 @@ module Hwaro
           output_dir = options.output_dir
           include_drafts = options.drafts
           verbose = options.verbose
+          force = options.force
 
           content_dir = File.join(hugo_path, "content")
 
@@ -27,7 +28,7 @@ module Hwaro
 
           scan_markdown_files(content_dir).each do |file_path|
             begin
-              result = process_file(file_path, content_dir, output_dir, include_drafts, verbose)
+              result = process_file(file_path, content_dir, output_dir, include_drafts, verbose, force)
               case result
               when :imported
                 imported += 1
@@ -72,6 +73,7 @@ module Hwaro
           output_dir : String,
           include_drafts : Bool,
           verbose : Bool,
+          force : Bool,
         ) : Symbol
           raw = File.read(file_path)
           fm_data, body = extract_frontmatter(raw)
@@ -180,7 +182,7 @@ module Hwaro
             file_slug = filename.sub(/\.(md|markdown)$/, "")
           end
 
-          written = write_content_file(output_dir, section, file_slug, frontmatter, body.strip, verbose)
+          written = write_content_file(output_dir, section, file_slug, frontmatter, body.strip, verbose, force)
           written ? :imported : :skipped
         end
 

--- a/src/services/importers/jekyll_importer.cr
+++ b/src/services/importers/jekyll_importer.cr
@@ -36,7 +36,7 @@ module Hwaro
 
           files.each do |file_info|
             begin
-              result = import_file(file_info, output_dir, options.verbose)
+              result = import_file(file_info, output_dir, options.verbose, options.force)
               case result
               when :imported
                 imported += 1
@@ -84,6 +84,7 @@ module Hwaro
           file_info : NamedTuple(path: String, draft: Bool),
           output_dir : String,
           verbose : Bool,
+          force : Bool,
         ) : Symbol
           raw = File.read(file_info[:path])
           frontmatter_yaml, body = parse_jekyll_file(raw)
@@ -208,7 +209,7 @@ module Hwaro
           end
 
           frontmatter = generate_frontmatter(fields)
-          written = write_content_file(output_dir, "posts", slug, frontmatter, body, verbose)
+          written = write_content_file(output_dir, "posts", slug, frontmatter, body, verbose, force)
 
           written ? :imported : :skipped
         end

--- a/src/services/importers/notion_importer.cr
+++ b/src/services/importers/notion_importer.cr
@@ -33,7 +33,7 @@ module Hwaro
 
           files.each do |file_path|
             begin
-              result = import_file(file_path, path, output_dir, options.verbose)
+              result = import_file(file_path, path, output_dir, options.verbose, options.force)
               case result
               when :imported
                 imported += 1
@@ -77,6 +77,7 @@ module Hwaro
           base_path : String,
           output_dir : String,
           verbose : Bool,
+          force : Bool,
         ) : Symbol
           raw = File.read(file_path)
           frontmatter_yaml, body = parse_markdown_file(raw)
@@ -145,7 +146,7 @@ module Hwaro
           section = "posts"
 
           frontmatter = generate_frontmatter(fields)
-          written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose)
+          written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
           written ? :imported : :skipped
         end
 

--- a/src/services/importers/obsidian_importer.cr
+++ b/src/services/importers/obsidian_importer.cr
@@ -39,7 +39,7 @@ module Hwaro
 
           files.each do |file_path|
             begin
-              result = import_file(file_path, path, output_dir, options.drafts, options.verbose)
+              result = import_file(file_path, path, output_dir, options.drafts, options.verbose, options.force)
               case result
               when :imported
                 imported += 1
@@ -85,6 +85,7 @@ module Hwaro
           output_dir : String,
           include_drafts : Bool,
           verbose : Bool,
+          force : Bool,
         ) : Symbol
           raw = File.read(file_path)
           frontmatter_yaml, body = parse_markdown_file(raw)
@@ -191,7 +192,7 @@ module Hwaro
           slug = slugify(fields["title"].as?(String) || File.basename(file_path, File.extname(file_path)))
 
           frontmatter = generate_frontmatter(fields)
-          written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose)
+          written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
           written ? :imported : :skipped
         end
 

--- a/src/services/importers/wordpress_importer.cr
+++ b/src/services/importers/wordpress_importer.cr
@@ -11,6 +11,7 @@ module Hwaro
           output_dir = options.output_dir
           include_drafts = options.drafts
           verbose = options.verbose
+          force = options.force
 
           unless File.exists?(wxr_path)
             return ImportResult.new(
@@ -30,7 +31,7 @@ module Hwaro
 
           items.each do |item|
             begin
-              result = process_item(item, output_dir, include_drafts, verbose)
+              result = process_item(item, output_dir, include_drafts, verbose, force)
               case result
               when :imported
                 imported += 1
@@ -73,6 +74,7 @@ module Hwaro
           output_dir : String,
           include_drafts : Bool,
           verbose : Bool,
+          force : Bool,
         ) : Symbol
           title = ""
           post_date = ""
@@ -150,7 +152,7 @@ module Hwaro
           # Convert HTML content to Markdown
           body = HtmlToMarkdown.convert(content_html)
 
-          written = write_content_file(output_dir, section, slug, frontmatter, body, verbose)
+          written = write_content_file(output_dir, section, slug, frontmatter, body, verbose, force)
           written ? :imported : :skipped
         end
       end


### PR DESCRIPTION
## Summary

`hwaro tool import` bundles three user-visible fixes on the shared CLI + `Base` paths:

- **Classified errors (#443)** — missing `<source-type>`, missing `<path>`, unknown source-type, and empty source directories all become `HwaroError`. The CLI returns `EXIT_USAGE` (2) with an `Error [HWARO_E_USAGE]:` prefix and a source-type-specific hint (e.g. *"Expected a Jekyll site root containing _posts/"*). Importer failures bubble up as `HWARO_E_IO` with the same taxonomy. `--json` / quiet consumers now get the structured payload for these paths.
- **Empty source = failure (#448)** — when the importer returns `imported=0, skipped=0, errors=0`, the CLI now raises `HWARO_E_USAGE` with a hint instead of logging `"0 imported, 0 skipped, 0 errors"` and exiting 0.
- **Collision visibility + `--force` (#449)** — `Base#write_content_file` collisions were previously silent skips with no escape hatch. We now emit a post-run warning `"N file(s) skipped because the destination already exists. Re-run with --force to overwrite."`, and the new `--force` flag overwrites the output. `force` is threaded through all 8 importers.

## Before / After

**Missing source-type**
```
# before: exit 1, ad-hoc "Missing source type..."
# after:
$ hwaro tool import
Error [HWARO_E_USAGE]: missing <source-type> argument
Usage: hwaro tool import <source-type> <path> — supported: wordpress, jekyll, ...
# exit 2
```

**Empty source directory**
```
# before: "Import complete: 0 imported, 0 skipped, 0 errors"  (exit 0)
# after:
Error [HWARO_E_USAGE]: no importable content found at: /tmp/empty
Expected a Jekyll site root containing _posts/ (and optionally _drafts/).
# exit 2
```

**Collision skip**
```
# before: silently skipped, no message, no recovery path
# after (no --force):
Import complete: 0 imported, 1 skipped, 0 errors
[WARN] 1 file(s) skipped because the destination already exists. Re-run with --force to overwrite.

# after (--force): overwrites
Import complete: 1 imported, 0 skipped, 0 errors
```

## Diff footprint

- `src/cli/commands/tool/import_command.cr` — classify all error paths, add `--force`, empty-source check, skipped warning, per-source hint.
- `src/config/options/import_options.cr`, `src/services/importers/base.cr` — add `force` field/param.
- 8 importer files — thread `options.force` through caller → signature → `write_content_file`.
- Specs: base + jekyll `--force` coverage, updated functional CLI specs for new `HWARO_E_USAGE` exit codes + empty-source path.

## Test plan

- [x] `just build` passes
- [x] `just fix` — 340 inspected, 0 failures
- [x] `just test` — 4584 examples, 0 failures
- [x] Smoke test on `/tmp` fixture: all four classified error paths return exit 2 with `HWARO_E_USAGE`; collision warning fires without `--force`; `--force` overwrites.

Closes #443, closes #448, closes #449