### PR TITLE
feat(doctor): warn when config file paths point to missing files

### DIFF
--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -624,12 +624,12 @@ describe Hwaro::Services::Doctor do
         Dir.mktmpdir do |dir|
           config_path = File.join(dir, "config.toml")
           File.write(config_path, <<-TOML)
-          title = "T"
-          base_url = "http://x"
-          [pwa]
-          enabled = true
-          icons = ["static/icon-192.png", "static/icon-512.png"]
-          TOML
+            title = "T"
+            base_url = "http://x"
+            [pwa]
+            enabled = true
+            icons = ["static/icon-192.png", "static/icon-512.png"]
+            TOML
 
           doctor = Hwaro::Services::Doctor.new(
             content_dir: File.join(dir, "content"),

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -571,6 +571,80 @@ describe Hwaro::Services::Doctor do
         end
       end
 
+      it "warns when [og] default_image path does not exist under static/" do
+        # Regression for https://github.com/hahwul/hwaro/issues/489
+        # The path-shaped fields in `config.toml` (`[og] default_image`,
+        # `[og.auto_image] logo`, `[pwa] icons`, `[pwa] offline_page`)
+        # used to slip past doctor unchecked. A typoed image path would
+        # only surface when the build emitted a 404 in production.
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, %(title = "T"\nbase_url = "http://x"\n[og]\ndefault_image = "/images/og-default.png"\n))
+          # No `static/images/og-default.png` exists.
+          doctor = Hwaro::Services::Doctor.new(
+            content_dir: File.join(dir, "content"),
+            config_path: config_path,
+            templates_dir: File.join(dir, "templates"),
+            static_dir: File.join(dir, "static"),
+          )
+          Dir.cd(dir) do
+            issues = doctor.run
+            issues.any? do |i|
+              i.id == "config-path-missing" &&
+                i.message.includes?("default_image") &&
+                i.message.includes?("/images/og-default.png")
+            end.should be_true
+          end
+        end
+      end
+
+      it "does not warn when [og] default_image points to a real file" do
+        Dir.mktmpdir do |dir|
+          static_dir = File.join(dir, "static")
+          FileUtils.mkdir_p(File.join(static_dir, "images"))
+          File.write(File.join(static_dir, "images", "og.png"), "fake png")
+
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, %(title = "T"\nbase_url = "http://x"\n[og]\ndefault_image = "/images/og.png"\n))
+
+          doctor = Hwaro::Services::Doctor.new(
+            content_dir: File.join(dir, "content"),
+            config_path: config_path,
+            templates_dir: File.join(dir, "templates"),
+            static_dir: static_dir,
+          )
+          Dir.cd(dir) do
+            issues = doctor.run
+            issues.any? { |i| i.id == "config-path-missing" }.should be_false
+          end
+        end
+      end
+
+      it "warns for missing [pwa] icons paths" do
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, <<-TOML)
+          title = "T"
+          base_url = "http://x"
+          [pwa]
+          enabled = true
+          icons = ["static/icon-192.png", "static/icon-512.png"]
+          TOML
+
+          doctor = Hwaro::Services::Doctor.new(
+            content_dir: File.join(dir, "content"),
+            config_path: config_path,
+            templates_dir: File.join(dir, "templates"),
+            static_dir: File.join(dir, "static"),
+          )
+          Dir.cd(dir) do
+            issues = doctor.run
+            missing = issues.select { |i| i.id == "config-path-missing" && i.message.includes?("[pwa] icons") }
+            missing.size.should eq(2)
+          end
+        end
+      end
+
       it "skips silently when the content directory doesn't exist" do
         Dir.mktmpdir do |dir|
           config_path = File.join(dir, "config.toml")

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -43,8 +43,9 @@ module Hwaro
       @content_dir : String
       @config_path : String
       @templates_dir : String
+      @static_dir : String
 
-      def initialize(@content_dir : String = "content", @config_path : String = "config.toml", @templates_dir : String = "templates")
+      def initialize(@content_dir : String = "content", @config_path : String = "config.toml", @templates_dir : String = "templates", @static_dir : String = "static")
       end
 
       def run : Array(Issue)
@@ -53,6 +54,7 @@ module Hwaro
         check_templates(issues)
         check_directory_structure(issues)
         check_content_frontmatter(issues)
