### PR TITLE
feat(data): expose data subdirectories as nested iterable maps

### DIFF
--- a/docs/content/templates/data-model.md
+++ b/docs/content/templates/data-model.md
@@ -65,7 +65,11 @@ Hwaro allows you to store auxiliary data in the `data/` directory. Files ending 
 data/
 ├── authors.yml
 ├── products.json
-└── config.toml
+├── config.toml
+└── users/
+    ├── alice.yml
+    ├── bob.yml
+    └── cho.yml
 ```
 
 #### Accessing Data
@@ -89,6 +93,26 @@ Can be accessed in templates:
   <p>{{ product.price }}</p>
 {% endfor %}
 ```
+
+#### Subdirectories
+
+Subdirectories under `data/` become nested maps. Each file becomes a child keyed by its filename (without extension), and the parent directory itself is iterable.
+
+Given the layout above, `data/users/alice.yml`, `data/users/bob.yml`, and `data/users/cho.yml` are exposed as:
+
+- `site.data.users.alice`, `site.data.users.bob`, `site.data.users.cho` — individual file contents
+- `site.data.users` — a map you can iterate to list every user
+
+```jinja
+{% for name, user in site.data.users %}
+  <h3>{{ name }}</h3>
+  <p>{{ user.bio }}</p>
+{% endfor %}
+```
+
+Directories nest arbitrarily: `data/users/admins/root.yml` → `site.data.users.admins.root`.
+
+**Conflicts.** If a directory and a file share the same stem (e.g. `data/users.yml` alongside `data/users/`), the **directory wins** and the file is ignored. Hwaro emits a warning during the build so the shadowed file is not silently dropped.
 
 ### Site Authors
 

--- a/spec/functional/data_files_spec.cr
+++ b/spec/functional/data_files_spec.cr
@@ -139,6 +139,42 @@ describe "Data Files: Subdirectory data loading" do
       html.should contain("LEVEL=99")
     end
   end
+
+  it "loads subdirectory files across formats" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {"index.md" => "---\ntitle: Home\n---\nHome"},
+      template_files: {
+        "page.html" => "J={{ site.data.api.v1.version }}|T={{ site.data.api.v2.version }}",
+      },
+      data_files: {
+        "api/v1.json" => %({"version": "1.0"}),
+        "api/v2.toml" => %(version = "2.0"),
+      },
+    ) do
+      html = File.read("public/index.html")
+      html.should contain("J=1.0")
+      html.should contain("T=2.0")
+    end
+  end
+
+  it "keeps root-level and subdirectory data independent" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {"index.md" => "---\ntitle: Home\n---\nHome"},
+      template_files: {
+        "page.html" => "THEME={{ site.data.settings.theme }}|USER={{ site.data.users.alice.age }}",
+      },
+      data_files: {
+        "settings.yml"    => "theme: dark",
+        "users/alice.yml" => "age: 30",
+      },
+    ) do
+      html = File.read("public/index.html")
+      html.should contain("THEME=dark")
+      html.should contain("USER=30")
+    end
+  end
 end
 
 describe "Data Files: No data directory" do

--- a/spec/functional/data_files_spec.cr
+++ b/spec/functional/data_files_spec.cr
@@ -104,6 +104,43 @@ describe "Data Files: Nested YAML data" do
   end
 end
 
