### PR TITLE
fix(shortcodes): treat inline <code> spans as opaque

### DIFF
--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -186,6 +186,43 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
       result.should contain("fenced1")
       result.should contain("fenced2")
     end
+
+    # Regression for https://github.com/hahwul/hwaro/issues/477
+    # Single-backtick inline code spans should be opaque to the shortcode
+    # processor, the same way fenced code blocks already are. The bug was
+    # that the call WAS substituted with a placeholder, then Markdown
+    # wrapped that placeholder in `<code>` and the post-processor never
+    # restored it (because of HTML-escaping inside `<code>`), leaving
+    # `<code>&lt;!--HWARO-SHORTCODE-PLACEHOLDER-N--&gt;</code>` in the
+    # rendered HTML and the search index.
+    it "leaves shortcodes inside single-backtick inline code spans untouched" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/youtube" => %(<iframe src="https://yt/embed/{{ id }}"></iframe>)}
+      content = %(Inline `{{ youtube(id="x") }}` should be literal.)
+      result = builder.test_sc_process(content, templates)
+      result.should contain(%(`{{ youtube(id="x") }}`))
+      result.should_not contain("HWARO-SHORTCODE-PLACEHOLDER")
+      result.should_not contain("<iframe")
+    end
+
+    it "still processes shortcodes outside the inline code span on the same line" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/youtube" => %(<iframe src="https://yt/embed/{{ id }}"></iframe>)}
+      content = %(Live: {{ youtube(id="real") }} and literal: `{{ youtube(id="x") }}`.)
+      result = builder.test_sc_process(content, templates)
+      result.should contain("https://yt/embed/real")
+      result.should contain(%(`{{ youtube(id="x") }}`))
+    end
+
+    it "honors longer backtick fences (`` ` `` inside a double-backtick span)" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/youtube" => %(<iframe></iframe>)}
+      # Double-backtick span lets the user include literal backticks inside.
+      content = %(Doc: ``a `b` {{ youtube(id="x") }}`` end.)
+      result = builder.test_sc_process(content, templates)
+      result.should contain(%(``a `b` {{ youtube(id="x") }}``))
+      result.should_not contain("<iframe")
+    end
   end
 
   describe "nested shortcodes" do

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -34,6 +34,13 @@ module Hwaro
         SHORTCODE_PLACEHOLDER_SUFFIX = "-->"
         SHORTCODE_PLACEHOLDER_RE     = /#{Regex.escape(SHORTCODE_PLACEHOLDER_PREFIX)}\d+#{Regex.escape(SHORTCODE_PLACEHOLDER_SUFFIX)}/
 
+        # Matches CommonMark-style inline code spans on a single line
+        # (1 to 3 leading backticks; the same count must close the span).
+        # Multi-line inline spans are rare and intentionally not handled —
+        # those are usually fenced blocks, which the line-based outer
+        # loop in `process_shortcodes_jinja` already skips.
+        INLINE_CODE_RE = /(`{1,3})((?:(?!\1)[^\n])+?)\1/
+
         # Process shortcodes in content (Jinja2/Crinja style)
         # Supports two syntax patterns:
         # 1. Explicit: {{ shortcode("name", arg1="value1", arg2="value2") }}
@@ -76,6 +83,19 @@ module Hwaro
         end
 
         private def process_shortcodes_in_text(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)? = nil, crinja_env_override : Crinja? = nil, depth : Int32 = 0) : String
+          # Inline code spans (`…`, ``…``) are opaque to the shortcode
+          # processor — running shortcodes inside `<code>` would both
+          # change the visible source the author meant to display and
+          # leak placeholder comments into the rendered HTML / search
+          # index after Markdown HTML-escapes them inside `<code>`.
+          # Mirror the protection that fenced code blocks already get
+          # in `process_shortcodes_jinja`.
+          process_outside_inline_code(content) do |chunk|
+            process_shortcodes_in_chunk(chunk, templates, context, shortcode_results, crinja_env_override, depth)
+          end
+        end
+
+        private def process_shortcodes_in_chunk(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)?, crinja_env_override : Crinja?, depth : Int32) : String
           # 1. Block shortcodes: {% name(args) %}body{% end %}
           # Use stack-based parsing to correctly handle nested block shortcodes
           # of the same type, instead of a single regex that matches the first {% end %}.
@@ -95,6 +115,23 @@ module Hwaro
           processed.gsub(/\{\{\s*([a-zA-Z_][\w\-]*)\s*\((.*?)\)\s*\}\}/) do |match|
             render_shortcode_result($1, $2, templates, context, shortcode_results, match, warn_missing: true, crinja_env_override: crinja_env_override)
           end
+        end
+
+        # Yield each contiguous run of non-inline-code text to `block`,
+        # passing inline code spans (`…`, ``…``) through verbatim. The
+        # caller reassembles the result; only non-code chunks are subject
+        # to shortcode substitution.
+        private def process_outside_inline_code(content : String, & : String -> String) : String
+          result = String::Builder.new
+          pos = 0
+          while match = INLINE_CODE_RE.match(content, pos)
+            match_start = match.begin
+            result << yield content[pos...match_start]
+            result << match[0]
+            pos = match_start + match[0].size
+          end
+          result << yield content[pos..]
+          result.to_s
         end
 
         # Stack-based block shortcode parser that correctly handles nested


### PR DESCRIPTION
## Summary

Single-backtick (and double/triple-backtick) inline code spans should display the raw shortcode call to readers. The processor was running the call anyway, then leaning on the post-Markdown placeholder restore pass — which doesn't see the placeholder once Markdown HTML-escapes it inside `<code>`. Result on a content sample like `` Inline `{{ youtube(id="x") }}` should be literal. ``:

```html
<p>Inline <code>&lt;!--HWARO-SHORTCODE-PLACEHOLDER-0--&gt;</code> should be literal.</p>
```

…and the same artifact in `search.json` (#477).

Mirror the fenced-code-block protection that `process_shortcodes_jinja` already applies at the line level: split each non-fenced chunk into `[text, inline-code, text, …]` segments via a CommonMark-style `INLINE_CODE_RE` and run the block / explicit / direct-call passes only on the text segments. Inline code spans pass through byte-for-byte, so the literal `{{ … }}` survives both Markdown and the search index.

## Test plan

- [x] New regression tests in `spec/unit/shortcode_processor_edge_cases_spec.cr`:
  - `` `{{ youtube(id="x") }}` `` is preserved verbatim and produces no `<iframe>`.
  - On the same line, a shortcode call OUTSIDE the backtick span still renders, while the one INSIDE survives.
  - Double-backtick spans (`` ``a `b` {{ youtube(id="x") }}`` ``) are also opaque.
- [x] `crystal spec` — 4716 examples, 0 failures.
- [x] `crystal tool format --check` clean.
- [x] Manual: `testapp/content/shortcode-test.md`'s "Escaped" example now renders as `<code>{{ youtube(id="literal-in-code") }}</code>` and `search.json` contains no `HWARO-SHORTCODE-PLACEHOLDER` strings.

Closes #477