### PR TITLE
fix(shortcodes): replace missing shortcode calls with an HTML comment

### DIFF
--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -169,16 +169,36 @@ describe Hwaro::Core::Build::Builder do
       shortcode_results["<!--HWARO-SHORTCODE-PLACEHOLDER-0-->"].should eq("<div>hi</div>")
     end
 
-    it "returns fallback when template not found" do
+    it "drops the call as an HTML comment when template not found" do
       builder = Hwaro::Core::Build::Builder.new
       env = Crinja.new
       templates = {} of String => String
       context = {} of String => Crinja::Value
 
+      # Regression for https://github.com/hahwul/hwaro/issues/480 — the
+      # original `{{ missing() }}` text used to leak through as the
+      # fallback; replace it with a source-only HTML comment so readers
+      # don't see broken text and search.json doesn't index it.
       result = builder.test_render_shortcode_result(
         "missing", nil, templates, context, nil, "{{ missing() }}", warn_missing: false, crinja_env_override: env
       )
-      result.should eq("{{ missing() }}")
+      result.should eq("<!-- hwaro: missing shortcode 'missing' -->")
+    end
+
+    it "passes Crinja-function names through verbatim so the page template can resolve them" do
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      env.functions["env"] = Crinja.function { |_| Crinja::Value.new("") }
+      templates = {} of String => String
+      context = {} of String => Crinja::Value
+
+      # `env(...)`, `asset(...)`, `url_for(...)`, … aren't shortcodes —
+      # they're template-engine functions that the page template
+      # evaluates later. The shortcode processor must leave them alone.
+      result = builder.test_render_shortcode_result(
+        "env", "name=\"FOO\"", templates, context, nil, %({{ env(name="FOO") }}), crinja_env_override: env
+      )
+      result.should eq(%({{ env(name="FOO") }}))
     end
 
     it "passes extra_args to the template" do

--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -53,26 +53,33 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
   end
 
   describe "unknown shortcodes" do
-    it "leaves direct-call references untouched when no template matches" do
+    # Regression for https://github.com/hahwul/hwaro/issues/480
+    # The old behavior left `{{ unknown(...) }}` literally in the output
+    # and the search index. Now we replace the call with an HTML comment
+    # so readers don't see broken text and `strip_html` drops it from
+    # `search.json`. The warning still fires (see "warns when ..." below).
+    it "replaces direct-call references with an HTML comment when no template matches" do
       builder = Hwaro::Core::Build::Builder.new
       content = %(text {{ unknown(arg="x") }} more)
       result = builder.test_sc_process(content, {} of String => String)
-      result.should eq(content)
+      result.should_not contain("{{ unknown")
+      result.should contain("<!-- hwaro: missing shortcode 'unknown' -->")
     end
 
-    it "leaves explicit shortcode() calls untouched when template missing" do
+    it "replaces explicit shortcode() calls with an HTML comment when template missing" do
       builder = Hwaro::Core::Build::Builder.new
       content = %({{ shortcode("missing", arg="x") }})
       result = builder.test_sc_process(content, {} of String => String)
-      result.should eq(content)
+      result.should_not contain("{{ shortcode")
+      result.should contain("<!-- hwaro: missing shortcode 'missing' -->")
     end
 
-    it "leaves block shortcodes untouched when template missing" do
+    it "replaces block shortcodes with an HTML comment when template missing" do
       builder = Hwaro::Core::Build::Builder.new
       content = %({% missing %}body{% end %})
       result = builder.test_sc_process(content, {} of String => String)
-      # Block path returns the original block as fallback, byte-for-byte
-      result.should eq(content)
+      result.should_not contain("{% missing %}")
+      result.should contain("<!-- hwaro: missing shortcode 'missing' -->")
     end
 
     it "warns when a direct-call shortcode name is not a registered template or Crinja function" do

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -138,6 +138,16 @@ module Hwaro
             args_str = open_match[2]? || open_match[3]?
             body_start = open_start + open_match[0].size
 
+            # `{% end %}` is the closing-tag literal; BLOCK_OPEN_RE happens to
+            # match it too (since `end` is a valid identifier), but treating
+            # it as an opening tag would silently consume a stray close. Emit
+            # it as-is so unmatched `{% end %}` reads as plain text.
+            if name == "end"
+              result << open_match[0]
+              pos = body_start
+              next
+            end
+
             # Find the matching {% end %} by tracking nesting depth
             nesting = 1
             scan_pos = body_start
@@ -208,10 +218,25 @@ module Hwaro
           template = templates[template_key]? || BuiltinShortcodes.templates[template_key]?
 
           unless template
-            if warn_missing && !crinja_function?(name, crinja_env_override)
-              warn_missing_shortcode(template_key)
+            # Direct-call syntax (`{{ name(args) }}`) doubles as Crinja's
+            # function-call syntax — `env`, `asset`, `url_for`, …, are
+            # legitimate references that the page-template engine will
+            # resolve later. Pass those through untouched.
+            return fallback if crinja_function?(name, crinja_env_override)
+
+            warn_missing_shortcode(template_key) if warn_missing
+
+            # Drop the call instead of leaking `{{ name(args) }}` into the
+            # rendered HTML and search index. Use the placeholder pipeline
+            # so block-level missing calls don't get wrapped in a stray
+            # `<p>`, mirroring how rendered shortcodes are handled.
+            placeholder_html = "<!-- hwaro: missing shortcode '#{name}' -->"
+            if results = shortcode_results
+              placeholder = "#{SHORTCODE_PLACEHOLDER_PREFIX}#{results.size}#{SHORTCODE_PLACEHOLDER_SUFFIX}"
+              results[placeholder] = placeholder_html
+              return placeholder
             end
-            return fallback
+            return placeholder_html
           end
 
           args = parse_shortcode_args_jinja(args_str)


### PR DESCRIPTION
## Summary

A direct call to a shortcode whose template doesn't exist used to leak the literal `{{ name(args) }}` text into the rendered HTML and the search index. The build still warned, but warnings are easy to miss in CI and the broken text reached readers (#480).

Drop the call instead of leaking it: emit `<!-- hwaro: missing shortcode '<name>' -->` so the artifact is invisible in the rendered page, greppable in source view, and removed by `strip_html` before it can land in `search.json`. Route the comment through the existing placeholder pipeline so block-level missing calls don't get wrapped in a stray `<p>` either, mirroring how rendered shortcodes are handled. Crinja-function names (`env`, `asset`, `url_for`, …) keep passing through untouched so the page-template engine can still resolve them.

While here, special-case `{% end %}` in the block parser. It was being matched by `BLOCK_OPEN_RE` (since `end` is a valid identifier) and silently consumed any stray closer as the body of an `end` shortcode — the existing "handles multiple unmatched end tags" test passed only because the buggy fallback path left the raw text in place. Emit unmatched `{% end %}` as plain text instead.

## Test plan

- [x] Updated tests in `spec/unit/shortcode_processor_edge_cases_spec.cr` and `spec/unit/builder_shortcode_spec.cr` to assert the new HTML-comment replacement for direct calls, explicit `shortcode("name")` calls, and block shortcodes — and that legitimate Crinja-function names still pass through verbatim.
- [x] `crystal spec` — 4713 examples, 0 failures.
- [x] `crystal tool format --check` clean.
- [x] Manual: rebuilt the binary; in `testapp` the `Unknown shortcode` example now emits `<!-- hwaro: missing shortcode 'nonexistent_thing' -->` in HTML and `search.json` no longer contains the raw `{{ nonexistent_thing(x="y") }}` text.

Closes #480