### PR TITLE
fix(taxonomies): generate listing pages for the `authors` taxonomy

### DIFF
--- a/spec/unit/taxonomies_spec.cr
+++ b/spec/unit/taxonomies_spec.cr
@@ -227,6 +227,49 @@ describe Hwaro::Content::Taxonomies do
         File.exists?(File.join(output_dir, "tags", "crystal-programming", "index.html")).should be_true
       end
     end
+
+    # Regression for https://github.com/hahwul/hwaro/issues/485
+    # `authors` is stored on a dedicated `page.authors` property (so the
+    # `site.authors` aggregation can use it) rather than in `page.taxonomies`.
+    # The taxonomy generator used to special-case only `tags`, so configuring
+    # `[[taxonomies]] name = "authors"` silently produced no listing pages.
+    it "generates index and term pages for the `authors` taxonomy" do
+      config = Hwaro::Models::Config.new
+      config.taxonomies = [Hwaro::Models::TaxonomyConfig.new("authors")]
+
+      site = Hwaro::Models::Site.new(config)
+
+      page1 = Hwaro::Models::Page.new("post1.md")
+      page1.title = "Post 1"
+      page1.url = "/post1/"
+      page1.authors = ["alice", "bob"]
+      page1.draft = false
+      page1.generated = false
+      page1.front_matter_keys = ["title", "authors"]
+
+      page2 = Hwaro::Models::Page.new("post2.md")
+      page2.title = "Post 2"
+      page2.url = "/post2/"
+      page2.authors = ["alice"]
+      page2.draft = false
+      page2.generated = false
+      page2.front_matter_keys = ["title", "authors"]
+
+      site.pages = [page1, page2]
+
+      Dir.mktmpdir do |output_dir|
+        templates = {
+          "taxonomy"      => "<html>{{ content }}</html>",
+          "taxonomy_term" => "<html>{{ content }}</html>",
+        }
+
+        Hwaro::Content::Taxonomies.generate(site, output_dir, templates)
+
+        File.exists?(File.join(output_dir, "authors", "index.html")).should be_true
+        File.exists?(File.join(output_dir, "authors", "alice", "index.html")).should be_true
+        File.exists?(File.join(output_dir, "authors", "bob", "index.html")).should be_true
+      end
+    end
   end
 end
 

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -222,18 +222,7 @@ module Hwaro
       end
 
       private def self.extract_terms_for(page : Models::Page, taxonomy : Models::TaxonomyConfig) : Array(String)
