### PR TITLE
fix(import): summarize unconverted template constructs after import

### DIFF
--- a/spec/unit/importers/jekyll_importer_spec.cr
+++ b/spec/unit/importers/jekyll_importer_spec.cr
@@ -282,6 +282,53 @@ describe Hwaro::Services::Importers::JekyllImporter do
       end
     end
 
+    it "reports how many files contain unconverted Liquid constructs" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "_posts")
+        FileUtils.mkdir_p(posts_dir)
+
+        File.write(File.join(posts_dir, "2024-01-01-liquid.md"), <<-JEKYLL
+          ---
+          title: "Liquid"
+          ---
+          Body with {% include header.html %}.
+          JEKYLL
+        )
+        File.write(File.join(posts_dir, "2024-01-02-clean.md"), <<-JEKYLL
+          ---
+          title: "Clean"
+          ---
+          Plain body.
+          JEKYLL
+        )
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "jekyll",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        # Capture the warning stream so the spec sees the summary log.
+        err = IO::Memory.new
+        original = Hwaro::Logger.err_io
+        Hwaro::Logger.err_io = err
+        begin
+          importer = Hwaro::Services::Importers::JekyllImporter.new
+          result = importer.run(options)
+          result.imported_count.should eq(2)
+        ensure
+          Hwaro::Logger.err_io = original
+        end
+
+        # Summary must include the count and the platform name so a user
+        # skimming the log knows how many files need manual cleanup.
+        err.to_s.should contain("1 file(s) contained unconverted Liquid")
+        # The clean file must not trip the per-file warning.
+        err.to_s.scan(/Liquid tags detected/).size.should eq(1)
+      end
+    end
+
     it "keeps categories and tags as separate taxonomy fields" do
       Dir.mktmpdir do |dir|
         posts_dir = File.join(dir, "_posts")

--- a/src/services/importers/astro_importer.cr
+++ b/src/services/importers/astro_importer.cr
@@ -14,6 +14,7 @@ module Hwaro
           imported = 0
           skipped = 0
           errors = 0
