### PR TITLE
fix(import): preserve categories as a separate taxonomy key

### DIFF
--- a/spec/unit/importers/hexo_importer_spec.cr
+++ b/spec/unit/importers/hexo_importer_spec.cr
@@ -42,7 +42,8 @@ describe Hwaro::Services::Importers::HexoImporter do
         content = File.read(output_file)
         content.should contain("+++")
         content.should contain("title = \"Hello Hexo\"")
-        content.should contain("tags = [\"hexo\", \"blog\", \"tech\"]")
+        content.should contain(%(tags = ["hexo", "blog"]))
+        content.should contain(%(categories = ["tech"]))
         content.should contain("Welcome to my Hexo blog.")
       end
     end
@@ -252,10 +253,10 @@ describe Hwaro::Services::Importers::HexoImporter do
         importer.run(options)
 
         content = File.read(File.join(output_dir, "posts", "nested-cats.md"))
-        content.should contain("\"frontend\"")
-        content.should contain("\"tech\"")
-        content.should contain("\"web\"")
-        content.should contain("\"design\"")
+        content.should contain(%(tags = ["frontend"]))
+        # Nested hierarchy flattens into the categories taxonomy while
+        # tags stay distinct.
+        content.should contain(%(categories = ["tech", "web", "design"]))
       end
     end
 

--- a/spec/unit/importers/hugo_importer_spec.cr
+++ b/spec/unit/importers/hugo_importer_spec.cr
@@ -193,10 +193,8 @@ describe Hwaro::Services::Importers::HugoImporter do
         content.should contain("title = \"YAML Post\"")
         content.should contain("updated =")
         content.should contain("description = \"Written in YAML\"")
-        # categories merged into tags
-        content.should contain("\"yaml\"")
-        content.should contain("\"hugo\"")
-        content.should contain("\"tutorials\"")
+        content.should contain(%(tags = ["yaml", "hugo"]))
+        content.should contain(%(categories = ["tutorials"]))
         content.should contain("YAML content goes here.")
       end
     end

--- a/spec/unit/importers/jekyll_importer_spec.cr
+++ b/spec/unit/importers/jekyll_importer_spec.cr
@@ -47,7 +47,8 @@ describe Hwaro::Services::Importers::JekyllImporter do
         content.should contain("+++")
         content.should contain("title = \"Hello World\"")
         content.should contain("template = \"post\"")
-        content.should contain("tags = [\"ruby\", \"web\", \"tutorial\"]")
+        content.should contain(%(categories = ["ruby", "web"]))
+        content.should contain(%(tags = ["tutorial"]))
         content.should contain("This is my first post.")
       end
     end
@@ -281,23 +282,23 @@ describe Hwaro::Services::Importers::JekyllImporter do
       end
     end
 
-    it "merges categories and tags into a single tags field" do
+    it "keeps categories and tags as separate taxonomy fields" do
       Dir.mktmpdir do |dir|
         posts_dir = File.join(dir, "_posts")
         FileUtils.mkdir_p(posts_dir)
 
         post_content = <<-JEKYLL
           ---
-          title: "Merged Tags"
+          title: "Split Taxonomies"
           category: programming
           tags:
             - crystal
-            - programming
+            - tutorial
           ---
           Content.
           JEKYLL
 
