### PR TITLE
fix(import/obsidian): flatten nested YAML arrays in tags and aliases

### DIFF
--- a/spec/unit/importers/obsidian_importer_spec.cr
+++ b/spec/unit/importers/obsidian_importer_spec.cr
@@ -41,6 +41,43 @@ describe Hwaro::Services::Importers::ObsidianImporter do
       end
     end
 
+    it "flattens nested YAML array tags (tags: [[a, b]])" do
+      Dir.mktmpdir do |dir|
+        # Obsidian users (via plugins or shorthand) can write nested arrays
+        # for tags. Previously the inner array was stringified to a JSON
+        # literal ('["a", "b"]') and landed as a single bogus tag.
+        post_content = <<-OBSIDIAN
+          ---
+          title: "Nested Tags"
+          tags: [[misc, research], [project/alpha]]
+          aliases: [[alt-name, other-name]]
+          ---
+          Body.
+          OBSIDIAN
+
+        File.write(File.join(dir, "nested.md"), post_content)
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "obsidian",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::ObsidianImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(1)
+
+        content = File.read(File.join(output_dir, "posts", "nested-tags.md"))
+        content.should contain(%(tags = ["misc", "research", "project/alpha"]))
+        content.should contain(%(aliases = ["alt-name", "other-name"]))
+        # Guard against the previous bug form: a tag value of `["misc"]`
+        # (stringified JSON), which serializes to the escaped quote below.
+        content.should_not contain(%q(\"misc))
+      end
+    end
+
     it "converts wiki-links to standard markdown links" do
       Dir.mktmpdir do |dir|
         post_content = <<-OBSIDIAN

--- a/src/services/importers/obsidian_importer.cr
+++ b/src/services/importers/obsidian_importer.cr
@@ -126,7 +126,7 @@ module Hwaro
             if tags_val = yaml["tags"]?
               case tags_val.raw
               when Array
-                tags_val.as_a.each { |t| tags << (t.as_s? || t.raw.to_s) }
+                flatten_yaml_strings(tags_val).each { |t| tags << t }
               when String
                 tags_val.as_s.split(/[\s,]+/).each { |t| tags << t.strip unless t.strip.empty? }
               end
@@ -151,7 +151,7 @@ module Hwaro
               aliases = [] of String
               case aliases_val.raw
               when Array
-                aliases_val.as_a.each { |a| aliases << (a.as_s? || a.raw.to_s) }
+                flatten_yaml_strings(aliases_val).each { |a| aliases << a }
               when String
                 aliases << aliases_val.as_s
               end
@@ -205,6 +205,28 @@ module Hwaro
             return {yaml_str, body}
           end
           {nil, content.strip}
+        end
+
+        # Recursively flatten a YAML array value into a flat list of strings.
+        # Obsidian users write nested arrays for tags (e.g. `tags: [[a, b]]`)
+        # and the naive per-element `t.raw.to_s` on an Array element yielded
+        # a JSON-literal tag like `["a", "b"]`. Skips nested hashes since
+        # they don't map to a scalar tag — the caller can warn separately
+        # if needed.
+        private def flatten_yaml_strings(value : YAML::Any) : Array(String)
+          result = [] of String
+          case value.raw
+          when Array
+            value.as_a.each do |item|
+              flatten_yaml_strings(item).each { |s| result << s }
+            end
+          when Hash
+            # Nested object: skip silently; tags/aliases don't carry objects.
+          else
+            s = value.as_s? || value.raw.to_s
+            result << s unless s.empty?
+          end
+          result
         end
 
         private def extract_inline_tags(body : String) : Array(String)


### PR DESCRIPTION
## Summary

Obsidian frontmatter such as `tags: [[misc, research]]` (nested YAML array) was stringified into a single bogus tag whose value was the JSON literal `[\"misc\", \"research\"]`. Same failure mode for `aliases`. The taxonomy pipeline then indexed that literal as one term.

Introduce `flatten_yaml_strings` in `ObsidianImporter` to recursively flatten array-of-arrays into a flat list of strings. Applied to both `tags` and `aliases`. Nested hashes are skipped silently — they don't map to a scalar tag.

## Before / After

Input:
```yaml
---
title: Obsidian note
tags: [[misc, research]]
aliases: [[alt-name]]
---
```

Before:
```toml
tags = ["[\"misc\", \"research\"]"]   # single bogus tag
aliases = ["[\"alt-name\"]"]
```

After:
```toml
tags = ["misc", "research"]
aliases = ["alt-name"]
```

## Diff footprint

- `src/services/importers/obsidian_importer.cr` — add `flatten_yaml_strings` helper; use it for `tags` and `aliases` array branches.
- `spec/unit/importers/obsidian_importer_spec.cr` — new spec covering nested arrays for both fields, with a defensive assertion against the stringified-JSON regression.

Scope note: other importers (astro, notion, hexo, jekyll) use the same per-element `t.raw.to_s` pattern and have the same latent bug, but issue #447 is obsidian-specific; I'll file a follow-up if the same field patterns surface in the wild for those tools.

## Test plan

- [x] `just build` passes
- [x] `just fix` — 340 inspected, 0 failures
- [x] `just test` — 4585 examples, 0 failures
- [x] Smoke test: `tags: [[misc, research]]` + `aliases: [[alt-name]]` round-trips to flat TOML arrays.

Closes #447