+          wrapped = 0
 
           unless Dir.exists?(path)
             return ImportResult.new(
@@ -46,6 +47,9 @@ module Hwaro
               case result
               when :imported
                 imported += 1
+              when :imported_wrapped
+                imported += 1
+                wrapped += 1
               when :skipped
                 skipped += 1
               end
@@ -53,6 +57,10 @@ module Hwaro
               errors += 1
               Logger.warn "Error importing #{file_path}: #{ex.message}"
             end
+          end
+
+          if wrapped > 0
+            Logger.warn "#{wrapped} file(s) contained MDX components. Imports kept the raw markup — each will render as literal text until you hand-convert them."
           end
 
           ImportResult.new(
@@ -186,13 +194,16 @@ module Hwaro
             fields["title"] = name.gsub(/[-_]/, " ").split.map(&.capitalize).join(" ")
           end
 
-          # Warn about MDX components in .mdx files
+          # MDX handling: strip import statements (no Crinja equivalent).
+          # Track remaining JSX-ish component markup so the `run` method
+          # can emit a single summary warning.
+          has_mdx_components = false
           if file_path.ends_with?(".mdx")
-            if body.includes?("import ") || body.matches?(/<[A-Z]/)
-              Logger.warn "MDX components detected in #{file_path} — manual conversion may be needed"
-            end
-            # Strip import statements
             body = body.gsub(/^import\s+.+$\n?/m, "")
+            if body.matches?(/<[A-Z]/)
+              Logger.warn "MDX components detected in #{file_path} — manual conversion needed."
+              has_mdx_components = true
+            end
           end
 
           # Determine section from content collection name
@@ -208,7 +219,8 @@ module Hwaro
 
           frontmatter = generate_frontmatter(fields)
           written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
-          written ? :imported : :skipped
+          return :skipped unless written
+          has_mdx_components ? :imported_wrapped : :imported
         end
 
         YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m

--- a/src/services/importers/eleventy_importer.cr
+++ b/src/services/importers/eleventy_importer.cr
@@ -17,6 +17,7 @@ module Hwaro
           imported = 0
           skipped = 0
           errors = 0
+          wrapped = 0
 
           unless Dir.exists?(path)
             return ImportResult.new(
@@ -45,6 +46,9 @@ module Hwaro
               case result
               when :imported
                 imported += 1
+              when :imported_wrapped
+                imported += 1
+                wrapped += 1
               when :skipped
                 skipped += 1
               end
@@ -52,6 +56,10 @@ module Hwaro
               errors += 1
               Logger.warn "Error importing #{file_path}: #{ex.message}"
             end
+          end
+
+          if wrapped > 0
+            Logger.warn "#{wrapped} file(s) contained Nunjucks/Liquid template tags. Imports kept the raw syntax — each will render as literal text until you hand-convert them."
           end
 
           ImportResult.new(
@@ -267,9 +275,12 @@ module Hwaro
             end
           end
 
-          # Warn about template tags
-          if body.matches?(TEMPLATE_TAG_PATTERN)
-            Logger.warn "Template tags detected in #{file_path} — manual conversion may be needed"
+          # Track files with Nunjucks/Liquid tags; the `run` method
+          # emits a single summary with the count so users know how
+          # many files need manual conversion.
+          has_template_tags = body.matches?(TEMPLATE_TAG_PATTERN)
+          if has_template_tags
+            Logger.warn "Template tags detected in #{file_path} — manual conversion needed."
           end
 
           # Determine section
@@ -285,7 +296,8 @@ module Hwaro
 
           frontmatter = generate_frontmatter(fields)
           written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
-          written ? :imported : :skipped
+          return :skipped unless written
+          has_template_tags ? :imported_wrapped : :imported
         end
 
         YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m

--- a/src/services/importers/hexo_importer.cr
+++ b/src/services/importers/hexo_importer.cr
@@ -17,6 +17,7 @@ module Hwaro
           imported = 0
           skipped = 0
           errors = 0
+          wrapped = 0
 
           unless Dir.exists?(path)
             return ImportResult.new(
@@ -40,6 +41,9 @@ module Hwaro
               case result
               when :imported
                 imported += 1
+              when :imported_wrapped
+                imported += 1
+                wrapped += 1
               when :skipped
                 skipped += 1
               end
@@ -47,6 +51,10 @@ module Hwaro
               errors += 1
               Logger.warn "Error importing #{file_info[:path]}: #{ex.message}"
             end
+          end
+
+          if wrapped > 0
+            Logger.warn "#{wrapped} file(s) contained Hexo tag plugins. Imports kept the raw syntax — each will render as literal text until you hand-convert them."
           end
 
           ImportResult.new(
@@ -217,13 +225,16 @@ module Hwaro
             fields["draft"] = true
           end
 
-          # Warn about Hexo tag plugins
-          if body.matches?(HEXO_TAG_PATTERN)
-            Logger.warn "Hexo tag plugins detected in #{file_info[:path]} — manual conversion may be needed"
-          end
-
-          # Handle Hexo's <!-- more --> excerpt separator
+          # Handle Hexo's <!-- more --> excerpt separator.
           body = body.gsub(/<!--\s*more\s*-->/, "")
+
+          # Track files with Hexo tag plugins; the `run` method emits a
+          # single summary so the user knows how many files need manual
+          # conversion even when per-file warnings scroll off.
+          has_hexo_tags = body.matches?(HEXO_TAG_PATTERN)
+          if has_hexo_tags
+            Logger.warn "Hexo tag plugins detected in #{file_info[:path]} — manual conversion needed."
+          end
 
           if slug.empty?
             if title = fields["title"]?.as?(String)
@@ -235,7 +246,8 @@ module Hwaro
 
           frontmatter = generate_frontmatter(fields)
           written = write_content_file(output_dir, "posts", slug, frontmatter, body.strip, verbose, force)
-          written ? :imported : :skipped
+          return :skipped unless written
+          has_hexo_tags ? :imported_wrapped : :imported
         end
 
         YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m

--- a/src/services/importers/hugo_importer.cr
+++ b/src/services/importers/hugo_importer.cr
@@ -25,6 +25,7 @@ module Hwaro
           imported = 0
           skipped = 0
           errors = 0
+          wrapped = 0
 
           scan_markdown_files(content_dir).each do |file_path|
             begin
@@ -32,6 +33,9 @@ module Hwaro
               case result
               when :imported
                 imported += 1
+              when :imported_wrapped
+                imported += 1
+                wrapped += 1
               when :skipped
                 skipped += 1
               end
@@ -39,6 +43,10 @@ module Hwaro
               errors += 1
               Logger.warn "Error processing #{file_path}: #{ex.message}"
             end
+          end
+
+          if wrapped > 0
+            Logger.warn "#{wrapped} file(s) contained Hugo shortcodes. Imports kept the raw syntax — each will render as literal text until you hand-convert them."
           end
 
           ImportResult.new(
@@ -84,9 +92,12 @@ module Hwaro
             return :skipped
           end
 
-          # Warn about Hugo shortcodes in body
-          if body.includes?("{{<") || body.includes?("{{%")
-            Logger.warn "Hugo shortcodes detected in #{file_path} — manual conversion may be needed"
+          # Track files with Hugo shortcodes so the `run` method can
+          # emit a single summary telling the user how many files need
+          # manual conversion.
+          has_shortcodes = body.includes?("{{<") || body.includes?("{{%")
+          if has_shortcodes
+            Logger.warn "Hugo shortcodes detected in #{file_path} — manual conversion needed."
           end
 
           # Map Hugo fields to Hwaro frontmatter
@@ -183,7 +194,8 @@ module Hwaro
           end
 
           written = write_content_file(output_dir, section, file_slug, frontmatter, body.strip, verbose, force)
-          written ? :imported : :skipped
+          return :skipped unless written
+          has_shortcodes ? :imported_wrapped : :imported
         end
 
         # Regex for TOML frontmatter: +++ on first line, +++ on its own line

--- a/src/services/importers/jekyll_importer.cr
+++ b/src/services/importers/jekyll_importer.cr
@@ -17,6 +17,7 @@ module Hwaro
           imported = 0
           skipped = 0
           errors = 0
+          wrapped = 0
 
           unless Dir.exists?(path)
             return ImportResult.new(
@@ -40,6 +41,9 @@ module Hwaro
               case result
               when :imported
                 imported += 1
+              when :imported_wrapped
+                imported += 1
+                wrapped += 1
               when :skipped
                 skipped += 1
               end
@@ -47,6 +51,10 @@ module Hwaro
               errors += 1
               Logger.warn "Error importing #{file_info[:path]}: #{ex.message}"
             end
+          end
+
+          if wrapped > 0
+            Logger.warn "#{wrapped} file(s) contained unconverted Liquid constructs. Imports kept the raw syntax — each will render as literal text until you hand-convert them."
           end
 
           ImportResult.new(
@@ -200,9 +208,14 @@ module Hwaro
             fields["draft"] = true
           end
 
-          # Warn about Liquid tags in body
-          if body.matches?(LIQUID_TAG_PATTERN)
-            Logger.warn "Liquid tags detected in #{file_info[:path]} - manual conversion may be needed"
+          # Track files that contain unconverted Liquid constructs. The
+          # per-file warning stays for verbose consumers; the `run`
+          # method emits a single summary warning with the total so
+          # users know how many files need manual conversion even when
+          # the per-file lines scroll off.
+          has_liquid = body.matches?(LIQUID_TAG_PATTERN)
+          if has_liquid
+            Logger.warn "Liquid tags detected in #{file_info[:path]} — manual conversion needed."
           end
 
           # Use slug from filename, or slugify the title
@@ -217,7 +230,8 @@ module Hwaro
           frontmatter = generate_frontmatter(fields)
           written = write_content_file(output_dir, "posts", slug, frontmatter, body, verbose, force)
 
-          written ? :imported : :skipped
+          return :skipped unless written
+          has_liquid ? :imported_wrapped : :imported
         end
 
         # Regex to match YAML frontmatter: opening --- on first line,


### PR DESCRIPTION
## Summary

All five importers that parse source-specific template syntax (Jekyll Liquid, Hugo shortcodes, Hexo tag plugins, Astro MDX, Eleventy Nunjucks/Liquid) emitted a per-file `[WARN]` when they detected unconverted constructs and then carried on. With bulk imports the per-file lines scrolled off, the final \"Import complete: N imported, 0 skipped, 0 errors\" read as a clean run, and users had no count to gauge how much manual cleanup was ahead.

Each importer now tracks files with unconverted constructs (via a new internal `:imported_wrapped` symbol returned from `import_file`) and emits a single aggregate `[WARN]` at the end of `run` with the total, the platform name, and a note that the surviving syntax will render as literal text until hand-converted.

## Approach note: why not auto-wrap in `{% raw %}`?

I initially tried wrapping bodies in Crinja's `{% raw %}...{% endraw %}` to keep `hwaro build` from tripping on the syntax. Two things surfaced during smoke testing:

1. Hwaro's content pipeline renders Markdown but doesn't apply Crinja to the content body (only the template layout). So `hwaro build` never actually fails on unwrapped Liquid in content — the issue's premise that build breaks is outdated. The syntax just renders as literal text.
2. Because the body isn't run through Crinja, the `{% raw %}` markers themselves end up as literal text in the rendered HTML, making the output noisier than leaving things alone.

So the right fix turned out to be Option 4 from the issue (summary list / count), not Option 1 (wrap). The per-file lines stay for verbose log users; the summary is the discoverability fix.

## Before / After

Importing a Jekyll vault with one Liquid-ridden post and one clean post:

Before:
```
[WARN] Liquid tags detected in /tmp/src/_posts/2024-01-01-liquid.md - manual conversion may be needed
Import complete: 2 imported, 0 skipped, 0 errors
```

After:
```
[WARN] Liquid tags detected in /tmp/src/_posts/2024-01-01-liquid.md — manual conversion needed.
[WARN] 1 file(s) contained unconverted Liquid constructs. Imports kept the raw syntax — each will render as literal text until you hand-convert them.
Import complete: 2 imported, 0 skipped, 0 errors
```

## Diff footprint

- `src/services/importers/jekyll_importer.cr`, `hugo_importer.cr`, `hexo_importer.cr`, `astro_importer.cr`, `eleventy_importer.cr` — count files with unconverted constructs; return `:imported_wrapped` from `import_file`; log a single summary warn at end of `run`.
- `spec/unit/importers/jekyll_importer_spec.cr` — new spec capturing `Logger.err_io` and asserting the summary format + that clean files don't trip the per-file warning.

## Test plan

- [x] `just build` passes
- [x] `just fix` — 340 inspected, 0 failures
- [x] `just test` — 4592 examples, 0 failures
- [x] Smoke test: mixed Jekyll vault logs one per-file warn + one summary warn; counts match files with Liquid.

Closes #444