### PR TITLE
fix(content): flatten [extra] front-matter subtable into page.extra

### DIFF
--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -338,9 +338,10 @@ describe Hwaro::Content::Processors::Markdown do
         MD
 
       result = processor.parse(raw)
-      result[:extra].has_key?("extra").should be_true
-      # The extra should contain "custom_field" within the nested structure
-      # Since [extra] is parsed as a TOML subtable, it becomes extra["extra"]
+      result[:extra].has_key?("extra").should be_false
+      result[:extra]["custom_field"].should eq("hello")
+      result[:extra]["custom_bool"].should be_true
+      result[:extra]["custom_int"].should eq(99_i64)
     end
 
     it "extracts top-level extra fields not in known keys" do

--- a/spec/unit/processors_spec.cr
+++ b/spec/unit/processors_spec.cr
@@ -681,5 +681,75 @@ describe Hwaro::Processor::Markdown do
       extra["extra_bool"].should be_true
       extra["extra_array"].should eq(["a", "b"])
     end
+
+    it "flattens the TOML [extra] subtable into page.extra" do
+      content = <<-MARKDOWN
+        +++
+        title = "Extra subtable test"
+
+        [extra]
+        color = "red"
+        rating = 5
+        tags_inner = ["a", "b"]
+        +++
+
+        # Content
+        MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      extra = result[:extra]
+
+      extra["color"].should eq("red")
+      extra["rating"].should eq(5_i64)
+      extra["tags_inner"].should eq(["a", "b"])
+      extra.has_key?("extra").should be_false
+    end
+
+    it "flattens a nested YAML extra mapping into page.extra" do
+      content = <<-MARKDOWN
+        ---
+        title: Extra subtable test
+        extra:
+          color: red
+          rating: 5
+          tags_inner:
+            - a
+            - b
+        ---
+
+        # Content
+        MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      extra = result[:extra]
+
+      extra["color"].should eq("red")
+      extra["rating"].should eq(5_i64)
+      extra["tags_inner"].should eq(["a", "b"])
+      extra.has_key?("extra").should be_false
+    end
+
+    it "flattens a nested JSON extra object into page.extra" do
+      content = <<-MARKDOWN
+        {
+          "title": "Extra subtable test",
+          "extra": {
+            "color": "red",
+            "rating": 5,
+            "tags_inner": ["a", "b"]
+          }
+        }
+
+        # Content
+        MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      extra = result[:extra]
+
+      extra["color"].should eq("red")
+      extra["rating"].should eq(5_i64)
+      extra["tags_inner"].should eq(["a", "b"])
+      extra.has_key?("extra").should be_false
+    end
   end
 end

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -288,6 +288,12 @@ module Hwaro
           unknown_keys = [] of String
           toml_fm.each do |key, value|
             next if KNOWN_FRONT_MATTER_KEYS.includes?(key)
+            if key == "extra" && (inner = value.as_h?)
+              inner.each do |inner_key, inner_value|
+                extra[inner_key] = extract_extra_value(inner_value)
+              end
+              next
+            end
             unknown_keys << key
             extra[key] = extract_extra_value(value)
           end
@@ -339,6 +345,14 @@ module Hwaro
               key = key_any.as_s?
               next unless key
               next if KNOWN_FRONT_MATTER_KEYS.includes?(key)
+              if key == "extra" && (inner = value.as_h?)
+                inner.each do |inner_key_any, inner_value|
+                  inner_key = inner_key_any.as_s?
+                  next unless inner_key
+                  extra[inner_key] = extract_extra_value(inner_value)
+                end
+                next
+              end
               unknown_keys << key
               extra[key] = extract_extra_value(value)
             end
@@ -384,6 +398,12 @@ module Hwaro
           unknown_keys = [] of String
           json_fm.as_h.each do |key, value|
             next if KNOWN_FRONT_MATTER_KEYS.includes?(key)
+            if key == "extra" && (inner = value.as_h?)
+              inner.each do |inner_key, inner_value|
+                extra[inner_key] = extract_extra_value(inner_value)
+              end
+              next
+            end
             unknown_keys << key
             extra[key] = extract_extra_value(value)
           end


### PR DESCRIPTION
## Summary
- Special-case the top-level `extra` key in TOML/YAML/JSON front matter: when its value is a table/mapping, merge its children directly into `page.extra` instead of stringifying the subtable into `page.extra["extra"]`.
- This makes the documented `[extra]` idiom work as written (e.g. `{{ page.extra.rating }}`), matching Zola's behavior.
- Updates the previously-locked-in buggy spec (`extracts extra fields from [extra] table`) to assert the flattened result, and adds fresh coverage for TOML, YAML, and JSON.

## Test plan
- [x] `crystal spec spec/unit/processors_spec.cr` — all pass (incl. 3 new flatten tests)
- [x] `crystal spec` — full suite passes (4665 examples, 0 failures)

Closes #472