### PR TITLE
fix(scaffold): make scaffolded search work under hwaro serve

### DIFF
--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -638,8 +638,9 @@ module Hwaro
 
               function loadSearchData(cb) {
                 if (searchData) return cb(searchData);
-                var base = document.querySelector('link[rel="stylesheet"]').href;
-                var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+                var link = document.querySelector('link[rel="stylesheet"][href*="/css/"]');
+                var path = link ? new URL(link.href, document.baseURI).pathname : '/css/';
+                var searchUrl = path.substring(0, path.indexOf('/css/')) + '/search.json';
                 fetch(searchUrl)
                   .then(function (r) { return r.json(); })
                   .then(function (data) { searchData = data; cb(data); })

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -976,12 +976,12 @@ module Hwaro
               }
 
               // ── Active Sidebar Link ──
-              var currentPath = window.location.pathname.replace(/\\/+$/, '') || '/';
+              var currentPath = window.location.pathname.replace(/\/+$/, '') || '/';
               var links = document.querySelectorAll('.chapter-links a');
               for (var i = 0; i < links.length; i++) {
                 var linkPath = links[i].getAttribute('href');
                 if (linkPath) {
-                  linkPath = linkPath.replace(/\\/+$/, '') || '/';
+                  linkPath = linkPath.replace(/\/+$/, '') || '/';
                   if (linkPath === currentPath) {
                     links[i].classList.add('active');
                     links[i].scrollIntoView({ block: 'center', behavior: 'instant' });
@@ -998,8 +998,9 @@ module Hwaro
 
               function loadSearchData(cb) {
                 if (searchData) return cb(searchData);
-                var base = document.querySelector('link[rel="stylesheet"]').href;
-                var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+                var link = document.querySelector('link[rel="stylesheet"][href*="/css/"]');
+                var path = link ? new URL(link.href, document.baseURI).pathname : '/css/';
+                var searchUrl = path.substring(0, path.indexOf('/css/')) + '/search.json';
                 fetch(searchUrl)
                   .then(function (r) { return r.json(); })
                   .then(function (data) { searchData = data; cb(data); })

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -781,8 +781,9 @@ module Hwaro
 
               function loadSearchData(cb) {
                 if (searchData) return cb(searchData);
-                var base = document.querySelector('link[rel="stylesheet"]').href;
-                var searchUrl = base.substring(0, base.indexOf('/css/')) + '/search.json';
+                var link = document.querySelector('link[rel="stylesheet"][href*="/css/"]');
+                var path = link ? new URL(link.href, document.baseURI).pathname : '/css/';
+                var searchUrl = path.substring(0, path.indexOf('/css/')) + '/search.json';
                 fetch(searchUrl)
                   .then(function (r) { return r.json(); })
                   .then(function (data) { searchData = data; cb(data); })


### PR DESCRIPTION
## Summary
- The scaffolded `loadSearchData` (docs/blog/book and their dark variants) built the `search.json` URL from the absolute href of the first stylesheet. Under `hwaro serve`, `base_url` is overridden to `http://<host>:<port>` (default `127.0.0.1:3000`), but users typically open `localhost:3000`, so the fetch was cross-origin and blocked by CORS — search silently returned no results. Switch to the link's pathname so the request resolves against the document origin while still supporting subpath deployments.
- Fix a parse error in the book scaffold's `book.js`: the trailing-slash regex `/\\/+$/` was emitted with a literal double backslash (quoted heredocs preserve `\\`), so the whole script failed to load and search + active-sidebar logic was dead.

Closes #510

## Test plan
- [x] `crystal spec spec/unit/` — 4400 examples, 0 failures
- [x] Manual: `hwaro init --scaffold=docs`, `hwaro serve`, headless Chrome confirms `Cmd+K` opens overlay and typing returns results (no CORS error)
- [x] Manual: same for `--scaffold=blog` and `--scaffold=book`
- [x] Manual: `--scaffold=docs-dark` (dark variants inherit `search_js_content`)
- [x] `node --check` on the generated `book.js` now passes (previously a SyntaxError)