-        name = taxonomy.name
-        if page.taxonomies.has_key?(name)
-          return page.taxonomies[name]
-        end
-
-        if page.front_matter_keys.includes?(name)
-          return [] of String
-        end
-
-        return page.tags if name == "tags"
-
-        [] of String
+        page.taxonomy_values(taxonomy.name)
       end
 
       private def self.apply_template(

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -365,7 +365,7 @@ module Hwaro::Core::Build::Phases::Transform
     all_pages.each do |page|
       page_lookup[page.path] = page
       taxonomy_names.each do |tax_name|
-        values = page.taxonomies[tax_name]? || (tax_name == "tags" ? page.tags : [] of String)
+        values = page.taxonomy_values(tax_name)
         values.each do |term|
           inv_tax = inverted[tax_name]? || (inverted[tax_name] = {} of String => Array(String))
           arr = inv_tax[term]? || (inv_tax[term] = [] of String)
@@ -390,7 +390,7 @@ module Hwaro::Core::Build::Phases::Transform
     # Include pages sharing taxonomy terms with changed pages
     changed_pages.each do |page|
       taxonomy_names.each do |tax_name|
-        values = page.taxonomies[tax_name]? || (tax_name == "tags" ? page.tags : [] of String)
+        values = page.taxonomy_values(tax_name)
         inv_tax = inverted[tax_name]?
         next unless inv_tax
         values.each do |term|
@@ -408,7 +408,7 @@ module Hwaro::Core::Build::Phases::Transform
 
       scores = Hash(String, Int32).new(0)
       taxonomy_names.each do |tax_name|
-        values = page.taxonomies[tax_name]? || (tax_name == "tags" ? page.tags : [] of String)
+        values = page.taxonomy_values(tax_name)
         inv_tax = inverted[tax_name]?
         next unless inv_tax
         values.each do |term|
@@ -560,7 +560,7 @@ module Hwaro::Core::Build::Phases::Transform
     pages.each do |page|
       page_lookup[page.path] = page
       taxonomy_names.each do |tax_name|
-        values = page.taxonomies[tax_name]? || (tax_name == "tags" ? page.tags : [] of String)
+        values = page.taxonomy_values(tax_name)
         values.each do |term|
           inv_tax = inverted[tax_name]? || (inverted[tax_name] = {} of String => Array(String))
           arr = inv_tax[term]? || (inv_tax[term] = [] of String)
@@ -577,7 +577,7 @@ module Hwaro::Core::Build::Phases::Transform
       scores = Hash(String, Int32).new(0)
       page_lang = page.language
       taxonomy_names.each do |tax_name|
-        values = page.taxonomies[tax_name]? || (tax_name == "tags" ? page.tags : [] of String)
+        values = page.taxonomy_values(tax_name)
         inv_tax = inverted[tax_name]?
         next unless inv_tax
         values.each do |term|

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -160,6 +160,22 @@ module Hwaro
         !@redirect_to.nil? && !@redirect_to.try(&.empty?)
       end
 
+      # Resolve the term list for a configured taxonomy `name`. Most
+      # taxonomies live in `@taxonomies`, but a few — `tags` and `authors`
+      # — are stored on dedicated `Page` properties so other features
+      # (the `tags` shortcut, the `site.authors` aggregation) can reach
+      # them without a hash lookup. Centralizing the fallback here keeps
+      # call sites (Taxonomies generator, related-posts scoring, …) from
+      # forgetting any of the special cases.
+      def taxonomy_values(name : String) : Array(String)
+        return @taxonomies[name] if @taxonomies.has_key?(name)
+        case name
+        when "tags"    then @tags
+        when "authors" then @authors
+        else                [] of String
+        end
+      end
+
       # Collect assets from page directory
       def collect_assets(content_dir : String) : Array(String)
         # Assets are only collected for page bundles (directories)


### PR DESCRIPTION
## Summary

Configuring `[[taxonomies]] name = "authors"` was silently a no-op even when pages declared `authors = [...]` in front matter — `tags` and `categories` produced index pages but `authors` never did.

Two bits of indirection caused the silent skip:

- The front-matter parser excludes `authors` (alongside `tags` and `aliases`) from `page.taxonomies` so the dedicated `page.authors` property and the `site.authors` aggregation can own the data.
- The taxonomy generator's `extract_terms_for` special-cased only `tags` when looking for the term list, then bailed out for any other excluded key, so `/authors/` and `/authors/<id>/` were never produced.

Add a `Page#taxonomy_values(name)` helper that resolves the term list for a configured taxonomy and falls back to `@tags` for `tags` and `@authors` for `authors`. Route the taxonomy generator and related-posts scoring (5 call sites in `phases/transform.cr`) through it so any future "stored on a dedicated property" key only needs the case branch added in one place.

## Test plan

- [x] New regression test in `spec/unit/taxonomies_spec.cr` configures `[[taxonomies]] name = "authors"`, points two pages at `["alice", "bob"]` / `["alice"]`, and asserts `public/authors/index.html`, `public/authors/alice/index.html`, and `public/authors/bob/index.html` are produced.
- [x] `crystal spec` — 4707 examples, 0 failures.
- [x] `crystal tool format --check` clean.
- [x] Manual: rebuilt the binary and confirmed `testapp`'s `/authors/`, `/authors/alice/`, and `/authors/bob/` are now generated alongside `/tags/` and `/categories/`.

Closes #485