### PR TITLE
fix(new): sanitize URL-unsafe characters in the path argument

### DIFF
--- a/spec/functional/cli_commands_spec.cr
+++ b/spec/functional/cli_commands_spec.cr
@@ -106,6 +106,78 @@ describe "CLI Tool Commands" do
         FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
       end
     end
+
+    it "does not emit a sanitize notice for already-safe paths" do
+      temp_dir = File.tempname("hwaro_test")
+      Dir.mkdir(temp_dir)
+      begin
+        project_dir = File.join(temp_dir, "test_site")
+        Dir.mkdir(project_dir)
+
+        Process.run(File.expand_path("../../bin/hwaro", __DIR__),
+          ["init", project_dir], output: IO::Memory.new, error: IO::Memory.new)
+
+        new_output = IO::Memory.new
+        new_error = IO::Memory.new
+        status = Process.run(
+          File.expand_path("../../bin/hwaro", __DIR__),
+          ["new", "posts/clean-path.md"],
+          chdir: project_dir, output: new_output, error: new_error)
+
+        status.success?.should be_true
+        new_output.to_s.should_not contain("Sanitized")
+        new_error.to_s.should_not contain("Sanitized")
+      ensure
+        FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
+      end
+    end
+
+    it "sanitizes --section the same way as <path>" do
+      temp_dir = File.tempname("hwaro_test")
+      Dir.mkdir(temp_dir)
+      begin
+        project_dir = File.join(temp_dir, "test_site")
+        Dir.mkdir(project_dir)
+
+        Process.run(File.expand_path("../../bin/hwaro", __DIR__),
+          ["init", project_dir], output: IO::Memory.new, error: IO::Memory.new)
+
+        status = Process.run(
+          File.expand_path("../../bin/hwaro", __DIR__),
+          ["new", "post", "-s", "my section", "-t", "Post"],
+          chdir: project_dir, output: IO::Memory.new, error: IO::Memory.new)
+
+        status.success?.should be_true
+        Dir.exists?(File.join(project_dir, "content", "my-section")).should be_true
+        Dir.exists?(File.join(project_dir, "content", "my section")).should be_false
+      ensure
+        FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
+      end
+    end
+
+    it "rejects a path that sanitizes to nothing with HWARO_E_USAGE" do
+      temp_dir = File.tempname("hwaro_test")
+      Dir.mkdir(temp_dir)
+      begin
+        project_dir = File.join(temp_dir, "test_site")
+        Dir.mkdir(project_dir)
+
+        Process.run(File.expand_path("../../bin/hwaro", __DIR__),
+          ["init", project_dir], output: IO::Memory.new, error: IO::Memory.new)
+
+        new_error = IO::Memory.new
+        status = Process.run(
+          File.expand_path("../../bin/hwaro", __DIR__),
+          ["new", "!!!", "-t", "T"],
+          chdir: project_dir, output: IO::Memory.new, error: new_error)
+
+        status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+        new_error.to_s.should contain("HWARO_E_USAGE")
+        new_error.to_s.should contain("no URL-safe characters")
+      ensure
+        FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
+      end
+    end
   end
 
   describe "hwaro completion" do

--- a/spec/functional/cli_commands_spec.cr
+++ b/spec/functional/cli_commands_spec.cr
@@ -53,6 +53,59 @@ describe "CLI Tool Commands" do
         FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
       end
     end
+
+    it "sanitizes URL-unsafe characters in the path and surfaces the rewrite" do
+      temp_dir = File.tempname("hwaro_test")
+      Dir.mkdir(temp_dir)
+      begin
+        project_dir = File.join(temp_dir, "test_site")
+        Dir.mkdir(project_dir)
+
+        Process.run(File.expand_path("../../bin/hwaro", __DIR__),
+          ["init", project_dir], output: IO::Memory.new, error: IO::Memory.new)
+
+        new_output = IO::Memory.new
+        new_error = IO::Memory.new
+        status = Process.run(
+          File.expand_path("../../bin/hwaro", __DIR__),
+          ["new", "special chars!@#", "-t", "Special Chars"],
+          chdir: project_dir, output: new_output, error: new_error)
+
+        status.success?.should be_true
+        # The sanitized directory lands on disk; the raw one does not.
+        Dir.exists?(File.join(project_dir, "content", "special-chars")).should be_true
+        Dir.exists?(File.join(project_dir, "content", "special chars!@#")).should be_false
+        new_output.to_s.should contain("Sanitized path")
+      ensure
+        FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
+      end
+    end
+
+    it "emits clean JSON under --json (no sanitize notice mixed in)" do
+      temp_dir = File.tempname("hwaro_test")
+      Dir.mkdir(temp_dir)
+      begin
+        project_dir = File.join(temp_dir, "test_site")
+        Dir.mkdir(project_dir)
+
+        Process.run(File.expand_path("../../bin/hwaro", __DIR__),
+          ["init", project_dir], output: IO::Memory.new, error: IO::Memory.new)
+
+        new_output = IO::Memory.new
+        new_error = IO::Memory.new
+        status = Process.run(
+          File.expand_path("../../bin/hwaro", __DIR__),
+          ["new", "bad path!", "-t", "BP", "--json"],
+          chdir: project_dir, output: new_output, error: new_error)
+
+        status.success?.should be_true
+        parsed = JSON.parse(new_output.to_s.strip)
+        parsed["status"].as_s.should eq("ok")
+        parsed["path"].as_s.should contain("bad-path")
+      ensure
+        FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
+      end
+    end
   end
 
   describe "hwaro completion" do

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -919,4 +919,54 @@ describe Hwaro::Services::Creator do
       Hwaro::Services::Creator.validate_and_normalize_path!("foo/../bar.md").should eq("bar.md")
     end
   end
