### PR TITLE
fix(multilingual): hide lang-switcher and emit hreflang in sitemap

### DIFF
--- a/spec/unit/crinja_resolve_fix_spec.cr
+++ b/spec/unit/crinja_resolve_fix_spec.cr
@@ -48,6 +48,38 @@ describe "Crinja resolver patches" do
     end
   end
 
+  describe "empty-collection truthiness (issue #486)" do
+    # Jinja2 treats empty collections as falsy so `{% if items %}` is
+    # the canonical guard for "render this block only if there's
+    # something to show". Crinja's default `truthy?` only saw `false`,
+    # `0`, `nil`, and `Undefined` as falsy — empty `[]` / `{}` / `""`
+    # rendered the block anyway, breaking the canonical lang-switcher
+    # idiom from `docs/templates/data-model.md`.
+    it "treats empty Array as falsy" do
+      env = Crinja.new
+      tpl = env.from_string("{% if items %}YES{% else %}NO{% endif %}")
+      tpl.render({"items" => [] of Crinja::Value}).should eq("NO")
+    end
+
+    it "treats non-empty Array as truthy" do
+      env = Crinja.new
+      tpl = env.from_string("{% if items %}YES{% else %}NO{% endif %}")
+      tpl.render({"items" => [Crinja::Value.new("x")]}).should eq("YES")
+    end
+
+    it "treats empty Hash as falsy" do
+      env = Crinja.new
+      tpl = env.from_string("{% if h %}YES{% else %}NO{% endif %}")
+      tpl.render({"h" => {} of String => Crinja::Value}).should eq("NO")
+    end
+
+    it "treats empty String as falsy" do
+      env = Crinja.new
+      tpl = env.from_string("{% if s %}YES{% else %}NO{% endif %}")
+      tpl.render({"s" => ""}).should eq("NO")
+    end
+  end
+
   describe "scope-vs-function priority (issue #224)" do
     it "prefers a context variable over a registered function with the same name" do
       env = Crinja.new

--- a/spec/unit/multilingual_spec.cr
+++ b/spec/unit/multilingual_spec.cr
@@ -24,6 +24,27 @@ describe Hwaro::Content::Multilingual do
     ko.translations.map(&.url).should eq(["/about/", "/ko/about/"])
   end
 
+  # Regression for https://github.com/hahwul/hwaro/issues/486
+  # `link_translations!` used to populate `page.translations` with a
+  # single self-entry for pages that have no actual cross-language
+  # variants. The canonical guard from docs/templates/data-model.md —
+  # `{% if page.translations %}<nav class="lang-switcher">…</nav>{% endif %}` —
+  # therefore always rendered an empty (or current-only) switcher on
+  # single-language pages.
+  it "leaves page.translations empty when no cross-language variant exists" do
+    config = Hwaro::Models::Config.new
+    config.default_language = "en"
+    config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+    only_en = Hwaro::Models::Page.new("solo.md")
+    only_en.title = "Solo"
+    only_en.url = "/solo/"
+
+    Hwaro::Content::Multilingual.link_translations!([only_en], config)
+
+    only_en.translations.should be_empty
+  end
+
   it "builds /<lang>/ prefixed URLs for nested index.<lang>.md files" do
     temp_dir = File.tempname("hwaro_multilingual")
     Dir.mkdir(temp_dir)

--- a/spec/unit/multilingual_utils_spec.cr
+++ b/spec/unit/multilingual_utils_spec.cr
@@ -340,9 +340,10 @@ describe Hwaro::Content::Multilingual do
       about_en.translations.size.should eq(2)
       about_ko.translations.size.should eq(2)
 
-      # contact page should not have translations (only one variant)
-      contact_en.translations.size.should eq(1)
-      contact_en.translations.first.code.should eq("en")
+      # Contact only exists in one language — `page.translations` is
+      # empty so the canonical `{% if page.translations %}` guard hides
+      # the language switcher entirely (#486).
+      contact_en.translations.should be_empty
     end
 
     it "sets is_default flag for default language translation" do

--- a/spec/unit/seo_spec.cr
+++ b/spec/unit/seo_spec.cr
@@ -184,6 +184,66 @@ describe Hwaro::Content::Seo::Sitemap do
         content.should_not contain("/secret/")
       end
     end
