### PR TITLE
fix(content): render page.summary to HTML, plain-text search.json

### DIFF
--- a/docs/content/templates/data-model.md
+++ b/docs/content/templates/data-model.md
@@ -297,7 +297,7 @@ Rendered HTML content is available as the top-level `content` variable.
 |----------|------|-------------|
 | page.word_count | Int | Word count |
 | page.reading_time | Int | Reading time (minutes) |
-| page.summary | String? | Content before <!-- more --> |
+| page.summary | String? | Rendered HTML for the chunk before `<!-- more -->`, falling back to `page.description` when no marker is present. Use with `\| safe` to embed (e.g. `{{ page.summary \| safe }}`); for `<meta name="description">` use `page.description` directly. |
 | page.assets | Array<String> | Static files in page bundle |
 
 ### Boolean Flags

--- a/spec/functional/edge_cases_spec.cr
+++ b/spec/functional/edge_cases_spec.cr
@@ -83,11 +83,38 @@ describe "Edge Cases: Summary via page_summary variable" do
         "post.md" => "---\ntitle: My Post\n---\nThis is the intro.\n\n<!-- more -->\n\nThis is the rest.",
       },
       template_files: {
-        "page.html" => "SUMMARY={{ page_summary }}|{{ content }}",
+        "page.html" => "SUMMARY={{ page_summary | safe }}|{{ content }}",
       },
     ) do
       html = File.read("public/post/index.html")
-      html.should contain("SUMMARY=This is the intro.")
+      # `page_summary` exposes rendered HTML for the chunk before the
+      # `<!-- more -->` marker (#491) — wrap markdown in `<p>` matches
+      # how full content renders.
+      html.should contain("SUMMARY=<p>This is the intro.</p>")
+    end
+  end
+
+  it "page_summary renders inline markdown to HTML rather than leaking raw markers" do
+    # Regression for https://github.com/hahwul/hwaro/issues/491 — the
+    # raw chunk before `<!-- more -->` previously came through verbatim
+    # (with `# Heading`, `**bold**`, etc.), so `{{ page.summary | safe }}`
+    # produced un-rendered markdown in the page.
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "post.md" => "---\ntitle: My Post\n---\n# Heading\n\nWith **bold** and a [link](/about/).\n\n<!-- more -->\n\nRest.",
+      },
+      template_files: {
+        "page.html" => "SUMMARY={{ page_summary | safe }}",
+      },
+    ) do
+      html = File.read("public/post/index.html")
+      html.should contain("<h1")
+      html.should contain("Heading</h1>")
+      html.should contain("<strong>bold</strong>")
+      html.should contain(%(<a href="/about/">link</a>))
+      html.should_not contain("# Heading")
+      html.should_not contain("**bold**")
     end
   end
 

--- a/spec/unit/search_spec.cr
+++ b/spec/unit/search_spec.cr
@@ -346,6 +346,33 @@ describe Hwaro::Content::Search do
       end
     end
 
+    # Regression for https://github.com/hahwul/hwaro/issues/491
+    # `strip_html` removed tags but left HTML entities (`&quot;`, `&amp;`, …)
+    # encoded, so `print("hi")` ended up as `print(&quot;hi&quot;)` in the
+    # JSON content field. Client-side fuzzy-search libraries match on the
+    # raw stored string, so a query for the literal source never hit.
+    it "decodes HTML entities to plain text in the content field" do
+      config = Hwaro::Models::Config.new
+      config.search.enabled = true
+      config.search.fields = ["content"]
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.title = "Test"
+      page.url = "/test/"
+      page.draft = false
+      # Markdown renders fenced code with HTML-escaped quotes inside
+      # `<pre><code>` — strip_html leaves those entities encoded.
+      page.raw_content = %(```python\nprint("hi")\n```)
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Search.generate([page], config, output_dir)
+
+        content = File.read(File.join(output_dir, "search.json"))
+        content.should contain(%(print(\\"hi\\")))
+        content.should_not contain("&quot;")
+      end
+    end
+
     it "handles multiple pages" do
       config = Hwaro::Models::Config.new
       config.search.enabled = true

--- a/src/content/hooks/markdown_hooks.cr
+++ b/src/content/hooks/markdown_hooks.cr
@@ -95,7 +95,10 @@ module Hwaro
           # Calculate derived fields
           page.calculate_word_count
           page.calculate_reading_time
-          page.extract_summary
+          if summary_md = page.extract_summary
+            summary_html, _ = Processor::Markdown.render(summary_md)
+            page.summary_html = summary_html
+          end
         end
 
         private def filter_drafts(ctx : Core::Lifecycle::BuildContext)

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -3,6 +3,7 @@ require "../models/config"
 require "../utils/logger"
 require "../utils/text_utils"
 require "./processors/markdown"
+require "html"
 require "json"
 require "uri"
 
@@ -100,8 +101,11 @@ module Hwaro
                 html_content, _ = Processor::Markdown.render(page.raw_content)
               end
 
-              # Strip HTML tags to get plain text
-              text_content = Utils::TextUtils.strip_html(html_content)
+              # Strip HTML tags AND decode entities so the index stores
+              # actual characters (`print("hi")`) rather than the HTML-
+              # escaped form (`print(&quot;hi&quot;)`). Client-side
+              # search libraries match on the raw stored string.
+              text_content = HTML.unescape(Utils::TextUtils.strip_html(html_content))
               data["content"] = cjk ? Utils::TextUtils.tokenize_cjk(text_content) : text_content
             when "tags"
               data["tags"] = page.tags

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -167,8 +167,14 @@ module Hwaro::Core::Build::Phases::ParseContent
     page.calculate_word_count
     page.calculate_reading_time
 
