### PR TITLE
fix(templates): convert ArgumentError on attribute access to a labeled UndefinedError

### DIFF
--- a/spec/unit/crinja_resolve_fix_spec.cr
+++ b/spec/unit/crinja_resolve_fix_spec.cr
@@ -1,0 +1,59 @@
+require "../spec_helper"
+require "../../src/ext/crinja_resolve_fix"
+
+# Regression tests for the resolver monkey-patches in
+# `src/ext/crinja_resolve_fix.cr`. Both behaviors here originate from
+# real bug reports against the vendored Crinja runtime.
+describe "Crinja resolver patches" do
+  describe "attribute access on indexable values (issue #482)" do
+    it "raises a Crinja::UndefinedError with template location instead of ArgumentError" do
+      env = Crinja.new
+      # Iterating a Hash with a single loop variable yields `Tuple(k, v)`
+      # per iteration; before the patch `tuple.name` triggered
+      # `String#to_i` (via the indexable fallback) and surfaced as
+      # `ArgumentError("Invalid Int32: \"name\"")` with a Crystal-
+      # internal stack trace and no template location.
+      template = env.from_string(%({% for k in items %}<{{ k.name }}>{% endfor %}))
+      items = {"alpha" => "x", "beta" => "y"}
+
+      ex = expect_raises(Crinja::UndefinedError) do
+        template.render({"items" => items})
+      end
+      msg = ex.message.not_nil!
+      msg.should contain("k.name")
+      msg.should contain("template:") # file:line:col formatting
+      msg.should_not contain("Invalid Int32")
+    end
+
+    it "raises with template location when accessing an attribute on a String value" do
+      env = Crinja.new
+      template = env.from_string("{{ s.name }}")
+
+      ex = expect_raises(Crinja::UndefinedError) do
+        template.render({"s" => "abc"})
+      end
+      ex.message.not_nil!.should contain("s.name")
+    end
+
+    it "still resolves numeric attribute access on arrays" do
+      env = Crinja.new
+      template = env.from_string("{{ a.0 }}")
+      template.render({"a" => [10, 20, 30]}).should eq("10")
+    end
+
+    it "renders an undefined attribute on a hash silently (default Undefined behavior)" do
+      env = Crinja.new
+      template = env.from_string("[{{ h.missing }}]")
+      template.render({"h" => {"x" => 1}}).should eq("[]")
+    end
+  end
+
+  describe "scope-vs-function priority (issue #224)" do
+    it "prefers a context variable over a registered function with the same name" do
+      env = Crinja.new
+      env.functions["asset"] = Crinja.function { |_| Crinja::Value.new("function-result") }
+      template = env.from_string(%({% for asset in items %}<{{ asset }}>{% endfor %}))
+      template.render({"items" => ["a", "b"]}).should eq("<a><b>")
+    end
+  end
+end

--- a/src/ext/crinja_resolve_fix.cr
+++ b/src/ext/crinja_resolve_fix.cr
@@ -60,7 +60,7 @@ module Crinja::Resolver
   def self.resolve_attribute(name, object : Crinja::Value) : Crinja::Value
     raise Crinja::UndefinedError.new(name.to_s) if object.undefined?
 
-    value = self.resolve_getattr(name, object)
+    value = resolve_getattr(name, object)
 
     if value.undefined?
       if object.indexable? && (idx = name.to_s.to_i?)

--- a/src/ext/crinja_resolve_fix.cr
+++ b/src/ext/crinja_resolve_fix.cr
@@ -1,5 +1,8 @@
-# Monkey-patch Crinja's variable resolution order.
-#
+# Monkey-patches for Crinja's runtime — kept here so we don't fork the
+# vendored library. Each patch carries an issue link so we can remove it
+# once Crinja ships an equivalent fix upstream.
+
+# === 1. Resolution-order fix ============================================
 # Upstream Crinja resolves global functions *before* context variables,
 # which means a loop variable whose name collides with a registered
 # function (e.g. `asset`) is shadowed by the function instead of the
@@ -22,5 +25,66 @@ class Crinja
     else
       value # return the original Undefined
     end