+
+    # Regression for https://github.com/hahwul/hwaro/issues/486
+    # Multilingual sites need `<xhtml:link rel="alternate" hreflang="..."
+    # href="...">` entries on every URL with a translation so search
+    # engines can pick the right language variant. The HTML `<head>`
+    # already exposes the same data via `hreflang_tags`, but Google's
+    # recommendation is to surface it in the sitemap too.
+    it "emits xhtml:link hreflang alternates for translated pages" do
+      config = Hwaro::Models::Config.new
+      config.sitemap.enabled = true
+      config.base_url = "https://example.com"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      site = Hwaro::Models::Site.new(config)
+
+      en = Hwaro::Models::Page.new("about.md")
+      en.url = "/about/"
+      en.render = true
+      en.in_sitemap = true
+      en.language = "en"
+
+      ko = Hwaro::Models::Page.new("about.ko.md")
+      ko.url = "/ko/about/"
+      ko.render = true
+      ko.in_sitemap = true
+      ko.language = "ko"
+
+      Hwaro::Content::Multilingual.link_translations!([en, ko], config)
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Sitemap.generate([en, ko], site, output_dir)
+
+        content = File.read(File.join(output_dir, "sitemap.xml"))
+        content.should contain(%(xmlns:xhtml="http://www.w3.org/1999/xhtml"))
+        content.should contain(%(<xhtml:link rel="alternate" hreflang="en" href="https://example.com/about/" />))
+        content.should contain(%(<xhtml:link rel="alternate" hreflang="ko" href="https://example.com/ko/about/" />))
+      end
+    end
+
+    it "omits the xhtml namespace when no page has translations" do
+      config = Hwaro::Models::Config.new
+      config.sitemap.enabled = true
+      config.base_url = "https://example.com"
+
+      site = Hwaro::Models::Site.new(config)
+
+      page = Hwaro::Models::Page.new("solo.md")
+      page.url = "/solo/"
+      page.render = true
+      page.in_sitemap = true
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Sitemap.generate([page], site, output_dir)
+
+        content = File.read(File.join(output_dir, "sitemap.xml"))
+        content.should_not contain("xmlns:xhtml")
+        content.should_not contain("<xhtml:link")
+      end
+    end
   end
 end
 

--- a/src/content/multilingual.cr
+++ b/src/content/multilingual.cr
@@ -62,6 +62,15 @@ module Hwaro
         default = config.default_language
 
         groups.each_value do |group_pages|
+          # A group of size 1 has no cross-language variants, just the
+          # page itself; leaving `page.translations` empty matches the
+          # canonical `{% if page.translations %}` guard from the
+          # docs (#486).
+          if group_pages.size <= 1
+            group_pages.each { |p| p.translations = [] of Models::TranslationLink }
+            next
+          end
+
           by_code = {} of String => Models::Page
           group_pages.each do |p|
             by_code[language_code(p, config)] = p

--- a/src/content/seo/sitemap.cr
+++ b/src/content/seo/sitemap.cr
@@ -51,9 +51,19 @@ module Hwaro
           priority = site.config.sitemap.priority
           priority_str = "    <priority>#{priority}</priority>\n"
 
+          # Multilingual sites benefit from `<xhtml:link rel="alternate"
+          # hreflang="...">` entries on every translated URL — Google's
+          # recommended way to expose hreflang in sitemaps. Only declare
+          # the namespace when we'll actually use it (#486).
+          has_translations = sitemap_pages.any? { |p| !p.translations.empty? }
+
           xml_content = String.build(sitemap_pages.size * 256) do |str|
             str << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            str << "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n"
+            if has_translations
+              str << "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\">\n"
+            else
+              str << "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n"
+            end
 
             sitemap_pages.each do |page|
               path = page.url.starts_with?('/') ? page.url : "/#{page.url}"
@@ -63,6 +73,19 @@ module Hwaro
 
               str << "  <url>\n"
               str << "    <loc>#{escaped_url}</loc>\n"
+
+              # Hreflang alternates — emit one per translation (including
+              # the current page itself; Google's spec asks for a self-
+              # referencing entry).
+              page.translations.each do |t|
+                t_path = t.url.starts_with?('/') ? t.url : "/#{t.url}"
+                t_full = base.empty? ? t_path : base + t_path
+                str << "    <xhtml:link rel=\"alternate\" hreflang=\""
+                str << Utils::TextUtils.escape_xml(t.code)
+                str << "\" href=\""
+                str << Utils::TextUtils.escape_xml(t_full)
+                str << "\" />\n"
+              end
 
               # Add lastmod if available
               if date = (page.updated || page.date)

