### PR TITLE
docs(sections): clarify sort_by × reverse natural direction

### DIFF
--- a/docs/content/templates/data-model.md
+++ b/docs/content/templates/data-model.md
@@ -207,8 +207,8 @@ For the current section URL in `section.html`, use `page.url`.
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| sort_by | String? | "date" | Sort by: date, weight, title |
-| reverse | Bool? | false | Reverse sort order |
+| sort_by | String? | "date" | Sort by: date (newest first), weight (lowest first), title (A→Z) |
+| reverse | Bool? | false | Flip the natural sort order — see [Writing › Sections › Sort direction](/writing/sections/#sort-direction) |
 | paginate | Int? | — | Pages per page |
 | transparent | Bool | false | Pass pages to parent |
 | generate_feeds | Bool | false | Generate RSS feed |

--- a/docs/content/writing/sections.md
+++ b/docs/content/writing/sections.md
@@ -39,8 +39,8 @@ Welcome to my blog.
 | description | string | — | Section description |
 | template | string | "section" | Template to use |
 | page_template | string | — | Default template for pages |
-| sort_by | string | "date" | Sort by: date, weight, title |
-| reverse | bool | false | Reverse sort order |
+| sort_by | string | "date" | Sort by: date, weight, title (see [Sort direction](#sort-direction)) |
+| reverse | bool | false | Flip the natural sort order (see [Sort direction](#sort-direction)) |
 | paginate | int | — | Pages per page |
 | paginate_path | string | "page" | Pagination URL pattern |
 | transparent | bool | false | Pass pages to parent |
@@ -48,6 +48,27 @@ Welcome to my blog.
 | redirect_to | string | — | Redirect URL |
 | draft | bool | false | Exclude from production |
 | weight | int | 0 | Section sort order |
+
+## Sort direction
+
+Each `sort_by` value has a different natural direction, chosen to match what authors usually want:
+
+| `sort_by` | Default order | With `reverse = true` |
+|-----------|---------------|------------------------|
+| `date`    | Newest first (descending) | Oldest first |
+| `weight`  | Lowest weight first (ascending) | Highest weight first |
+| `title`   | A → Z (ascending) | Z → A |
+
+`reverse` flips whichever direction is natural for the chosen `sort_by`. For example, a blog index sorted by `date` is newest-first by default; setting `reverse = true` switches it to oldest-first.
+
+```toml
++++
+title = "Blog"
+sort_by = "date"
+# reverse = false (default) → newest first
+# reverse = true            → oldest first
++++
+```
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Investigation for #483 showed the code is correct (matches Hugo's per-`sort_by` natural direction: `date` DESC, `weight`/`title` ASC; `reverse` flips it). The bug is in the docs: the one-line "Reverse sort order" description doesn't mention that the natural direction depends on `sort_by`, so users who set `reverse = false` for `sort_by = "date"` see newest-first output and assume it's a bug.

- Add a new **Sort direction** section in `writing/sections.md` with a per-value table and a worked example.
- Cross-link from the section front-matter table in `templates/data-model.md` so the template-side reference points at the same explanation.

## Test plan

- [x] `cd docs && hwaro build` — 63 pages, no warnings; the new `#sort-direction` anchor is reachable from both cross-links.
- [x] No code changes, so existing specs are unaffected.

Closes #483