### PR TITLE
fix(templates): populate pages and subsections inside get_section()

### DIFF
--- a/spec/unit/phases_render_spec.cr
+++ b/spec/unit/phases_render_spec.cr
@@ -27,6 +27,10 @@ module Hwaro::Core::Build
     def test_report_render_failures(failures, verbose)
       report_render_failures(failures, verbose)
     end
+
+    def test_build_global_vars(site : Models::Site)
+      build_global_vars(site)
+    end
   end
 end
 
@@ -264,6 +268,100 @@ describe Hwaro::Core::Build::Phases::Render do
       output = buffer.to_s
       output.should contain("Render failed for 8 pages: Unterminated tag")
       output.should contain("… and 3 more")
+    end
+  end
+
+  # Regression for https://github.com/hahwul/hwaro/issues/481
+  # `get_section()` reads its data from the `__sections_by_key__` map that
+  # `build_global_vars` builds. The section value used to be populated from
+  # `Section#pages` (an unfilled array on the model) and dropped subsections
+  # entirely, so every `get_section(...).pages_count` came back as 0.
+  describe "#build_global_vars / get_section data" do
+    it "fills section.pages from the live page list (not the empty Section#pages property)" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "http://example.com"
+      site = Hwaro::Models::Site.new(config)
+
+      posts = Hwaro::Models::Section.new("posts/_index.md")
+      posts.title = "Posts"
+      posts.section = "posts"
+      posts.url = "/posts/"
+      posts.language = "en"
+
+      hello = Hwaro::Models::Page.new("posts/hello.md")
+      hello.title = "Hello"
+      hello.section = "posts"
+      hello.url = "/posts/hello/"
+      hello.language = "en"
+
+      second = Hwaro::Models::Page.new("posts/second.md")
+      second.title = "Second"
+      second.section = "posts"
+      second.url = "/posts/second/"
+      second.language = "en"
+
+      # `_index.md` files become `Section` objects in `site.sections`;
+      # only regular pages go into `site.pages`. `pages_for_section`
+      # bucketing reads from `site.pages`, so adding the Section to
+      # both lists would double-count.
+      site.sections << posts
+      site.pages << hello << second
+      site.build_lookup_index
+
+      builder = Hwaro::Core::Build::Builder.new
+      vars = builder.test_build_global_vars(site)
+      sections_by_key = vars["__sections_by_key__"].raw.as(Hash)
+      posts_val = sections_by_key["posts"].raw.as(Hash)
+
+      posts_val["pages_count"].raw.should eq(2)
+      posts_val["pages"].raw.as(Array).size.should eq(2)
+    end
+
+    it "exposes subsections so {{ section.subsections }} works inside get_section()" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "http://example.com"
+      site = Hwaro::Models::Site.new(config)
+
+      posts = Hwaro::Models::Section.new("posts/_index.md")
+      posts.title = "Posts"
+      posts.section = "posts"
+      posts.url = "/posts/"
+      posts.language = "en"
+
+      cli_series = Hwaro::Models::Section.new("posts/cli-series/_index.md")
+      cli_series.title = "CLI Series"
+      cli_series.section = "posts/cli-series"
+      cli_series.url = "/posts/cli-series/"
+      cli_series.language = "en"
+
+      posts.subsections << cli_series
+
+      hello = Hwaro::Models::Page.new("posts/hello.md")
+      hello.title = "Hello"
+      hello.section = "posts"
+      hello.url = "/posts/hello/"
+      hello.language = "en"
+
+      part1 = Hwaro::Models::Page.new("posts/cli-series/part1.md")
+      part1.title = "Part 1"
+      part1.section = "posts/cli-series"
+      part1.url = "/posts/cli-series/part1/"
+      part1.language = "en"
+
+      site.sections << posts << cli_series
+      site.pages << hello << part1
+      site.build_lookup_index
+
+      builder = Hwaro::Core::Build::Builder.new
+      vars = builder.test_build_global_vars(site)
+      sections_by_key = vars["__sections_by_key__"].raw.as(Hash)
+      posts_val = sections_by_key["posts"].raw.as(Hash)
+
+      subsections = posts_val["subsections"].raw.as(Array)
+      subsections.size.should eq(1)
+      first_sub = subsections.first.raw.as(Hash)
+      first_sub["name"].raw.should eq("posts/cli-series")
+      first_sub["pages_count"].raw.should eq(1)
     end
   end
 end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -800,21 +800,33 @@ module Hwaro::Core::Build::Phases::Render
     all_sections_array = [] of Crinja::Value
     sections_by_key = {} of String => Crinja::Value
 
