### PR TITLE
chore(docker): optimize build caching and image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Build artifacts
+bin/
+lib/
+**/*.o
+**/*.dwarf
+
+# Git & VCS
+.git/
+.gitignore
+
+# Dev tooling
+.github/
+.claude/
+.ameba.yml
+.editorconfig
+AGENTS.md
+CONTRIBUTING.md
+CHANGELOG.md
+justfile
+
+# Nix
+flake.nix
+flake.lock
+shards.nix
+result
+
+# Packaging
+aur/
+snap/
+
+# Tests & docs
+spec/
+docs/
+
+# Docker itself (keep entrypoint.sh — it's COPY'd into the runner stage)
+docker/*
+!docker/entrypoint.sh
+Dockerfile
+.dockerignore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,17 @@
 ##= BUILDER =##
 FROM crystallang/crystal:1.20.0 AS builder
 WORKDIR /hwaro
-COPY . .
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends zlib1g-dev pkg-config && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    shards install --production && \
-    shards build --release --no-debug --production
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY shard.yml shard.lock ./
+RUN shards install --production
+
+COPY . .
+RUN shards build --release --no-debug --production && \
+    strip /hwaro/bin/hwaro
 
 ##= RUNNER =##
 FROM debian:13-slim
@@ -16,9 +20,9 @@ FROM debian:13-slim
 LABEL org.opencontainers.image.title="Hwaro"
 LABEL org.opencontainers.image.description="Hwaro (화로) is a lightweight and fast static site generator written in Crystal."
 LABEL org.opencontainers.image.authors="HAHWUL <hahwul@gmail.com>"
-LABEL org.opencontainers.image.source=https://github.com/hahwul/hwaro
+LABEL org.opencontainers.image.source="https://github.com/hahwul/hwaro"
 LABEL org.opencontainers.image.documentation="https://github.com/hahwul/hwaro"
-LABEL org.opencontainers.image.licenses=MIT
+LABEL org.opencontainers.image.licenses="MIT"
 
 # GitHub Action labels
 LABEL "com.github.actions.name"="Hwaro Deploy to Pages"
@@ -36,8 +40,6 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /hwaro/bin/hwaro /usr/local/bin/hwaro
-COPY docker/entrypoint.sh /entrypoint.sh
-
-RUN chmod +x /entrypoint.sh
+COPY --chmod=755 docker/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Split `shards install` from source `COPY` so that dependency installation is reused from cache whenever only source changes (verified locally: `shards install` hits `CACHED` on source-only rebuilds).
- Add `.dockerignore` to keep the build context lean and — more importantly — prevent host build artifacts from leaking into the Linux builder (e.g. a macOS ARM64 `src/ext/stb_impl.o` created during local builds would otherwise be copied in, skipping recompilation and breaking `ld`).
- `strip` the release binary in the builder (6.8M → 6.2M, ~600 KB saved; no debug info present anyway since build uses `--no-debug`).
- Use `COPY --chmod=755` for `entrypoint.sh` and drop the extra `RUN chmod` layer.
- Quote the two unquoted OCI label values for consistency with surrounding labels.

Non-root `USER` was considered but intentionally skipped: this image is primarily used as a GitHub Action (composite action mounting `/github/workspace`), where mismatched UIDs against the runner-owned checkout would risk breaking `git` operations in ways that can't be verified locally. Worth revisiting separately.

## Test plan
- [x] `docker build -f docker/Dockerfile -t hwaro:test .` succeeds from a clean cache
- [x] `hwaro --version` and `hwaro --help` run in the built image
- [x] Source-only change rebuild preserves cached `shards install` layer
- [x] `.dockerignore` prevents host `src/ext/*.o` from entering the build context
- [x] Release workflow publishes image to `ghcr.io/hahwul/hwaro` successfully
- [x] GitHub Action (`action.yml`) end-to-end run still builds and deploys Pages