### PR TITLE
fix(tool): stop false positives in check-links and unused-assets

### DIFF
--- a/spec/unit/deadlink_command_spec.cr
+++ b/spec/unit/deadlink_command_spec.cr
@@ -238,6 +238,41 @@ describe Hwaro::CLI::Commands::Tool::DeadlinkCommand do
       end
     end
 
+    # Regression for https://github.com/hahwul/hwaro/issues/488
+    # The previous resolver computed `target + ".md"` AFTER joining the
+    # URL, so for a trailing-slash URL like `/about/` the candidate
+    # became `content/about/.md` (note the stray slash). A leaf page
+    # whose URL ends with `/` was therefore reported as a dead link
+    # even though `content/about.md` clearly existed.
+    it "resolves trailing-slash URLs to a sibling .md file (leaf page)" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "about.md"), "leaf page")
+        link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+          file: File.join(dir, "test.md"), url: "/about/", kind: :internal
+        )
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        results = cmd.check_internal_links_for_test([link], dir)
+
+        results.should be_empty
+      end
+    end
+
+    it "resolves trailing-slash URLs nested under a section" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "posts"))
+        File.write(File.join(dir, "posts", "hello.md"), "leaf page")
+        link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+          file: File.join(dir, "test.md"), url: "/posts/hello/", kind: :internal
+        )
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        results = cmd.check_internal_links_for_test([link], dir)
+
+        results.should be_empty
+      end
+    end
+
     it "detects broken image paths" do
       Dir.mktmpdir do |dir|
         File.write(File.join(dir, "test.md"), "content")

--- a/spec/unit/unused_assets_spec.cr
+++ b/spec/unit/unused_assets_spec.cr
@@ -246,16 +246,16 @@ describe Hwaro::Services::UnusedAssets do
           File.write(File.join("static", "css", "style.css"), "body{color:#333}")
 
           File.write("config.toml", <<-TOML)
-          title = "T"
-          base_url = "http://x"
+            title = "T"
+            base_url = "http://x"
 
-          [assets]
-          enabled = true
+            [assets]
+            enabled = true
 
