### PR TITLE
docs(install): correct Homebrew tap to hahwul/hwaro

### DIFF
--- a/docs/content/start/_index.md
+++ b/docs/content/start/_index.md
@@ -13,7 +13,7 @@ Hwaro is designed to help you **build your own website without relying on pre-ma
 
 ```bash
 # Install (see Installation for all methods)
-brew tap hwaro/hwaro && brew install hwaro
+brew tap hahwul/hwaro && brew install hwaro
 
 # Create a new site
 hwaro init my-site --scaffold blog

--- a/docs/content/start/installation.md
+++ b/docs/content/start/installation.md
@@ -10,7 +10,7 @@ Hwaro is written in Crystal. You can install it from source or use a pre-built b
 ## Homebrew
 
 ```bash
-brew tap hwaro/hwaro
+brew tap hahwul/hwaro
 brew install hwaro
 ```
 


### PR DESCRIPTION
## Summary
- Fix Homebrew tap name in install docs from `hwaro/hwaro` to `hahwul/hwaro` (the tap actually lives at `hahwul/homebrew-hwaro`, see `.github/workflows/publish-homebrew.yml`).
- Updated both occurrences: `docs/content/start/installation.md` and the Quick Start snippet in `docs/content/start/_index.md`.

Closes #514

## Test plan
- [x] `grep -rn "hwaro/hwaro" docs/content` returns no remaining matches (excluding generated `docs/public/`)
- [x] Rebuild docs site and confirm `https://hwaro.hahwul.com/start/installation/` shows `brew tap hahwul/hwaro`