-        File.write(File.join(posts_dir, "2024-05-01-merged-tags.md"), post_content)
+        File.write(File.join(posts_dir, "2024-05-01-split-taxonomies.md"), post_content)
 
         output_dir = File.join(dir, "output")
         options = Hwaro::Config::Options::ImportOptions.new(
@@ -309,9 +310,9 @@ describe Hwaro::Services::Importers::JekyllImporter do
         importer = Hwaro::Services::Importers::JekyllImporter.new
         importer.run(options)
 
-        content = File.read(File.join(output_dir, "posts", "merged-tags.md"))
-        # "programming" should appear only once (deduplication)
-        content.should contain("tags = [\"programming\", \"crystal\"]")
+        content = File.read(File.join(output_dir, "posts", "split-taxonomies.md"))
+        content.should contain(%(categories = ["programming"]))
+        content.should contain(%(tags = ["crystal", "tutorial"]))
       end
     end
 

--- a/spec/unit/importers/wordpress_importer_spec.cr
+++ b/spec/unit/importers/wordpress_importer_spec.cr
@@ -102,6 +102,28 @@ MULTI_WXR = <<-XML
   </rss>
   XML
 
+UNCATEGORIZED_WXR = <<-XML
+  <?xml version="1.0" encoding="UTF-8"?>
+  <rss version="2.0"
+    xmlns:wp="http://wordpress.org/export/1.2/"
+    xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/">
+  <channel>
+    <item>
+      <title>Default Category</title>
+      <wp:post_date>2024-04-01 00:00:00</wp:post_date>
+      <wp:post_name>default-category</wp:post_name>
+      <wp:status>publish</wp:status>
+      <wp:post_type>post</wp:post_type>
+      <category domain="category" nicename="uncategorized"><![CDATA[Uncategorized]]></category>
+      <category domain="post_tag" nicename="news"><![CDATA[News]]></category>
+      <content:encoded><![CDATA[<p>Body.</p>]]></content:encoded>
+      <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+    </item>
+  </channel>
+  </rss>
+  XML
+
 NO_SLUG_WXR = <<-XML
   <?xml version="1.0" encoding="UTF-8"?>
   <rss version="2.0"
@@ -159,9 +181,29 @@ describe Hwaro::Services::Importers::WordPressImporter do
         content.should contain("title = \"Hello World\"")
         content.should contain("date = \"2024-01-15 10:30:00\"")
         content.should contain("description = \"A short excerpt\"")
-        content.should contain("tags = [\"Crystal\", \"Web\"]")
+        content.should contain(%(tags = ["Crystal", "Web"]))
+        content.should contain(%(categories = ["Tutorial"]))
         content.should contain("This is my first post.")
         content.should_not contain("draft")
+      end
+    end
+
+    it "skips the default WordPress 'Uncategorized' category" do
+      Dir.mktmpdir do |tmpdir|
+        wxr_path = write_wxr(tmpdir, UNCATEGORIZED_WXR)
+        output_dir = File.join(tmpdir, "content")
+
+        importer = Hwaro::Services::Importers::WordPressImporter.new
+        result = importer.run(make_options(wxr_path, output_dir))
+        result.imported_count.should eq(1)
+
+        content = File.read(File.join(output_dir, "posts", "default-category.md"))
+        content.should contain(%(tags = ["News"]))
+        # Uncategorized is the placeholder default category — omit it
+        # rather than importing every WP post with a bogus "Uncategorized"
+        # classification.
+        content.should_not contain("Uncategorized")
+        content.should_not contain("categories =")
       end
     end
 

--- a/src/services/importers/hexo_importer.cr
+++ b/src/services/importers/hexo_importer.cr
@@ -153,26 +153,33 @@ module Hwaro
               end
             end
 
-            # Categories (merge into tags)
+            tags = tags.uniq
+            fields["tags"] = tags unless tags.empty?
+
+            # Categories — preserve as their own taxonomy key. Hexo supports
+            # nested arrays (`[[tech, rust], [life]]`) for hierarchical
+            # categories; we flatten the hierarchy since hwaro's taxonomy
+            # is currently flat. The values stay distinct from tags.
+            categories = [] of String
+
             if cats = yaml["categories"]?
               case cats.raw
               when Array
                 cats.as_a.each do |c|
                   case c.raw
                   when Array
-                    # Hexo supports nested categories as arrays
-                    c.as_a.each { |sub| tags << (sub.as_s? || sub.raw.to_s) }
+                    c.as_a.each { |sub| categories << (sub.as_s? || sub.raw.to_s) }
                   else
-                    tags << (c.as_s? || c.raw.to_s)
+                    categories << (c.as_s? || c.raw.to_s)
                   end
                 end
               when String
-                cats.as_s.split(/[\s,]+/).each { |c| tags << c.strip unless c.strip.empty? }
+                cats.as_s.split(/[\s,]+/).each { |c| categories << c.strip unless c.strip.empty? }
               end
             end
 
-            tags = tags.uniq
-            fields["tags"] = tags unless tags.empty?
+            categories = categories.uniq
+            fields["categories"] = categories unless categories.empty?
 
             # Description
             if desc = yaml["description"]?

--- a/src/services/importers/hugo_importer.cr
+++ b/src/services/importers/hugo_importer.cr
@@ -120,13 +120,13 @@ module Hwaro
 
             # tags
             tags = array_string_value(data, "tags")
-
-            # categories — merge into tags
-            categories = array_string_value(data, "categories")
-            unless categories.empty?
-              tags = tags + categories
-            end
             fields["tags"] = tags unless tags.empty?
+
+            # categories — preserve as its own taxonomy key; hwaro's
+            # scaffold `[[taxonomies]]` defines tags and categories as
+            # separate classifications.
+            categories = array_string_value(data, "categories")
+            fields["categories"] = categories unless categories.empty?
 
             # series
             if series = string_value(data, "series")

--- a/src/services/importers/jekyll_importer.cr
+++ b/src/services/importers/jekyll_importer.cr
@@ -123,24 +123,30 @@ module Hwaro
               fields["template"] = layout.as_s? || layout.raw.to_s
             end
 
-            # Tags: merge categories and tags
-            tags = [] of String
+            # Categories and tags are kept as separate taxonomies so the
+            # imported content matches hwaro's scaffold taxonomy shape
+            # (`[[taxonomies]]` defines both keys distinctly).
+            categories = [] of String
 
             if cats = yaml["categories"]?
               case cats.raw
               when Array
-                cats.as_a.each { |c| tags << (c.as_s? || c.raw.to_s) }
+                cats.as_a.each { |c| categories << (c.as_s? || c.raw.to_s) }
               when String
-                cats.as_s.split(/[\s,]+/).each { |c| tags << c.strip unless c.strip.empty? }
+                cats.as_s.split(/[\s,]+/).each { |c| categories << c.strip unless c.strip.empty? }
               end
             end
 
             if cat = yaml["category"]?
               if cat_s = cat.as_s?
-                cat_s.split(/[\s,]+/).each { |c| tags << c.strip unless c.strip.empty? }
+                cat_s.split(/[\s,]+/).each { |c| categories << c.strip unless c.strip.empty? }
               end
             end
 
+            categories = categories.uniq
+            fields["categories"] = categories unless categories.empty?
+
+            tags = [] of String
             if tag_val = yaml["tags"]?
               case tag_val.raw
               when Array

--- a/src/services/importers/wordpress_importer.cr
+++ b/src/services/importers/wordpress_importer.cr
@@ -84,6 +84,7 @@ module Hwaro
           content_html = ""
           excerpt = ""
           tags = [] of String
+          categories = [] of String
 
           item.children.each do |child|
             next unless child.element?
@@ -108,10 +109,20 @@ module Hwaro
                 excerpt = child.content.strip
               end
             when "category"
+              # WXR encodes both tags and categories as <category> elements
+              # distinguished by the `domain` attribute. Keep them as
+              # separate taxonomies so the import matches hwaro's scaffold
+              # shape (tags + categories distinct). Default WordPress
+              # category "Uncategorized" is skipped — it's a placeholder
+              # rather than a real classification.
               domain = child["domain"]?
-              if domain == "post_tag"
-                tag_value = child.content.strip
-                tags << tag_value unless tag_value.empty?
+              value = child.content.strip
+              next if value.empty?
+              case domain
+              when "post_tag"
+                tags << value
+              when "category"
+                categories << value unless value == "Uncategorized"
               end
             end
           end
@@ -145,7 +156,8 @@ module Hwaro
           fields["date"] = date_str
           fields["description"] = excerpt unless excerpt.empty?
           fields["draft"] = true if is_draft
-          fields["tags"] = tags unless tags.empty?
+          fields["tags"] = tags.uniq unless tags.empty?
+          fields["categories"] = categories.uniq unless categories.empty?
 
           frontmatter = generate_frontmatter(fields)
 


### PR DESCRIPTION
## Summary

Hwaro scaffolds ship with `[[taxonomies]]` defining **tags** and **categories** as distinct classifications, but every importer that encountered a `categories` front-matter field either folded it into `tags` (Jekyll, Hugo, Hexo) or dropped it entirely (WordPress). Imported content could never match the scaffold's taxonomy shape and any category-specific templating broke silently.

Each importer now emits `categories` as its own key:

- **Jekyll** — both `categories: [...]` and the singular `category: foo` route to `categories`; `tags` stays independent.
- **Hugo** — stop concatenating `categories` into `tags`; emit as its own key.
- **Hexo** — nested hierarchy (`categories: [[tech, rust], [life]]`) still flattens since hwaro's taxonomy is flat, but lands in `categories`, not `tags`.
- **WordPress** — WXR's `<category domain="category">` now maps to `categories`; the placeholder default `"Uncategorized"` is skipped so every WP post doesn't arrive pre-classified as Uncategorized.

## Before / After

**Jekyll** (`category: programming`, `tags: [crystal, tutorial]`):
```diff
-tags = ["programming", "crystal", "tutorial"]
+categories = ["programming"]
+tags = ["crystal", "tutorial"]
```

**Hugo** (`tags = ["intro", "hugo"]`, `categories = ["blog"]`):
```diff
-tags = ["intro", "hugo", "blog"]
+tags = ["intro", "hugo"]
+categories = ["blog"]
```

**Hexo** (`categories: [[tech, web], [design]]`, `tags: [frontend]`):
```diff
-tags = ["frontend", "tech", "web", "design"]
+tags = ["frontend"]
+categories = ["tech", "web", "design"]
```

**WordPress** (`<category domain="category">Tutorial</category>`):
```diff
 tags = ["Crystal", "Web"]
+categories = ["Tutorial"]
```

## Diff footprint

- `src/services/importers/jekyll_importer.cr` — separate `categories` + `category` collection.
- `src/services/importers/hugo_importer.cr` — drop the `tags + categories` concat.
- `src/services/importers/hexo_importer.cr` — split the nested-array branch out to `categories`.
- `src/services/importers/wordpress_importer.cr` — route `<category domain="category">` to `categories`; skip `"Uncategorized"`.
- Specs updated across all 4 importers + new WordPress spec for the Uncategorized-skip.

## Test plan

- [x] `just build` passes
- [x] `just fix` — 340 inspected, 0 failures
- [x] `just test` — 4586 examples, 0 failures
- [x] Covered: basic Jekyll/Hugo/Hexo/WP round-trips emit `categories` + `tags` as separate keys; Hexo nested arrays flatten into categories; WP Uncategorized is dropped.

Closes #445