-          [[assets.bundles]]
-          name = "main.css"
-          files = ["css/reset.css", "css/style.css"]
-          TOML
+            [[assets.bundles]]
+            name = "main.css"
+            files = ["css/reset.css", "css/style.css"]
+            TOML
 
           service = Hwaro::Services::UnusedAssets.new(
             content_dir: "content",
@@ -284,13 +284,13 @@ describe Hwaro::Services::UnusedAssets do
           File.write(File.join("static", "assets", "css", "02-typography.css"), "p{}")
 
           File.write("config.toml", <<-TOML)
-          title = "T"
-          base_url = "http://x"
+            title = "T"
+            base_url = "http://x"
 
-          [auto_includes]
-          enabled = true
-          dirs = ["assets/css"]
-          TOML
+            [auto_includes]
+            enabled = true
+            dirs = ["assets/css"]
+            TOML
 
           service = Hwaro::Services::UnusedAssets.new(
             content_dir: "content",

--- a/spec/unit/unused_assets_spec.cr
+++ b/spec/unit/unused_assets_spec.cr
@@ -229,5 +229,79 @@ describe Hwaro::Services::UnusedAssets do
         result.referenced_count.should eq(1)
       end
     end
+
+    # Regression for https://github.com/hahwul/hwaro/issues/488
+    # Files declared in `[[assets.bundles]] files = [...]` are consumed
+    # by the asset pipeline at build time, not referenced from
+    # content/templates — so the previous scan flagged them as "Unused"
+    # even though the build actively reads them.
+    it "treats files declared in [[assets.bundles]] as referenced" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          FileUtils.mkdir_p(File.join("static", "css"))
+          FileUtils.mkdir_p("templates")
+
+          File.write(File.join("static", "css", "reset.css"), "*{margin:0}")
+          File.write(File.join("static", "css", "style.css"), "body{color:#333}")
+
+          File.write("config.toml", <<-TOML)
+          title = "T"
+          base_url = "http://x"
+
+          [assets]
+          enabled = true
+
+          [[assets.bundles]]
+          name = "main.css"
+          files = ["css/reset.css", "css/style.css"]
+          TOML
+
+          service = Hwaro::Services::UnusedAssets.new(
+            content_dir: "content",
+            static_dir: "static",
+            templates_dir: "templates",
+          )
+          result = service.run
+          result.total_assets.should eq(2)
+          result.unused_files.should be_empty
+        end
+      end
+    end
+
+    # Regression for https://github.com/hahwul/hwaro/issues/488
+    # Files inside `[auto_includes] dirs = [...]` are also consumed by
+    # the build (the auto-include tags glob those directories at render
+    # time), so they shouldn't be flagged either.
+    it "treats files under [auto_includes] dirs as referenced" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          FileUtils.mkdir_p(File.join("static", "assets", "css"))
+          FileUtils.mkdir_p("templates")
+
+          File.write(File.join("static", "assets", "css", "01-reset.css"), "*{}")
+          File.write(File.join("static", "assets", "css", "02-typography.css"), "p{}")
+
+          File.write("config.toml", <<-TOML)
+          title = "T"
+          base_url = "http://x"
+
+          [auto_includes]
+          enabled = true
+          dirs = ["assets/css"]
+          TOML
+
+          service = Hwaro::Services::UnusedAssets.new(
+            content_dir: "content",
+            static_dir: "static",
+            templates_dir: "templates",
+          )
+          result = service.run
+          result.total_assets.should eq(2)
+          result.unused_files.should be_empty
+        end
+      end
+    end
   end
 end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -211,10 +211,19 @@ module Hwaro
                          File.join(base_dir, link.url)
                        end
 
+              # Most internal URLs are written with a trailing slash
+              # (`/about/`, `/posts/hello/`) — strip it before computing
+              # the leaf-file candidate so `target_no_slash + ".md"`
+              # resolves to `content/about.md` instead of the broken
+              # `content/about/.md` the old code produced. The directory
+              # candidates (`_index.md` / `index.md`) work either way.
+              target_no_slash = target.rstrip("/")
+
               exists = File.exists?(target) ||
-                       File.exists?(target + ".md") ||
-                       File.exists?(File.join(target, "_index.md")) ||
-                       File.exists?(File.join(target, "index.md")) ||
+                       File.exists?(target_no_slash + ".md") ||
+                       File.exists?(target_no_slash + ".markdown") ||
+                       File.exists?(File.join(target_no_slash, "_index.md")) ||
+                       File.exists?(File.join(target_no_slash, "index.md")) ||
                        (link.kind != :image && taxonomy_url?(link.url, taxonomy_names))
 
               unless exists

--- a/src/services/unused_assets.cr
+++ b/src/services/unused_assets.cr
@@ -5,6 +5,7 @@
 # Reports unreferenced files that may be candidates for removal.
 
 require "json"
+require "../models/config"
 require "../utils/logger"
 
 module Hwaro
@@ -132,7 +133,38 @@ module Hwaro
           end
         end
 
+        # Files declared in `config.toml` (`[[assets.bundles]] files`,
+        # `[auto_includes] dirs`, …) are consumed by the build pipeline
+        # itself, not referenced from content/templates — without this
+        # the scan reported them as "Unused" even though the build
+        # actively reads them. See #488.
+        add_config_references(refs)
+
         refs
+      end
+
+      private def add_config_references(refs : Set(String)) : Nil
+        return unless File.exists?("config.toml")
+        config = Models::Config.load
+        config.assets.bundles.each do |bundle|
+          bundle.files.each { |path| refs << File.basename(path) }
+          # The compiled bundle name (e.g. `main.css`) is referenced
+          # from templates via `{{ asset(name=...) }}`; that already
+          # gets picked up by the regex scan above, so no extra work
+          # needed here.
+        end
+        config.auto_includes.dirs.each do |rel_dir|
+          dir = File.join(@static_dir, rel_dir)
+          next unless Dir.exists?(dir)
+          Dir.glob(File.join(dir, "**", "*")) do |path|
+            next if File.directory?(path)
+            refs << File.basename(path)
+          end
+        end
+      rescue
+        # Treat config-load failures as "no extra references" so the
+        # tool stays best-effort rather than crashing on a partial
+        # site.
       end
     end
   end


### PR DESCRIPTION
## Summary

Two `hwaro tool` subcommands flagged valid setups as problems, making them noisy in CI (#488).

### `tool check-links`

Internal URLs that resolve to existing pages were reported dead:

```
[DEAD] content/posts/third.md
  └─ URL: /about/ (internal)
  └─ Internal link target not found
```

The resolver computed `target + ".md"` AFTER joining the URL, so a trailing-slash URL like `/about/` produced `content/about/.md` (note the stray slash) and never matched `content/about.md`. Strip the trailing slash before computing leaf-file candidates so leaf pages — which is most of them — resolve. Also try `.markdown` while we're here.

### `tool unused-assets`

Files declared in `[[assets.bundles]] files = [...]` and `[auto_includes] dirs = [...]` are read by the build pipeline itself, not referenced from content/templates. The scan previously reported them as "Unused" even when the bundle config was actively consuming them. Load `config.toml` and add those declarations to the referenced-basename set; failures to read the config fall through silently so the tool stays best-effort.

## Test plan

- [x] New regression tests in `spec/unit/deadlink_command_spec.cr`:
  - `/about/` resolves to `content/about.md` (trailing-slash leaf).
  - `/posts/hello/` resolves to `content/posts/hello.md`.
- [x] New regression tests in `spec/unit/unused_assets_spec.cr`:
  - Files declared in `[[assets.bundles]] files` come back as referenced.
  - Files inside `[auto_includes] dirs` come back as referenced.
- [x] `crystal spec` — 4729 examples, 0 failures.
- [x] `crystal tool format --check` clean.
- [x] Manual: in `testapp`, `hwaro tool check-links` no longer flags `/about/` (the only remaining "dead" entries are real missing images), and `hwaro tool unused-assets` reports `Unused: 0` instead of 2.

Closes #488