### PR TITLE
ci(homebrew): fix Ruby interpolation in formula test block

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -24,7 +24,7 @@ jobs:
             system "shards install"
             system "shards build --release --no-debug --production"
             bin.install "bin/hwaro"
-          test: system "{bin}/hwaro", "version"
+          test: 'system "#{bin}/hwaro", "version"'
           update_readme_table: false
           ignore_warnings: true
           skip_commit: false


### PR DESCRIPTION
## Summary
- The current YAML for `homebrew-releaser` produces a formula whose `test` block reads `system "{bin}/hwaro", "version"` — a literal path, not Ruby interpolation. This breaks `brew test hwaro` and `brew audit`.
- Switched to `#{bin}` and single-quoted the YAML value so the `#` isn't parsed as a YAML comment start.
- The next published release will regenerate `Formula/hwaro.rb` correctly.

Refs #516 (noticed while investigating that issue; does not by itself fix the user's PATH report).

## Test plan
- [x] `ruby -ryaml -e "puts YAML.load_file('.github/workflows/publish-homebrew.yml')['jobs']['homebrew-releaser']['steps'][0]['with']['test']"` prints `system "#{bin}/hwaro", "version"`
- [ ] After next release, verify `Formula/hwaro.rb` in `hahwul/homebrew-hwaro` contains `system "#{bin}/hwaro", "version"` and `brew test hwaro` succeeds