### PR TITLE
fix(init): surface bare scaffold and --list-scaffolds in --help

### DIFF
--- a/spec/unit/init_command_spec.cr
+++ b/spec/unit/init_command_spec.cr
@@ -210,4 +210,25 @@ describe Hwaro::CLI::Commands::InitCommand do
       config.should contain("theme = \"github-dark\"")
     end
   end
+
+  describe "--list-scaffolds" do
+    it "prints every built-in scaffold registered in the Registry" do
+      sink = IO::Memory.new
+      previous_io = Hwaro::Logger.io
+      Hwaro::Logger.io = sink
+      begin
+        Hwaro::CLI::Commands::InitCommand.new.run(["--list-scaffolds"])
+      ensure
+        Hwaro::Logger.io = previous_io
+      end
+
+      output = sink.to_s
+      output.should contain("Available scaffolds:")
+      Hwaro::Services::Scaffolds::Registry.all.each do |scaffold|
+        output.should contain(scaffold.type.to_s)
+        output.should contain(scaffold.description)
+      end
+      output.should contain("(default)")
+    end
+  end
 end

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -71,11 +71,10 @@ module Hwaro
         # cannot be enumerated without additional input, so only built-ins
         # are listed here.
         private def print_scaffolds(json : Bool)
-          entries = Services::Scaffolds::Registry.all.map do |scaffold|
-            {name: scaffold.type.to_s, description: scaffold.description, kind: "builtin"}
-          end
-
           if json
+            entries = Services::Scaffolds::Registry.all.map do |scaffold|
+              {name: scaffold.type.to_s, description: scaffold.description, kind: "builtin"}
+            end
             STDOUT.puts entries.to_json
           else
             log_scaffold_list
@@ -87,11 +86,13 @@ module Hwaro
         # error path so the three outputs stay in sync with the Registry.
         private def log_scaffold_list
           default_type = Config::Options::ScaffoldType::Simple
+          scaffolds = Services::Scaffolds::Registry.all
+          name_width = scaffolds.max_of(&.type.to_s.size)
           Logger.info "Available scaffolds:"
-          Services::Scaffolds::Registry.all.each do |scaffold|
+          scaffolds.each do |scaffold|
             name = scaffold.type.to_s
             suffix = scaffold.type == default_type ? " (default)" : ""
-            Logger.info "  #{name.ljust(10)} - #{scaffold.description}#{suffix}"
+            Logger.info "  #{name.ljust(name_width)} - #{scaffold.description}#{suffix}"
           end
         end
 

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -78,10 +78,20 @@ module Hwaro
           if json
             STDOUT.puts entries.to_json
           else
-            Logger.info "Available scaffolds:"
-            entries.each do |e|
-              Logger.info "  #{e[:name].ljust(10)} - #{e[:description]}"
-            end
+            log_scaffold_list
+          end
+        end
+
+        # Emit the built-in scaffold list to the standard info logger.
+        # Shared by `--help`, `--list-scaffolds`, and the invalid-scaffold
+        # error path so the three outputs stay in sync with the Registry.
+        private def log_scaffold_list
+          default_type = Config::Options::ScaffoldType::Simple
+          Logger.info "Available scaffolds:"
+          Services::Scaffolds::Registry.all.each do |scaffold|
+            name = scaffold.type.to_s
+            suffix = scaffold.type == default_type ? " (default)" : ""
+            Logger.info "  #{name.ljust(10)} - #{scaffold.description}#{suffix}"
           end
         end
 
@@ -115,14 +125,7 @@ module Hwaro
                   scaffold = Config::Options::ScaffoldType.from_string(type)
                 rescue ex : ArgumentError
                   Logger.error(ex.message || "Unknown error")
-                  Logger.info "Available scaffolds:"
-                  Logger.info "  simple    - Basic pages structure with homepage and about page"
-                  Logger.info "  blog      - Blog-focused structure with posts, archives, and taxonomies"
-                  Logger.info "  blog-dark - Blog-focused structure with dark theme"
-                  Logger.info "  docs      - Documentation-focused structure with organized sections and sidebar"
-                  Logger.info "  docs-dark - Documentation-focused structure with dark theme"
-                  Logger.info "  book      - Book-style structure with chapters and prev/next navigation"
-                  Logger.info "  book-dark - Book-style structure with dark theme"
+                  log_scaffold_list
                   Logger.info ""
                   Logger.info "Remote scaffolds:"
                   Logger.info "  github:owner/repo[/path] - GitHub repository shorthand"
@@ -164,19 +167,17 @@ module Hwaro
             parser.on("--skip-sample-content", "Skip creating sample content files") { skip_sample_content = true }
             parser.on("--skip-taxonomies", "Skip taxonomies configuration and templates") { skip_taxonomies = true }
 
+            # Introspection (handled in #run before parsing; registered here so
+            # they appear in --help output).
+            parser.on("--list-scaffolds", "List available built-in scaffolds and exit") { }
+            parser.on("--json", "Emit machine-readable JSON output (with --list-scaffolds)") { }
+
             # Debug & output
             CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             parser.on("-h", "--help", "Show this help") do
               Logger.info parser.to_s
               Logger.info ""
-              Logger.info "Available scaffolds:"
-              Logger.info "  simple    - Basic pages structure with homepage and about page (default)"
-              Logger.info "  blog      - Blog-focused structure with posts, archives, and taxonomies"
-              Logger.info "  blog-dark - Blog-focused structure with dark theme"
-              Logger.info "  docs      - Documentation-focused structure with organized sections and sidebar"
-              Logger.info "  docs-dark - Documentation-focused structure with dark theme"
-              Logger.info "  book      - Book-style structure with chapters and prev/next navigation"
-              Logger.info "  book-dark - Book-style structure with dark theme"
+              log_scaffold_list
               Logger.info ""
               Logger.info "Remote scaffolds:"
               Logger.info "  github:owner/repo        - GitHub repository shorthand"


### PR DESCRIPTION
## Summary
- `hwaro init --help` now lists every built-in scaffold (including `bare`) by pulling from `Services::Scaffolds::Registry.all`, so the listing can't drift from the registered set.
- The same helper backs the invalid-scaffold error path and `--list-scaffolds`, keeping all three outputs in sync.
- Registers `--list-scaffolds` and `--json` on the option parser so they show up in `hwaro init --help`.

## Test plan
- [x] `crystal spec spec/unit/init_command_spec.cr`
- [x] `./bin/hwaro init --help` shows `bare` and documents `--list-scaffolds` / `--json`
- [x] `./bin/hwaro init /tmp/x --scaffold invalid` lists `bare` in the error output
- [x] `./bin/hwaro init --list-scaffolds` output unchanged semantically
- [x] `./bin/ameba src/cli/commands/init_command.cr`

Closes #462