+
+  describe ".url_safe_path?" do
+    it "returns true for plain ASCII paths" do
+      Hwaro::Services::Creator.url_safe_path?("posts/hello-world.md").should be_true
+      Hwaro::Services::Creator.url_safe_path?("my_post.md").should be_true
+      Hwaro::Services::Creator.url_safe_path?("docs/v1.2/intro.md").should be_true
+    end
+
+    it "returns true for CJK / Unicode letter paths" do
+      Hwaro::Services::Creator.url_safe_path?("한글/포스트.md").should be_true
+      Hwaro::Services::Creator.url_safe_path?("café/résumé.md").should be_true
+    end
+
+    it "returns false for paths with spaces or reserved punctuation" do
+      Hwaro::Services::Creator.url_safe_path?("special chars!@#").should be_false
+      Hwaro::Services::Creator.url_safe_path?("posts/hello world.md").should be_false
+      Hwaro::Services::Creator.url_safe_path?("a?b.md").should be_false
+    end
+  end
+
+  describe ".sanitize_url_path" do
+    it "is a no-op for already-safe paths" do
+      Hwaro::Services::Creator.sanitize_url_path("posts/hello.md").should eq("posts/hello.md")
+      Hwaro::Services::Creator.sanitize_url_path("한글/포스트.md").should eq("한글/포스트.md")
+    end
+
+    it "collapses unsafe characters to a single hyphen per run" do
+      Hwaro::Services::Creator.sanitize_url_path("special chars!@#").should eq("special-chars")
+      Hwaro::Services::Creator.sanitize_url_path("a!!!b").should eq("a-b")
+    end
+
+    it "trims leading and trailing hyphens per segment" do
+      Hwaro::Services::Creator.sanitize_url_path("!foo!/!bar!").should eq("foo/bar")
+    end
+
+    it "preserves path separators and the RFC 3986 unreserved set" do
+      Hwaro::Services::Creator.sanitize_url_path("posts/my_post.v2.md").should eq("posts/my_post.v2.md")
+      Hwaro::Services::Creator.sanitize_url_path("a/b/c~d.md").should eq("a/b/c~d.md")
+    end
+
+    it "preserves original casing" do
+      # Filesystem case-sensitivity varies; silently lowercasing could
+      # clobber an existing sibling file.
+      Hwaro::Services::Creator.sanitize_url_path("Posts/MyPost.md").should eq("Posts/MyPost.md")
+    end
+
+    it "handles mixed CJK and unsafe characters" do
+      Hwaro::Services::Creator.sanitize_url_path("한글 테스트/포스트").should eq("한글-테스트/포스트")
+    end
+  end
 end

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -968,5 +968,21 @@ describe Hwaro::Services::Creator do
     it "handles mixed CJK and unsafe characters" do
       Hwaro::Services::Creator.sanitize_url_path("한글 테스트/포스트").should eq("한글-테스트/포스트")
     end
+
+    it "drops segments that sanitize to empty so no leading slash appears" do
+      # "!!!" sanitizes to an empty segment — the overall path must not
+      # turn into "/foo.md" (which would look absolute to File.join).
+      Hwaro::Services::Creator.sanitize_url_path("!!!/foo.md").should eq("foo.md")
+      Hwaro::Services::Creator.sanitize_url_path("posts/!!!/bar").should eq("posts/bar")
+    end
+
+    it "raises ArgumentError when every segment sanitizes away" do
+      expect_raises(ArgumentError, /no URL-safe characters/) do
+        Hwaro::Services::Creator.sanitize_url_path("!!!")
+      end
+      expect_raises(ArgumentError, /no URL-safe characters/) do
+        Hwaro::Services::Creator.sanitize_url_path("!!!/???")
+      end
+    end
   end
 end

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -102,9 +102,36 @@ module Hwaro
           # the RFC 3986 unreserved ASCII set pass through untouched. We
           # surface the rewrite via `Logger.info` so the author sees what
           # landed on disk — silent transformation would be confusing.
