### PR TITLE
fix(tool): classify missing/invalid argument errors under HWARO_E_USAGE

### DIFF
--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -65,12 +65,13 @@ describe "hwaro tool (router)" do
     output.should contain("subcommand")
   end
 
-  it "exits 2 and prints a concise unknown-command error to stderr" do
+  it "exits with HWARO_E_USAGE on an unknown subcommand" do
     status, output, error = run_hwaro_no_chdir(["tool", "nonexistent-subcommand"])
     status.success?.should be_false
-    status.exit_code.should eq(2)
-    # Concise error goes to stderr, not stdout — the full help/banner
-    # must NOT be dumped on a typo.
+    status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+    # Structured classified error on stderr; help banner must not be
+    # dumped to stdout on a typo.
+    error.should contain("HWARO_E_USAGE")
     error.should contain("unknown command 'tool nonexistent-subcommand'")
     error.should contain("hwaro tool --help")
     output.should_not contain("Available subcommands")
@@ -78,15 +79,24 @@ describe "hwaro tool (router)" do
 
   it "suggests the closest subcommand for near-miss typos" do
     status, _, error = run_hwaro_no_chdir(["tool", "stts"])
-    status.exit_code.should eq(2)
+    status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
     error.should contain("Did you mean 'stats'?")
   end
 
   it "omits the suggestion when no candidate is close" do
     status, _, error = run_hwaro_no_chdir(["tool", "xyzabc"])
-    status.exit_code.should eq(2)
+    status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
     error.should_not contain("Did you mean")
     error.should contain("hwaro tool --help")
+  end
+
+  it "emits a JSON error payload under --json for an unknown subcommand" do
+    status, output, _ = run_hwaro_no_chdir(["tool", "nonexistent-subcommand", "--json"])
+    status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+    parsed = JSON.parse(output.strip)
+    parsed["status"].as_s.should eq("error")
+    parsed["error"]["code"].as_s.should eq("HWARO_E_USAGE")
+    parsed["error"]["message"].as_s.should contain("unknown command")
   end
 
   it "prints help and exits 0 when invoked with help" do
@@ -329,11 +339,67 @@ describe "hwaro tool import" do
 end
 
 describe "hwaro tool export" do
-  it "exits 1 and prints an error when no target-type is given" do
+  it "exits with HWARO_E_USAGE when target-type is missing" do
     with_initialized_project do |project_dir|