+describe "Data Files: Subdirectory data loading" do
+  it "exposes files under data/<dir>/ as an iterable map and per-file keys" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {"index.md" => "---\ntitle: Home\n---\nHome"},
+      template_files: {
+        "page.html" => "{% for name, u in site.data.users %}{{ name }}:{{ u.age }},{% endfor %}|alice_age={{ site.data.users.alice.age }}",
+      },
+      data_files: {
+        "users/alice.yml" => "age: 30",
+        "users/bob.yml"   => "age: 25",
+      },
+    ) do
+      html = File.read("public/index.html")
+      html.should contain("alice:30,")
+      html.should contain("bob:25,")
+      html.should contain("alice_age=30")
+    end
+  end
+
+  it "supports deeply nested subdirectories" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {"index.md" => "---\ntitle: Home\n---\nHome"},
+      template_files: {
+        "page.html" => "LEVEL={{ site.data.users.admins.root.level }}",
+      },
+      data_files: {
+        "users/admins/root.yml" => "level: 99",
+      },
+    ) do
+      html = File.read("public/index.html")
+      html.should contain("LEVEL=99")
+    end
+  end
+end
+
 describe "Data Files: No data directory" do
   it "builds successfully without data directory" do
     build_site(

--- a/spec/unit/phases_initialize_spec.cr
+++ b/spec/unit/phases_initialize_spec.cr
@@ -287,6 +287,94 @@ describe Hwaro::Core::Build::Phases::Initialize do
         end
       end
     end
+
+    it "exposes subdirectory files as a nested iterable map" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data/users")
+          File.write("data/users/alice.yml", "age: 30\n")
+          File.write("data/users/bob.yml", "age: 25\n")
+
+          builder = Hwaro::Core::Build::Builder.new
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          builder.test_load_data_files(site)
+
+          users = site.data["users"]?
+          users.should_not be_nil
+          dict = users.not_nil!.raw.as(Crinja::Dictionary)
+          dict.keys.map { |k| k.raw.as(String) }.sort!.should eq(["alice", "bob"])
+          users.not_nil!["alice"]["age"].raw.should eq(30_i64)
+        end
+      end
+    end
+
+    it "nests arbitrarily deep subdirectories" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data/users/admins")
+          File.write("data/users/admins/root.yml", "level: 99\n")
+
+          builder = Hwaro::Core::Build::Builder.new
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          builder.test_load_data_files(site)
+
+          site.data["users"]["admins"]["root"]["level"].raw.should eq(99_i64)
+        end
+      end
+    end
+
+    it "lets directory shadow a same-stem sibling file and warns" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data/users")
+          File.write("data/users.yml", "shadowed: true\n")
+          File.write("data/users/alice.yml", "age: 30\n")
+
+          previous_io = Hwaro::Logger.io
+          sink = IO::Memory.new
+          Hwaro::Logger.io = sink
+
+          begin
+            builder = Hwaro::Core::Build::Builder.new
+            site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+            builder.test_load_data_files(site)
+
+            users = site.data["users"]
+            users["alice"]["age"].raw.should eq(30_i64)
+            users["shadowed"].raw.should be_a(Crinja::Undefined)
+
+            sink.to_s.should contain("data/users.yml")
+            sink.to_s.should contain("directory takes precedence")
+          ensure
+            Hwaro::Logger.io = previous_io
+          end
+        end
+      end
+    end
+
+    it "warns when duplicate stems (e.g. .yml and .yaml) collide" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data")
+          File.write("data/config.yml", "theme: light\n")
+          File.write("data/config.yaml", "theme: dark\n")
+
+          previous_io = Hwaro::Logger.io
+          sink = IO::Memory.new
+          Hwaro::Logger.io = sink
+
+          begin
+            builder = Hwaro::Core::Build::Builder.new
+            site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+            builder.test_load_data_files(site)
+
+            sink.to_s.should contain("Duplicate data key")
+          ensure
+            Hwaro::Logger.io = previous_io
+          end
+        end
+      end
+    end
   end
 
   describe "#create_fresh_crinja_env" do

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -280,6 +280,14 @@ module Hwaro::Core::Build::Phases::Initialize
     if node.children.empty?
       node.value || Crinja::Value.new(nil)
     else
+      # Invariant: depth-first processing + directory-wins collision
+      # handling means a node with children must never also carry a
+      # leaf value — the leaf would have been rejected with a warning.
+      # Guard here so a future change to the sort or conflict rules
+      # fails loudly instead of silently dropping data.
+      if source = node.source_path
+        raise "load_data_files invariant broken: node at '#{source}' has both leaf value and children"
+      end
       converted = {} of String => Crinja::Value
       node.children.each do |k, child|
         converted[k] = data_tree_to_crinja(child)

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -208,50 +208,99 @@ module Hwaro::Core::Build::Phases::Initialize
     env
   end
 
-  # Load data files from data/ directory
+  # Tree node used while assembling `site.data` from the `data/` directory.
+  # Each node can hold a leaf value (a parsed data file) and/or a map of
+  # children (subdirectory entries). When both are present the children
+  # win — see `load_data_files`.
+  private class DataTreeNode
+    getter children : Hash(String, DataTreeNode) = {} of String => DataTreeNode
+    property value : Crinja::Value? = nil
+    property source_path : String? = nil
+  end
+
+  # Load data files from `data/`, preserving directory structure.
+  #
+  # A file at `data/users/alice.yml` is exposed as `site.data.users.alice`,
+  # and the parent map `site.data.users` is iterable in templates
+  # (`{% for name, user in site.data.users %}`). When a directory and a
+  # sibling file share the same stem (e.g. `data/users.yml` alongside
+  # `data/users/`), the directory wins and a warning is emitted for the
+  # shadowed file.
   private def load_data_files(site : Models::Site)
     site.data.clear
 
     return unless Dir.exists?("data")
 
+    root = DataTreeNode.new
+
+    # Process deeper paths first so directory namespaces are established
+    # before any same-stem root-level file can claim the key.
+    entries = [] of {Array(String), String, String}
     Dir.glob("data/**/*.{yml,yaml,json,toml}") do |path|
       next if File.directory?(path)
-
-      relative_path = Path[path].relative_to("data")
-      key = relative_path.stem
-      ext = relative_path.extension.downcase
-
-      content = File.read(path)
-
-      begin
-        value = case ext
-                when ".yml", ".yaml"
-                  if parsed = YAML.parse(content)
-                    Utils::CrinjaUtils.from_yaml(parsed)
-                  else
-                    Crinja::Value.new(nil)
-                  end
-                when ".json"
-                  if parsed = JSON.parse(content)
-                    Utils::CrinjaUtils.from_json(parsed)
-                  else
-                    Crinja::Value.new(nil)
-                  end
-                when ".toml"
-                  if parsed = TOML.parse(content)
-                    Utils::CrinjaUtils.from_toml(parsed)
-                  else
-                    Crinja::Value.new(nil)
-                  end
-                else
-                  Crinja::Value.new(nil)
-                end
-
-        site.data[key] = value
-        Logger.debug "Loaded data file: #{path} as site.data.#{key}"
-      rescue ex
-        Logger.warn "Failed to parse data file #{path}: #{ex.message}"
-      end
+      rel = Path[path].relative_to("data")
+      parts = rel.parts
+      stem = Path[parts.last].stem
+      dir_parts = parts[0...-1]
+      entries << {dir_parts, stem, path}
     end
+    entries.sort_by! { |(dir_parts, _, _)| -dir_parts.size }
+
+    entries.each do |(dir_parts, stem, path)|
+      value = parse_data_file(path)
+      next unless value
+
+      node = root
+      dir_parts.each do |segment|
+        node = node.children[segment] ||= DataTreeNode.new
+      end
+
+      existing = node.children[stem]?
+      if existing && !existing.children.empty?
+        Logger.warn "Data file '#{path}' is shadowed by directory 'data/#{(dir_parts + [stem]).join('/')}/'; directory takes precedence."
+        next
+      end
+
+      leaf = existing || DataTreeNode.new
+      if prior = leaf.source_path
+        Logger.warn "Duplicate data key for 'site.data.#{(dir_parts + [stem]).join('.')}': '#{path}' overwrites '#{prior}'."
+      end
+      leaf.value = value
+      leaf.source_path = path
+      node.children[stem] = leaf
+      Logger.debug "Loaded data file: #{path} as site.data.#{(dir_parts + [stem]).join('.')}"
+    end
+
+    root.children.each do |key, child|
+      site.data[key] = data_tree_to_crinja(child)
+    end
+  end
+
+  private def data_tree_to_crinja(node : DataTreeNode) : Crinja::Value
+    if node.children.empty?
+      node.value || Crinja::Value.new(nil)
+    else
+      converted = {} of String => Crinja::Value
+      node.children.each do |k, child|
+        converted[k] = data_tree_to_crinja(child)
+      end
+      Crinja::Value.new(converted)
+    end
+  end
+
+  private def parse_data_file(path : String) : Crinja::Value?
+    ext = File.extname(path).downcase
+    content = File.read(path)
+    case ext
+    when ".yml", ".yaml"
+      Utils::CrinjaUtils.from_yaml(YAML.parse(content))
+    when ".json"
+      Utils::CrinjaUtils.from_json(JSON.parse(content))
+    when ".toml"
+      Utils::CrinjaUtils.from_toml(TOML.parse(content))
+    end
+  rescue ex
+    Logger.warn "Failed to parse data file #{path}: #{ex.message}"
+    nil
   end
 end


### PR DESCRIPTION
## Summary

- Files under `data/<dir>/` are now grouped into a nested map at `site.data.<dir>`, so templates can iterate every entry (`{% for name, user in site.data.users %}`) in addition to accessing each file by stem (`site.data.users.alice`).
- Nesting is arbitrary depth: `data/users/admins/root.yml` → `site.data.users.admins.root`.
- When a directory and a sibling file share the same stem (e.g. `data/users.yml` alongside `data/users/`), the directory wins and a `[WARN]` log is emitted for the shadowed file. Duplicate-stem collisions across extensions (`.yml` vs `.yaml`) also warn.

### ⚠️ Behavioral change

Previously, every file under `data/**` was flattened to `site.data.<stem>` regardless of its directory. `data/users/alice.yml` resolved to `site.data.alice`, not `site.data.users.alice`, and same-stem files in sibling directories silently overwrote each other.

After this PR the directory path is preserved. Templates that relied on the old flat path for any file inside a subdirectory need to be updated to use the full nested path. The old behavior was undocumented and silently lossy on collisions; this PR makes the directory structure authoritative.

### Before

`data/users/alice.yml` flattened to `site.data.alice`, losing the `users` namespace entirely. `site.data.users` didn't exist, and same-stem files under sibling paths silently overwrote each other.

### After

```text
data/
└── users/
    ├── alice.yml
    └── bob.yml
```

```jinja
{% for name, user in site.data.users %}
  <h3>{{ name }}</h3>
  <p>{{ user.bio }}</p>
{% endfor %}
```

### Implementation

- `src/core/build/phases/initialize.cr`: `load_data_files` rewritten to build a `DataTreeNode` tree (deepest paths processed first so directory namespaces win by construction), then converted to `Crinja::Value` maps. Parsing logic extracted to `parse_data_file`. `data_tree_to_crinja` raises if a node ever holds both a leaf value and children, so a future change to the sort or conflict rules fails loudly instead of silently dropping data.
- Docs updated in `docs/content/templates/data-model.md`.

## Test plan

- [x] `crystal spec` — full suite 4662/4662 pass
- [x] `./bin/ameba` clean on changed files
- [x] Unit tests cover: nested map exposure, deep nesting, directory-shadows-file + warning, duplicate-stem warning
- [x] Functional tests cover: template iteration over `site.data.users`, leaf access by stem, JSON/TOML files under subdirectories, root-level files coexisting with subdirectory namespaces