### PR TITLE
fix(dates): RFC 822 pubDate format + TOML datetime literal in scaffolds

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -172,6 +172,27 @@ describe Hwaro::Services::Creator do
       end
     end
 
+    # Regression for https://github.com/hahwul/hwaro/issues/487
+    # The default date should be a TOML datetime literal (unquoted, ISO 8601
+    # with offset) so it round-trips back through the parser as a real `Time`,
+    # matching the form authors use for hand-written front matter.
+    it "writes the default date as an unquoted TOML datetime literal" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Date Form")
+          Hwaro::Services::Creator.new.run(options)
+
+          content = File.read("content/drafts/post.md")
+          # No quoted form anywhere on the date line.
+          content.should_not match(/^date = "[^"]*"$/m)
+          # ISO 8601 with explicit offset (e.g. `2026-04-25T16:26:10+09:00` or `…Z`).
+          content.should match(/^date = \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)$/m)
+        end
+      end
+    end
+
     it "creates a file when path starts with content/" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do

--- a/spec/unit/feeds_spec.cr
+++ b/spec/unit/feeds_spec.cr
@@ -1447,6 +1447,50 @@ describe Hwaro::Content::Seo::Feeds do
       rss.should_not contain("<pubDate>")
     end
 
+    # Regression for https://github.com/hahwul/hwaro/issues/487
+    # Per RFC 822/2822, day-of-month must be two digits; some readers reject
+    # single-digit days.
+    it "uses two-digit day-of-month in pubDate (RFC 822)" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("post.md")
+      page.title = "Single-digit Day"
+      page.url = "/post/"
+      page.date = Time.utc(2026, 3, 4, 12, 0, 0)
+      page.raw_content = "Content"
+
+      rss = Hwaro::Content::Seo::Feeds.generate_rss(
+        [page], config, "rss.xml", false, "Test", ""
+      )
+
+      rss.should contain("<pubDate>Wed, 04 Mar 2026 12:00:00 +0000</pubDate>")
+    end
+
+    # Regression for https://github.com/hahwul/hwaro/issues/487
+    # Date-only TOML/YAML values are anchored to the build host's local TZ by
+    # the parser; converting them to UTC at output time used to push the
+    # calendar date back by one day on `+09:00` hosts.
+    it "preserves the calendar date for TZ-less midnight values" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("post.md")
+      page.title = "Date Only"
+      page.url = "/post/"
+      # Mimic what a TOML local-date (`date = 2026-03-05`) becomes after
+      # parsing on a `+09:00` host: midnight in `Asia/Seoul`.
+      seoul = Time::Location.fixed("Asia/Seoul", 9 * 3600)
+      page.date = Time.local(2026, 3, 5, 0, 0, 0, location: seoul)
+      page.raw_content = "Content"
+
+      rss = Hwaro::Content::Seo::Feeds.generate_rss(
+        [page], config, "rss.xml", false, "Test", ""
+      )
+
+      rss.should contain("<pubDate>Thu, 05 Mar 2026 00:00:00 +0000</pubDate>")
+    end
+
     it "includes description with content" do
       config = Hwaro::Models::Config.new
       config.base_url = "https://example.com"

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -182,6 +182,30 @@ module Hwaro
           base_url.empty? ? path : base_url + path
         end
 
