### PR TITLE
fix(import/wordpress): parse <pubDate> and convert <table> to pipe-table

### DIFF
--- a/spec/unit/importers/html_to_markdown_spec.cr
+++ b/spec/unit/importers/html_to_markdown_spec.cr
@@ -88,5 +88,36 @@ describe Hwaro::Services::Importers::HtmlToMarkdown do
       result = Hwaro::Services::Importers::HtmlToMarkdown.convert(html)
       result.should contain("**bold *and italic***")
     end
+
+    it "converts a table with <thead> and <tbody> into a Markdown pipe-table" do
+      html = <<-HTML
+        <table>
+          <thead><tr><th>A</th><th>B</th></tr></thead>
+          <tbody>
+            <tr><td>1</td><td>2</td></tr>
+            <tr><td>3</td><td>4</td></tr>
+          </tbody>
+        </table>
+        HTML
+      result = Hwaro::Services::Importers::HtmlToMarkdown.convert(html)
+      result.should contain("| A | B |")
+      result.should contain("| --- | --- |")
+      result.should contain("| 1 | 2 |")
+      result.should contain("| 3 | 4 |")
+    end
+
+    it "promotes the first row to a header when no <th> is present" do
+      html = "<table><tr><td>x</td><td>y</td></tr><tr><td>1</td><td>2</td></tr></table>"
+      result = Hwaro::Services::Importers::HtmlToMarkdown.convert(html)
+      result.should contain("| x | y |")
+      result.should contain("| --- | --- |")
+      result.should contain("| 1 | 2 |")
+    end
+
+    it "escapes pipe characters inside table cells" do
+      html = "<table><tr><th>k</th><th>v</th></tr><tr><td>a</td><td>x | y</td></tr></table>"
+      result = Hwaro::Services::Importers::HtmlToMarkdown.convert(html)
+      result.should contain(%q(| a | x \| y |))
+    end
   end
 end

--- a/spec/unit/importers/wordpress_importer_spec.cr
+++ b/spec/unit/importers/wordpress_importer_spec.cr
@@ -124,6 +124,46 @@ UNCATEGORIZED_WXR = <<-XML
   </rss>
   XML
 
+PUBDATE_ONLY_WXR = <<-XML
+  <?xml version="1.0" encoding="UTF-8"?>
+  <rss version="2.0"
+    xmlns:wp="http://wordpress.org/export/1.2/"
+    xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/">
+  <channel>
+    <item>
+      <title>PubDate Only</title>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+      <wp:post_name>pubdate-only</wp:post_name>
+      <wp:status>publish</wp:status>
+      <wp:post_type>post</wp:post_type>
+      <content:encoded><![CDATA[<p>Body.</p>]]></content:encoded>
+      <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+    </item>
+  </channel>
+  </rss>
+  XML
+
+TABLE_WXR = <<-XML
+  <?xml version="1.0" encoding="UTF-8"?>
+  <rss version="2.0"
+    xmlns:wp="http://wordpress.org/export/1.2/"
+    xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/">
+  <channel>
+    <item>
+      <title>Table Post</title>
+      <wp:post_date>2024-01-15 10:30:00</wp:post_date>
+      <wp:post_name>table-post</wp:post_name>
+      <wp:status>publish</wp:status>
+      <wp:post_type>post</wp:post_type>
+      <content:encoded><![CDATA[<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>]]></content:encoded>
+      <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+    </item>
+  </channel>
+  </rss>
+  XML
+
 NO_SLUG_WXR = <<-XML
   <?xml version="1.0" encoding="UTF-8"?>
   <rss version="2.0"
@@ -185,6 +225,39 @@ describe Hwaro::Services::Importers::WordPressImporter do
         content.should contain(%(categories = ["Tutorial"]))
         content.should contain("This is my first post.")
         content.should_not contain("draft")
