### PR TITLE
feat(frontmatter): support JSON front matter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Update **all** of the following:
 ### Security
 - **HTML/XML output**: `Utils::TextUtils.escape_xml(value)` or `HTML.escape(value)`.
 - **Inline JS**: Escape `</` → `<\/` in JSON data to prevent `</script>` breakout.
-- **Front matter (TOML/YAML)**: Always use safe casts (`.as_s?`, `.as_bool?`, `.as_i?`, `.as_a?`) on `TOML::Any` / `YAML::Any` values, never unchecked `.as_s`.
+- **Front matter (TOML/YAML/JSON)**: Always use safe casts (`.as_s?`, `.as_bool?`, `.as_i?`, `.as_a?`) on `TOML::Any` / `YAML::Any` / `JSON::Any` values, never unchecked `.as_s`.
 - **Crinja filter args**: Use `.to_s` instead of `.as_s`.
 - **Paths**: Always use `PathUtils.sanitize_path` for user-provided or content-derived paths.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- JSON front matter support for content files (Hugo-style, starts with `{`, balanced braces delimit the block)
+- `hwaro tool convert to-json` subcommand plus TOML↔JSON and YAML↔JSON conversions
+- `front_matter_format = "json"` under `[content.new]` for JSON scaffolds from `hwaro new`
+- `content-frontmatter-json-error` validator rule
+
 ## v0.12.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@
 
 ---
 
-Hwaro processes Markdown content with TOML or YAML front matter and Jinja2-compatible templates (Crinja) to build high-performance static sites. It features parallel builds, incremental caching, and a built-in dev server with live reload.
+Hwaro processes Markdown content with TOML, YAML, or JSON front matter and Jinja2-compatible templates (Crinja) to build high-performance static sites. It features parallel builds, incremental caching, and a built-in dev server with live reload.
 
 <details>
 <summary><strong>Features</strong></summary>
 
 ### Content & Templating
-- Markdown with TOML/YAML front matter
+- Markdown with TOML/YAML/JSON front matter
 - Jinja2 templates (inheritance, includes, macros)
 - Markdown extensions: task lists, footnotes, definition lists, math (KaTeX/MathJax), Mermaid diagrams, emoji, etc
 - Built-in shortcodes (YouTube, Vimeo, Gist, Alert, Figure, Tweet, CodePen) and custom shortcode support

--- a/docs/content/start/_index.md
+++ b/docs/content/start/_index.md
@@ -5,7 +5,7 @@ description = "Get up and running with Hwaro"
 
 ## What is Hwaro?
 
