### PR TITLE
fix(shortcodes): use HTML-comment placeholder to avoid stray <p> wrap

### DIFF
--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -136,7 +136,7 @@ describe Hwaro::Core::Build::Builder do
 
       content = "{{ test(val=\"hello\") }}"
       result = builder.test_process_shortcodes_jinja(content, templates, context, shortcode_results, crinja_env_override: env)
-      result.should contain("HWARO-SHORTCODE-PLACEHOLDER-")
+      result.should contain("<!--HWARO-SHORTCODE-PLACEHOLDER-")
       shortcode_results.size.should eq(1)
       shortcode_results.values.first.should eq("<b>hello</b>")
     end
@@ -165,8 +165,8 @@ describe Hwaro::Core::Build::Builder do
       result = builder.test_render_shortcode_result(
         "box", "text=\"hi\"", templates, context, shortcode_results, "fallback", crinja_env_override: env
       )
-      result.should eq("HWARO-SHORTCODE-PLACEHOLDER-0")
-      shortcode_results["HWARO-SHORTCODE-PLACEHOLDER-0"].should eq("<div>hi</div>")
+      result.should eq("<!--HWARO-SHORTCODE-PLACEHOLDER-0-->")
+      shortcode_results["<!--HWARO-SHORTCODE-PLACEHOLDER-0-->"].should eq("<div>hi</div>")
     end
 
     it "returns fallback when template not found" do
@@ -199,11 +199,11 @@ describe Hwaro::Core::Build::Builder do
     it "replaces placeholders with rendered HTML" do
       builder = Hwaro::Core::Build::Builder.new
       results = {
-        "HWARO-SHORTCODE-PLACEHOLDER-0" => "<b>bold</b>",
-        "HWARO-SHORTCODE-PLACEHOLDER-1" => "<i>italic</i>",
+        "<!--HWARO-SHORTCODE-PLACEHOLDER-0-->" => "<b>bold</b>",
+        "<!--HWARO-SHORTCODE-PLACEHOLDER-1-->" => "<i>italic</i>",
       }
 
-      html = "<p>HWARO-SHORTCODE-PLACEHOLDER-0 and HWARO-SHORTCODE-PLACEHOLDER-1</p>"
+      html = "<p><!--HWARO-SHORTCODE-PLACEHOLDER-0--> and <!--HWARO-SHORTCODE-PLACEHOLDER-1--></p>"
       output = builder.test_replace_shortcode_placeholders(html, results)
       output.should eq("<p><b>bold</b> and <i>italic</i></p>")
     end
@@ -220,12 +220,31 @@ describe Hwaro::Core::Build::Builder do
     it "keeps unmatched placeholders as-is" do
       builder = Hwaro::Core::Build::Builder.new
       results = {
-        "HWARO-SHORTCODE-PLACEHOLDER-0" => "<b>found</b>",
+        "<!--HWARO-SHORTCODE-PLACEHOLDER-0-->" => "<b>found</b>",
       }
 
-      html = "HWARO-SHORTCODE-PLACEHOLDER-0 HWARO-SHORTCODE-PLACEHOLDER-99"
+      html = "<!--HWARO-SHORTCODE-PLACEHOLDER-0--> <!--HWARO-SHORTCODE-PLACEHOLDER-99-->"
       output = builder.test_replace_shortcode_placeholders(html, results)
-      output.should eq("<b>found</b> HWARO-SHORTCODE-PLACEHOLDER-99")
+      output.should eq("<b>found</b> <!--HWARO-SHORTCODE-PLACEHOLDER-99-->")
+    end
+
+    it "does not wrap block-level shortcode output in <p> when on its own line" do
+      # End-to-end pipe: shortcode substitution → Markdown → placeholder replace.
+      # Regression test for https://github.com/hahwul/hwaro/issues/473.
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      templates = {"shortcodes/block" => "<div class=\"my-block\">Block</div>"}
+      context = {} of String => Crinja::Value
+      results = {} of String => String
+
+      content = "Some paragraph.\n\n{{ block() }}\n\nAnother paragraph.\n"
+      substituted = builder.test_process_shortcodes_jinja(content, templates, context, results, crinja_env_override: env)
+      rendered, _ = Hwaro::Processor::Markdown.render(substituted)
+      output = builder.test_replace_shortcode_placeholders(rendered, results)
+
+      output.should contain("<div class=\"my-block\">Block</div>")
+      output.should_not contain("<p><div")
+      output.should_not contain("</div></p>")
     end
   end
 

--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -249,7 +249,7 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
         results,
       )
 
-      output.should contain("HWARO-SHORTCODE-PLACEHOLDER-")
+      output.should contain("<!--HWARO-SHORTCODE-PLACEHOLDER-")
       results.size.should eq(1)
       results.first_value.should contain("<span>placeheld</span>")
     end

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -23,6 +23,17 @@ module Hwaro
         BLOCK_OPEN_RE         = /\{\%\s*([a-zA-Z_][\w\-]*)\s*(?:\((.*?)\)|((?:\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^,%\s]+)\s*,?\s*)*))\s*\%\}/
         BLOCK_CLOSE_RE        = /\{\%\s*end\s*\%\}/
 
