### PR TITLE
feat(content): support nested [extra.*] subtables

### DIFF
--- a/spec/unit/page_methods_spec.cr
+++ b/spec/unit/page_methods_spec.cr
@@ -300,7 +300,7 @@ describe Hwaro::Models::Page do
 
     it "initializes extra as empty hash" do
       page = Hwaro::Models::Page.new("test.md")
-      page.extra.should eq({} of String => String | Bool | Int64 | Float64 | Array(String))
+      page.extra.should eq({} of String => Hwaro::Models::ExtraValue)
     end
 
     it "can set extra metadata" do

--- a/spec/unit/processors_spec.cr
+++ b/spec/unit/processors_spec.cr
@@ -751,5 +751,127 @@ describe Hwaro::Processor::Markdown do
       extra["tags_inner"].should eq(["a", "b"])
       extra.has_key?("extra").should be_false
     end
+
+    it "preserves nested TOML [extra.author] as a hash on page.extra" do
+      content = <<-MARKDOWN
+        +++
+        title = "Nested extra test"
+
+        [extra.author]
+        name = "Bob"
+        email = "b@example.com"
+
+        [extra.seo]
+        og_image = "/a.png"
+        +++
+
+        # Content
+        MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      extra = result[:extra]
+
+      author = extra["author"].as(Hash(String, Hwaro::Models::ExtraValue))
+      author["name"].should eq("Bob")
+      author["email"].should eq("b@example.com")
+
+      seo = extra["seo"].as(Hash(String, Hwaro::Models::ExtraValue))
+      seo["og_image"].should eq("/a.png")
+    end
+
+    it "preserves a nested YAML extra mapping as a hash on page.extra" do
+      content = <<-MARKDOWN
+        ---
+        title: Nested extra test
+        extra:
+          author:
+            name: Bob
+            email: b@example.com
+          seo:
+            og_image: /a.png
+        ---
+
+        # Content
+        MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      extra = result[:extra]
+
+      author = extra["author"].as(Hash(String, Hwaro::Models::ExtraValue))
+      author["name"].should eq("Bob")
+      author["email"].should eq("b@example.com")
+
+      seo = extra["seo"].as(Hash(String, Hwaro::Models::ExtraValue))
+      seo["og_image"].should eq("/a.png")
+    end
+
+    it "preserves a nested JSON extra object as a hash on page.extra" do
+      content = <<-MARKDOWN
+        {
+          "title": "Nested extra test",
+          "extra": {
+            "author": { "name": "Bob", "email": "b@example.com" },
+            "seo":    { "og_image": "/a.png" }
+          }
+        }
+
+        # Content
+        MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      extra = result[:extra]
+
+      author = extra["author"].as(Hash(String, Hwaro::Models::ExtraValue))
+      author["name"].should eq("Bob")
+      author["email"].should eq("b@example.com")
+    end
+
+    it "preserves TOML arrays-of-tables inside extra" do
+      content = <<-MARKDOWN
+        +++
+        title = "Array-of-tables"
+
+        [[extra.authors]]
+        name = "Alice"
+
+        [[extra.authors]]
+        name = "Bob"
+        +++
+
+        # Content
+        MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      authors = result[:extra]["authors"].as(Array(Hwaro::Models::ExtraValue))
+      authors.size.should eq(2)
+      authors[0].as(Hash(String, Hwaro::Models::ExtraValue))["name"].should eq("Alice")
+      authors[1].as(Hash(String, Hwaro::Models::ExtraValue))["name"].should eq("Bob")
+    end
+
+    it "exposes nested extra as traversable Crinja value via from_extra" do
+      content = <<-MARKDOWN
+        +++
+        title = "Nested extra"
+        [extra.author]
+        name = "Bob"
+        +++
+
+        body
+        MARKDOWN
+
+      result = Hwaro::Processor::Markdown.parse(content)
+      extra = result[:extra]
+
+      # Mirror `render.cr`'s template exposure path.
+      crinja_extra = {} of String => Crinja::Value
+      extra.each { |k, v| crinja_extra[k] = Hwaro::Utils::CrinjaUtils.from_extra(v) }
+
+      env = Crinja.new
+      env.context["page"] = Crinja::Value.new({
+        "extra" => Crinja::Value.new(crinja_extra),
+      })
+      rendered = env.from_string("{{ page.extra.author.name }}").render
+      rendered.should eq("Bob")
+    end
   end
 end

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -510,7 +510,9 @@ module Hwaro
         # `page.extra["x"]?.as?(Array(String))` consumers keep working.
         private def extract_extra_value(value : TOML::Any) : Models::ExtraValue
           if h = value.as_h?
