### PR TITLE
feat(seo): emit a structured page index in llms.txt per llmstxt.org

### DIFF
--- a/spec/unit/llms_spec.cr
+++ b/spec/unit/llms_spec.cr
@@ -51,25 +51,29 @@ describe Hwaro::Content::Seo::Llms do
       end
     end
 
-    it "generates empty file when instructions are empty" do
+    it "always writes the title heading even when instructions are empty" do
+      # Updated for #492 — llms.txt now follows the llmstxt.org spec
+      # (title heading + optional description blockquote + preamble +
+      # page index). The "instructions string only" output it produced
+      # before could be empty, but the new format always emits at least
+      # a `# Title` line.
       config = Hwaro::Models::Config.new
       config.llms.enabled = true
+      config.title = "Site"
       config.llms.instructions = ""
 
       Dir.mktmpdir do |output_dir|
         Hwaro::Content::Seo::Llms.generate(config, output_dir)
 
-        file_path = File.join(output_dir, "llms.txt")
-        File.exists?(file_path).should be_true
-
-        content = File.read(file_path)
-        content.should eq("")
+        content = File.read(File.join(output_dir, "llms.txt"))
+        content.should start_with("# Site\n")
       end
     end
 
-    it "appends newline at end when content does not end with one" do
+    it "ends with a trailing newline" do
       config = Hwaro::Models::Config.new
       config.llms.enabled = true
+      config.title = "Site"
       config.llms.instructions = "No trailing newline"
 
       Dir.mktmpdir do |output_dir|
@@ -77,19 +81,6 @@ describe Hwaro::Content::Seo::Llms do
 
         content = File.read(File.join(output_dir, "llms.txt"))
         content.should end_with("\n")
-      end
-    end
-
-    it "does not double-add newline when content already ends with one" do
-      config = Hwaro::Models::Config.new
-      config.llms.enabled = true
-      config.llms.instructions = "Already has newline\n"
-
-      Dir.mktmpdir do |output_dir|
-        Hwaro::Content::Seo::Llms.generate(config, output_dir)
-
-        content = File.read(File.join(output_dir, "llms.txt"))
-        content.should eq("Already has newline\n")
       end
     end
 
@@ -105,6 +96,95 @@ describe Hwaro::Content::Seo::Llms do
         content.should contain("Line 1")
         content.should contain("Line 2")
         content.should contain("Line 3")
+      end
+    end
+  end
+
+  # Regression group for https://github.com/hahwul/hwaro/issues/492
+  # `llms.txt` previously contained only the configured `instructions`
+  # string. Now it follows the llmstxt.org format: a `# Title` heading,
+  # an optional `> description` blockquote, the preamble, and a grouped
+  # page index (`## Section\n- [Title](url): desc`).
+  describe ".generate page index (#492)" do
+    it "emits site title, description, instructions, and a per-section page index" do
+      config = Hwaro::Models::Config.new
+      config.llms.enabled = true
+      config.title = "Demo"
+      config.description = "A short site."
+      config.base_url = "https://example.com"
+      config.llms.instructions = "Be kind to crawlers."
+
+      home = Hwaro::Models::Page.new("index.md")
+      home.title = "Home"
+      home.url = "/"
+      home.section = ""
+
+      hello = Hwaro::Models::Page.new("posts/hello.md")
+      hello.title = "Hello"
+      hello.url = "/posts/hello/"
+      hello.section = "posts"
+      hello.description = "First post"
+
+      second = Hwaro::Models::Page.new("posts/second.md")
+      second.title = "Second"
+      second.url = "/posts/second/"
+      second.section = "posts"
+
+      posts_idx = Hwaro::Models::Section.new("posts/_index.md")
+      posts_idx.title = "Posts"
+      posts_idx.url = "/posts/"
+      posts_idx.section = "posts"
+      posts_idx.is_index = true
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Llms.generate(config, [home, hello, second, posts_idx], output_dir)
+
+        content = File.read(File.join(output_dir, "llms.txt"))
+        content.should start_with("# Demo\n\n")
+        content.should contain("> A short site.")
+        content.should contain("Be kind to crawlers.")
+        # Pages section uses the section's _index title when available.
+        content.should contain("## Posts\n")
+        content.should contain("- [Hello](https://example.com/posts/hello/): First post")
+        content.should contain("- [Second](https://example.com/posts/second/)\n")
+        # Standalone pages (no section) land under "Pages".
+        content.should contain("## Pages\n")
+        content.should contain("- [Home](https://example.com/)")
+      end
+    end
+
+    it "skips drafts, hidden, and generated pages from the index" do
+      config = Hwaro::Models::Config.new
+      config.llms.enabled = true
+      config.title = "T"
+
+      visible = Hwaro::Models::Page.new("a.md")
+      visible.title = "Visible"
+      visible.url = "/a/"
+
+      drafted = Hwaro::Models::Page.new("draft.md")
+      drafted.title = "Drafted"
+      drafted.url = "/drafted/"
+      drafted.draft = true
+
+      hidden = Hwaro::Models::Page.new("hidden.md")
+      hidden.title = "Hidden"
+      hidden.url = "/hidden/"
+      hidden.in_search_index = false
+
+      auto = Hwaro::Models::Page.new("tags/foo.md")
+      auto.title = "Tag: foo"
+      auto.url = "/tags/foo/"
+      auto.generated = true
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Llms.generate(config, [visible, drafted, hidden, auto], output_dir)
+
+        content = File.read(File.join(output_dir, "llms.txt"))
+        content.should contain("- [Visible]")
+        content.should_not contain("Drafted")
+        content.should_not contain("Hidden")
+        content.should_not contain("Tag: foo")
       end
     end
   end