--- a/src/ext/crinja_resolve_fix.cr
+++ b/src/ext/crinja_resolve_fix.cr
@@ -56,6 +56,35 @@ end
 #    loud error is more helpful than silent empty output.
 #
 # See: https://github.com/hahwul/hwaro/issues/482
+# === 3. Empty-collection falsiness (Jinja2 alignment) ==================
+# Upstream `Value#truthy?` only treats `false`, `0`, `nil`, and
+# `Undefined` as falsy. Python Jinja2 also treats empty collections —
+# `[]`, `{}`, `""` — as falsy, which is what `{% if items %}` and
+# `{% if page.translations %}` rely on across hwaro's docs and
+# scaffolds. Without this patch, the canonical lang-switcher idiom
+#
+#   {% if page.translations %}<nav>…</nav>{% endif %}
+#
+# always rendered an empty `<nav>` for pages with no translations,
+# because Crinja saw `[]` as truthy.
+#
+# See: https://github.com/hahwul/hwaro/issues/486
+struct Crinja::Value
+  def truthy?
+    raw = @raw
+    return false if raw == false
+    return false if raw.is_a?(Number) && raw == 0
+    return false if raw.nil?
+    return false if undefined?
+    return false if raw.is_a?(String) && raw.empty?
+    return false if raw.is_a?(Crinja::SafeString) && raw.to_s.empty?
+    return false if raw.is_a?(Indexable) && raw.empty?
+    return false if raw.is_a?(Hash) && raw.empty?
+    return false if raw.is_a?(Crinja::Tuple) && raw.empty?
+    true
+  end
+end
+
 module Crinja::Resolver
   def self.resolve_attribute(name, object : Crinja::Value) : Crinja::Value
     raise Crinja::UndefinedError.new(name.to_s) if object.undefined?


### PR DESCRIPTION
## Summary

Three small changes that, together, make the canonical multilingual patterns from the docs actually behave as documented (#486).

### `page.translations` no longer carries a self-only entry

`link_translations!` used to populate `page.translations` with a single self-link for pages that have no cross-language variants. The canonical `{% if page.translations %}<nav>…</nav>{% endif %}` guard therefore always rendered an empty (or current-only) switcher on single-language pages. Leave the array empty when the language group has only one member.

### `Crinja::Value#truthy?` now matches Jinja2 semantics

Even with the fix above, `{% if [] %}` was still truthy in Crinja (only `false` / `0` / `nil` / `Undefined` were falsy), so the empty `<nav>` artefact survived. Patch `truthy?` so empty `Array`, `Hash`, `String`, `SafeString`, `Tuple` are falsy too — matching Python Jinja2 and the convention everywhere in hwaro's docs and scaffolds.

### `sitemap.xml` exposes hreflang alternates

Multilingual sites only had `<link rel="alternate">` entries in the HTML head; Google also recommends surfacing them in `sitemap.xml`. When any page has translations, declare `xmlns:xhtml` on `<urlset>` and emit `<xhtml:link rel="alternate" hreflang="…" href="…" />` per translation (including the self-referencing entry per spec).

### Sample output

```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <loc>http://localhost:3000/ko/about/</loc>
    <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/about/" />
    <xhtml:link rel="alternate" hreflang="ko" href="http://localhost:3000/ko/about/" />
    ...
  </url>
  ...
</urlset>
```

## Test plan

- [x] New regression in `spec/unit/multilingual_spec.cr`: a single-variant page gets an empty `page.translations`.
- [x] Updated `spec/unit/multilingual_utils_spec.cr` "does not link unrelated pages" to assert empty (was 1 with self).
- [x] New regression group in `spec/unit/crinja_resolve_fix_spec.cr` covering Jinja2-aligned truthiness for empty `Array`, `Hash`, `String`.
- [x] New regression in `spec/unit/seo_spec.cr` for `xhtml:link rel="alternate"` entries (and a negative test that omits the namespace when no page has translations).
- [x] `crystal spec` — 4742 examples, 0 failures.
- [x] `crystal tool format --check` and `bin/ameba` clean.
- [x] Manual: rebuilt the binary against `testapp`. The non-translated `edge-cases.md` page no longer renders an empty `<nav class="lang-switcher">`; the translated `about.md` still renders the EN/KO switcher; `public/sitemap.xml` now contains `<xhtml:link>` entries on `/about/` and `/ko/about/`.

Closes #486