+      end
+    end
+
+    it "falls back to <pubDate> when <wp:post_date> is missing" do
+      Dir.mktmpdir do |tmpdir|
+        wxr_path = write_wxr(tmpdir, PUBDATE_ONLY_WXR)
+        output_dir = File.join(tmpdir, "content")
+
+        importer = Hwaro::Services::Importers::WordPressImporter.new
+        result = importer.run(make_options(wxr_path, output_dir))
+        result.imported_count.should eq(1)
+
+        content = File.read(File.join(output_dir, "posts", "pubdate-only.md"))
+        # RFC 822 → canonical frontmatter date format. Some exporters
+        # omit <wp:post_date> and only populate the RSS <pubDate>; we
+        # don't want those posts to arrive dateless.
+        content.should contain(%(date = "2024-01-01 00:00:00"))
+      end
+    end
+
+    it "converts <table> in content to a Markdown pipe-table" do
+      Dir.mktmpdir do |tmpdir|
+        wxr_path = write_wxr(tmpdir, TABLE_WXR)
+        output_dir = File.join(tmpdir, "content")
+
+        importer = Hwaro::Services::Importers::WordPressImporter.new
+        result = importer.run(make_options(wxr_path, output_dir))
+        result.imported_count.should eq(1)
+
+        content = File.read(File.join(output_dir, "posts", "table-post.md"))
+        content.should contain("| A | B |")
+        content.should contain("| --- | --- |")
+        content.should contain("| 1 | 2 |")
       end
     end
 

--- a/src/services/importers/base.cr
+++ b/src/services/importers/base.cr
@@ -96,6 +96,8 @@ module Hwaro
             "%Y-%m-%dT%H:%M:%S%:z",
             "%Y-%m-%d",
             "%B %d, %Y",
+            # RFC 822 (WordPress <pubDate>, RSS feeds)
+            "%a, %d %b %Y %H:%M:%S %z",
           ]
 
           formats.each do |fmt|

--- a/src/services/importers/html_to_markdown.cr
+++ b/src/services/importers/html_to_markdown.cr
@@ -53,6 +53,37 @@ module Hwaro
             items.map { |m| "- #{strip_tags(m[1]).strip}" }.join("\n") + "\n\n"
           end
 
+          # Tables — convert <table> into Markdown pipe-tables. Uses the
+          # first row as the header (typical for WXR exports, which wrap
+          # headers in <thead><tr><th>). If no <th> is present the first
+          # row is still promoted to a header so the table is legal
+          # Markdown. Nested tables fall through strip_tags (the inner
+          # table text is flattened) — WP blog posts rarely nest tables.
+          result = result.gsub(/<table[^>]*>(.*?)<\/table>/mi) do
+            inner = $1
+            rows = inner.scan(/<tr[^>]*>(.*?)<\/tr>/mi).map do |m|
+              m[1].scan(/<(?:th|td)[^>]*>(.*?)<\/(?:th|td)>/mi).map do |cell|
+                strip_tags(cell[1]).strip.gsub(/\s+/, " ").gsub("|", "\\|")
+              end
+            end
+            rows.reject!(&.empty?)
+            if rows.empty?
+              ""
+            else
+              width = rows.max_of(&.size)
+              header = rows.shift
+              header += [""] * (width - header.size)
+              lines = [] of String
+              lines << "| #{header.join(" | ")} |"
+              lines << "| #{(["---"] * width).join(" | ")} |"
+              rows.each do |row|
+                padded = row + [""] * (width - row.size)
+                lines << "| #{padded.join(" | ")} |"
+              end
+              lines.join("\n") + "\n\n"
+            end
+          end
+
           # Horizontal rules
           result = result.gsub(/<hr\s*\/?>/, "\n---\n\n")
 

--- a/src/services/importers/wordpress_importer.cr
+++ b/src/services/importers/wordpress_importer.cr
@@ -78,6 +78,7 @@ module Hwaro
         ) : Symbol
           title = ""
           post_date = ""
+          pub_date = ""
           status = ""
           post_type = ""
           post_name = ""