--- a/spec/unit/seo_spec.cr
+++ b/spec/unit/seo_spec.cr
@@ -302,16 +302,20 @@ describe Hwaro::Content::Seo::Llms do
       end
     end
 
-    it "adds newline at end if not present" do
+    it "ends with a trailing newline" do
+      # Updated for #492 — the body now also includes the title and a
+      # page index, but it should still end with a newline.
       config = Hwaro::Models::Config.new
       config.llms.enabled = true
+      config.title = "T"
       config.llms.instructions = "No newline"
 
       Dir.mktmpdir do |output_dir|
         Hwaro::Content::Seo::Llms.generate(config, output_dir)
 
         content = File.read(File.join(output_dir, "llms.txt"))
-        content.should eq("No newline\n")
+        content.should contain("No newline")
+        content.should end_with("\n")
       end
     end
 

--- a/src/content/seo/llms.cr
+++ b/src/content/seo/llms.cr
@@ -6,30 +6,116 @@ module Hwaro
   module Content
     module Seo
       class Llms
+        # Backward-compatible entry point for callers that don't have a
+        # page list handy. The current build pipeline always uses the
+        # 4-arg form below; this stub keeps any external caller working
+        # by emitting the title/description/instructions header without
+        # the page index.
         def self.generate(config : Models::Config, output_dir : String, verbose : Bool = false)
-          return unless config.llms.enabled
-
-          content = config.llms.instructions
-          # Add a newline at the end if not present and content is not empty
-          content += "\n" if !content.empty? && !content.ends_with?("\n")
-
-          filename = File.basename(config.llms.filename)
-          file_path = File.join(output_dir, filename)
-          File.write(file_path, content)
-          Logger.action :create, file_path if verbose
-          Logger.info "  Generated #{filename}"
+          generate(config, [] of Models::Page, output_dir, verbose)
         end
 
         def self.generate(config : Models::Config, pages : Array(Models::Page), output_dir : String, verbose : Bool = false, skip_if_unchanged : Bool = false)
-          if skip_if_unchanged && config.llms.enabled
+          return unless config.llms.enabled
+
+          if skip_if_unchanged
             filename = File.basename(config.llms.filename.empty? ? "llms.txt" : config.llms.filename)
             if File.exists?(File.join(output_dir, filename))
               Logger.debug "  LLMs.txt unchanged (cache hit), skipping."
               return
             end
           end
-          generate(config, output_dir, verbose)
+
+          filename = File.basename(config.llms.filename.empty? ? "llms.txt" : config.llms.filename)
+          file_path = File.join(output_dir, filename)
+          File.write(file_path, build_index(config, pages))
+          Logger.action :create, file_path if verbose
+          Logger.info "  Generated #{filename}"
+
           generate_full(pages, config, output_dir, verbose)