+        # Placeholder left in the content stream for each rendered shortcode
+        # before Markdown runs. HTML-comment form so CommonMark treats it as
+        # an HTML block (type 2) when on its own line — otherwise block-level
+        # shortcode output ends up wrapped in a stray <p>. Inline usage still
+        # works because comments are preserved verbatim inside paragraphs.
+        # The %d is substituted with the placeholder index at emit time, and
+        # the regex is used by `replace_shortcode_placeholders` after Markdown.
+        SHORTCODE_PLACEHOLDER_PREFIX = "<!--HWARO-SHORTCODE-PLACEHOLDER-"
+        SHORTCODE_PLACEHOLDER_SUFFIX = "-->"
+        SHORTCODE_PLACEHOLDER_RE     = /#{Regex.escape(SHORTCODE_PLACEHOLDER_PREFIX)}\d+#{Regex.escape(SHORTCODE_PLACEHOLDER_SUFFIX)}/
+
         # Process shortcodes in content (Jinja2/Crinja style)
         # Supports two syntax patterns:
         # 1. Explicit: {{ shortcode("name", arg1="value1", arg2="value2") }}
@@ -208,12 +219,7 @@ module Hwaro
           html = render_shortcode_jinja(template, args, context, crinja_env_override: crinja_env_override, shortcode_name: name)
 
           if results = shortcode_results
-            # HTML-comment form so CommonMark treats the placeholder as an
-            # HTML block (type 2) when it sits on its own line — otherwise
-            # block-level shortcode output ends up wrapped in a stray <p>.
-            # Inline usage still works: comments inside a paragraph are
-            # preserved verbatim and replaced in-place after Markdown runs.
-            placeholder = "<!--HWARO-SHORTCODE-PLACEHOLDER-#{results.size}-->"
+            placeholder = "#{SHORTCODE_PLACEHOLDER_PREFIX}#{results.size}#{SHORTCODE_PLACEHOLDER_SUFFIX}"
             results[placeholder] = html
             placeholder
           else
@@ -290,7 +296,7 @@ module Hwaro
         # Replace shortcode placeholders with their rendered HTML content
         private def replace_shortcode_placeholders(html : String, shortcode_results : Hash(String, String)) : String
           return html if shortcode_results.empty?
-          html.gsub(/<!--HWARO-SHORTCODE-PLACEHOLDER-\d+-->/) do |match|
+          html.gsub(SHORTCODE_PLACEHOLDER_RE) do |match|
             shortcode_results[match]? || match
           end
         end

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -208,7 +208,12 @@ module Hwaro
           html = render_shortcode_jinja(template, args, context, crinja_env_override: crinja_env_override, shortcode_name: name)
 
           if results = shortcode_results
-            placeholder = "HWARO-SHORTCODE-PLACEHOLDER-#{results.size}"
+            # HTML-comment form so CommonMark treats the placeholder as an
+            # HTML block (type 2) when it sits on its own line — otherwise
+            # block-level shortcode output ends up wrapped in a stray <p>.
+            # Inline usage still works: comments inside a paragraph are
+            # preserved verbatim and replaced in-place after Markdown runs.
+            placeholder = "<!--HWARO-SHORTCODE-PLACEHOLDER-#{results.size}-->"
             results[placeholder] = html
             placeholder
           else
@@ -285,7 +290,7 @@ module Hwaro
         # Replace shortcode placeholders with their rendered HTML content
         private def replace_shortcode_placeholders(html : String, shortcode_results : Hash(String, String)) : String
           return html if shortcode_results.empty?
-          html.gsub(/HWARO-SHORTCODE-PLACEHOLDER-\d+/) do |match|
+          html.gsub(/<!--HWARO-SHORTCODE-PLACEHOLDER-\d+-->/) do |match|
             shortcode_results[match]? || match
           end
         end


### PR DESCRIPTION
## Summary
- Block-level shortcode output (`<div>`, `<table>`, `<figure>`, …) on its own line was wrapped in a stray `<p>`, yielding invalid `<p><div>…</div></p>`. Root cause: the placeholder (`HWARO-SHORTCODE-PLACEHOLDER-N`) is a bare token, so CommonMark treated it as inline text and wrapped the surrounding paragraph.
- Switch the placeholder format to an HTML comment: `<!--HWARO-SHORTCODE-PLACEHOLDER-N-->`. CommonMark recognizes comments on their own line as an HTML block (spec §4.6 type 2) and does not wrap them; inline usage still works because comments are preserved verbatim inside paragraphs.
- Only two lines change in `shortcode_processor.cr` — the format string and the replacement regex.
- Updates three existing specs that encoded the old placeholder format and adds an end-to-end regression test (shortcode substitution → Markdown render → placeholder replace) that asserts block output is not wrapped.

## Test plan
- [x] `crystal spec spec/unit/builder_shortcode_spec.cr spec/unit/shortcode_processor_edge_cases_spec.cr` — 66/66 pass.
- [x] `crystal spec` — 4666 examples, 0 failures.
- [x] Manually verified via a Markd fixture: bare token → `<p>HWARO…</p>`; HTML comment → no `<p>` on own line, preserved inline.

Closes #473