### PR TITLE
feat(deploy): support Codeberg Pages via platform tool

### DIFF
--- a/docs/content/deploy/codeberg-pages/index.md
+++ b/docs/content/deploy/codeberg-pages/index.md
@@ -8,12 +8,12 @@ Deploy your Hwaro site to [Codeberg Pages](https://codeberg.page/) — free stat
 
 ## How Codeberg Pages Works
 
-Codeberg serves static sites in two ways:
+Codeberg serves static sites in two modes:
 
-- A repository named **`pages`** under your account → published at `https://USERNAME.codeberg.page/`
-- A branch named **`pages`** in any other repository → published at `https://USERNAME.codeberg.page/REPO/`
+- **User / org site** — a repository named **`pages`** under your account. Codeberg serves the *default branch* of that repo at `https://USERNAME.codeberg.page/`.
+- **Project site** — any other repository. Codeberg serves a branch named **`pages`** at `https://USERNAME.codeberg.page/REPO/`.
 
-The deploy workflow is the same in both cases: push the contents of `public/` to a `pages` branch.
+This distinction matters: a project site pushes to a `pages` *branch*, while a user site pushes to the *default branch* (typically `main`) of the `pages` *repo*. The workflow below defaults to the project-site case and exposes `PAGES_BRANCH` so the user-site case is a one-line change.
 
 ## Prerequisites
 
@@ -23,7 +23,9 @@ The deploy workflow is the same in both cases: push the contents of `public/` to
 
 ## Method 1: Forgejo Actions (Recommended)
 
-Codeberg supports [Forgejo Actions](https://forgejo.org/docs/latest/user/actions/), which is GitHub Actions–compatible. Note that Forgejo Actions is opt-in per repository — enable it under **Settings → Actions** before the workflow will run.
+Codeberg supports [Forgejo Actions](https://forgejo.org/docs/latest/user/actions/), which is GitHub Actions–compatible. Forgejo Actions is opt-in per repository — enable it under **Settings → Actions** before the workflow will run.
+
+> Forgejo also accepts workflows under `.gitea/workflows/` for backwards compatibility, but `.forgejo/workflows/` is the upstream-blessed path and the one Hwaro generates.
 
 ### Generate the Workflow
 
@@ -47,6 +49,10 @@ jobs:
     runs-on: docker
     container:
       image: ghcr.io/hahwul/hwaro:latest
+    env:
+      # Project site: "pages" (default). User/org site (repo named
+      # "pages"): override to your default branch, e.g. "main".
+      PAGES_BRANCH: pages
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,14 +65,25 @@ jobs:
           CODEBERG_TOKEN: ${{ secrets.CODEBERG_TOKEN }}
         run: |
           cd public
-          git init -b pages
+          git init -b "$PAGES_BRANCH"
           git config user.name  "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.codeberg.org"
+          git config user.email "${{ github.actor }}@noreply.codeberg.org"
           git add -A
           git commit -m "Deploy: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           git push --force \
             "https://${{ github.actor }}:$CODEBERG_TOKEN@codeberg.org/${{ github.repository }}.git" \
-            pages
+            "$PAGES_BRANCH"
+```
+
+> **Branch history is not preserved.** Each run starts with a fresh `git init` and force-pushes, so the published branch is treated as a publish-only artifact. Keep your source on `main` (or wherever you develop); never edit the `pages` branch by hand.
+
+### User Site vs Project Site
+
+The default `PAGES_BRANCH: pages` targets a **project site** (any repo, served at `USERNAME.codeberg.page/REPO/`). For a **user / org site** in a repo literally named `pages`, change the branch to your default branch:
+
+```yaml
+    env:
+      PAGES_BRANCH: main   # default branch of the `pages` repo
 ```
 
 ### Add the Token Secret
@@ -101,15 +118,16 @@ set -e
 
 SOURCE_DIR="${1:?Usage: deploy-codeberg.sh <source-dir>}"
 REMOTE_URL="${CODEBERG_REMOTE:-$(git remote get-url origin)}"
+PAGES_BRANCH="${PAGES_BRANCH:-pages}"
 TMPDIR=$(mktemp -d)
 
 cp -r "$SOURCE_DIR"/. "$TMPDIR"
 
 cd "$TMPDIR"
-git init -b pages
+git init -b "$PAGES_BRANCH"
 git add -A
 git commit -m "Deploy to Codeberg Pages"
-git push --force "$REMOTE_URL" pages
+git push --force "$REMOTE_URL" "$PAGES_BRANCH"
 
 rm -rf "$TMPDIR"
 ```
@@ -134,7 +152,12 @@ hwaro deploy codeberg-pages
 
 # Preview without deploying
 hwaro deploy codeberg-pages --dry-run
+
+# User site (push to the default branch instead of `pages`)
+PAGES_BRANCH=main hwaro deploy codeberg-pages
 ```
+
+As with Method 1, the script force-pushes a fresh init — branch history is not preserved.
 
 ## Method 3: Manual Branch Deploy
 
@@ -148,33 +171,68 @@ git commit -m "Deploy"
 git push --force https://codeberg.org/USERNAME/REPO.git pages
 ```
 
+For a user site (`pages` repo), substitute the default branch name (e.g. `main`) for `pages` in both the `init` and `push` commands.
+
 ## Custom Domain
 
-Codeberg Pages supports custom domains. Place a `.domains` file in the root of your `pages` branch listing the domains to serve, one per line:
+Codeberg Pages supports custom domains via a `.domains` file plus a DNS record. See the [official Codeberg docs](https://docs.codeberg.org/codeberg-pages/using-custom-domain/) for the authoritative version.
+
+> **Repo names with dots are unsupported.** Use `-` or `_` in the repo name if you plan to attach a custom domain.
+
+### 1. Add a `.domains` file
+
+Place a `.domains` file at the root of the served branch listing the domains, one per line. The **first line is the canonical domain**; all subsequent domains are 301-redirected to it. Empty lines and `#` comments are allowed.
 
 ```
 www.example.org
 example.org
 ```
 
-Add the file under `static/.domains` so Hwaro copies it into `public/` on every build:
+Drop it under `static/.domains` so Hwaro copies it into `public/` on every build:
 
 ```
 static/
 └── .domains
 ```
 
-Then point your DNS at Codeberg:
+### 2. Configure DNS
 
-| Type  | Name | Value                |
-|-------|------|----------------------|
-| CNAME | www  | USERNAME.codeberg.page |
-| A     | @    | 217.197.91.145        |
-| AAAA  | @    | 2a0a:1580:6:5::3      |
+Pick **one** of the three options below.
 
-(Verify the latest IPs on the [Codeberg Pages docs](https://docs.codeberg.org/codeberg-pages/).)
+**Option A — CNAME (recommended, simplest).** Point your domain at one of these names:
 
-Update `config.toml`:
+| Site type     | CNAME target                              |
+|---------------|-------------------------------------------|
+| Personal site | `USERNAME.codeberg.page`                  |
+| Project site  | `REPO.USERNAME.codeberg.page`             |
+| Custom branch | `BRANCH.REPO.USERNAME.codeberg.page`      |
+
+CNAME delegates *the whole hostname*, so you cannot run email (MX) on the same name with this option.
+
+**Option B — ALIAS + TXT.** If your DNS provider supports `ALIAS` (or `ANAME`) records:
+
+| Type  | Name | Value                                |
+|-------|------|--------------------------------------|
+| ALIAS | @    | `codeberg.page`                      |
+| TXT   | @    | `REPO.USERNAME.codeberg.page` (or `USERNAME.codeberg.page` for a user site) |
+
+**Option C — A + AAAA + TXT.** Use this if your provider doesn't support ALIAS, or if your zone uses DNSSEC (which is incompatible with the `codeberg.page` CNAME):
+
+| Type | Name | Value                                |
+|------|------|--------------------------------------|
+| A    | @    | `217.197.84.141`                     |
+| AAAA | @    | `2a0a:4580:103f:c0de::2`             |
+| TXT  | @    | `REPO.USERNAME.codeberg.page` (or `USERNAME.codeberg.page` for a user site) |
+
+> Verify the latest IPs on the [Codeberg Pages docs](https://docs.codeberg.org/codeberg-pages/using-custom-domain/) before relying on them — Codeberg occasionally rotates them.
+
+If your zone uses CAA records, add an entry that allows Let's Encrypt so Codeberg can issue a TLS certificate:
+
+```
+@   CAA   0 issue "letsencrypt.org"
+```
+
+### 3. Update `base_url`
 
 ```toml
 base_url = "https://www.example.org"
@@ -185,7 +243,7 @@ base_url = "https://www.example.org"
 ### Workflow Doesn't Run
 
 - Make sure Forgejo Actions is enabled under **Settings → Actions** for the repository
-- Confirm the workflow file is committed at `.forgejo/workflows/deploy.yml`
+- Confirm the workflow file is committed at `.forgejo/workflows/deploy.yml` (or `.gitea/workflows/deploy.yml`)
 
 ### Push Fails with 401 / 403
 
@@ -195,11 +253,19 @@ base_url = "https://www.example.org"
 ### 404 on the Deployed Site
 
 - Codeberg Pages may take a minute or two to publish after the first push
-- Confirm the branch is named exactly `pages`
+- For a project site, confirm the branch is named exactly `pages`
+- For a user site, confirm the repo is named exactly `pages` and `PAGES_BRANCH` matches its default branch
 - Verify `base_url` matches the published URL (no trailing slash)
+
+### Custom Domain Doesn't Resolve to HTTPS
+
+- Confirm the `.domains` file is present at the root of the published branch
+- If you have CAA records, make sure `letsencrypt.org` is allowed
+- Allow a few minutes for the certificate to be issued after DNS propagates
 
 ## See Also
 
 - [Deploy Configuration](/deploy/config/) — Target setup and matchers
 - [CLI Reference](/start/cli/) — All deploy command options
+- [Codeberg Pages docs](https://docs.codeberg.org/codeberg-pages/) — Upstream reference
 - Other platforms: [GitHub Pages](/deploy/github-pages/) | [GitLab CI](/deploy/gitlab-ci/) | [Netlify](/deploy/netlify/) | [Cloudflare Pages](/deploy/cloudflare-pages/)

--- a/docs/content/deploy/codeberg-pages/index.md
+++ b/docs/content/deploy/codeberg-pages/index.md
@@ -1,0 +1,205 @@
++++
+title = "Codeberg Pages"
+description = "Deploy your Hwaro site to Codeberg Pages"
+weight = 7
++++
+
+Deploy your Hwaro site to [Codeberg Pages](https://codeberg.page/) — free static hosting backed by Codeberg's Forgejo instance.
+
+## How Codeberg Pages Works
+
+Codeberg serves static sites in two ways:
+
+- A repository named **`pages`** under your account → published at `https://USERNAME.codeberg.page/`
+- A branch named **`pages`** in any other repository → published at `https://USERNAME.codeberg.page/REPO/`
+
+The deploy workflow is the same in both cases: push the contents of `public/` to a `pages` branch.
+
+## Prerequisites
+
+- Codeberg account
+- Repository on Codeberg (either `pages` for a user site, or any repo for a project site)
+- A Codeberg access token with `write:repository` scope (Settings → Applications → Generate new token)
+
+## Method 1: Forgejo Actions (Recommended)
+
+Codeberg supports [Forgejo Actions](https://forgejo.org/docs/latest/user/actions/), which is GitHub Actions–compatible. Note that Forgejo Actions is opt-in per repository — enable it under **Settings → Actions** before the workflow will run.
+
+### Generate the Workflow
+
+```bash
+hwaro tool platform codeberg-pages
+```
+
+This writes `.forgejo/workflows/deploy.yml`:
+
+```yaml
+---
+name: Hwaro Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: docker
+    container:
+      image: ghcr.io/hahwul/hwaro:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build site
+        run: hwaro build
+
+      - name: Deploy to Codeberg Pages
+        env:
+          CODEBERG_TOKEN: ${{ secrets.CODEBERG_TOKEN }}
+        run: |
+          cd public
+          git init -b pages
+          git config user.name  "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.codeberg.org"
+          git add -A
+          git commit -m "Deploy: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          git push --force \
+            "https://${{ github.actor }}:$CODEBERG_TOKEN@codeberg.org/${{ github.repository }}.git" \
+            pages
+```
+
+### Add the Token Secret
+
+1. Go to your repository **Settings → Actions → Secrets**
+2. Add a new secret named `CODEBERG_TOKEN`
+3. Paste your Codeberg access token (with `write:repository` scope)
+
+### Set Base URL
+
+Update `config.toml`:
+
+```toml
+# User/org site (repo named "pages")
+base_url = "https://USERNAME.codeberg.page"
+
+# Project site (any other repo)
+base_url = "https://USERNAME.codeberg.page/REPO"
+```
+
+Push to `main` and the workflow will build and deploy automatically.
+
+## Method 2: Deploy via `hwaro deploy`
+
+If you'd rather deploy from your local machine, wire it up as a `[[deployment.targets]]` entry that calls a small shell script.
+
+Create `scripts/deploy-codeberg.sh`:
+
+```bash
+#!/bin/bash
+set -e
+
+SOURCE_DIR="${1:?Usage: deploy-codeberg.sh <source-dir>}"
+REMOTE_URL="${CODEBERG_REMOTE:-$(git remote get-url origin)}"
+TMPDIR=$(mktemp -d)
+
+cp -r "$SOURCE_DIR"/. "$TMPDIR"
+
+cd "$TMPDIR"
+git init -b pages
+git add -A
+git commit -m "Deploy to Codeberg Pages"
+git push --force "$REMOTE_URL" pages
+
+rm -rf "$TMPDIR"
+```
+
+```bash
+chmod +x scripts/deploy-codeberg.sh
+```
+
+Add the target to `config.toml`:
+
+```toml
+[[deployment.targets]]
+name = "codeberg-pages"
+command = "scripts/deploy-codeberg.sh {source}"
+```
+
+Then build and deploy:
+
+```bash
+hwaro build
+hwaro deploy codeberg-pages
+
+# Preview without deploying
+hwaro deploy codeberg-pages --dry-run
+```
+
+## Method 3: Manual Branch Deploy
+
+```bash
+hwaro build
+
+cd public
+git init -b pages
+git add -A
+git commit -m "Deploy"
+git push --force https://codeberg.org/USERNAME/REPO.git pages
+```
+
+## Custom Domain
+
+Codeberg Pages supports custom domains. Place a `.domains` file in the root of your `pages` branch listing the domains to serve, one per line:
+
+```
+www.example.org
+example.org
+```
+
+Add the file under `static/.domains` so Hwaro copies it into `public/` on every build:
+
+```
+static/
+└── .domains
+```
+
+Then point your DNS at Codeberg:
+
+| Type  | Name | Value                |
+|-------|------|----------------------|
+| CNAME | www  | USERNAME.codeberg.page |
+| A     | @    | 217.197.91.145        |
+| AAAA  | @    | 2a0a:1580:6:5::3      |
+
+(Verify the latest IPs on the [Codeberg Pages docs](https://docs.codeberg.org/codeberg-pages/).)
+
+Update `config.toml`:
+
+```toml
+base_url = "https://www.example.org"
+```
+
+## Troubleshooting
+
+### Workflow Doesn't Run
+
+- Make sure Forgejo Actions is enabled under **Settings → Actions** for the repository
+- Confirm the workflow file is committed at `.forgejo/workflows/deploy.yml`
+
+### Push Fails with 401 / 403
+
+- Re-check the `CODEBERG_TOKEN` secret value and that the token still has `write:repository` scope
+- Tokens are tied to your account — make sure the actor has push access to the target repo
+
+### 404 on the Deployed Site
+
+- Codeberg Pages may take a minute or two to publish after the first push
+- Confirm the branch is named exactly `pages`
+- Verify `base_url` matches the published URL (no trailing slash)
+
+## See Also
+
+- [Deploy Configuration](/deploy/config/) — Target setup and matchers
+- [CLI Reference](/start/cli/) — All deploy command options
+- Other platforms: [GitHub Pages](/deploy/github-pages/) | [GitLab CI](/deploy/gitlab-ci/) | [Netlify](/deploy/netlify/) | [Cloudflare Pages](/deploy/cloudflare-pages/)

--- a/docs/content/deploy/github-pages/index.md
+++ b/docs/content/deploy/github-pages/index.md
@@ -252,4 +252,4 @@ my-site/
 
 - [Deploy Configuration](/deploy/config/) — Target setup and matchers
 - [CLI Reference](/start/cli/) — All deploy command options
-- Other platforms: [GitLab CI](/deploy/gitlab-ci/) | [Netlify](/deploy/netlify/) | [Vercel](/deploy/vercel/)
+- Other platforms: [GitLab CI](/deploy/gitlab-ci/) | [Netlify](/deploy/netlify/) | [Vercel](/deploy/vercel/) | [Codeberg Pages](/deploy/codeberg-pages/)

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -386,6 +386,7 @@ hwaro tool platform vercel        # Generate Vercel config
 hwaro tool platform cloudflare    # Generate Cloudflare Pages config
 hwaro tool platform github-pages  # Generate GitHub Pages deploy workflow
 hwaro tool platform gitlab-ci     # Generate GitLab CI config
+hwaro tool platform codeberg-pages # Generate Codeberg Pages (Forgejo Actions) workflow
 hwaro tool doctor                 # Diagnose config/template/structure issues
 hwaro tool import hugo /path      # Import from Hugo
 hwaro tool import jekyll /path    # Import from Jekyll

--- a/docs/content/start/tools/platform.md
+++ b/docs/content/start/tools/platform.md
@@ -15,6 +15,7 @@ hwaro tool platform cloudflare
 # CI/CD workflows
 hwaro tool platform github-pages
 hwaro tool platform gitlab-ci
+hwaro tool platform codeberg-pages
 
 # Output to custom path
 hwaro tool platform netlify -o deploy/netlify.toml
@@ -34,6 +35,7 @@ hwaro tool platform vercel --stdout
 | cloudflare | `wrangler.toml` | Workers/Pages site config |
 | github-pages | `.github/workflows/deploy.yml` | GitHub Actions build + deploy workflow |
 | gitlab-ci | `.gitlab-ci.yml` | GitLab CI/CD pipeline |
+| codeberg-pages | `.forgejo/workflows/deploy.yml` | Codeberg Pages (Forgejo Actions) deploy workflow |
 
 ## Options
 
@@ -105,5 +107,5 @@ Each config includes:
 
 ## See Also
 
-- [GitHub Pages](/deploy/github-pages/) | [GitLab CI](/deploy/gitlab-ci/) | [Netlify](/deploy/netlify/) | [Vercel](/deploy/vercel/) | [Cloudflare Pages](/deploy/cloudflare-pages/) — Platform deploy guides
+- [GitHub Pages](/deploy/github-pages/) | [GitLab CI](/deploy/gitlab-ci/) | [Netlify](/deploy/netlify/) | [Vercel](/deploy/vercel/) | [Cloudflare Pages](/deploy/cloudflare-pages/) | [Codeberg Pages](/deploy/codeberg-pages/) — Platform deploy guides
 - [CLI Reference](/start/cli/#tool) — All tool commands

--- a/docs/data/sidebar.yml
+++ b/docs/data/sidebar.yml
@@ -116,5 +116,7 @@
       url: /deploy/vercel/
     - title: Cloudflare Pages
       url: /deploy/cloudflare-pages/
+    - title: Codeberg Pages
+      url: /deploy/codeberg-pages/
     - title: Docker
       url: /deploy/docker/

--- a/spec/unit/platform_config_spec.cr
+++ b/spec/unit/platform_config_spec.cr
@@ -207,9 +207,26 @@ describe Hwaro::Services::PlatformConfig do
         result.should contain("runs-on: docker")
         result.should contain("ghcr.io/hahwul/hwaro:latest")
         result.should contain("hwaro build")
-        result.should contain("git init -b pages")
         result.should contain("CODEBERG_TOKEN")
         result.should contain("codeberg.org/${{ github.repository }}.git")
+      end
+
+      it "exposes the pages branch as a configurable env var defaulting to 'pages'" do
+        config = Hwaro::Models::Config.new
+        generator = Hwaro::Services::PlatformConfig.new(config)
+        result = generator.generate("codeberg-pages")
+
+        result.should contain("PAGES_BRANCH: pages")
+        result.should contain("git init -b \"$PAGES_BRANCH\"")
+      end
+
+      it "uses Codeberg's noreply email domain" do
+        config = Hwaro::Models::Config.new
+        generator = Hwaro::Services::PlatformConfig.new(config)
+        result = generator.generate("codeberg-pages")
+
+        result.should contain("@noreply.codeberg.org")
+        result.should_not contain("users.noreply.codeberg.org")
       end
     end
 

--- a/spec/unit/platform_config_spec.cr
+++ b/spec/unit/platform_config_spec.cr
@@ -20,6 +20,12 @@ describe Hwaro::Services::PlatformConfig do
       generator = Hwaro::Services::PlatformConfig.new(config)
       generator.output_filename("cloudflare").should eq("wrangler.toml")
     end
+
+    it "returns .forgejo workflow path for codeberg-pages" do
+      config = Hwaro::Models::Config.new
+      generator = Hwaro::Services::PlatformConfig.new(config)
+      generator.output_filename("codeberg-pages").should eq(".forgejo/workflows/deploy.yml")
+    end
   end
 
   describe "#generate" do
@@ -188,6 +194,22 @@ describe Hwaro::Services::PlatformConfig do
             result.should_not contain("to = \"/posts/my-post/\"")
           end
         end
+      end
+    end
+
+    describe "codeberg-pages" do
+      it "generates a Forgejo Actions workflow that builds and pushes to a pages branch" do
+        config = Hwaro::Models::Config.new
+        generator = Hwaro::Services::PlatformConfig.new(config)
+        result = generator.generate("codeberg-pages")
+
+        result.should contain("name: Hwaro Deploy")
+        result.should contain("runs-on: docker")
+        result.should contain("ghcr.io/hahwul/hwaro:latest")
+        result.should contain("hwaro build")
+        result.should contain("git init -b pages")
+        result.should contain("CODEBERG_TOKEN")
+        result.should contain("codeberg.org/${{ github.repository }}.git")
       end
     end
 

--- a/spec/unit/tool_commands_spec.cr
+++ b/spec/unit/tool_commands_spec.cr
@@ -322,7 +322,7 @@ describe Hwaro::CLI::Commands::Tool::PlatformCommand do
 
     it "has all supported platforms as positional choices" do
       meta = Hwaro::CLI::Commands::Tool::PlatformCommand.metadata
-      meta.positional_choices.should eq(["netlify", "vercel", "cloudflare", "github-pages", "gitlab-ci"])
+      meta.positional_choices.should eq(["netlify", "vercel", "cloudflare", "github-pages", "gitlab-ci", "codeberg-pages"])
     end
 
     it "output flag takes a value" do

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -7,7 +7,7 @@ require "../utils/logger"
 module Hwaro
   module Services
     class PlatformConfig
-      SUPPORTED_PLATFORMS = ["netlify", "vercel", "cloudflare", "github-pages", "gitlab-ci"]
+      SUPPORTED_PLATFORMS = ["netlify", "vercel", "cloudflare", "github-pages", "gitlab-ci", "codeberg-pages"]
 
       @config : Models::Config
 
@@ -26,6 +26,8 @@ module Hwaro
           generate_github_pages
         when "gitlab-ci"
           generate_gitlab_ci
+        when "codeberg-pages"
+          generate_codeberg_pages
         else
           raise "Unsupported platform: #{platform}. Supported: #{SUPPORTED_PLATFORMS.join(", ")}"
         end
@@ -33,12 +35,13 @@ module Hwaro
 
       def output_filename(platform : String) : String
         case platform
-        when "netlify"      then "netlify.toml"
-        when "vercel"       then "vercel.json"
-        when "cloudflare"   then "wrangler.toml"
-        when "github-pages" then ".github/workflows/deploy.yml"
-        when "gitlab-ci"    then ".gitlab-ci.yml"
-        else                     raise "Unsupported platform: #{platform}"
+        when "netlify"        then "netlify.toml"
+        when "vercel"         then "vercel.json"
+        when "cloudflare"     then "wrangler.toml"
+        when "github-pages"   then ".github/workflows/deploy.yml"
+        when "gitlab-ci"      then ".gitlab-ci.yml"
+        when "codeberg-pages" then ".forgejo/workflows/deploy.yml"
+        else                       raise "Unsupported platform: #{platform}"
         end
       end
 
@@ -207,6 +210,52 @@ module Hwaro
         lines << "      - public"
         lines << "  only:"
         lines << "    - main"
+        lines << ""
+
+        lines.join("\n")
+      end
+
+      # Forgejo Actions workflow that builds the site and force-pushes the
+      # generated `public/` directory to a `pages` branch — Codeberg Pages
+      # serves whichever branch is named `pages` (or any branch in a repo
+      # called `pages`). The workflow assumes a `CODEBERG_TOKEN` secret
+      # with write access; the deploy push uses the actor + token form so
+      # it works without preconfiguring SSH keys on the runner.
+      private def generate_codeberg_pages : String
+        lines = [] of String
+        lines << "---"
+        lines << "name: Hwaro Deploy"
+        lines << ""
+        lines << "on:"
+        lines << "  push:"
+        lines << "    branches: [main]"
+        lines << "  workflow_dispatch:"
+        lines << ""
+        lines << "jobs:"
+        lines << "  deploy:"
+        lines << "    runs-on: docker"
+        lines << "    container:"
+        lines << "      image: ghcr.io/hahwul/hwaro:latest"
+        lines << "    steps:"
+        lines << "      - name: Checkout"
+        lines << "        uses: actions/checkout@v4"
+        lines << ""
+        lines << "      - name: Build site"
+        lines << "        run: #{build_command}"
+        lines << ""
+        lines << "      - name: Deploy to Codeberg Pages"
+        lines << "        env:"
+        lines << "          CODEBERG_TOKEN: ${{ secrets.CODEBERG_TOKEN }}"
+        lines << "        run: |"
+        lines << "          cd #{output_dir}"
+        lines << "          git init -b pages"
+        lines << "          git config user.name  \"${{ github.actor }}\""
+        lines << "          git config user.email \"${{ github.actor }}@users.noreply.codeberg.org\""
+        lines << "          git add -A"
+        lines << "          git commit -m \"Deploy: $(date -u +'%Y-%m-%dT%H:%M:%SZ')\""
+        lines << "          git push --force \\"
+        lines << "            \"https://${{ github.actor }}:$CODEBERG_TOKEN@codeberg.org/${{ github.repository }}.git\" \\"
+        lines << "            pages"
         lines << ""
 
         lines.join("\n")

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -216,11 +216,20 @@ module Hwaro
       end
 
       # Forgejo Actions workflow that builds the site and force-pushes the
-      # generated `public/` directory to a `pages` branch — Codeberg Pages
-      # serves whichever branch is named `pages` (or any branch in a repo
-      # called `pages`). The workflow assumes a `CODEBERG_TOKEN` secret
-      # with write access; the deploy push uses the actor + token form so
-      # it works without preconfiguring SSH keys on the runner.
+      # generated `public/` directory to the configured pages branch.
+      #
+      # Codeberg Pages publishes:
+      #   - Project site: a branch named `pages` in any repo →
+      #     https://USER.codeberg.page/REPO/  (default of this workflow).
+      #   - User/org site: the *default* branch of a repo named `pages` →
+      #     https://USER.codeberg.page/. Override `PAGES_BRANCH` to e.g.
+      #     `main` to target a user site without forking the workflow.
+      #
+      # Each run starts with a fresh `git init`, so commit history on the
+      # pages branch is intentionally not preserved — the branch is treated
+      # as a publish-only artifact. Auth uses the token-form remote URL so
+      # no SSH keys need to be preconfigured on the runner; the token must
+      # be supplied via the `CODEBERG_TOKEN` repository secret.
       private def generate_codeberg_pages : String
         lines = [] of String
         lines << "---"
@@ -236,6 +245,10 @@ module Hwaro
         lines << "    runs-on: docker"
         lines << "    container:"
         lines << "      image: ghcr.io/hahwul/hwaro:latest"
+        lines << "    env:"
+        lines << "      # Project site: \"pages\" (default). User/org site (repo named"
+        lines << "      # \"pages\"): override to your default branch, e.g. \"main\"."
+        lines << "      PAGES_BRANCH: pages"
         lines << "    steps:"
         lines << "      - name: Checkout"
         lines << "        uses: actions/checkout@v4"
@@ -248,14 +261,14 @@ module Hwaro
         lines << "          CODEBERG_TOKEN: ${{ secrets.CODEBERG_TOKEN }}"
         lines << "        run: |"
         lines << "          cd #{output_dir}"
-        lines << "          git init -b pages"
+        lines << "          git init -b \"$PAGES_BRANCH\""
         lines << "          git config user.name  \"${{ github.actor }}\""
-        lines << "          git config user.email \"${{ github.actor }}@users.noreply.codeberg.org\""
+        lines << "          git config user.email \"${{ github.actor }}@noreply.codeberg.org\""
         lines << "          git add -A"
         lines << "          git commit -m \"Deploy: $(date -u +'%Y-%m-%dT%H:%M:%SZ')\""
         lines << "          git push --force \\"
         lines << "            \"https://${{ github.actor }}:$CODEBERG_TOKEN@codeberg.org/${{ github.repository }}.git\" \\"
-        lines << "            pages"
+        lines << "            \"$PAGES_BRANCH\""
         lines << ""
 
         lines.join("\n")


### PR DESCRIPTION
## Summary
- Add `codeberg-pages` to `hwaro tool platform`, generating a Forgejo Actions workflow at `.forgejo/workflows/deploy.yml` that builds the site and force-pushes `public/` to a `pages` branch (the convention Codeberg Pages serves from).
- New deploy guide at `/deploy/codeberg-pages/` covering Forgejo Actions setup, a local-deploy alternative wired through `[[deployment.targets]]`, manual branch deploy, custom domains via `.domains`, and troubleshooting.
- Wire the new platform into the sidebar, CLI reference, and `tool platform` docs; add unit coverage in `platform_config_spec` and `tool_commands_spec`.

Closes #512

## Test plan
- [x] `crystal spec` — 4744 examples, 0 failures
- [x] `bin/hwaro tool platform codeberg-pages --stdout` produces the expected Forgejo Actions YAML
- [x] `bin/hwaro build -i docs` renders the new doc page successfully