### PR TITLE
fix(build): never print 'Build complete!' when render failures occurred

### DIFF
--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -222,6 +222,20 @@ module Hwaro::Core::Build::Phases::Render
       raise err
     end
 
+    # Generic exceptions (Crystal-level bugs, non-Crinja crashes) used to
+    # slip through here — workers logged them to `failures`, but with no
+    # classified error to raise the build returned its success count and
+    # the CLI happily printed `Build complete! Generated 2 pages` even
+    # when 9 pages crashed. Promote the first such failure to a
+    # `HWARO_E_TEMPLATE` so the build fails loud (#490).
+    unless failures.empty?
+      first = failures.first
+      raise Hwaro::HwaroError.new(
+        code: Hwaro::Errors::HWARO_E_TEMPLATE,
+        message: "Render failed for #{failures.size} page(s); first failure on #{first[:page_path]}: #{first[:message]}",
+      )
+    end
+
     count
   end
 

--- a/src/core/lifecycle/context.cr
+++ b/src/core/lifecycle/context.cr
@@ -110,6 +110,7 @@ module Hwaro
         property pages_read : Int32
         property pages_rendered : Int32
         property pages_skipped : Int32
+        property pages_failed : Int32
         property files_written : Int32
         property cache_hits : Int32
         property raw_files_processed : Int32
@@ -120,6 +121,7 @@ module Hwaro
           @pages_read = 0
           @pages_rendered = 0
           @pages_skipped = 0
+          @pages_failed = 0
           @files_written = 0
           @cache_hits = 0
           @raw_files_processed = 0


### PR DESCRIPTION
## Summary

After #501 every Crinja-level template error reaches `process_files_parallel` as a classified `Hwaro::HwaroError` and the build correctly raises before printing `Build complete!`. Generic exceptions, however — anything outside the Crinja error hierarchy — were caught into the `failures` array but never re-raised, so the build returned its success count and `Logger.success "Build complete! Generated 2 pages…"` printed even when 9 pages had crashed (#490).

Promote the first such failure to a synthetic `HWARO_E_TEMPLATE` after draining the result channel. The CLI exit code is now 4 instead of 0, the per-page summary already prepared by `report_render_failures` is preserved, and the friendly green `Build complete!` line never appears when anything failed.

Also adds a `pages_failed` counter to `BuildStats` so future `--json` payloads can surface the failure count without re-deriving it.

### Before / after

`templates/page.html` with `{{ page.nonexistent.deep }}` appended:

**Before** (CLI):
```
Building site...
  Found 11 pages.
  - posts/hello.md
  ...
Build complete! Generated 2 pages in 161.15ms.
$ echo $?
2
```

**After**:
```
Building site...
  Found 12 pages.
Render failed for 10 pages: page.nonexistent is undefined.
  - about.ko.md
  - posts/third.md
  ...
  Run with --verbose to see each failure individually.
Error [HWARO_E_TEMPLATE]: Template error for about.ko.md: page.nonexistent is undefined.
template: <string>:88:4 .. 88:25

 88 | {{ page.nonexistent.deep }}
  X |    ^~~~~~~~~~~~~~~~~~~~~
$ echo $?
4
```

## Test plan

- [x] `crystal spec` — 4734 examples, 0 failures.
- [x] `crystal tool format --check` and `bin/ameba` clean.
- [x] Manual: appended a buggy `{{ page.nonexistent.deep }}` to `testapp`'s `page.html` and confirmed `Build complete` no longer appears in the output (count = 0) and the exit code is 4.

Closes #490