-      status, output, _ = run_hwaro(["tool", "export"], chdir: project_dir)
-      status.success?.should be_false
-      output.size.should be > 0
+      status, _, err = run_hwaro(["tool", "export"], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+      err.should contain("<target-type>")
+    end
+  end
+
+  it "exits with HWARO_E_USAGE on unknown target-type" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(
+        ["tool", "export", "definitely-not-real"], chdir: project_dir
+      )
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+      err.should contain("unknown target type")
+    end
+  end
+end
+
+describe "hwaro tool convert" do
+  it "exits with HWARO_E_USAGE when format is missing" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(["tool", "convert"], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+      err.should contain("<format>")
+    end
+  end
+
+  it "exits with HWARO_E_USAGE on unknown format" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(
+        ["tool", "convert", "to-xml"], chdir: project_dir
+      )
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+      err.should contain("unknown format")
+    end
+  end
+end
+
+describe "hwaro tool list" do
+  it "exits with HWARO_E_USAGE when filter is missing" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(["tool", "list"], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+      err.should contain("<filter>")
+    end
+  end
+
+  it "emits a JSON error payload under --json when filter is missing" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(
+        ["tool", "list", "--json"], chdir: project_dir
+      )
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      parsed = JSON.parse(output.strip)
+      parsed["error"]["code"].as_s.should eq("HWARO_E_USAGE")
     end
   end
 end

--- a/src/cli/commands/tool/convert_command.cr
+++ b/src/cli/commands/tool/convert_command.cr
@@ -10,6 +10,7 @@ require "json"
 require "option_parser"
 require "../../metadata"
 require "../../../services/frontmatter_converter"
+require "../../../utils/errors"
 require "../../../utils/logger"
 
 module Hwaro
@@ -55,17 +56,17 @@ module Hwaro
               end
             end
 
+            Logger.quiet = true if json_output
+            Runner.json_mode = true if json_output
+
+            supported = POSITIONAL_CHOICES.join(", ")
+
             unless format
-              Logger.error "Missing format argument. Use 'to-yaml', 'to-toml', or 'to-json'"
-              Logger.info ""
-              Logger.info "Usage: hwaro tool convert <to-yaml|to-toml|to-json> [options]"
-              Logger.info ""
-              Logger.info "Examples:"
-              Logger.info "  hwaro tool convert to-yaml"
-              Logger.info "  hwaro tool convert to-toml"
-              Logger.info "  hwaro tool convert to-json"
-              Logger.info "  hwaro tool convert to-yaml --content-dir=posts"
-              exit(1)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "missing <format> argument",
+                hint: "Usage: hwaro tool convert <to-yaml|to-toml|to-json> — supported: #{supported}.",
+              )
             end
 
             converter = Services::FrontmatterConverter.new(content_dir)
@@ -84,9 +85,11 @@ module Hwaro
               puts result.to_json if json_output
               exit(1) unless result.success
             else
-              Logger.error "Unknown format: #{format}"
-              Logger.info "Use 'to-yaml', 'to-toml', or 'to-json'"
-              exit(1)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "unknown format: #{format}",
+                hint: "Supported: #{supported}.",
+              )
             end
           end
         end

--- a/src/cli/commands/tool/convert_command.cr
+++ b/src/cli/commands/tool/convert_command.cr
@@ -59,13 +59,11 @@ module Hwaro
             Logger.quiet = true if json_output
             Runner.json_mode = true if json_output
 
-            supported = POSITIONAL_CHOICES.join(", ")
-
             unless format
               raise Hwaro::HwaroError.new(
                 code: Hwaro::Errors::HWARO_E_USAGE,
                 message: "missing <format> argument",
-                hint: "Usage: hwaro tool convert <to-yaml|to-toml|to-json> — supported: #{supported}.",
+                hint: "Usage: hwaro tool convert <to-yaml|to-toml|to-json> — supported: #{POSITIONAL_CHOICES.join(", ")}.",
               )
             end
 
@@ -88,7 +86,7 @@ module Hwaro
               raise Hwaro::HwaroError.new(
                 code: Hwaro::Errors::HWARO_E_USAGE,
                 message: "unknown format: #{format}",
-                hint: "Supported: #{supported}.",
+                hint: "Supported: #{POSITIONAL_CHOICES.join(", ")}.",
               )
             end
           end

--- a/src/cli/commands/tool/export_command.cr
+++ b/src/cli/commands/tool/export_command.cr
@@ -10,6 +10,7 @@ require "../../../config/options/export_options"
 require "../../../services/exporters/base"
 require "../../../services/exporters/hugo_exporter"
 require "../../../services/exporters/jekyll_exporter"
+require "../../../utils/errors"
 require "../../../utils/logger"
 
 module Hwaro
@@ -46,9 +47,11 @@ module Hwaro
             supported = POSITIONAL_CHOICES.join(", ")
 
             if options.target_type.empty?
-              Logger.error "Missing target type. Usage: hwaro tool export <target-type> [options]"
-              Logger.info "Supported: #{supported}"
-              exit(1)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "missing <target-type> argument",
+                hint: "Usage: hwaro tool export <target-type> — supported: #{supported}.",
+              )
             end
 
             exporter = case options.target_type
@@ -57,9 +60,11 @@ module Hwaro
                        when "jekyll"
                          Services::Exporters::JekyllExporter.new
                        else
-                         Logger.error "Unknown target type: #{options.target_type}"
-                         Logger.info "Supported: #{supported}"
-                         exit(1)
+                         raise Hwaro::HwaroError.new(
+                           code: Hwaro::Errors::HWARO_E_USAGE,
+                           message: "unknown target type: #{options.target_type}",
+                           hint: "Supported: #{supported}.",
+                         )
                        end
 
             Logger.info "Exporting to #{options.target_type}: #{options.output_dir}"

--- a/src/cli/commands/tool/list_command.cr
+++ b/src/cli/commands/tool/list_command.cr
@@ -59,29 +59,14 @@ module Hwaro
             Logger.quiet = true if json_output
             Runner.json_mode = true if json_output
 
+            supported = POSITIONAL_CHOICES.join(", ")
+
             unless filter
-              if json_output
-                err = Hwaro::HwaroError.new(
-                  code: Hwaro::Errors::HWARO_E_USAGE,
-                  message: "Missing filter argument. Use 'all', 'drafts', or 'published'",
-                )
-                puts err.to_error_payload.to_json
-                exit(err.exit_code)
-              end
-              Logger.error "Missing filter argument. Use 'all', 'drafts', or 'published'"
-              Logger.info ""
-              Logger.info "Usage: hwaro tool list <all|drafts|published> [options]"
-              Logger.info ""
-              Logger.info "Filters:"
-              Logger.info "  all        List all content files"
-              Logger.info "  drafts     List only draft content files"
-              Logger.info "  published  List only published content files"
-              Logger.info ""
-              Logger.info "Examples:"
-              Logger.info "  hwaro tool list all"
-              Logger.info "  hwaro tool list drafts"
-              Logger.info "  hwaro tool list published --content-dir=posts"
-              exit(1)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "missing <filter> argument",
+                hint: "Usage: hwaro tool list <all|drafts|published> — supported: #{supported}.",
+              )
             end
 
             lister = Services::ContentLister.new(content_dir)