@@ -96,6 +97,10 @@ module Hwaro
               title = child.content.strip
             when "post_date"
               post_date = child.content.strip
+            when "pubDate"
+              # RFC 822. Fallback when <wp:post_date> is missing (some
+              # exporters omit it and only populate the RSS pubDate).
+              pub_date = child.content.strip
             when "status"
               status = child.content.strip
             when "post_type"
@@ -143,11 +148,13 @@ module Hwaro
           # Determine section
           section = post_type == "post" ? "posts" : ""
 
-          # Parse and format date
+          # Parse and format date — prefer the precise `<wp:post_date>`
+          # (local time, no TZ noise) and fall back to RFC 822 `<pubDate>`.
           date_str : String? = nil
-          unless post_date.empty?
-            parsed = parse_date(post_date)
-            date_str = format_date(parsed) if parsed
+          if !post_date.empty? && (parsed = parse_date(post_date))
+            date_str = format_date(parsed)
+          elsif !pub_date.empty? && (parsed = parse_date(pub_date))
+            date_str = format_date(parsed)
           end
 
           # Build frontmatter fields


### PR DESCRIPTION
## Summary

Fixes two WXR-specific losses in the WordPress importer:

1. **`<pubDate>` ignored** — exporters that omit `<wp:post_date>` and only populate the RSS `<pubDate>` produced dateless imports. We now parse both, preferring the precise `<wp:post_date>` and falling back to the RFC 822 `<pubDate>`. The shared `parse_date` gains the RFC 822 format (`%a, %d %b %Y %H:%M:%S %z`).
2. **`<table>` collapsed to cell text** — `HtmlToMarkdown` had no table handling, so `<tr>` / `<td>` were stripped alongside every other unknown tag and the user got a single line of concatenated cell text. Convert `<table>` to a Markdown pipe-table, promoting the first row to a header when no `<th>` is present and escaping literal `|` inside cells.

## Before / After

Input (from issue repro, no `<wp:post_date>`):
```xml
<item>
  <title>Hello WP</title>
  <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
  <content:encoded><![CDATA[
    <p>Some <strong>content</strong>.</p>
    <table><thead><tr><th>A</th><th>B</th></tr></thead>
    <tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>
  ]]></content:encoded>
  <wp:post_name>hello-wp</wp:post_name>
  <wp:status>publish</wp:status>
  <wp:post_type>post</wp:post_type>
</item>
```

Before:
```toml
+++
title = "Hello WP"
# (no date)
+++

Some **content**.

A  B  1  2  3  4
```

After:
```toml
+++
title = "Hello WP"
date = "2024-01-01 00:00:00"
+++

Some **content**.

| A | B |
| --- | --- |
| 1 | 2 |
| 3 | 4 |
```

## Diff footprint

- `src/services/importers/base.cr` — add RFC 822 to `parse_date` (benefits every importer, not just WP).
- `src/services/importers/wordpress_importer.cr` — capture `<pubDate>`; use as fallback when `<wp:post_date>` is absent or unparseable.
- `src/services/importers/html_to_markdown.cr` — new `<table>` handler producing pipe-tables; first row promoted to header, `|` escaped in cells.
- Specs: new WP fixtures for pubDate-only and table cases; `HtmlToMarkdown` table coverage (thead/tbody, no-`<th>`, pipe escaping).

Scope note: the issue also flagged nested blockquotes / `<figure>`+`<figcaption>` / embeds being flattened. Those are lower-frequency shapes and would expand the HTML-to-Markdown surface significantly; skipped here to keep this PR tight. Can file a follow-up if they surface in practice.

## Test plan

- [x] `just build` passes
- [x] `just fix` — 340 inspected, 0 failures (ameba auto-adjusted a `map + max` to `max_of` in the new code)
- [x] `just test` — 4591 examples, 0 failures
- [x] Smoke test on the issue's WXR: `date` populated from `<pubDate>`, table renders as pipe-table.

Closes #446