-    # Extract summary from <!-- more --> marker
-    page.extract_summary
+    # Extract summary from <!-- more --> marker. Stores the raw markdown
+    # chunk on the model; render it to HTML now so `page.summary` can
+    # expose proper HTML (not raw `# Heading` text) at template time —
+    # see https://github.com/hahwul/hwaro/issues/491.
+    if summary_md = page.extract_summary
+      summary_html, _ = Processor::Markdown.render(summary_md)
+      page.summary_html = summary_html
+    end
 
     if page.is_a?(Models::Section)
       page.transparent = data[:transparent]

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -705,7 +705,7 @@ module Hwaro::Core::Build::Phases::Render
           "in_sitemap"   => Crinja::Value.new(p.in_sitemap),
           "language"     => Crinja::Value.new(p.language || default_language),
           "weight"       => Crinja::Value.new(p.weight),
-          "summary"      => Crinja::Value.new(p.effective_summary || ""),
+          "summary"      => Crinja::Value.new(p.summary_html || p.effective_summary || ""),
           "word_count"   => Crinja::Value.new(p.word_count),
           "reading_time" => Crinja::Value.new(p.reading_time),
           "tags"         => Crinja::Value.new(p.tags.map { |t| Crinja::Value.new(t) }),
@@ -1085,7 +1085,7 @@ module Hwaro::Core::Build::Phases::Render
       "tags"            => tags_crinja,
       "assets"          => assets_crinja,
       "extra"           => extra_crinja,
-      "summary"         => Crinja::Value.new(page.effective_summary || ""),
+      "summary"         => Crinja::Value.new(page.summary_html || page.effective_summary || ""),
       "word_count"      => Crinja::Value.new(page.word_count),
       "reading_time"    => Crinja::Value.new(page.reading_time),
       "permalink"       => Crinja::Value.new(page.permalink || ""),
@@ -1129,7 +1129,7 @@ module Hwaro::Core::Build::Phases::Render
     vars["page"] = Crinja::Value.new(page_obj)
 
     # Flat variables for new properties
-    vars["page_summary"] = Crinja::Value.new(page.effective_summary || "")
+    vars["page_summary"] = Crinja::Value.new(page.summary_html || page.effective_summary || "")
     vars["page_word_count"] = Crinja::Value.new(page.word_count)
     vars["page_reading_time"] = Crinja::Value.new(page.reading_time)
     vars["page_permalink"] = Crinja::Value.new(page.permalink || "")

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -40,6 +40,12 @@ module Hwaro
       property taxonomies : Hash(String, Array(String))
       property front_matter_keys : Array(String)
       property weight : Int32
+      # Rendered HTML for the chunk before `<!-- more -->`. Populated by
+      # the build pipeline after `extract_summary` runs and the markdown
+      # processor is available; nil for pages without a `<!-- more -->`
+      # marker (in which case `page.summary` falls back to `description`).
+      # See https://github.com/hahwul/hwaro/issues/491.
+      property summary_html : String?
       property taxonomy_name : String?
       property taxonomy_term : String?
       property in_sitemap : Bool
@@ -137,6 +143,7 @@ module Hwaro
         @authors = [] of String
         @extra = {} of String => ExtraValue
         @summary = nil
+        @summary_html = nil
         @in_search_index = true
         @insert_anchor_links = false
         @word_count = 0


### PR DESCRIPTION
## Summary

Two derived-content surfaces were emitting the wrong encoding (#491):

### `search.json` content field

\`strip_html\` removed tags but didn't decode HTML entities, so a snippet like \`print("hi")\` ended up as \`print(&quot;hi&quot;)\` in the JSON content field. Client-side fuzzy-search libraries match on the raw stored string and never hit the literal source. Run \`HTML.unescape\` after \`strip_html\` so the index stores actual characters.

### \`page.summary\`

The chunk before \`<!-- more -->\` came through as raw markdown (\`# Heading\`, \`**bold**\`, \`[link](/about/)\`). \`{{ page.summary }}\` produced un-rendered markdown in pages and noise in \`<meta name="description">\`. Render the chunk to HTML at parse time and store it on the page; expose that HTML through \`page.summary\` (and the flat alias \`page_summary\`).

When no \`<!-- more -->\` marker is present, \`page.summary\` still falls back to \`page.description\` (plain text), so description-style usage continues to work without \`| safe\`. The data-model doc now spells out the semantic and recommends \`{{ page.summary | safe }}\` for embedding.

## Test plan

- [x] New regression in \`spec/unit/search_spec.cr\` builds a page whose rendered HTML contains \`&quot;\` and asserts the JSON content field stores the decoded \`print("hi")\`.
- [x] New regression in \`spec/functional/edge_cases_spec.cr\` covers a \`<!-- more -->\` summary that contains \`# Heading\`, \`**bold**\`, and \`[link]\` — asserts the rendered output contains \`<h1>\`, \`<strong>\`, and \`<a href>\` (and **not** the raw \`#\` / \`**\` markers).
- [x] Updated the existing "page_summary exposed from <!-- more --> marker" test to reflect the new HTML semantic (\`SUMMARY=<p>This is the intro.</p>\`).
- [x] \`crystal spec\` — 4724 examples, 0 failures.
- [x] \`crystal tool format --check\` clean.
- [x] Manual: rebuilt the binary; \`testapp\`'s \`hello.md\` now shows the rendered \`<h1>Heading One</h1><p>Some content.</p>\` HTML inside its \`<blockquote>\`-wrapped \`{{ page.summary | safe }}\`, and \`search.json\` now contains the decoded \`print("hi")\` (was \`print(&quot;hi&quot;)\`).

Closes #491