+    # `Section#pages` is the model property and is *not* populated by the
+    # build pipeline — it stays `[]`. The live page list lives in
+    # `site.pages_for_section(name, language)`. Compute the page array
+    # once per section so `get_section(...).pages` and `.pages_count`
+    # match what `section.html` would render. Also stash the live result
+    # so the second pass can copy `pages_count` into each parent's
+    # subsection entry.
+    section_data_by_path = {} of String => {pages: Array(Crinja::Value), hash: Hash(String, Crinja::Value)}
+
     site.sections.each do |s|
-      section_pages = s.pages.map do |sp|
-        # Reuse cached page values (contains title/url/date and more)
+      live_pages = site.pages_for_section(s.section, s.language)
+      section_pages = live_pages.map do |sp|
         cached_page_crinja_value(sp, default_lang)
       end
-      section_val = Crinja::Value.new({
+      hash = {
         "path"        => Crinja::Value.new(s.path),
         "name"        => Crinja::Value.new(s.section),
         "title"       => Crinja::Value.new(s.title),
         "description" => Crinja::Value.new(s.description || ""),
         "url"         => Crinja::Value.new(s.url),
         "pages"       => Crinja::Value.new(section_pages),
-        "pages_count" => Crinja::Value.new(s.pages.size),
+        "pages_count" => Crinja::Value.new(section_pages.size),
         "assets"      => Crinja::Value.new(s.assets.map { |a| Crinja::Value.new(a) }),
-      })
+        "subsections" => Crinja::Value.new([] of Crinja::Value),
+      } of String => Crinja::Value
+      section_val = Crinja::Value.new(hash)
+      section_data_by_path[s.path] = {pages: section_pages, hash: hash}
       all_sections_array << section_val
 
       # Build O(1) lookup map for get_section() — match by path, name, and URL
@@ -822,6 +834,23 @@ module Hwaro::Core::Build::Phases::Render
       sections_by_key[s.section] ||= section_val unless s.section.empty?
       sections_by_key[s.url] ||= section_val
     end
+
+    # Second pass: link each section's `subsections` to its children so
+    # `get_section("posts").subsections` returns the same data shape as
+    # the parent. Iterates `site.sections` (not `site.pages`) because
+    # only Section objects carry the `subsections` chain.
+    site.sections.each do |s|
+      next if s.subsections.empty?
+      data = section_data_by_path[s.path]?
+      next unless data
+      subs_array = data[:hash]["subsections"].raw.as(Array)
+      s.subsections.each do |child|
+        if child_data = section_data_by_path[child.path]?
+          subs_array << Crinja::Value.new(child_data[:hash])
+        end
+      end
+    end
+
     vars["__all_sections__"] = Crinja::Value.new(all_sections_array)
     vars["__sections_by_key__"] = Crinja::Value.new(sections_by_key)
 


### PR DESCRIPTION
## Summary

\`get_section(path=…)\` is documented to expose \`.pages\`, \`.pages_count\`, and \`.subsections\` of the matched section, but:

- The section value returned by \`__sections_by_key__\` was built from \`Section#pages\` — a model property the build pipeline never populates (the live page list lives on \`site.pages_for_section\`). So \`{{ get_section('posts').pages_count }}\` came back as 0 even when the section had pages.
- The value omitted the \`subsections\` key entirely, so \`{{ get_section('posts').subsections }}\` was always nil.

Build the value from live data instead:

- Use \`site.pages_for_section(section_name, language)\` for \`pages\` and \`pages_count\`, matching what \`section.html\` itself iterates over.
- Add a \`subsections\` array, populated in a second pass so each entry references the same hash as the corresponding direct \`__sections_by_key__\` lookup. Templates can then walk the section tree (\`{{ get_section('docs').subsections[0].pages_count }}\`) without re-calling \`get_section\`.

The lookup keys (path / name / URL) and the \`__all_sections__\` array are unchanged, so existing call sites keep working — they just now see non-zero pages.

## Test plan

- [x] New regression tests in \`spec/unit/phases_render_spec.cr\` (via a new \`test_build_global_vars\` harness):
  - \`pages_count\` and \`pages.size\` reflect the section's regular pages plus subsection entries.
  - \`subsections\` is populated with the right name and \`pages_count\`.
- [x] \`crystal spec\` — 4714 examples, 0 failures.
- [x] \`crystal tool format --check\` clean.
- [x] Manual: \`testapp\` now reports \`get_section: Posts count=4 pages_len=4 subs=1\` for all three documented \`path=\` forms (name / source path / URL); previously all three returned 0 pages and 0 subsections.

Closes #481