@@ -94,17 +79,11 @@ module Hwaro
                              when "published", "pub"
                                Services::ContentFilter::Published
                              else
-                               if json_output
-                                 err = Hwaro::HwaroError.new(
-                                   code: Hwaro::Errors::HWARO_E_USAGE,
-                                   message: "Unknown filter: #{filter}",
-                                 )
-                                 puts err.to_error_payload.to_json
-                                 exit(err.exit_code)
-                               end
-                               Logger.error "Unknown filter: #{filter}"
-                               Logger.info "Use 'all', 'drafts', or 'published'"
-                               exit(1)
+                               raise Hwaro::HwaroError.new(
+                                 code: Hwaro::Errors::HWARO_E_USAGE,
+                                 message: "unknown filter: #{filter}",
+                                 hint: "Supported: #{supported}.",
+                               )
                              end
 
             if json_output

--- a/src/cli/commands/tool_command.cr
+++ b/src/cli/commands/tool_command.cr
@@ -32,6 +32,7 @@ require "./tool/stats_command"
 require "./tool/validate_command"
 require "./tool/unused_assets_command"
 require "./tool/agents_md_command"
+require "../../utils/errors"
 require "../../utils/logger"
 require "../../utils/command_suggester"
 
@@ -103,22 +104,29 @@ module Hwaro
             if handler = @@sub_handlers[subcommand]?
               handler.call(args)
             else
-              ToolCommand.report_unknown_subcommand(subcommand)
-              exit(2)
+              ToolCommand.report_unknown_subcommand(subcommand, args)
             end
           end
         end
 
-        # Concise unknown-subcommand error emitted to stderr, mirroring the
-        # top-level Runner behavior. No full help dump here — users can run
-        # `hwaro tool --help` to see every subcommand.
-        def self.report_unknown_subcommand(subcommand : String, io : IO = STDERR)
-          io.puts "Error: unknown command 'tool #{subcommand}'"
-          candidates = ToolCommand.subcommands.map(&.name)
-          if suggestion = Utils::CommandSuggester.suggest(subcommand, candidates)
-            io.puts "Did you mean '#{suggestion}'?"
+        # Raise a classified usage error for an unknown `tool <subcommand>`,
+        # mirroring the top-level Runner behavior. The `Did you mean …`
+        # suggestion is printed to stderr in text mode only; the final
+        # `Error [HWARO_E_USAGE]: …` line (and the help hint) come from the
+        # Runner's shared `emit_hwaro_error` path.
+        def self.report_unknown_subcommand(subcommand : String, args : Array(String) = [] of String)
+          json_mode = args.includes?("--json")
+          unless json_mode
+            candidates = ToolCommand.subcommands.map(&.name)
+            if suggestion = Utils::CommandSuggester.suggest(subcommand, candidates)
+              STDERR.puts "Did you mean '#{suggestion}'?"
+            end
           end
-          io.puts "Run 'hwaro tool --help' to see all subcommands."
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "unknown command 'tool #{subcommand}'",
+            hint: "Run 'hwaro tool --help' to see all subcommands.",
+          )
         end
 
         # Category display order and membership for help output


### PR DESCRIPTION
## Summary
- `tool export`, `tool convert`, `tool list`, and `tool <unknown>` now raise `HwaroError(HWARO_E_USAGE, …)` for missing/invalid positional arguments, matching the existing classified-error pattern used by `tool import`, `new`, and `build`.
- Users get the consistent `Error [HWARO_E_USAGE]: …` text form on stderr (exit code 2); `--json` callers get the standard `{status, error: {code, category, message, hint}}` payload on stdout — both routed through the Runner's shared `emit_hwaro_error`.
- Dropped the manual `--json` branches in `tool list` that were bypassing the Runner; they're unnecessary now that the error is raised instead of printed.

## User-visible output change
The verbose multi-line help that used to accompany `tool convert` and `tool list` argument errors (per-filter descriptions, example invocations) is gone, replaced by a single-line classified-error hint. The equivalent detail is still available via `hwaro tool <cmd> --help`. This is intentional to match the classified-error convention already used by `tool import`.

## Test plan
- [x] `crystal spec` (4638 examples, 0 failures)
- [x] `./bin/hwaro tool export` / `tool convert` / `tool list` / `tool bogus` — all emit `Error [HWARO_E_USAGE]: …` with exit 2
- [x] `./bin/hwaro tool list --json` / `tool convert --json` / `tool bogus --json` — all emit the structured JSON error payload
- [x] `./bin/hwaro tool stts` — still prints the `Did you mean 'stats'?` suggestion before the classified error
- [x] `./bin/ameba` clean on all touched files

Closes #463