-            extract_extra_hash(h)
+            out = {} of String => Models::ExtraValue
+            h.each { |k, v| out[k] = extract_extra_value(v) }
+            out
           elsif arr = value.as_a?
             extract_extra_array(arr)
           elsif str = value.as_s?
@@ -567,12 +569,6 @@ module Hwaro
           else
             value.to_s
           end
-        end
-
-        private def extract_extra_hash(h : Hash(String, TOML::Any)) : Hash(String, Models::ExtraValue)
-          out = {} of String => Models::ExtraValue
-          h.each { |k, v| out[k] = extract_extra_value(v) }
-          out
         end
 
         # If every element is a plain string, preserve the `Array(String)` type

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -246,7 +246,7 @@ module Hwaro
               sort_by:             nil.as(String?),
               reverse:             nil.as(Bool?),
               authors:             [] of String,
-              extra:               {} of String => String | Bool | Int64 | Float64 | Array(String),
+              extra:               {} of String => Models::ExtraValue,
               in_search_index:     true,
               insert_anchor_links: false,
               page_template:       nil.as(String?),
@@ -284,7 +284,7 @@ module Hwaro
           updated = parse_toml_time(toml_fm["updated"]?)
           expires = parse_toml_time(toml_fm["expires"]?)
 
-          extra = {} of String => String | Bool | Int64 | Float64 | Array(String)
+          extra = {} of String => Models::ExtraValue
           unknown_keys = [] of String
           toml_fm.each do |key, value|
             next if KNOWN_FRONT_MATTER_KEYS.includes?(key)
@@ -338,7 +338,7 @@ module Hwaro
           updated = parse_time(yaml_fm["updated"]?.try(&.as_s?))
           expires = parse_time(yaml_fm["expires"]?.try(&.as_s?))
 
-          extra = {} of String => String | Bool | Int64 | Float64 | Array(String)
+          extra = {} of String => Models::ExtraValue
           unknown_keys = [] of String
           if fm_hash = yaml_fm.as_h?
             fm_hash.each do |key_any, value|
@@ -394,7 +394,7 @@ module Hwaro
           updated = parse_time(json_fm["updated"]?.try(&.as_s?))
           expires = parse_time(json_fm["expires"]?.try(&.as_s?))
 
-          extra = {} of String => String | Bool | Int64 | Float64 | Array(String)
+          extra = {} of String => Models::ExtraValue
           unknown_keys = [] of String
           json_fm.as_h.each do |key, value|
             next if KNOWN_FRONT_MATTER_KEYS.includes?(key)
@@ -461,7 +461,7 @@ module Hwaro
           fm : TOML::Table | YAML::Any | JSON::Any,
           date : Time?,
           updated : Time?,
-          extra : Hash(String, String | Bool | Int64 | Float64 | Array(String)),
+          extra : Hash(String, Models::ExtraValue),
           front_matter_keys : Array(String),
           taxonomies : Hash(String, Array(String)),
           tags : Array(String),
@@ -503,9 +503,17 @@ module Hwaro
           }
         end
 