-          sanitized = Services::Creator.sanitize_url_path(normalized)
+          begin
+            sanitized = Services::Creator.sanitize_url_path(normalized)
+          rescue ex : ArgumentError
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: ex.message || "Invalid <path> argument",
+              hint: "Usage: hwaro new <path> [options] — run 'hwaro new --help' for details.",
+            )
+          end
           if sanitized != normalized
             Logger.info "Sanitized path: '#{normalized}' → '#{sanitized}' (URL-unsafe characters replaced)"
+          end
+
+          # --section is joined to the on-disk path just like <path>, so it
+          # has to go through the same sanitizer or a space-laden --section
+          # reintroduces the exact problem we just fixed for <path>.
+          if section = options.section
+            begin
+              sanitized_section = Services::Creator.sanitize_url_path(section)
+            rescue ex : ArgumentError
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: ex.message || "Invalid --section argument",
+                hint: "Sections become directory names; use ASCII letters/digits, CJK, or `- . _ ~`.",
+              )
+            end
+            if sanitized_section != section
+              Logger.info "Sanitized section: '#{section}' → '#{sanitized_section}' (URL-unsafe characters replaced)"
+              options.section = sanitized_section
+            end
           end
 
           # Feed the sanitized path back into the Creator. The stored

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -95,11 +95,23 @@ module Hwaro
               hint: "Usage: hwaro new <path> [options] — run 'hwaro new --help' for details.",
             )
           end
-          # Feed the normalized path back into the Creator. The stored
+
+          # Auto-sanitize URL-unsafe characters (spaces, `!@#$%…`) in each
+          # path segment so the on-disk directory also works as a clean URL
+          # path once the site is built. CJK / Unicode letters, digits, and
+          # the RFC 3986 unreserved ASCII set pass through untouched. We
+          # surface the rewrite via `Logger.info` so the author sees what
+          # landed on disk — silent transformation would be confusing.
+          sanitized = Services::Creator.sanitize_url_path(normalized)
+          if sanitized != normalized
+            Logger.info "Sanitized path: '#{normalized}' → '#{sanitized}' (URL-unsafe characters replaced)"
+          end
+
+          # Feed the sanitized path back into the Creator. The stored
           # path keeps the `content/` prefix so downstream branches that
           # check `starts_with?("content/")` take the already-rooted
           # path as-is (see Creator#run).
-          options.path = normalized
+          options.path = sanitized
 
           created_path = Services::Creator.new.run(options, load_config_if_present)
 

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -64,6 +64,12 @@ module Hwaro
         full[root_prefix.size..]
       end
 
+      # Path separator used by hwaro-managed content paths. Hwaro stores
+      # and emits POSIX-style paths internally (the normalizer canonicalizes
+      # to this), so URL-safety checks compare against '/' rather than
+      # `File::SEPARATOR` to stay consistent on Windows hosts too.
+      PATH_SEP = '/'
+
       # Return true when every segment of `path` is already URL-safe and
       # does not need auto-sanitization. "URL-safe" here means the segment
       # uses only the RFC 3986 unreserved ASCII set (`A-Z a-z 0-9 - . _ ~`)
@@ -71,7 +77,7 @@ module Hwaro
       # percent-encoding surprises.
       def self.url_safe_path?(path : String) : Bool
         path.each_char do |char|
-          next if char == File::SEPARATOR
+          next if char == PATH_SEP
           next if url_safe_char?(char)
           return false
         end
@@ -81,12 +87,27 @@ module Hwaro
       # Rewrite a path so every segment is URL-safe (see `url_safe_path?`).
       # Unsafe characters (spaces, `!@#$%^&*()`, etc.) are collapsed to a
       # single `-`; leading/trailing hyphens per segment are trimmed.
+      # Segments that reduce to the empty string after sanitization are
+      # dropped so the result never grows spurious `//` or leading-slash
+      # artifacts.
       #
       # Preserves original casing — filesystems differ on case sensitivity,
       # and silently lowercasing could clobber existing content. Authors
       # who want an all-lowercase slug can pass one explicitly.
+      #
+      # Raises `ArgumentError` when every segment sanitizes away — the
+      # caller (the CLI) wraps that into a classified usage error.
       def self.sanitize_url_path(path : String) : String