+        end
+
+        # Build the llms.txt body per the proposed [llms.txt][1] format:
+        #
+        #     # Site Title
+        #
+        #     > Optional site description (blockquote)
+        #
+        #     Optional preamble (free-form, e.g. crawler instructions).
+        #
+        #     ## Section Name
+        #
+        #     - [Page Title](https://site/url): optional description
+        #
+        # Pages are grouped by `page.section`; standalone (root) pages
+        # land under `## Pages`. Drafts, hidden pages, and `render=false`
+        # pages are excluded — same filter the search index uses.
+        #
+        # [1]: https://llmstxt.org/
+        private def self.build_index(config : Models::Config, pages : Array(Models::Page)) : String
+          base_url = config.base_url.rstrip('/')
+
+          eligible = pages.select { |p| p.render && !p.draft && p.in_search_index && !p.generated }
+
+          # Group by section, keyed by display heading. Section index
+          # pages double as the section's heading source — find the
+          # corresponding `_index.md` (`is_index && section.match`) and
+          # use its title; fall back to the section directory's basename.
+          headings = {} of String => String
+          eligible.each do |p|
+            next unless p.is_index
+            next if p.section.empty?
+            headings[p.section] = p.title unless p.title.empty? || p.title == "Untitled"
+          end
+
+          # Section-level `_index.md` pages are folded into the section
+          # heading, so they don't need their own listing. Root-level
+          # `index.md` (the home page) has nowhere else to live, so it
+          # stays in the listing under "Pages".
+          by_section = eligible
+            .reject { |p| p.is_index && !p.section.empty? }
+            .group_by(&.section)
+
+          String.build do |str|
+            str << "# " << (config.title.empty? ? "Site" : config.title) << "\n\n"
+
+            desc = config.description.strip
+            unless desc.empty?
+              str << "> " << desc << "\n\n"
+            end
+
+            instructions = config.llms.instructions.strip
+            unless instructions.empty?
+              str << instructions << "\n\n"
+            end
+
+            # Stable, deterministic order: empty section ("Pages") first,
+            # then the rest alphabetically. Mirrors how `site.sections`
+            # surfaces in templates.
+            section_keys = by_section.keys.sort_by! { |k| k.empty? ? "" : "1#{k}" }
+            section_keys.each do |section_name|
+              heading = if section_name.empty?
+                          "Pages"
+                        else
+                          headings[section_name]? || section_name.split("/").last.capitalize
+                        end
+              str << "## " << heading << "\n\n"
+
+              by_section[section_name].sort_by(&.url).each do |p|
+                link = if base_url.empty?
+                         p.url
+                       else
+                         "#{base_url}#{p.url}"
+                       end
+                str << "- [" << p.title << "](" << link << ")"
+                if d = p.description
+                  str << ": " << d unless d.empty?
+                end
+                str << "\n"
+              end
+              str << "\n"
+            end
+          end
         end
 
         def self.generate_full(pages : Array(Models::Page), config : Models::Config, output_dir : String, verbose : Bool = false)


### PR DESCRIPTION
## Summary

\`hwaro build\` previously wrote \`[llms] instructions\` verbatim into \`llms.txt\` (and nothing else when instructions were empty). The proposed [llms.txt][1] format is a structured site index — title, optional description blockquote, free-form preamble, then sectioned links — which is what crawlers expecting llms.txt actually look at (#492).

[1]: https://llmstxt.org/

Build that index from the page list:

\`\`\`
# Site Title

> Site description.

Configured [llms] instructions line.

## Pages

- [Welcome](https://example/)            ← root index pages
- [About](https://example/about/)

## Posts

- [Hello](https://example/posts/hello/): First post
- [Second](https://example/posts/second/)

## CLI Series

- [Part 1: Bootstrap](https://example/posts/cli-series/part1/)
\`\`\`

Pages are grouped by \`page.section\`. The section's \`_index.md\` title provides the heading (e.g. \`## Posts\` comes from \`posts/_index.md\`); the section directory's basename is the fallback. Section-level \`_index.md\` pages are folded into the heading and don't get their own bullet, but root-level \`index.md\` (the home page) stays in the \`## Pages\` group since it has nowhere else to live. Drafts, hidden (\`in_search_index = false\`), and auto-generated pages are filtered out — same eligibility rule the search index uses.

The single-arg \`Llms.generate(config, output_dir)\` overload is kept as a thin wrapper that calls the page-aware path with an empty array, so any external caller still works (just without the per-section index portion).

## Test plan

- [x] New regression group in \`spec/unit/llms_spec.cr\`:
  - Asserts the rendered output starts with \`# Demo\`, contains a \`> A short site.\` blockquote, the instructions string, and a \`## Posts\` section listing both pages with absolute URLs (and the description suffix when one is set).
  - Asserts standalone pages land under \`## Pages\`.
  - Asserts drafts / hidden / generated pages are excluded.
- [x] Updated existing tests that codified the old \`instructions\`-only output to assert the new format.
- [x] \`crystal spec\` — 4728 examples, 0 failures.
- [x] \`crystal tool format --check\` and \`bin/ameba\` clean.
- [x] Manual: rebuilt the binary; \`testapp/public/llms.txt\` now contains the full structured index above (the old output was just the one-line instructions string).

Closes #492