-Hwaro is a lightweight and fast static site generator (SSG) written in [Crystal](https://crystal-lang.org). It processes Markdown content with TOML or YAML front matter and Jinja2-compatible templates (Crinja) to build high-performance static sites.
+Hwaro is a lightweight and fast static site generator (SSG) written in [Crystal](https://crystal-lang.org). It processes Markdown content with TOML, YAML, or JSON front matter and Jinja2-compatible templates (Crinja) to build high-performance static sites.
 
 Hwaro is designed to help you **build your own website without relying on pre-made themes**. Instead of picking a theme and tweaking it, you craft your templates and styles from scratch, giving you full control over every aspect of your site. With parallel builds, incremental caching, and a dev server with live reload, Hwaro keeps the development experience fast and smooth.
 

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -374,6 +374,7 @@ hwaro tool list all             # List all content files
 hwaro tool list drafts          # List draft files
 hwaro tool convert to-yaml      # Convert frontmatter to YAML
 hwaro tool convert to-toml      # Convert frontmatter to TOML
+hwaro tool convert to-json      # Convert frontmatter to JSON
 hwaro tool check-links          # Check for dead external links
 hwaro tool stats                # Show content statistics
 hwaro tool validate             # Validate content frontmatter and markup
@@ -406,7 +407,7 @@ hwaro tool check-links --json
 | Category | Subcommand | Description |
 |----------|------------|-------------|
 | Content | [list](/start/tools/list/) | List content files by status (all, drafts, published) |
-| Content | [convert](/start/tools/convert/) | Convert frontmatter between YAML and TOML formats |
+| Content | [convert](/start/tools/convert/) | Convert frontmatter between TOML, YAML, and JSON formats |
 | Content | [check-links](/start/tools/check-links/) | Check for dead links in content files |
 | Content | [stats](/start/tools/stats/) | Show content statistics |
 | Content | [validate](/start/tools/validate/) | Validate content frontmatter and markup |

--- a/docs/content/start/tools/convert.md
+++ b/docs/content/start/tools/convert.md
@@ -1,10 +1,10 @@
 +++
 title = "convert"
-description = "Convert frontmatter between YAML and TOML formats"
+description = "Convert frontmatter between TOML, YAML, and JSON formats"
 weight = 1
 +++
 
-Convert frontmatter between YAML and TOML formats across your content files.
+Convert frontmatter between TOML, YAML, and JSON formats across your content files.
 
 ```bash
 # Convert all frontmatter to YAML
@@ -12,6 +12,9 @@ hwaro tool convert to-yaml
 
 # Convert all frontmatter to TOML
 hwaro tool convert to-toml
+
+# Convert all frontmatter to JSON
+hwaro tool convert to-json
 
 # Convert only in a specific directory
 hwaro tool convert to-yaml -c posts
@@ -64,6 +67,21 @@ tags:
   - crystal
   - tutorial
 ---
+
+Content here.
+```
+
+After `hwaro tool convert to-json`:
+
+```markdown
+{
+  "title": "My Post",
+  "date": "2024-01-15",
+  "tags": [
+    "crystal",
+    "tutorial"
+  ]
+}
 
 Content here.
 ```

--- a/docs/content/start/tools/validate.md
+++ b/docs/content/start/tools/validate.md
@@ -31,7 +31,7 @@ hwaro tool validate --json
 - Missing `description` in frontmatter
 - Images without alt text (`![](url)`)
 - Broken internal links (`@/` prefixed paths that don't resolve)
-- Frontmatter parse errors (TOML/YAML)
+- Frontmatter parse errors (TOML/YAML/JSON)
 - Invalid date formats
 - Mixed-case tags (e.g., `Crystal` instead of `crystal`)
 - Draft files (reported as info)
@@ -63,6 +63,7 @@ Found 0 error(s), 2 warning(s), 2 info(s)
 | `content-date-invalid` | warning | Unrecognized date format |
 | `content-frontmatter-toml-error` | error | TOML frontmatter parse error |
 | `content-frontmatter-yaml-error` | error | YAML frontmatter parse error |
+| `content-frontmatter-json-error` | error | JSON frontmatter parse error |
 | `content-read-error` | error | Failed to read content file |
 | `content-tag-mixed-case` | info | Tag has mixed case |
 | `content-draft` | info | File marked as draft |

--- a/docs/content/writing/_index.md
+++ b/docs/content/writing/_index.md
@@ -3,7 +3,7 @@ title = "Writing"
 description = "Create content with Markdown and front matter"
 +++
 
-Content lives in the `content/` directory. Write Markdown with TOML (`+++`) or YAML (`---`) front matter.
+Content lives in the `content/` directory. Write Markdown with TOML (`+++`), YAML (`---`), or JSON (`{...}`) front matter. TOML is the default; YAML is widely recommended; JSON is supported for users who prefer it.
 
 ## Content Types
 

--- a/docs/content/writing/archetypes.md
+++ b/docs/content/writing/archetypes.md
@@ -7,7 +7,7 @@ toc = true
 
 Archetypes are content templates that define default front matter and content structure for new pages. When you create content with `hwaro new`, archetypes provide consistent starting points.
 
-`hwaro init` ships a starter `archetypes/default.md` (and scaffold-specific archetypes like `posts.md` for the blog scaffold) so `hwaro new` picks up front matter (TOML by default, YAML is also supported) with a `description` field out of the box. Edit or extend them to match your site's conventions.
+`hwaro init` ships a starter `archetypes/default.md` (and scaffold-specific archetypes like `posts.md` for the blog scaffold) so `hwaro new` picks up front matter (TOML by default, with YAML and JSON also supported) with a `description` field out of the box. Edit or extend them to match your site's conventions.
 
 ## Overview
 
@@ -103,7 +103,7 @@ default fields of that template are controlled by `[content.new]` in
 
 ```toml
 [content.new]
-front_matter_format = "toml"         # "toml" (default) or "yaml"
+front_matter_format = "toml"         # "toml" (default), "yaml", or "json"
 default_fields = ["description"]      # extra keys to scaffold with empty values
 bundle = false                        # true: scaffold foo/index.md instead of foo.md
 ```

--- a/docs/content/writing/pages.md
+++ b/docs/content/writing/pages.md
@@ -18,7 +18,7 @@ date = "2024-01-15"
 Your content in **Markdown**.
 ```
 
-The `+++` block is TOML front matter. YAML is also supported using `---` delimiters. Content below becomes HTML.
+The `+++` block is TOML front matter. YAML (`---` delimiters) and JSON (a top-level `{...}` object at the start of the file) are also supported. Content below becomes HTML.
 
 ```markdown
 ---
@@ -28,6 +28,17 @@ date: "2024-01-15"
 
 Your content in **Markdown**.
 ```
+
+```markdown
+{
+  "title": "My Page",
+  "date": "2024-01-15"
+}
+
+Your content in **Markdown**.
+```
+
+For JSON, the first balanced `{...}` at the very start of the file is the front matter — no fence is needed. The file must begin with `{` (no leading whitespace).
 
 ## Front Matter
 

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -806,10 +806,21 @@ describe Hwaro::Models::Config do
       config.content_new.front_matter_format.should eq("yaml")
     end
 
-    it "keeps the default format when the configured value is unknown" do
+    it "accepts 'json' as a front_matter_format value" do
       config = load_config(<<-TOML)
         [content.new]
         front_matter_format = "json"
+        TOML
+
+      config.content_new.front_matter_format.should eq("json")
+      config.content_new.json?.should be_true
+      config.content_new.toml?.should be_false
+    end
+
+    it "keeps the default format when the configured value is unknown" do
+      config = load_config(<<-TOML)
+        [content.new]
+        front_matter_format = "xml"
         TOML
 
       config.content_new.front_matter_format.should eq("toml")

--- a/spec/unit/content_validator_spec.cr
+++ b/spec/unit/content_validator_spec.cr
@@ -223,6 +223,23 @@ describe Hwaro::Services::ContentValidator do
       end
     end
 
+    it "reports unbalanced JSON braces as a parse error" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        # File starts with `{` but never closes — we want a loud error, not a
+        # silent fall-through to "no frontmatter".
+        File.write(File.join(content_dir, "unbalanced.md"), %({"title": "Never closes\n\nbody\n))
+
+        validator = Hwaro::Services::ContentValidator.new(content_dir)
+        issues = validator.run
+        issue = issues.find { |i| i.id == "content-frontmatter-json-error" }
+        issue.should_not be_nil
+        issue.not_nil!.message.should contain("unbalanced braces")
+      end
+    end
+
     it "detects invalid date format" do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")

--- a/spec/unit/content_validator_spec.cr
+++ b/spec/unit/content_validator_spec.cr
@@ -196,6 +196,33 @@ describe Hwaro::Services::ContentValidator do
       end
     end
 
+    it "works with JSON frontmatter" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "json.md"), %({"title": "JSON Post", "description": "A JSON post", "date": "2024-01-15"}\n\n# Content\n))
+
+        validator = Hwaro::Services::ContentValidator.new(content_dir)
+        issues = validator.run
+        errors_and_warnings = issues.select { |i| i.level == :error || i.level == :warning }
+        errors_and_warnings.should be_empty
+      end
+    end
+
+    it "detects JSON frontmatter parse errors" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "bad-json.md"), %({"title": "P", "bad": }\n\n# Content\n))
+
+        validator = Hwaro::Services::ContentValidator.new(content_dir)
+        issues = validator.run
+        issues.any? { |i| i.id == "content-frontmatter-json-error" }.should be_true
+      end
+    end
+
     it "detects invalid date format" do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -339,6 +339,32 @@ describe Hwaro::Services::Creator do
       end
     end
 
+    it "emits JSON front matter when config selects json" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+
+          config = Hwaro::Models::Config.new
+          config.content_new.front_matter_format = "json"
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello")
+          Hwaro::Services::Creator.new.run(options, config)
+
+          content = File.read("content/drafts/post.md")
+          content.should start_with("{")
+          # The JSON block must be parseable and contain the expected fields.
+          end_idx = content.index("}\n").not_nil! + 1
+          parsed = JSON.parse(content[0, end_idx])
+          parsed["title"].as_s.should eq("Hello")
+          parsed["description"].as_s.should eq("")
+          # Since the draft was placed in content/drafts, draft should be true
+          parsed["draft"].as_bool.should be_true
+          content.should_not contain("+++\n")
+          content.should_not contain("---\n")
+        end
+      end
+    end
+
     it "honours custom default_fields from config" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -353,7 +353,7 @@ describe Hwaro::Services::Creator do
           content = File.read("content/drafts/post.md")
           content.should start_with("{")
           # The JSON block must be parseable and contain the expected fields.
-          end_idx = content.index("}\n").not_nil! + 1
+          end_idx = content.index!("}\n") + 1
           parsed = JSON.parse(content[0, end_idx])
           parsed["title"].as_s.should eq("Hello")
           parsed["description"].as_s.should eq("")

--- a/spec/unit/defaults_agents_md_spec.cr
+++ b/spec/unit/defaults_agents_md_spec.cr
@@ -21,8 +21,9 @@ describe Hwaro::Services::Defaults::AgentsMd do
       content = Hwaro::Services::Defaults::AgentsMd.content
       content.should contain "## Content"
       content.should contain "Pages"
-      content.should contain "Front matter can use either TOML"
+      content.should contain "Front matter can use TOML"
       content.should contain "YAML"
+      content.should contain "JSON"
     end
 
     it "includes Templates section" do

--- a/spec/unit/frontmatter_converter_spec.cr
+++ b/spec/unit/frontmatter_converter_spec.cr
@@ -42,6 +42,26 @@ describe Hwaro::Services::FrontmatterConverter do
       content = "Some text\n---\ntitle: Test\n---\n"
       converter.detect_format(content).should eq(Hwaro::Services::FrontmatterFormat::Unknown)
     end
+
+    it "detects JSON frontmatter" do
+      content = %({"title": "Test"}\n\n# Content)
+      converter.detect_format(content).should eq(Hwaro::Services::FrontmatterFormat::JSON)
+    end
+
+    it "detects multiline JSON frontmatter" do
+      content = "{\n  \"title\": \"Test\",\n  \"draft\": false\n}\n\n# Content"
+      converter.detect_format(content).should eq(Hwaro::Services::FrontmatterFormat::JSON)
+    end
+
+    it "does not detect JSON when braces never balance" do
+      content = %({"title": "Test")
+      converter.detect_format(content).should eq(Hwaro::Services::FrontmatterFormat::Unknown)
+    end
+
+    it "does not detect JSON when { is not at start" do
+      content = %( {"title": "Test"}\n\n# Content)
+      converter.detect_format(content).should eq(Hwaro::Services::FrontmatterFormat::Unknown)
+    end
   end
 
   describe "#convert_file" do
@@ -353,6 +373,102 @@ describe Hwaro::Services::FrontmatterConverter do
     end
   end
 
+  describe "JSON conversions" do
+    it "converts YAML file to JSON" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "test.md")
+        File.write(file_path, "---\ntitle: Hello\ndraft: false\ntags:\n  - a\n  - b\n---\n\n# Body")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::JSON).should be_true
+
+        converted = File.read(file_path)
+        converted.should start_with("{")
+        parsed = JSON.parse(converted[0, converted.index("}\n").not_nil! + 1])
+        parsed["title"].as_s.should eq("Hello")
+        parsed["draft"].as_bool.should be_false
+        parsed["tags"].as_a.map(&.as_s).should eq(["a", "b"])
+        converted.should contain("# Body")
+      end
+    end
+
+    it "converts TOML file to JSON" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "test.md")
+        File.write(file_path, "+++\ntitle = \"Hello\"\nweight = 5\n+++\n\n# Body")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::JSON).should be_true
+
+        converted = File.read(file_path)
+        parsed = JSON.parse(converted[0, converted.index("}\n").not_nil! + 1])
+        parsed["title"].as_s.should eq("Hello")
+        parsed["weight"].as_i.should eq(5)
+      end
+    end
+
+    it "converts JSON file to TOML" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "test.md")
+        File.write(file_path, %({"title": "Hi", "draft": true}\n\n# Body))
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+
+        converted = File.read(file_path)
+        converted.should start_with("+++\n")
+        converted.should contain(%(title = "Hi"))
+        converted.should contain("draft = true")
+        converted.should contain("# Body")
+      end
+    end
+
+    it "converts JSON file to YAML" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "test.md")
+        File.write(file_path, %({"title": "Hi", "tags": ["x", "y"]}\n\n# Body))
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::YAML).should be_true
+
+        converted = File.read(file_path)
+        converted.should start_with("---\n")
+        converted.should contain("title:")
+        converted.should contain("Hi")
+        converted.should contain("# Body")
+      end
+    end
+
+    it "skips JSON files already in target JSON format" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "test.md")
+        original = %({"title": "Hi"}\n\n# Body)
+        File.write(file_path, original)
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::JSON).should be_false
+        File.read(file_path).should eq(original)
+      end
+    end
+
+    it "convert_to_json converts a mixed directory" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "a.md"), "+++\ntitle = \"A\"\n+++\n\n# A")
+        File.write(File.join(content_dir, "b.md"), "---\ntitle: B\n---\n\n# B")
+        File.write(File.join(content_dir, "c.md"), %({"title": "C"}\n\n# C))
+
+        converter = Hwaro::Services::FrontmatterConverter.new(content_dir)
+        result = converter.convert_to_json
+
+        result.success.should be_true
+        result.converted_count.should eq(2)
+        result.skipped_count.should eq(1)
+      end
+    end
+  end
+
   describe "round-trip conversion" do
     it "preserves data through YAML -> TOML -> YAML" do
       Dir.mktmpdir do |dir|
@@ -515,6 +631,10 @@ describe Hwaro::Services::FrontmatterFormat do
 
   it "has TOML variant" do
     Hwaro::Services::FrontmatterFormat::TOML.should_not be_nil
+  end
+
+  it "has JSON variant" do
+    Hwaro::Services::FrontmatterFormat::JSON.should_not be_nil
   end
 
   it "has Unknown variant" do

--- a/spec/unit/frontmatter_converter_spec.cr
+++ b/spec/unit/frontmatter_converter_spec.cr
@@ -384,7 +384,7 @@ describe Hwaro::Services::FrontmatterConverter do
 
         converted = File.read(file_path)
         converted.should start_with("{")
-        parsed = JSON.parse(converted[0, converted.index("}\n").not_nil! + 1])
+        parsed = JSON.parse(converted[0, converted.index!("}\n") + 1])
         parsed["title"].as_s.should eq("Hello")
         parsed["draft"].as_bool.should be_false
         parsed["tags"].as_a.map(&.as_s).should eq(["a", "b"])
@@ -401,7 +401,7 @@ describe Hwaro::Services::FrontmatterConverter do
         converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::JSON).should be_true
 
         converted = File.read(file_path)
-        parsed = JSON.parse(converted[0, converted.index("}\n").not_nil! + 1])
+        parsed = JSON.parse(converted[0, converted.index!("}\n") + 1])
         parsed["title"].as_s.should eq("Hello")
         parsed["weight"].as_i.should eq(5)
       end

--- a/spec/unit/frontmatter_converter_spec.cr
+++ b/spec/unit/frontmatter_converter_spec.cr
@@ -494,6 +494,37 @@ describe Hwaro::Services::FrontmatterConverter do
         final.should contain(original_body)
       end
     end
+
+    it "preserves data through JSON -> TOML -> YAML -> JSON" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "test.md")
+
+        original_body = "\n# Trip\n\nBody paragraph.\n"
+        File.write(file_path, %({"title": "Round Trip", "draft": true, "weight": 5, "tags": ["a", "b"]}\n#{original_body}))
+
+        # JSON -> TOML
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+        File.read(file_path).should start_with("+++\n")
+
+        # TOML -> YAML
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::YAML).should be_true
+        File.read(file_path).should start_with("---\n")
+
+        # YAML -> JSON
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::JSON).should be_true
+        final = File.read(file_path)
+        final.should start_with("{")
+
+        end_idx = final.index!("}\n") + 1
+        parsed = JSON.parse(final[0, end_idx])
+        parsed["title"].as_s.should eq("Round Trip")
+        parsed["draft"].as_bool.should be_true
+        parsed["weight"].as_i.should eq(5)
+        parsed["tags"].as_a.map(&.as_s).should eq(["a", "b"])
+        final.should contain(original_body)
+      end
+    end
   end
 
   describe "error handling" do

--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -746,14 +746,13 @@ describe Hwaro::Content::Processors::Markdown do
     end
 
     it "leaves content untouched when file does not start with {" do
-      raw = <<-MD
-         {"not": "frontmatter"}
-
-         Body
-         MD
+      # Leading whitespace means the { is not at byte 0, so this is not a JSON
+      # frontmatter block — parser should fall through to the no-frontmatter path.
+      raw = " {\"not\": \"frontmatter\"}\n\nBody\n"
 
       result = processor.parse(raw)
       result[:title].should eq("Untitled")
+      result[:content].should contain("Body")
     end
 
     it "extracts non-taxonomy-keyword arrays into taxonomies" do

--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -645,6 +645,131 @@ describe Hwaro::Content::Processors::Markdown do
   end
 
   # ---------------------------------------------------------------------------
+  # JSON front matter ({...} balanced at file start)
+  # ---------------------------------------------------------------------------
+  describe "JSON front matter parsing" do
+    it "parses basic JSON fields" do
+      raw = <<-MD
+        {
+          "title": "My JSON Post",
+          "draft": false
+        }
+
+        Content here
+        MD
+
+      result = processor.parse(raw)
+      result[:title].should eq("My JSON Post")
+      result[:draft].should be_false
+      result[:content].should contain("Content here")
+    end
+
+    it "parses description and image" do
+      raw = <<-MD
+        {"title": "Post", "description": "A brief summary", "image": "/images/hero.jpg"}
+
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:description].should eq("A brief summary")
+      result[:image].should eq("/images/hero.jpg")
+    end
+
+    it "parses tags array" do
+      raw = <<-MD
+        {"title": "Tagged", "tags": ["crystal", "web"]}
+
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:tags].should eq(["crystal", "web"])
+      result[:taxonomies].has_key?("tags").should be_true
+      result[:taxonomies]["tags"].should eq(["crystal", "web"])
+    end
+
+    it "parses integer and boolean fields" do
+      raw = <<-MD
+        {"title": "P", "weight": 5, "toc": true, "draft": true}
+
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:weight].should eq(5)
+      result[:toc].should be_true
+      result[:draft].should be_true
+    end
+
+    it "parses date as ISO string" do
+      raw = <<-MD
+        {"title": "Dated", "date": "2024-01-15"}
+
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:date].should_not be_nil
+      result[:date].not_nil!.year.should eq(2024)
+    end
+
+    it "captures unknown keys into extra" do
+      raw = <<-MD
+        {"title": "P", "custom_field": "hello", "rating": 4}
+
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:extra]["custom_field"].should eq("hello")
+      result[:extra]["rating"].should eq(4_i64)
+    end
+
+    it "handles nested braces inside string values" do
+      raw = <<-MD
+        {"title": "Tricky {nested}", "description": "a } b { c"}
+
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:title].should eq("Tricky {nested}")
+      result[:description].should eq("a } b { c")
+    end
+
+    it "handles escaped quotes inside strings" do
+      raw = %({"title": "She said \\"hi\\"", "description": "x"}\n\nBody\n)
+
+      result = processor.parse(raw)
+      result[:title].should eq(%(She said "hi"))
+    end
+
+    it "leaves content untouched when file does not start with {" do
+      raw = <<-MD
+         {"not": "frontmatter"}
+
+         Body
+         MD
+
+      result = processor.parse(raw)
+      result[:title].should eq("Untitled")
+    end
+
+    it "extracts non-taxonomy-keyword arrays into taxonomies" do
+      raw = <<-MD
+        {"title": "P", "tags": ["a"], "categories": ["tech"]}
+
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:taxonomies]["tags"].should eq(["a"])
+      result[:taxonomies]["categories"].should eq(["tech"])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Default values (no front matter or missing fields)
   # ---------------------------------------------------------------------------
   describe "default values" do

--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -766,6 +766,24 @@ describe Hwaro::Content::Processors::Markdown do
       result[:taxonomies]["tags"].should eq(["a"])
       result[:taxonomies]["categories"].should eq(["tech"])
     end
+
+    it "raises HwaroError for unbalanced JSON when a file_path is provided" do
+      raw = %({"title": "Never closes\n\nbody\n)
+
+      expect_raises(Hwaro::HwaroError, /unbalanced braces/) do
+        processor.parse(raw, "content/broken.md")
+      end
+    end
+
+    it "silently ignores unbalanced JSON when no file_path is provided (library use)" do
+      # Without a file_path the parser has no caller context to raise against,
+      # so we keep the historic graceful-nil behaviour and treat the file as
+      # having no front matter.
+      raw = %({"title": "Never closes\n\nbody\n)
+
+      result = processor.parse(raw)
+      result[:title].should eq("Untitled")
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/unit/tool_commands_spec.cr
+++ b/spec/unit/tool_commands_spec.cr
@@ -114,9 +114,9 @@ describe Hwaro::CLI::Commands::Tool::ConvertCommand do
       meta.positional_args.should eq(["format"])
     end
 
-    it "has to-yaml and to-toml as positional choices" do
+    it "has to-yaml, to-toml, and to-json as positional choices" do
       meta = Hwaro::CLI::Commands::Tool::ConvertCommand.metadata
-      meta.positional_choices.should eq(["to-yaml", "to-toml"])
+      meta.positional_choices.should eq(["to-yaml", "to-toml", "to-json"])
     end
 
     it "content-dir flag takes a value" do

--- a/src/cli/commands/tool/convert_command.cr
+++ b/src/cli/commands/tool/convert_command.cr
@@ -1,9 +1,10 @@
 # Convert command for converting frontmatter formats
 #
-# This command converts frontmatter in content files between YAML and TOML formats.
+# This command converts frontmatter in content files between YAML, TOML, and JSON formats.
 # Usage:
 #   hwaro tool convert to-yaml  - Convert all frontmatter to YAML format
 #   hwaro tool convert to-toml  - Convert all frontmatter to TOML format
+#   hwaro tool convert to-json  - Convert all frontmatter to JSON format
 
 require "json"
 require "option_parser"
@@ -18,9 +19,9 @@ module Hwaro
         class ConvertCommand
           # Single source of truth for command metadata
           NAME               = "convert"
-          DESCRIPTION        = "Convert frontmatter format (YAML <-> TOML)"
+          DESCRIPTION        = "Convert frontmatter format (TOML / YAML / JSON)"
           POSITIONAL_ARGS    = ["format"]
-          POSITIONAL_CHOICES = ["to-yaml", "to-toml"]
+          POSITIONAL_CHOICES = ["to-yaml", "to-toml", "to-json"]
 
           # Flags defined here are used both for OptionParser and completion generation
           FLAGS = [
@@ -45,7 +46,7 @@ module Hwaro
             json_output = false
 
             OptionParser.parse(args) do |parser|
-              parser.banner = "Usage: hwaro tool convert <to-yaml|to-toml> [options]"
+              parser.banner = "Usage: hwaro tool convert <to-yaml|to-toml|to-json> [options]"
               CLI.register_flag(parser, CONTENT_DIR_FLAG) { |v| content_dir = v }
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
@@ -55,13 +56,14 @@ module Hwaro
             end
 
             unless format
-              Logger.error "Missing format argument. Use 'to-yaml' or 'to-toml'"
+              Logger.error "Missing format argument. Use 'to-yaml', 'to-toml', or 'to-json'"
               Logger.info ""
-              Logger.info "Usage: hwaro tool convert <to-yaml|to-toml> [options]"
+              Logger.info "Usage: hwaro tool convert <to-yaml|to-toml|to-json> [options]"
               Logger.info ""
               Logger.info "Examples:"
               Logger.info "  hwaro tool convert to-yaml"
               Logger.info "  hwaro tool convert to-toml"
+              Logger.info "  hwaro tool convert to-json"
               Logger.info "  hwaro tool convert to-yaml --content-dir=posts"
               exit(1)
             end
@@ -71,19 +73,19 @@ module Hwaro
             case format.as(String).downcase
             when "to-yaml"
               result = converter.convert_to_yaml
-              if json_output
-                puts result.to_json
-              end
+              puts result.to_json if json_output
               exit(1) unless result.success
             when "to-toml"
               result = converter.convert_to_toml
-              if json_output
-                puts result.to_json
-              end
+              puts result.to_json if json_output
+              exit(1) unless result.success
+            when "to-json"
+              result = converter.convert_to_json
+              puts result.to_json if json_output
               exit(1) unless result.success
             else
               Logger.error "Unknown format: #{format}"
-              Logger.info "Use 'to-yaml' or 'to-toml'"
+              Logger.info "Use 'to-yaml', 'to-toml', or 'to-json'"
               exit(1)
             end
           end

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -1,7 +1,7 @@
 # Markdown processor for converting Markdown to HTML
 #
 # This processor handles:
-# - TOML and YAML front matter parsing
+# - TOML, YAML, and JSON front matter parsing
 # - Markdown to HTML conversion using Markd
 # - Table of Contents generation with header IDs
 # - Syntax highlighting support via HighlightingRenderer
@@ -9,12 +9,14 @@
 require "markd"
 require "yaml"
 require "toml"
+require "json"
 require "xml"
 require "./base"
 require "./syntax_highlighter"
 require "./markdown_extensions"
 require "../../models/toc"
 require "../../utils/errors"
+require "../../utils/frontmatter_scanner"
 require "../../utils/logger"
 require "../../utils/text_utils"
 
@@ -42,7 +44,12 @@ module Hwaro
         # Regex for YAML front matter
         YAML_FRONT_MATTER_REGEX = /\A---\s*\n(.*?\n?)^---\s*$\n?(.*)\z/m
 
-        # Known front-matter keys (shared between TOML and YAML parsers).
+        # JSON front matter is delimited by balanced braces. The file must begin
+        # with `{` (no leading whitespace) and the first balanced `{...}` is the
+        # front matter; the remainder is the markdown body.
+        # See `find_json_front_matter_end` for the brace scanner.
+
+        # Known front-matter keys (shared between TOML, YAML, and JSON parsers).
         # Using a Set for O(1) lookup instead of Array#includes? O(n).
         KNOWN_FRONT_MATTER_KEYS = Set{
           "title", "description", "image", "draft", "template", "in_sitemap",
@@ -150,13 +157,17 @@ module Hwaro
         def parse(raw_content : String, file_path : String = "")
           markdown_content = raw_content
 
-          # Try TOML Front Matter (+++) then YAML Front Matter (---)
+          # Try TOML (+++), YAML (---), then JSON ({...}) front matter
           if match = raw_content.match(TOML_FRONT_MATTER_REGEX)
             result = extract_from_toml(match[1], file_path)
             markdown_content = match[2]
           elsif match = raw_content.match(YAML_FRONT_MATTER_REGEX)
             result = extract_from_yaml(match[1], file_path)
             markdown_content = match[2]
+          elsif raw_content.starts_with?('{') && (end_idx = Utils::FrontmatterScanner.find_json_end(raw_content))
+            result = extract_from_json(raw_content[0, end_idx], file_path)
+            body = raw_content[end_idx..]
+            markdown_content = body.lchop("\r\n").lchop("\n")
           end
 
           if result
@@ -336,9 +347,53 @@ module Hwaro
           nil
         end
 
+        # Extract front matter fields from JSON content
+        private def extract_from_json(raw : String, file_path : String)
+          json_fm = begin
+            JSON.parse(raw)
+          rescue ex
+            if file_path.empty?
+              Logger.warn "Invalid JSON: #{ex.message}"
+              return
+            end
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_CONTENT,
+              message: "Invalid JSON frontmatter in #{file_path}: #{ex.message}",
+              hint: "Check JSON frontmatter object at start of file",
+            )
+          end
+          return unless json_fm.as_h?
+
+          date = parse_time(json_fm["date"]?.try(&.as_s?))
+          updated = parse_time(json_fm["updated"]?.try(&.as_s?))
+          expires = parse_time(json_fm["expires"]?.try(&.as_s?))
+
+          extra = {} of String => String | Bool | Int64 | Float64 | Array(String)
+          unknown_keys = [] of String
+          json_fm.as_h.each do |key, value|
+            next if KNOWN_FRONT_MATTER_KEYS.includes?(key)
+            unknown_keys << key
+            extra[key] = extract_extra_value(value)
+          end
+          warn_typo_keys(unknown_keys, file_path)
+
+          front_matter_keys = json_fm.as_h.keys
+          taxonomies = extract_taxonomies(json_fm, front_matter_keys)
+          tags = fm_string_array(json_fm, "tags")
+          taxonomies["tags"] = tags if tags.present?
+
+          result = build_front_matter_result(json_fm, date, updated, extra, front_matter_keys, taxonomies, tags)
+          result.merge({expires: expires})
+        rescue ex : Hwaro::HwaroError
+          raise ex
+        rescue ex
+          Logger.warn "Invalid JSON in #{file_path}: #{ex.message}" unless file_path.empty?
+          nil
+        end
+
         # Shared helper: extract a Bool from a front matter value, returning the
         # given default when the key is absent or not a boolean.
-        private def fm_bool(fm : TOML::Table | YAML::Any, key : String, default : Bool) : Bool
+        private def fm_bool(fm : TOML::Table | YAML::Any | JSON::Any, key : String, default : Bool) : Bool
           val = fm[key]?
           return default unless val
           bool_val = val.as_bool?
@@ -346,31 +401,32 @@ module Hwaro
         end
 
         # Shared helper: extract a nilable Bool from a front matter value.
-        private def fm_bool?(fm : TOML::Table | YAML::Any, key : String) : Bool?
+        private def fm_bool?(fm : TOML::Table | YAML::Any | JSON::Any, key : String) : Bool?
           fm[key]?.try(&.as_bool?)
         end
 
         # Shared helper: extract a nilable Int32 from a front matter value.
-        private def fm_int?(fm : TOML::Table | YAML::Any, key : String) : Int32?
+        private def fm_int?(fm : TOML::Table | YAML::Any | JSON::Any, key : String) : Int32?
           fm[key]?.try(&.as_i?)
         end
 
         # Shared helper: extract a String with a default from a front matter value.
-        private def fm_string(fm : TOML::Table | YAML::Any, key : String, default : String) : String
+        private def fm_string(fm : TOML::Table | YAML::Any | JSON::Any, key : String, default : String) : String
           fm[key]?.try(&.as_s?) || default
         end
 
         # Shared helper: extract a string array from a front matter value.
         # Uses compact_map(&.as_s?) instead of map(&.as_s) to safely skip
         # non-string elements rather than raising at runtime.
-        private def fm_string_array(fm : TOML::Table | YAML::Any, key : String) : Array(String)
+        private def fm_string_array(fm : TOML::Table | YAML::Any | JSON::Any, key : String) : Array(String)
           fm[key]?.try(&.as_a?.try { |a| a.compact_map(&.as_s?) }) || [] of String
         end
 
         # Build the front matter result NamedTuple from any front matter source.
-        # This eliminates duplication between extract_from_toml and extract_from_yaml.
+        # This eliminates duplication between extract_from_toml, extract_from_yaml,
+        # and extract_from_json.
         private def build_front_matter_result(
-          fm : TOML::Table | YAML::Any,
+          fm : TOML::Table | YAML::Any | JSON::Any,
           date : Time?,
           updated : Time?,
           extra : Hash(String, String | Bool | Int64 | Float64 | Array(String)),
@@ -415,8 +471,8 @@ module Hwaro
           }
         end
 
-        # Extract extra value from TOML::Any or YAML::Any
-        private def extract_extra_value(value : TOML::Any | YAML::Any) : String | Bool | Int64 | Float64 | Array(String)
+        # Extract extra value from TOML::Any, YAML::Any, or JSON::Any
+        private def extract_extra_value(value : TOML::Any | YAML::Any | JSON::Any) : String | Bool | Int64 | Float64 | Array(String)
           if str = value.as_s?
             str
           elsif (bool_val = value.as_bool?) != nil
@@ -662,7 +718,7 @@ module Hwaro
         # These are excluded from automatic taxonomy extraction.
         NON_TAXONOMY_ARRAY_KEYS = Set{"tags", "aliases", "authors"}
 
-        private def extract_taxonomies(front_matter : TOML::Table | YAML::Any, keys : Array(String)) : Hash(String, Array(String))
+        private def extract_taxonomies(front_matter : TOML::Table | YAML::Any | JSON::Any, keys : Array(String)) : Hash(String, Array(String))
           taxonomies = {} of String => Array(String)
 
           # Iterate all keys: TOML::Table yields {String, TOML::Any},

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -47,7 +47,7 @@ module Hwaro
         # JSON front matter is delimited by balanced braces. The file must begin
         # with `{` (no leading whitespace) and the first balanced `{...}` is the
         # front matter; the remainder is the markdown body.
-        # See `find_json_front_matter_end` for the brace scanner.
+        # See `Utils::FrontmatterScanner.find_json_end` for the brace scanner.
 
         # Known front-matter keys (shared between TOML, YAML, and JSON parsers).
         # Using a Set for O(1) lookup instead of Array#includes? O(n).
@@ -164,10 +164,22 @@ module Hwaro
           elsif match = raw_content.match(YAML_FRONT_MATTER_REGEX)
             result = extract_from_yaml(match[1], file_path)
             markdown_content = match[2]
-          elsif raw_content.starts_with?('{') && (end_idx = Utils::FrontmatterScanner.find_json_end(raw_content))
-            result = extract_from_json(raw_content[0, end_idx], file_path)
-            body = raw_content[end_idx..]
-            markdown_content = body.lchop("\r\n").lchop("\n")
+          elsif raw_content.starts_with?('{')
+            # A leading `{` signals JSON frontmatter intent. If the scanner can
+            # locate a balanced object we parse it; if not, the file is almost
+            # certainly a truncated/mistyped JSON header — surface it as a
+            # content error rather than silently treating it as body text.
+            if end_idx = Utils::FrontmatterScanner.find_json_end(raw_content)
+              result = extract_from_json(raw_content[0, end_idx], file_path)
+              body = raw_content[end_idx..]
+              markdown_content = body.lchop("\r\n").lchop("\n")
+            elsif !file_path.empty?
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_CONTENT,
+                message: "Invalid JSON frontmatter in #{file_path}: unbalanced braces",
+                hint: "The file starts with `{` so hwaro treated it as JSON frontmatter. Close the object with a matching `}` or remove the leading `{`.",
+              )
+            end
           end
 
           if result

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -213,7 +213,8 @@ module Hwaro
     class ContentNewConfig
       FORMAT_TOML    = "toml"
       FORMAT_YAML    = "yaml"
-      VALID_FORMATS  = {FORMAT_TOML, FORMAT_YAML}
+      FORMAT_JSON    = "json"
+      VALID_FORMATS  = {FORMAT_TOML, FORMAT_YAML, FORMAT_JSON}
       BUILTIN_FIELDS = {"title", "date", "draft", "tags"}
 
       property front_matter_format : String
@@ -228,6 +229,14 @@ module Hwaro
 
       def toml? : Bool
         @front_matter_format == FORMAT_TOML
+      end
+
+      def yaml? : Bool
+        @front_matter_format == FORMAT_YAML
+      end
+
+      def json? : Bool
+        @front_matter_format == FORMAT_JSON
       end
 
       # Extra fields, with built-ins filtered out and duplicates removed,

--- a/src/services/content_lister.cr
+++ b/src/services/content_lister.cr
@@ -6,6 +6,7 @@
 require "json"
 require "yaml"
 require "toml"
+require "../utils/frontmatter_scanner"
 require "../utils/logger"
 
 module Hwaro
@@ -222,6 +223,20 @@ module Hwaro
             end
           rescue ex
             Logger.debug "YAML front matter parsing failed for #{file_path}: #{ex.message}"
+          end
+          # Try JSON Front Matter (balanced {...} at file start)
+        elsif content.starts_with?('{') && (end_idx = Hwaro::Utils::FrontmatterScanner.find_json_end(content))
+          begin
+            json_fm = JSON.parse(content[0, end_idx])
+            if json_fm.as_h?
+              title = json_fm["title"]?.try(&.as_s?) || title
+              draft = json_fm["draft"]?.try(&.as_bool?) || false
+              if str_val = json_fm["date"]?.try(&.as_s?)
+                date = parse_time(str_val)
+              end
+            end
+          rescue ex
+            Logger.debug "JSON front matter parsing failed for #{file_path}: #{ex.message}"
           end
         end
 

--- a/src/services/content_lister.cr
+++ b/src/services/content_lister.cr
@@ -225,7 +225,7 @@ module Hwaro
             Logger.debug "YAML front matter parsing failed for #{file_path}: #{ex.message}"
           end
           # Try JSON Front Matter (balanced {...} at file start)
-        elsif content.starts_with?('{') && (end_idx = Hwaro::Utils::FrontmatterScanner.find_json_end(content))
+        elsif content.starts_with?('{') && (end_idx = Utils::FrontmatterScanner.find_json_end(content))
           begin
             json_fm = JSON.parse(content[0, end_idx])
             if json_fm.as_h?

--- a/src/services/content_validator.cr
+++ b/src/services/content_validator.cr
@@ -200,7 +200,6 @@ module Hwaro
         nil
       end
 
-
       private def check_date_format(file_path : String, date_str : String, issues : Array(Issue))
         formats = [
           "%Y-%m-%d %H:%M:%S",

--- a/src/services/content_validator.cr
+++ b/src/services/content_validator.cr
@@ -9,6 +9,7 @@ require "yaml"
 require "toml"
 require "./doctor"
 require "../utils/errors"
+require "../utils/frontmatter_scanner"
 require "../utils/logger"
 
 module Hwaro
@@ -164,10 +165,41 @@ module Hwaro
               message: "YAML frontmatter parse error: #{ex.message}")
             return
           end
+        elsif content.starts_with?('{') && (end_idx = Hwaro::Utils::FrontmatterScanner.find_json_end(content))
+          begin
+            json_data = JSON.parse(content[0, end_idx])
+            if h = json_data.as_h?
+              result = {} of String => FrontmatterValue
+              h.each do |k, value|
+                if s = value.as_s?
+                  result[k] = s
+                elsif b = value.as_bool?
+                  result[k] = b
+                elsif i = value.as_i?
+                  result[k] = i.to_i64
+                elsif f = value.as_f?
+                  result[k] = f
+                end
+              end
+              if tags_node = h["tags"]?
+                if arr = tags_node.as_a?
+                  tag_strs = arr.compact_map(&.as_s?)
+                  result["_tags"] = tag_strs.join(",") unless tag_strs.empty?
+                end
+              end
+              return result
+            end
+            return
+          rescue ex
+            issues << Issue.new(id: "content-frontmatter-json-error", level: :error, category: "content", file: file_path,
+              message: "JSON frontmatter parse error: #{ex.message}")
+            return
+          end
         end
 
         nil
       end
+
 
       private def check_date_format(file_path : String, date_str : String, issues : Array(Issue))
         formats = [

--- a/src/services/content_validator.cr
+++ b/src/services/content_validator.cr
@@ -165,7 +165,13 @@ module Hwaro
               message: "YAML frontmatter parse error: #{ex.message}")
             return
           end
-        elsif content.starts_with?('{') && (end_idx = Hwaro::Utils::FrontmatterScanner.find_json_end(content))
+        elsif content.starts_with?('{')
+          end_idx = Utils::FrontmatterScanner.find_json_end(content)
+          unless end_idx
+            issues << Issue.new(id: "content-frontmatter-json-error", level: :error, category: "content", file: file_path,
+              message: "JSON frontmatter parse error: unbalanced braces")
+            return
+          end
           begin
             json_data = JSON.parse(content[0, end_idx])
             if h = json_data.as_h?

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -1,4 +1,5 @@
 require "file_utils"
+require "json"
 require "time"
 require "../config/options/new_options"
 require "../models/config"
@@ -366,10 +367,12 @@ module Hwaro
         tags : Array(String),
         content_new : Models::ContentNewConfig,
       ) : String
-        if content_new.toml?
-          build_toml_front_matter(title, date, is_draft, tags, content_new.extra_fields)
-        else
+        if content_new.json?
+          build_json_front_matter(title, date, is_draft, tags, content_new.extra_fields)
+        elsif content_new.yaml?
           build_yaml_front_matter(title, date, is_draft, tags, content_new.extra_fields)
+        else
+          build_toml_front_matter(title, date, is_draft, tags, content_new.extra_fields)
         end
       end
 
@@ -403,6 +406,22 @@ module Hwaro
             tags.each { |tag| str << "  - \"#{escape_string(tag)}\"\n" }
           end
           str << "---\n\n"
+          str << "# #{title}\n"
+        end
+      end
+
+      private def build_json_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String)) : String
+        fields = {} of String => JSON::Any
+        fields["title"] = JSON::Any.new(title)
+        fields["date"] = JSON::Any.new(date)
+        extra_fields.each { |f| fields[f] = JSON::Any.new("") }
+        fields["draft"] = JSON::Any.new(true) if is_draft
+        unless tags.empty?
+          fields["tags"] = JSON::Any.new(tags.map { |t| JSON::Any.new(t) })
+        end
+        String.build do |str|
+          str << JSON::Any.new(fields).to_pretty_json
+          str << "\n\n"
           str << "# #{title}\n"
         end
       end

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -419,11 +419,7 @@ module Hwaro
         unless tags.empty?
           fields["tags"] = JSON::Any.new(tags.map { |t| JSON::Any.new(t) })
         end
-        String.build do |str|
-          str << JSON::Any.new(fields).to_pretty_json
-          str << "\n\n"
-          str << "# #{title}\n"
-        end
+        "#{JSON::Any.new(fields).to_pretty_json}\n\n# #{title}\n"
       end
 
       private def escape_string(value : String) : String

--- a/src/services/defaults/agents_md.cr
+++ b/src/services/defaults/agents_md.cr
@@ -45,11 +45,11 @@ module Hwaro
 
             ## Notes for AI Agents
 
-            1. **Front matter** can be TOML (`+++`) or YAML (`---`). Pick one per file and keep delimiters matched.
+            1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
             2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
             3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
             4. **Always preview** with `hwaro serve` before committing.
-            5. **Validate front matter syntax** (TOML or YAML) and `config.toml` after edits.
+            5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
             6. **Use `{{ base_url }}` prefix** for URLs in templates.
             7. **Escape user content** with `{{ value | escape }}` in templates.
 
@@ -120,7 +120,7 @@ module Hwaro
 
             ### Pages
 
-            Create `.md` files in `content/`. Front matter can use either TOML (`+++`) or YAML (`---`) — TOML is the default.
+            Create `.md` files in `content/`. Front matter can use TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start) — TOML is the default.
 
             ```toml
             +++
@@ -320,11 +320,11 @@ module Hwaro
 
             ## Notes for AI Agents
 
-            1. **Front matter** can be TOML (`+++`) or YAML (`---`). Pick one per file and keep delimiters matched.
+            1. **Front matter** can be TOML (`+++`), YAML (`---`), or JSON (`{...}` at file start). Pick one per file and keep delimiters matched.
             2. **Rendered content** is `{{ content | safe }}`, not `{{ page.content }}`.
             3. **Custom metadata** is `page.extra.field`, not `page.params.field`.
             4. **Always preview** with `hwaro serve` before committing.
-            5. **Validate front matter syntax** (TOML or YAML) and `config.toml` after edits.
+            5. **Validate front matter syntax** (TOML, YAML, or JSON) and `config.toml` after edits.
             6. **Use `{{ base_url }}` prefix** for URLs in templates.
             7. **Escape user content** with `{{ value | escape }}` in templates.
 

--- a/src/services/frontmatter_converter.cr
+++ b/src/services/frontmatter_converter.cr
@@ -78,7 +78,7 @@ module Hwaro
           FrontmatterFormat::TOML
         elsif content.starts_with?("#{YAML_DELIMITER}\n") || content.starts_with?("#{YAML_DELIMITER}\r\n")
           FrontmatterFormat::YAML
-        elsif content.starts_with?('{') && Hwaro::Utils::FrontmatterScanner.find_json_end(content)
+        elsif content.starts_with?('{') && Utils::FrontmatterScanner.find_json_end(content)
           FrontmatterFormat::JSON
         else
           FrontmatterFormat::Unknown
@@ -208,7 +208,7 @@ module Hwaro
       # Split JSON-frontmatter content into (json_string, body). Returns nil if
       # the file does not start with a balanced JSON object.
       private def split_json_frontmatter(content : String) : {String, String}?
-        end_idx = Hwaro::Utils::FrontmatterScanner.find_json_end(content)
+        end_idx = Utils::FrontmatterScanner.find_json_end(content)
         return unless end_idx
 
         json_str = content[0, end_idx]

--- a/src/services/frontmatter_converter.cr
+++ b/src/services/frontmatter_converter.cr
@@ -209,7 +209,7 @@ module Hwaro
       # the file does not start with a balanced JSON object.
       private def split_json_frontmatter(content : String) : {String, String}?
         end_idx = Hwaro::Utils::FrontmatterScanner.find_json_end(content)
-        return nil unless end_idx
+        return unless end_idx
 
         json_str = content[0, end_idx]
         body = content[end_idx..].lchop("\r\n").lchop("\n")

--- a/src/services/frontmatter_converter.cr
+++ b/src/services/frontmatter_converter.cr
@@ -1,11 +1,12 @@
 # Frontmatter Converter Service
 #
 # This service provides functionality to convert frontmatter between
-# YAML and TOML formats in content files.
+# YAML, TOML, and JSON formats in content files.
 
 require "json"
 require "yaml"
 require "toml"
+require "../utils/frontmatter_scanner"
 require "../utils/logger"
 
 module Hwaro
@@ -14,6 +15,7 @@ module Hwaro
     enum FrontmatterFormat
       YAML
       TOML
+      JSON
       Unknown
     end
 
@@ -65,12 +67,19 @@ module Hwaro
         convert_files(FrontmatterFormat::TOML)
       end
 
+      # Convert all content files to JSON format
+      def convert_to_json : ConversionResult
+        convert_files(FrontmatterFormat::JSON)
+      end
+
       # Detect the frontmatter format of a file
       def detect_format(content : String) : FrontmatterFormat
         if content.starts_with?("#{TOML_DELIMITER}\n") || content.starts_with?("#{TOML_DELIMITER}\r\n")
           FrontmatterFormat::TOML
         elsif content.starts_with?("#{YAML_DELIMITER}\n") || content.starts_with?("#{YAML_DELIMITER}\r\n")
           FrontmatterFormat::YAML
+        elsif content.starts_with?('{') && Hwaro::Utils::FrontmatterScanner.find_json_end(content)
+          FrontmatterFormat::JSON
         else
           FrontmatterFormat::Unknown
         end
@@ -124,7 +133,7 @@ module Hwaro
         skipped = 0
         errors = 0
 
-        format_name = target_format == FrontmatterFormat::YAML ? "YAML" : "TOML"
+        format_name = format_label(target_format)
         Logger.info "Converting frontmatter to #{format_name} format..."
         Logger.info ""
 
@@ -176,7 +185,35 @@ module Hwaro
           yaml_to_toml(content)
         when {FrontmatterFormat::TOML, FrontmatterFormat::YAML}
           toml_to_yaml(content)
+        when {FrontmatterFormat::YAML, FrontmatterFormat::JSON}
+          yaml_to_json(content)
+        when {FrontmatterFormat::JSON, FrontmatterFormat::YAML}
+          json_to_yaml(content)
+        when {FrontmatterFormat::TOML, FrontmatterFormat::JSON}
+          toml_to_json(content)
+        when {FrontmatterFormat::JSON, FrontmatterFormat::TOML}
+          json_to_toml(content)
         end
+      end
+
+      private def format_label(fmt : FrontmatterFormat) : String
+        case fmt
+        when FrontmatterFormat::YAML then "YAML"
+        when FrontmatterFormat::TOML then "TOML"
+        when FrontmatterFormat::JSON then "JSON"
+        else                              "Unknown"
+        end
+      end
+
+      # Split JSON-frontmatter content into (json_string, body). Returns nil if
+      # the file does not start with a balanced JSON object.
+      private def split_json_frontmatter(content : String) : {String, String}?
+        end_idx = Hwaro::Utils::FrontmatterScanner.find_json_end(content)
+        return nil unless end_idx
+
+        json_str = content[0, end_idx]
+        body = content[end_idx..].lchop("\r\n").lchop("\n")
+        {json_str, body}
       end
 
       private def yaml_to_toml(content : String) : String?
@@ -213,6 +250,172 @@ module Hwaro
             nil
           end
         end
+      end
+
+      private def yaml_to_json(content : String) : String?
+        if match = content.match(/\A---\s*\n(.*?\n?)^---\s*$\n?(.*)\z/m)
+          yaml_str = match[1]
+          body = match[2]
+          begin
+            yaml_data = YAML.parse(yaml_str)
+            json_str = yaml_to_json_string(yaml_data)
+            "#{json_str}\n#{body}"
+          rescue ex
+            Logger.debug "YAML parse error: #{ex.message}"
+            nil
+          end
+        end
+      end
+
+      private def toml_to_json(content : String) : String?
+        if match = content.match(/\A\+\+\+\s*\n(.*?\n?)^\+\+\+\s*$\n?(.*)\z/m)
+          toml_str = match[1]
+          body = match[2]
+          begin
+            toml_data = TOML.parse(toml_str)
+            json_str = toml_to_json_string(toml_data)
+            "#{json_str}\n#{body}"
+          rescue ex
+            Logger.debug "TOML parse error: #{ex.message}"
+            nil
+          end
+        end
+      end
+
+      private def json_to_yaml(content : String) : String?
+        return unless parts = split_json_frontmatter(content)
+        json_str, body = parts
+        begin
+          json_data = JSON.parse(json_str)
+          yaml_body = convert_json_to_yaml_string(json_data)
+          "#{YAML_DELIMITER}\n#{yaml_body}#{YAML_DELIMITER}\n#{body}"
+        rescue ex
+          Logger.debug "JSON parse error: #{ex.message}"
+          nil
+        end
+      end
+
+      private def json_to_toml(content : String) : String?
+        return unless parts = split_json_frontmatter(content)
+        json_str, body = parts
+        begin
+          json_data = JSON.parse(json_str)
+          # Reuse the YAML→TOML builder by going through YAML::Any.
+          yaml_any = json_to_yaml_any(json_data)
+          toml_body = TomlBuilder.new.build(yaml_any)
+          "#{TOML_DELIMITER}\n#{toml_body}#{TOML_DELIMITER}\n#{body}"
+        rescue ex
+          Logger.debug "JSON parse error: #{ex.message}"
+          nil
+        end
+      end
+
+      # Pretty-print a YAML::Any tree as a JSON object (2-space indent).
+      private def yaml_to_json_string(yaml : YAML::Any) : String
+        return "{}" unless yaml.as_h?
+        yaml_any_to_json_any(yaml).to_pretty_json
+      end
+
+      # Pretty-print a TOML::Table as a JSON object (2-space indent).
+      private def toml_to_json_string(toml : TOML::Table) : String
+        root = JSON::Any.new({} of String => JSON::Any)
+        hash = root.as_h
+        toml.each do |key, value|
+          hash[key] = toml_any_to_json_any(value)
+        end
+        root.to_pretty_json
+      end
+
+      private def yaml_any_to_json_any(yaml : YAML::Any) : JSON::Any
+        raw = yaml.raw
+        case raw
+        when Bool    then JSON::Any.new(raw)
+        when Int32   then JSON::Any.new(raw.to_i64)
+        when Int64   then JSON::Any.new(raw)
+        when Float32 then JSON::Any.new(raw.to_f64)
+        when Float64 then JSON::Any.new(raw)
+        when String  then JSON::Any.new(raw)
+        when Time    then JSON::Any.new(raw.to_rfc3339)
+        when Nil     then JSON::Any.new(nil)
+        when Array
+          arr = yaml.as_a.map { |v| yaml_any_to_json_any(v) }
+          JSON::Any.new(arr)
+        when Hash
+          hash = {} of String => JSON::Any
+          yaml.as_h.each do |k, v|
+            key_str = k.as_s? || k.to_s
+            hash[key_str] = yaml_any_to_json_any(v)
+          end
+          JSON::Any.new(hash)
+        else
+          JSON::Any.new(yaml.to_s)
+        end
+      end
+
+      private def toml_any_to_json_any(value : TOML::Any) : JSON::Any
+        raw = value.raw
+        case raw
+        when Bool    then JSON::Any.new(raw)
+        when Int64   then JSON::Any.new(raw)
+        when Float64 then JSON::Any.new(raw)
+        when String  then JSON::Any.new(raw)
+        when Time    then JSON::Any.new(raw.to_rfc3339)
+        when Array
+          arr = raw.map do |item|
+            item.is_a?(TOML::Any) ? toml_any_to_json_any(item) : JSON::Any.new(item.to_s)
+          end
+          JSON::Any.new(arr)
+        when Hash
+          if raw.is_a?(Hash(String, TOML::Any))
+            hash = {} of String => JSON::Any
+            raw.each do |k, v|
+              hash[k] = toml_any_to_json_any(v)
+            end
+            JSON::Any.new(hash)
+          else
+            JSON::Any.new(raw.to_s)
+          end
+        else
+          JSON::Any.new(value.to_s)
+        end
+      end
+
+      # Convert JSON::Any to YAML::Any so the existing TomlBuilder can consume it.
+      private def json_to_yaml_any(json : JSON::Any) : YAML::Any
+        raw = json.raw
+        case raw
+        when Bool    then YAML::Any.new(raw)
+        when Int64   then YAML::Any.new(raw)
+        when Float64 then YAML::Any.new(raw)
+        when String  then YAML::Any.new(raw)
+        when Nil     then YAML::Any.new(nil)
+        when Array
+          arr = json.as_a.map { |v| json_to_yaml_any(v) }
+          YAML::Any.new(arr)
+        when Hash
+          hash = {} of YAML::Any => YAML::Any
+          json.as_h.each do |k, v|
+            hash[YAML::Any.new(k)] = json_to_yaml_any(v)
+          end
+          YAML::Any.new(hash)
+        else
+          YAML::Any.new(json.to_s)
+        end
+      end
+
+      # Produce the body of a YAML block (without the `---` fences) for a JSON
+      # document by routing through the existing YAML converter.
+      private def convert_json_to_yaml_string(json : JSON::Any) : String
+        yaml_any = json_to_yaml_any(json)
+        # Build a hash like the TOML path does so we get identical formatting.
+        hash = {} of String => YAML::Any
+        if h = yaml_any.as_h?
+          h.each do |k, v|
+            key_str = k.as_s? || k.to_s
+            hash[key_str] = v
+          end
+        end
+        hash.to_yaml.lchop("---\n")
       end
 
       private def convert_yaml_to_toml_string(yaml : YAML::Any, indent : Int32 = 0) : String

--- a/src/utils/frontmatter_scanner.cr
+++ b/src/utils/frontmatter_scanner.cr
@@ -15,7 +15,7 @@ module Hwaro
       # inside quoted strings are ignored.
       def find_json_end(content : String) : Int32?
         bytes = content.to_slice
-        return nil if bytes.size == 0 || bytes[0] != '{'.ord.to_u8
+        return if bytes.size == 0 || bytes[0] != '{'.ord.to_u8
 
         depth = 0
         in_string = false

--- a/src/utils/frontmatter_scanner.cr
+++ b/src/utils/frontmatter_scanner.cr
@@ -1,0 +1,52 @@
+# Shared helpers for locating non-regex frontmatter boundaries.
+#
+# TOML (`+++`) and YAML (`---`) use fixed line delimiters and are matched
+# with regex at the call site. JSON frontmatter uses balanced braces — this
+# module provides a brace-aware scanner that respects string literals.
+
+module Hwaro
+  module Utils
+    module FrontmatterScanner
+      extend self
+
+      # Returns the end offset (exclusive) of the first balanced top-level JSON
+      # object at byte 0 of `content`, or nil if the input does not start with
+      # `{` or the braces never balance. Tracks string-literal state so braces
+      # inside quoted strings are ignored.
+      def find_json_end(content : String) : Int32?
+        bytes = content.to_slice
+        return nil if bytes.size == 0 || bytes[0] != '{'.ord.to_u8
+
+        depth = 0
+        in_string = false
+        escaped = false
+        i = 0
+
+        while i < bytes.size
+          c = bytes[i]
+          if in_string
+            if escaped
+              escaped = false
+            elsif c == '\\'.ord.to_u8
+              escaped = true
+            elsif c == '"'.ord.to_u8
+              in_string = false
+            end
+          else
+            case c
+            when '"'.ord.to_u8
+              in_string = true
+            when '{'.ord.to_u8
+              depth += 1
+            when '}'.ord.to_u8
+              depth -= 1
+              return i + 1 if depth == 0
+            end
+          end
+          i += 1
+        end
+        nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds JSON as a third front matter format alongside TOML and YAML, following Hugo's convention: the file begins with `{` and the first balanced `{...}` is the front matter. TOML stays the default, YAML remains recommended, JSON is there for users who prefer it.
- Extends parsing (markdown processor, content lister, content validator), the converter (with TOML↔JSON and YAML↔JSON), `hwaro new` scaffolds, and the `hwaro tool convert to-json` subcommand.
- New shared brace-aware scanner at `src/utils/frontmatter_scanner.cr` (respects string literals and escapes) so all four parse sites share one implementation.

### Usage
```markdown
{
  "title": "My Page",
  "date": "2024-01-15",
  "tags": ["crystal"]
}

본문 시작...
```

Config switch for `hwaro new`:
```toml
[content.new]
front_matter_format = "json"
```

Validator: new rule `content-frontmatter-json-error`.

## Test plan
- [x] `crystal spec spec/` — 4617 examples, 0 failures (+25 new specs)
- [x] Full `crystal build` succeeds
- [x] Docs site builds clean (`hwaro build -i docs`)
- [ ] Manual: create a JSON front matter page, run `hwaro build` / `hwaro serve`, verify rendering
- [ ] Manual: `hwaro tool convert to-json` / `to-toml` round-trip on a sample repo
- [ ] Manual: `hwaro new` with `front_matter_format = "json"` produces a valid JSON-headed file