-        path.split(File::SEPARATOR).map { |seg| sanitize_url_segment(seg) }.join(File::SEPARATOR)
+        return path if url_safe_path?(path)
+
+        sanitized_segments = path.split(PATH_SEP).map { |seg| sanitize_url_segment(seg) }.reject(&.empty?)
+        if sanitized_segments.empty?
+          raise ArgumentError.new(
+            "Path '#{path}' contains no URL-safe characters after sanitization. " \
+            "Use ASCII letters/digits, CJK, or one of `- . _ ~` in at least one segment."
+          )
+        end
+        sanitized_segments.join(PATH_SEP)
       end
 
       private def self.sanitize_url_segment(segment : String) : String

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -5,6 +5,7 @@ require "../config/options/new_options"
 require "../models/config"
 require "../utils/errors"
 require "../utils/logger"
+require "../utils/text_utils"
 
 module Hwaro
   module Services
@@ -61,6 +62,57 @@ module Hwaro
         end
 
         full[root_prefix.size..]
+      end
+
+      # Return true when every segment of `path` is already URL-safe and
+      # does not need auto-sanitization. "URL-safe" here means the segment
+      # uses only the RFC 3986 unreserved ASCII set (`A-Z a-z 0-9 - . _ ~`)
+      # plus CJK / Unicode letters, which static hosts serve without
+      # percent-encoding surprises.
+      def self.url_safe_path?(path : String) : Bool
+        path.each_char do |char|
+          next if char == File::SEPARATOR
+          next if url_safe_char?(char)
+          return false
+        end
+        true
+      end
+
+      # Rewrite a path so every segment is URL-safe (see `url_safe_path?`).
+      # Unsafe characters (spaces, `!@#$%^&*()`, etc.) are collapsed to a
+      # single `-`; leading/trailing hyphens per segment are trimmed.
+      #
+      # Preserves original casing — filesystems differ on case sensitivity,
+      # and silently lowercasing could clobber existing content. Authors
+      # who want an all-lowercase slug can pass one explicitly.
+      def self.sanitize_url_path(path : String) : String
+        path.split(File::SEPARATOR).map { |seg| sanitize_url_segment(seg) }.join(File::SEPARATOR)
+      end
+
+      private def self.sanitize_url_segment(segment : String) : String
+        return segment if segment.empty?
+        String.build(segment.bytesize) do |io|
+          last_was_hyphen = false
+          segment.each_char do |char|
+            if url_safe_char?(char)
+              io << char
+              last_was_hyphen = false
+            else
+              unless last_was_hyphen
+                io << '-'
+                last_was_hyphen = true
+              end
+            end
+          end
+        end.strip('-')
+      end
+
+      private def self.url_safe_char?(char : Char) : Bool
+        return true if char.ascii_letter? || char.ascii_number?
+        return true if char == '-' || char == '_' || char == '.' || char == '~'
+        return true if Utils::TextUtils.cjk_char?(char)
+        return true if !char.ascii? && char.letter?
+        false
       end
 
       def run(options : Config::Options::NewOptions, config : Models::Config? = nil)


### PR DESCRIPTION
## Summary
- Per-segment auto-sanitizes characters outside the RFC 3986 unreserved set (spaces, `!@#\$%…`) in the `<path>` argument to `hwaro new`, so the on-disk directory layout also works as a clean URL once the site is built.
- CJK / Unicode letters, digits, `-`, `.`, `_`, and `~` pass through unchanged; casing is preserved (filesystem case-sensitivity varies and silently lowercasing could clobber sibling files).
- The rewrite is surfaced via `Logger.info` (`Sanitized path: 'x' → 'y' (URL-unsafe characters replaced)`) so authors see what landed on disk. Under `--json`, the notice is silenced and the emitted payload's `path` field reflects the sanitized form.

## Before
```bash
$ hwaro new "special chars!@#" -t "Special Chars"
Created new content: content/special chars!@#/special-chars.md
```

## After
```bash
$ hwaro new "special chars!@#" -t "Special Chars"
Sanitized path: 'special chars!@#' → 'special-chars' (URL-unsafe characters replaced)
Created new content: content/special-chars/special-chars.md
```

## Test plan
- [x] `crystal spec` (4649 examples, 0 failures)
- [x] `./bin/ameba` clean on touched files
- [x] Manual: `hwaro new "special chars!@#"` lands under `content/special-chars/`
- [x] Manual: `hwaro new "한글 테스트/포스트"` → `content/한글-테스트/포스트/…` (CJK preserved, space replaced)
- [x] Manual: `hwaro new "bad path!" --json` emits a clean JSON payload with no sanitize notice mixed in
- [x] Manual: `hwaro new posts/clean-path` shows no sanitize notice

Closes #465