+        check_referenced_paths(issues, config) if config
         ignore = config.try(&.doctor.ignore) || [] of String
         issues.reject { |i| ignore.includes?(i.id) }
       end
@@ -398,6 +400,50 @@ module Hwaro
               message: first_line.empty? ? "Invalid front matter" : first_line)
           end
         end
+      end
+
+      # Validate that path-shaped fields in `config.toml` actually point at
+      # files that exist on disk. The build pipeline doesn't fail when a
+      # referenced asset is missing — it just emits a 404 in production —
+      # so a typoed `[og] default_image` would otherwise only surface in
+      # the wild. Each missing path becomes a `[warn]` issue under the
+      # `config-path-missing` id (suppressible via `[doctor] ignore = [...]`).
+      # See https://github.com/hahwul/hwaro/issues/489.
+      private def check_referenced_paths(issues : Array(Issue), config : Models::Config)
+        emit = ->(label : String, value : String) do
+          return if value.empty?
+          return if path_resolves?(value)
+          issues << Issue.new(
+            id: "config-path-missing",
+            level: :warning,
+            category: "config",
+            file: @config_path,
+            message: "#{label}: #{value} — file not found",
+          )
+        end
+
+        config.og.default_image.try { |v| emit.call("[og] default_image", v) }
+        config.og.auto_image.logo.try { |v| emit.call("[og.auto_image] logo", v) }
+        config.og.auto_image.background_image.try { |v| emit.call("[og.auto_image] background_image", v) }
+        config.pwa.offline_page.try { |v| emit.call("[pwa] offline_page", v) }
+        config.pwa.icons.each_with_index do |icon, idx|
+          emit.call("[pwa] icons[#{idx}]", icon)
+        end
+      end
+
+      # Decide whether a config-shaped path string points at an existing
+      # file. Authors write these in three flavors:
+      # - URL-style (`/images/og.png`) → resolved against `static/`
+      # - `static/foo.png` → already rooted under static/ (use as-is)
+      # - `content/foo.md` or any other repo-relative path → use as-is
+      private def path_resolves?(path : String) : Bool
+        candidates = [path]
+        if path.starts_with?("/")
+          candidates << File.join(@static_dir, path.lchop("/"))
+        elsif !path.starts_with?("#{@static_dir}#{File::SEPARATOR}") && !path.starts_with?("#{@content_dir}#{File::SEPARATOR}")
+          candidates << File.join(@static_dir, path)
+        end
+        candidates.any? { |c| File.exists?(c) }
       end
     end
   end


### PR DESCRIPTION
## Summary

`hwaro doctor` reported `looks great!` even when several path-shaped config fields pointed at files that didn't exist. A typoed `[og] default_image = "/images/og.png"` only surfaced as a 404 in production; the build pipeline doesn't fail on missing referenced assets, so doctor was the right place to catch this (#489).

Add a `check_referenced_paths` pass that resolves URL-style values (`/images/og.png`) against `static/`, accepts already-rooted paths (`static/...`, `content/...`) as-is, and emits a `[warn]` issue with the `config-path-missing` id for any path that doesn't exist.

Covered fields:

- `[og] default_image`
- `[og.auto_image] logo`, `background_image`
- `[pwa] offline_page`, `icons[]`

A new `static_dir:` parameter on `Services::Doctor.new` lets the spec suite point the resolver at a temp dir; the CLI uses the default `static/` (matching build conventions). Suppression via `[doctor] ignore = ["config-path-missing"]` works the same as any other id.

### Sample output

```
Config:
  [warn] config.toml: [og] default_image: /images/og-default.png — file not found
  [warn] config.toml: [pwa] icons[0]: static/icon-192.png — file not found

Found 0 error(s), 2 warning(s), 0 info(s)
```

## Test plan

- [x] New regression tests in `spec/unit/doctor_spec.cr`:
  - `[og] default_image = "/images/og-default.png"` without a corresponding `static/images/og-default.png` is reported.
  - The same URL with the file in place is **not** reported.
  - `[pwa] icons = [...]` produces one `config-path-missing` per missing entry.
- [x] `crystal spec` — 4730 examples, 0 failures.
- [x] `crystal tool format --check` clean.
- [x] Manual: `cd testapp && hwaro doctor` now flags `[og] default_image: /images/og-default.png — file not found`. Previously: `[ok] No issues found. Your site looks great!` despite the missing file.

Closes #489