-        # Extract extra value from TOML::Any, YAML::Any, or JSON::Any
-        private def extract_extra_value(value : TOML::Any | YAML::Any | JSON::Any) : String | Bool | Int64 | Float64 | Array(String)
-          if str = value.as_s?
+        # Recursively convert a front-matter value to `Models::ExtraValue`.
+        # Preserves nested tables/maps as `Hash(String, ExtraValue)` so
+        # `[extra.author] name = "x"` round-trips to `{{ page.extra.author.name }}`.
+        # Arrays of all-strings stay as `Array(String)` so existing
+        # `page.extra["x"]?.as?(Array(String))` consumers keep working.
+        private def extract_extra_value(value : TOML::Any) : Models::ExtraValue
+          if h = value.as_h?
+            extract_extra_hash(h)
+          elsif arr = value.as_a?
+            extract_extra_array(arr)
+          elsif str = value.as_s?
             str
           elsif (bool_val = value.as_bool?) != nil
             bool_val.as(Bool)
@@ -513,10 +521,68 @@ module Hwaro
             int.to_i64
           elsif float = value.as_f?
             float
-          elsif arr = value.as_a?
-            arr.compact_map(&.as_s?)
           else
             value.to_s
+          end
+        end
+
+        private def extract_extra_value(value : YAML::Any) : Models::ExtraValue
+          if h = value.as_h?
+            out = {} of String => Models::ExtraValue
+            h.each do |k_any, v|
+              key = k_any.as_s? || k_any.to_s
+              out[key] = extract_extra_value(v)
+            end
+            out
+          elsif arr = value.as_a?
+            extract_extra_array(arr)
+          elsif str = value.as_s?
+            str
+          elsif (bool_val = value.as_bool?) != nil
+            bool_val.as(Bool)
+          elsif int = value.as_i64?
+            int
+          elsif float = value.as_f?
+            float
+          else
+            value.to_s
+          end
+        end
+
+        private def extract_extra_value(value : JSON::Any) : Models::ExtraValue
+          if h = value.as_h?
+            out = {} of String => Models::ExtraValue
+            h.each { |k, v| out[k] = extract_extra_value(v) }
+            out
+          elsif arr = value.as_a?
+            extract_extra_array(arr)
+          elsif str = value.as_s?
+            str
+          elsif (bool_val = value.as_bool?) != nil
+            bool_val.as(Bool)
+          elsif int = value.as_i64?
+            int
+          elsif float = value.as_f?
+            float
+          else
+            value.to_s
+          end
+        end
+
+        private def extract_extra_hash(h : Hash(String, TOML::Any)) : Hash(String, Models::ExtraValue)
+          out = {} of String => Models::ExtraValue
+          h.each { |k, v| out[k] = extract_extra_value(v) }
+          out
+        end
+
+        # If every element is a plain string, preserve the `Array(String)` type
+        # so downstream `.as?(Array(String))` calls (e.g. `jsonld.cr`) keep
+        # matching. Mixed arrays widen to `Array(ExtraValue)`.
+        private def extract_extra_array(arr : Array(TOML::Any) | Array(YAML::Any) | Array(JSON::Any)) : Array(String) | Array(Models::ExtraValue)
+          if arr.all? { |v| !v.as_s?.nil? }
+            arr.compact_map(&.as_s?)
+          else
+            arr.map { |v| extract_extra_value(v).as(Models::ExtraValue) }
           end
         end
 

