### PR TITLE
fix(shortcodes): resolve nested block placeholders all the way down

### DIFF
--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -378,6 +378,52 @@ describe Hwaro::Core::Build::Builder do
     end
   end
 
+  describe "nested block shortcodes" do
+    # Regression for https://github.com/hahwul/hwaro/issues/478
+    # Inner block shortcodes were rendered into `shortcode_results` under
+    # their own placeholder, then embedded literally in the outer's body.
+    # The single-pass `replace_shortcode_placeholders` only resolved the
+    # outer placeholder, leaving the inner one as
+    # `<!--HWARO-SHORTCODE-PLACEHOLDER-N-->` in the final HTML.
+    it "resolves inner-block placeholders inside outer-block bodies" do
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      templates = {
+        "shortcodes/alert"   => %(<div class="alert">{{ body }}</div>),
+        "shortcodes/callout" => %(<span class="cb">{{ body }}</span>),
+      }
+      shortcode_results = {} of String => String
+      content = "{% alert %}outer with {% callout %}inner{% end %}{% end %}"
+
+      processed = builder.test_process_shortcodes_jinja(
+        content, templates, {} of String => Crinja::Value, shortcode_results, env
+      )
+      final = builder.test_replace_shortcode_placeholders(processed, shortcode_results)
+
+      final.should contain(%(<div class="alert">))
+      final.should contain(%(<span class="cb">inner</span>))
+      final.should_not contain("HWARO-SHORTCODE-PLACEHOLDER")
+    end
+
+    it "resolves nesting up to MAX_SHORTCODE_NESTING levels" do
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      templates = {
+        "shortcodes/wrap" => %(<x>{{ body }}</x>),
+      }
+      shortcode_results = {} of String => String
+      content = "{% wrap %}1{% wrap %}2{% wrap %}3{% wrap %}4{% end %}{% end %}{% end %}{% end %}"
+
+      processed = builder.test_process_shortcodes_jinja(
+        content, templates, {} of String => Crinja::Value, shortcode_results, env
+      )
+      final = builder.test_replace_shortcode_placeholders(processed, shortcode_results)
+
+      final.should eq("<x>1<x>2<x>3<x>4</x></x></x></x>")
+      final.should_not contain("HWARO-SHORTCODE-PLACEHOLDER")
+    end
+  end
+
   describe "nested shortcodes" do
     it "processes shortcodes nested inside block body" do
       builder = Hwaro::Core::Build::Builder.new

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -371,12 +371,27 @@ module Hwaro
           end
         end
 
-        # Replace shortcode placeholders with their rendered HTML content
+        # Replace shortcode placeholders with their rendered HTML content.
+        #
+        # Block shortcodes can nest, and the inner placeholder gets baked
+        # into the outer template's `{{ body }}` before either of them
+        # actually lands in the rendered HTML. A single gsub pass would
+        # only resolve the outermost placeholder, leaving an
+        # `<!--HWARO-SHORTCODE-PLACEHOLDER-N-->` artifact one level
+        # inwards. Loop until the result stops changing (or until we hit
+        # the same depth limit the recursive renderer uses) so every
+        # nested level resolves.
         private def replace_shortcode_placeholders(html : String, shortcode_results : Hash(String, String)) : String
           return html if shortcode_results.empty?
-          html.gsub(SHORTCODE_PLACEHOLDER_RE) do |match|
-            shortcode_results[match]? || match
+          result = html
+          (MAX_SHORTCODE_NESTING + 1).times do
+            replaced = result.gsub(SHORTCODE_PLACEHOLDER_RE) do |match|
+              shortcode_results[match]? || match
+            end
+            return replaced if replaced == result
+            result = replaced
           end
+          result
         end
 
         # True when `name` is a registered Crinja function in the env used


### PR DESCRIPTION
## Summary

Block shortcodes can nest, and `process_block_shortcodes` already recurses into the body to render the inner ones. Each rendered shortcode is stored in `shortcode_results` under a placeholder comment, and the inner placeholder gets baked into the outer template's `{{ body }}` before either of them actually lands in the rendered HTML.

`replace_shortcode_placeholders` ran a single `gsub` pass, so it only resolved the outermost placeholder — the inner one kept showing up as `<!--HWARO-SHORTCODE-PLACEHOLDER-N-->` one level inwards in the final output. `docs/writing/shortcodes.md` advertises up to 5 levels of nesting, but a single level was already broken (#478).

Loop the replacement until the result stops changing, capped at `MAX_SHORTCODE_NESTING + 1` iterations as a safety net. The cap matches the recursion depth limit on the rendering side, so anything that successfully rendered will fully resolve.

## Test plan

- [x] New regression tests in `spec/unit/builder_shortcode_spec.cr`:
  - `{% alert %}outer with {% callout %}inner{% end %}{% end %}` — both layers render and no `HWARO-SHORTCODE-PLACEHOLDER` is left in the output.
  - 4-deep `{% wrap %}1{% wrap %}2…{% end %}…{% end %}` nesting collapses to `<x>1<x>2<x>3<x>4</x></x></x></x>`.
- [x] `crystal spec` — 4720 examples, 0 failures.
- [x] `crystal tool format --check` clean.
- [x] Manual: rebuilt the binary; the "Nested" example in `testapp/content/shortcode-test.md` now renders the inner `<div class="sc-alert sc-alert--info">…</div>` inside the outer alert (was `<!--HWARO-SHORTCODE-PLACEHOLDER-5-->` previously).

Closes #478