### PR TITLE
fix(markdown): preserve KaTeX inline math delimiters past Markd inline parsing

### DIFF
--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -120,7 +120,9 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       content = "The formula $x^2$ is simple."
       result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
       result.should contain("math-inline")
-      result.should contain("\\(x^2\\)")
+      # Doubled backslashes so Markd's inline parser yields `\(...\)` after rendering;
+      # see "math (extended) keeps KaTeX delimiters" below.
+      result.should contain("\\\\(x^2\\\\)")
     end
 
     it "does not match dollar signs with spaces" do
@@ -327,6 +329,30 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       content = "$$$$"
       result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
       result.should contain("math-display")
+    end
+
+    # Regression for https://github.com/hahwul/hwaro/issues/484
+    # Markd's inline parser interprets `\(` as a backslash-escape of `(`, so the
+    # backslash needs to survive into the rendered HTML for KaTeX auto-render to
+    # match the expression.
+    it "keeps KaTeX delimiters in the rendered HTML for inline math" do
+      cfg = make_config(math: true)
+      html, _ = Hwaro::Processor::Markdown.render(
+        "Inline $x^2 + y^2$ here.",
+        markdown_config: cfg,
+      )
+      html.should contain(%(<span class="math math-inline">\\(x^2 + y^2\\)</span>))
+      html.should_not contain(">(x^2 + y^2)<")
+    end
+
+    it "keeps KaTeX delimiters in the rendered HTML for display math" do
+      cfg = make_config(math: true)
+      html, _ = Hwaro::Processor::Markdown.render(
+        "$$\nE = mc^2\n$$",
+        markdown_config: cfg,
+      )
+      html.should contain(%(<div class="math math-display">\\[))
+      html.should contain(%(\\]</div>))
     end
   end
 

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -187,9 +187,14 @@ module Hwaro
           end
 
           # Inline math: $...$ (single line, no space after opening or before closing $)
+          # NOTE: Inline `<span>` content participates in CommonMark inline parsing,
+          # so the KaTeX delimiters need an extra backslash to survive — `\\(` in
+          # the markdown source renders to `\(` in HTML, which KaTeX auto-render
+          # expects. Display math uses `<div>` (HTML block, opaque to Markd) and
+          # therefore keeps a single backslash.
           result = result.gsub(/(?<![\\$])\$(?!\s)([^\n$]+?)(?<!\s)\$(?!\d)/) do |_|
             escaped = Utils::TextUtils.escape_xml($~[1])
-            "<span class=\"math math-inline\">\\(#{escaped}\\)</span>"
+            "<span class=\"math math-inline\">\\\\(#{escaped}\\\\)</span>"
           end
 
           result


### PR DESCRIPTION
## Summary

- Inline math was preprocessed to `<span class="math math-inline">\(x^2\)</span>`, but Markd's CommonMark inline parser interprets `\(` as a backslash-escape of `(`, so the rendered HTML ended up as `(x^2)` and KaTeX auto-render never matched it.
- Doubling the backslash in the preprocess emission (`\\(...\\)`) makes Markd unescape it back to the expected `\(...\)`. Display math is unchanged — `<div>` is treated as an HTML block by Markd, so its content is opaque to the inline pass.

## Test plan

- [x] New regression test in `spec/unit/markdown_extensions_spec.cr` runs the math content through `Hwaro::Processor::Markdown.render` and asserts the rendered HTML contains `<span class="math math-inline">\(x^2 + y^2\)</span>` (and a parallel display-math assertion to catch any future change there).
- [x] `crystal spec` — 4703 examples, 0 failures.
- [x] Manual: rebuilt the binary and confirmed `testapp` now emits `\(x^2 + y^2\)` for inline math while display math continues to emit `\[...\]`.

Closes #484