+        # Format a Time as an RFC 822/2822 datetime suitable for RSS `<pubDate>`.
+        # `Time#to_rfc2822` omits the leading zero on day-of-month, which some
+        # readers reject; force `two_digit_day: true`.
+        #
+        # Date-only TOML/YAML values (e.g. `date = 2026-03-05`) are anchored to
+        # the build host's local zone by the parsers. Naively converting those
+        # to UTC pushes the calendar date back by the host's offset, so a
+        # `+09:00` host would emit `Wed, 04 Mar 2026 15:00:00 +0000` for a date
+        # the author wrote as 5 Mar. Detect "midnight in a non-UTC zone" and
+        # re-anchor to UTC of the same wall-clock date instead.
+        private def self.format_rfc822(time : Time) : String
+          normalized = if time.location != Time::Location::UTC &&
+                          time.hour == 0 && time.minute == 0 &&
+                          time.second == 0 && time.nanosecond == 0
+                         Time.utc(time.year, time.month, time.day)
+                       else
+                         time.to_utc
+                       end
+          String.build do |io|
+            formatter = Time::Format::Formatter.new(normalized, io)
+            formatter.rfc_2822(time_zone_gmt: false, two_digit_day: true)
+          end
+        end
+
         def self.generate_rss(
           pages : Array(Models::Page),
           config : Models::Config,
@@ -220,7 +244,7 @@ module Hwaro
               str << "      <description>#{Utils::TextUtils.escape_xml(content)}</description>\n"
 
               if pub_date = page.date
-                str << "      <pubDate>#{pub_date.to_rfc2822}</pubDate>\n"
+                str << "      <pubDate>#{format_rfc822(pub_date)}</pubDate>\n"
               end
 
               str << "    </item>\n"

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -237,7 +237,10 @@ module Hwaro
                      options.draft == true
                    end
 
-        date = options.date || Time.local.to_s("%Y-%m-%d %H:%M:%S")
+        # ISO 8601 with explicit offset — round-trips back through TOML/YAML
+        # parsers as a real datetime (TOML offset-datetime / YAML timestamp)
+        # rather than a string fallback.
+        date = options.date || Time.local.to_s("%Y-%m-%dT%H:%M:%S%:z")
         tags = options.tags
 
         # Find archetype, extracting any hwaro directives (e.g. bundle=true)
@@ -464,12 +467,19 @@ module Hwaro
         end
       end
 
+      # TOML datetime literal pattern (local-date / local-datetime /
+      # offset-datetime per the spec). When the value matches, emit unquoted
+      # so the parser returns a real `Time`; otherwise fall back to a quoted
+      # string so unusual `--date` inputs still produce valid TOML.
+      TOML_DATETIME_RE = /\A\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)?\z/
+
       private def build_toml_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String)) : String
         safe_title = escape_string(title)
+        date_literal = date.matches?(TOML_DATETIME_RE) ? date : "\"#{escape_string(date)}\""
         String.build do |str|
           str << "+++\n"
           str << "title = \"#{safe_title}\"\n"
-          str << "date = \"#{date}\"\n"
+          str << "date = #{date_literal}\n"
           extra_fields.each { |f| str << "#{f} = \"\"\n" }
           str << "draft = true\n" if is_draft
           unless tags.empty?


### PR DESCRIPTION
## Summary

Three small date-handling papercuts that bit together in #487:

- **RSS `<pubDate>`** was emitted via `Time#to_rfc2822`, which omits the leading zero on day-of-month — RFC 822/2822 compliant readers can reject single-digit days. Switch to `Time::Format::Formatter#rfc_2822` with `two_digit_day: true`.
- **Date-only TOML/YAML values** (`date = 2026-03-05`) are anchored to the build host's local zone by the parsers. Naively converting those to UTC at output time pushed the calendar date back by one day on `+09:00` hosts. When the input is at midnight in a non-UTC location, re-anchor to midnight UTC of the same wall-clock date so the calendar date the author wrote is stable across hosts.
- **`hwaro new`** wrote `date = "2026-04-25 16:26:10"` as a quoted string, diverging from the unquoted TOML datetime literal authors use in hand-written front matter. Generate ISO 8601 with explicit offset and emit unquoted in TOML when the value matches a TOML datetime literal pattern (fall back to a quoted string for unusual `--date` inputs).

## Test plan

- [x] New regression tests in `spec/unit/feeds_spec.cr`:
  - `<pubDate>Wed, 04 Mar 2026 12:00:00 +0000</pubDate>` (two-digit day)
  - `<pubDate>Thu, 05 Mar 2026 00:00:00 +0000</pubDate>` for a `Time.local(..., +09:00)` midnight (TZ-less calendar date preserved).
- [x] New regression test in `spec/unit/creator_spec.cr` asserting the default `date = ` line matches `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)` and is **not** quoted.
- [x] `crystal spec` — 4706 examples, 0 failures.
- [x] Manual: rebuilt the binary and confirmed
  - `testapp` RSS now emits `Thu, 05 Mar 2026 00:00:00 +0000` (was `Wed, 4 Mar 2026 15:00:00 +0000`).
  - `hwaro new posts/test.md --title "Date Test"` writes `date = 2026-04-25T17:27:36+09:00` (unquoted offset-datetime literal).

Closes #487