--- a/src/content/seo/jsonld.cr
+++ b/src/content/seo/jsonld.cr
@@ -295,26 +295,38 @@ module Hwaro
           %(<script type="application/ld+json">#{json.gsub("</", "<\\/")}</script>)
         end
 
+        # Coerce a `page.extra[key]` value to `Array(String)` regardless of whether
+        # the parser produced `Array(String)` (all-strings case) or `Array(ExtraValue)`
+        # (mixed case). Non-string elements are filtered out.
+        private def extra_string_array(page : Models::Page, key : String) : Array(String)?
+          raw = page.extra[key]?
+          case raw
+          when Array(String)
+            raw
+          when Array
+            raw.compact_map { |v| v.as?(String) }
+          else
+            nil
+          end
+        end
+
         private def extract_faq_items(page : Models::Page) : Array(NamedTuple(question: String, answer: String))
           items = [] of NamedTuple(question: String, answer: String)
 
           # Parse from page content: look for ## Q: ... / A: ... pattern
           # or from extra["faq"] if available as string pairs
-          if faq_raw = page.extra["faq"]?
-            case faq_raw
-            when Array(String)
-              # Pairs: ["Q1", "A1", "Q2", "A2"]
-              faq_raw.each_slice(2) do |pair|
-                if pair.size == 2
-                  items << {question: pair[0], answer: pair[1]}
-                end
+          if faq_pairs = extra_string_array(page, "faq")
+            # Pairs: ["Q1", "A1", "Q2", "A2"]
+            faq_pairs.each_slice(2) do |pair|
+              if pair.size == 2
+                items << {question: pair[0], answer: pair[1]}
               end
             end
           end
 
           # Also check faq_questions / faq_answers parallel arrays
-          if questions = page.extra["faq_questions"]?.try(&.as?(Array(String)))
-            if answers = page.extra["faq_answers"]?.try(&.as?(Array(String)))
+          if questions = extra_string_array(page, "faq_questions")
+            if answers = extra_string_array(page, "faq_answers")
               questions.zip(answers).each do |q, a|
                 items << {question: q, answer: a}
               end
@@ -327,21 +339,18 @@ module Hwaro
         private def extract_howto_steps(page : Models::Page) : Array(NamedTuple(name: String, text: String))
           steps = [] of NamedTuple(name: String, text: String)
 
-          if steps_raw = page.extra["howto_steps"]?
-            case steps_raw
-            when Array(String)
-              # Pairs: ["Step Name", "Step Text", ...]
-              steps_raw.each_slice(2) do |pair|
-                if pair.size == 2
-                  steps << {name: pair[0], text: pair[1]}
-                end
+          if steps_pairs = extra_string_array(page, "howto_steps")
+            # Pairs: ["Step Name", "Step Text", ...]
+            steps_pairs.each_slice(2) do |pair|
+              if pair.size == 2
+                steps << {name: pair[0], text: pair[1]}
               end
             end
           end
 
           # Also check howto_names / howto_texts parallel arrays
-          if names = page.extra["howto_names"]?.try(&.as?(Array(String)))
-            if texts = page.extra["howto_texts"]?.try(&.as?(Array(String)))
+          if names = extra_string_array(page, "howto_names")
+            if texts = extra_string_array(page, "howto_texts")
               names.zip(texts).each do |n, t|
                 steps << {name: n, text: t}
               end

--- a/src/content/seo/jsonld.cr
+++ b/src/content/seo/jsonld.cr
@@ -299,14 +299,11 @@ module Hwaro
         # the parser produced `Array(String)` (all-strings case) or `Array(ExtraValue)`
         # (mixed case). Non-string elements are filtered out.
         private def extra_string_array(page : Models::Page, key : String) : Array(String)?
-          raw = page.extra[key]?
-          case raw
+          case raw = page.extra[key]?
           when Array(String)
             raw
           when Array
             raw.compact_map { |v| v.as?(String) }
-          else
-            nil
           end
         end
 

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -1,5 +1,11 @@
 module Hwaro
   module Models
+    # Recursive value type for `page.extra`. Keeps `Array(String)` in the union
+    # so existing call sites that assign a plain string literal array
+    # (`page.extra["x"] = ["a", "b"]`) continue to compile — Crystal arrays are
+    # invariant so `Array(String)` is not assignable to `Array(ExtraValue)`.
+    alias ExtraValue = String | Bool | Int64 | Float64 | Array(String) | Array(ExtraValue) | Hash(String, ExtraValue)
+
     struct TranslationLink
       property code : String
       property url : String
@@ -47,8 +53,10 @@ module Hwaro
       # New: Authors field (array of author names)
       property authors : Array(String)
 
-      # New: Extra field for arbitrary custom metadata from front matter
-      property extra : Hash(String, String | Bool | Int64 | Float64 | Array(String))
+      # New: Extra field for arbitrary custom metadata from front matter.
+      # Values are recursive (`ExtraValue`) so nested `[extra.*]` subtables
+      # and arrays-of-tables round-trip into `{{ page.extra.a.b }}` in templates.
+      property extra : Hash(String, ExtraValue)
 
       # New: Summary - content before <!-- more --> marker or auto-generated
       property summary : String?
@@ -127,7 +135,7 @@ module Hwaro
 
         # New field defaults
         @authors = [] of String
-        @extra = {} of String => String | Bool | Int64 | Float64 | Array(String)
+        @extra = {} of String => ExtraValue
         @summary = nil
         @in_search_index = true
         @insert_anchor_links = false

--- a/src/utils/crinja_utils.cr
+++ b/src/utils/crinja_utils.cr
@@ -74,11 +74,19 @@ module Hwaro
         end
       end
 
-      # Convert an extra field value (from front matter) to Crinja::Value
-      def from_extra(value : String | Bool | Int64 | Float64 | Array(String)) : Crinja::Value
+      # Convert an extra field value (from front matter) to Crinja::Value.
+      # Recursive so nested `[extra.*]` hashes and arrays-of-hashes
+      # traverse via `{{ page.extra.a.b }}` in templates.
+      def from_extra(value : Hwaro::Models::ExtraValue) : Crinja::Value
         case value
+        when Hash
+          converted = {} of String => Crinja::Value
+          value.each { |k, v| converted[k] = from_extra(v) }
+          Crinja::Value.new(converted)
         when Array(String)
           Crinja::Value.new(value.map { |s| Crinja::Value.new(s) })
+        when Array
+          Crinja::Value.new(value.map { |v| from_extra(v) })
         else
           Crinja::Value.new(value)
         end


### PR DESCRIPTION
## Summary
Extends the `[extra]` flatten work from #474 so nested front-matter tables survive the round-trip into templates. Users can now write the same idiom Zola/Hugo support:

```toml
+++
[extra.author]
name = "Bob"
email = "b@example.com"

[[extra.authors]]
name = "Alice"
+++
```

and reach it with `{{ page.extra.author.name }}` / `{{ page.extra.authors[0].name }}`.

### Design
- Introduce a recursive alias `Hwaro::Models::ExtraValue = String | Bool | Int64 | Float64 | Array(String) | Array(ExtraValue) | Hash(String, ExtraValue)` in `src/models/page.cr`. `Array(String)` stays in the union because Crystal arrays are invariant — existing code that assigns `page.extra["x"] = ["a", "b"]` must keep compiling.
- Rewrite `extract_extra_value` in `src/content/processors/markdown.cr` as per-format overloads (TOML / YAML / JSON) that recurse into tables and arrays. Arrays of all-strings stay as `Array(String)` so downstream `.as?(Array(String))` consumers don't break.
- Make `CrinjaUtils.from_extra` recursive so nested hashes and arrays become traversable `Crinja::Value` trees — no template-side changes needed.
- Migrate the `src/content/seo/jsonld.cr` call sites that did `.as?(Array(String))` onto a small private `extra_string_array` helper that tolerates both the preserved `Array(String)` and the mixed `Array(ExtraValue)` shapes.

### What's unchanged
- Flat `[extra] color = "red"` keeps working — templates still render `{{ page.extra.color }}` the same way.
- No template changes needed.
- `Models::Config` / section extras / data-file loaders are untouched; they already used recursive crinja_utils paths.

### Non-goals
- No new Crinja filters or deep-path accessors.
- `Time`/date values inside `extra` still stringify via `to_s` (pre-existing behavior).
- `jsonld.cr` still expects pair-arrays for FAQ/HowTo — richer `[[extra.faq.items]]` style input is a separate feature.

## Test plan
- [x] `crystal spec` — 4671 examples, 0 failures (5 new nested-extra specs added).
- [x] Covers TOML `[extra.author]`, YAML nested mappings, JSON nested objects, TOML arrays-of-tables (`[[extra.authors]]`), and an end-to-end Crinja traversal asserting `{{ page.extra.author.name }}` renders correctly.
- [x] Pre-existing extra flatten specs (TOML/YAML/JSON) continue to pass unchanged.

Refs #472