+  end
+end
+
+# === 2. Safer attribute resolution on indexable values ==================
+# Upstream `Resolver.resolve_attribute` calls `name.to_i` (which raises
+# `ArgumentError("Invalid Int32: \"<name>\"")` on non-numeric names) for
+# any indexable value, including Strings. The most common way to hit
+# this is iterating a hash with a single loop variable —
+#
+#   {% for k in site.taxonomies.tags %}{{ k.name }}{% endfor %}
+#
+# yields hash keys (Strings), and `k.name` then runs `"<key>".to_i`.
+# The user sees a Crystal-internal stack trace with no template
+# file:line:col, which makes the typo (`for k, v in …`) impossible to
+# locate.
+#
+# Two changes here:
+#
+# 1. Use `to_i?` so non-numeric attribute names cleanly fall through
+#    instead of crashing the resolver.
+# 2. When attribute access is non-numeric *and* the underlying value is
+#    a String, raise `UndefinedError`. Crinja's `MemberExpression`
+#    evaluator catches and re-raises it labeled with the full
+#    expression (`k.name`), which our `Error [HWARO_E_TEMPLATE]`
+#    formatter prints with template file:line:col. Default `Undefined`
+#    renders as empty, which is the correct behavior for hashes /
+#    objects (`{% if page.optional %}`-style guards rely on it), but
+#    on a primitive String the access is almost always a typo, so a
+#    loud error is more helpful than silent empty output.
+#
+# See: https://github.com/hahwul/hwaro/issues/482
+module Crinja::Resolver
+  def self.resolve_attribute(name, object : Crinja::Value) : Crinja::Value
+    raise Crinja::UndefinedError.new(name.to_s) if object.undefined?
+
+    value = self.resolve_getattr(name, object)
+
+    if value.undefined?
+      if object.indexable? && (idx = name.to_s.to_i?)
+        if v = object[idx]?
+          return Crinja::Value.new v
+        end
+      end
+
+      # Strings, SafeStrings, and Tuples don't have hash-style attribute
+      # access — `.attr` on these is almost always a typo. The most
+      # common case is iterating a hash with a single loop variable,
+      # which yields `Tuple(key, value)` per iteration:
+      #
+      #   {% for tag in site.taxonomies.tags %}{{ tag.name }}{% endfor %}
+      #                                            ^~~~~~~~~ — `tag` is a Tuple
+      #
+      # Raise so the evaluator can label the expression and the
+      # template error formatter shows file:line:col.
+      raw = object.raw
+      if raw.is_a?(String) || raw.is_a?(Crinja::SafeString) || raw.is_a?(Crinja::Tuple)
+        raise Crinja::UndefinedError.new(name.to_s)
+      end
+    end
+
+    value
   end
 end


### PR DESCRIPTION
## Summary

Iterating a hash with a single loop variable — the canonical user typo — used to crash the build with no template location:

```jinja
{% for tag in site.taxonomies.tags %}{{ tag.name }}({{ tag.count }}); {% endfor %}
```

`tag` is a `Tuple(key, value)`. Crinja's resolver, on seeing the non-numeric attribute `name`, falls back to `name.to_i` (the indexable-by-integer-index path), which raises `ArgumentError("Invalid Int32: \"name\"")` deep inside Crystal's `String#to_i32`. The user saw a Crystal-internal stack trace with no template file:line:col (#482).

Two changes in `crinja_resolve_fix.cr`:

1. Use `to_i?` in the indexable-fallback branch so non-numeric names skip the integer index path instead of crashing.
2. After that fallback, raise `UndefinedError` for `String`, `SafeString`, and `Tuple` values — these have no hash-style attribute access, so a non-numeric `.attr` is a user typo, and a loud error is more helpful than silent empty output. Crinja's `MemberExpression` evaluator catches and re-raises the `UndefinedError` with the full expression name, and the existing `Error [HWARO_E_TEMPLATE]` formatter prints the template line and a caret for the offending range.

Hashes and crinja-attribute-aware objects keep their existing silent-`Undefined` behavior, so `{% if page.optional %}` guards still work.

### Before / after

**Before** (build output):
```
Parallel render failed for posts/hello.md: Invalid Int32: "name"
```

**After**:
```
Error [HWARO_E_TEMPLATE]: Template error for about.ko.md: tag.name is undefined.
template: <string>:88:41 .. 88:49

 88 | {% for tag in site.taxonomies.tags %}{{ tag.name }}({{ tag.count }}); {% endfor %}
  X |                                         ^~~~~~~~
```

## Test plan

- [x] New regression tests in `spec/unit/crinja_resolve_fix_spec.cr`:
  - Single-var hash iteration with `tag.name` access raises `Crinja::UndefinedError` whose message contains `k.name` and the template location, and does **not** contain `Invalid Int32`.
  - `{{ s.name }}` on a String value raises with the same labeling.
  - Numeric attribute access on arrays still works (`{{ a.0 }}` → `10`).
  - Undefined attribute on a hash still renders silently as empty.
  - Pre-existing scope-vs-function priority fix (#224) still works.
- [x] `crystal spec` — 4723 examples, 0 failures.
- [x] `crystal tool format --check` clean.
- [x] Manual: rebuilt the binary, added the buggy single-var loop to `testapp/templates/page.html`, and confirmed the new pretty-printed error replaces the old `Invalid Int32` crash.

Closes #482