### PR TITLE
feat(markdown): GitHub admonitions, custom heading IDs, inline-md in definition lists

### DIFF
--- a/docs/content/writing/pages.md
+++ b/docs/content/writing/pages.md
@@ -352,6 +352,8 @@ The output is a `<div class="admonition admonition-{type}">` with a title paragr
 
 Disable by setting `admonitions = false` under `[markdown]` in `config.toml`.
 
+Limitations: matching is type-case-sensitive (`[!NOTE]` only, not `[!note]`), and a nested blockquote inside an admonition body closes the outer admonition early. There is no inline escape — backslash-escaping (`\[!NOTE\]`) renders the same characters and still triggers the admonition, so disable the feature if you need to render the literal token.
+
 ### Custom Heading IDs
 
 Append `{#custom-id}` to a heading line to override the auto-generated slug. Useful when you want stable anchor URLs that don't break on title edits.
@@ -362,9 +364,11 @@ Append `{#custom-id}` to a heading line to override the auto-generated slug. Use
 
 Renders as `<h2 id="install">Installation Guide</h2>`. The TOC and any `[link](#install)` will use the custom id.
 
-Allowed id characters: letters, digits, `_`, `-`, `:`. The id must start with a letter.
+Allowed id characters: letters, digits, `_`, `-`, `:`. The id must start with a letter. CommonMark allows up to 3 leading spaces before an ATX heading; deeper indentation makes the line a code block, in which case `{#id}` is not applied.
 
 Disable by setting `heading_ids = false` under `[markdown]` in `config.toml`.
+
+Custom heading IDs require `markdown.safe = false`. Under safe mode the `{#id}` syntax is stripped from the rendered output and no id is applied — use raw HTML headings if you need both safe mode and explicit ids. Writing the same `{#id}` twice in one page produces duplicate id attributes; the first anchor wins.
 
 ### Definition Lists
 

--- a/docs/content/writing/pages.md
+++ b/docs/content/writing/pages.md
@@ -335,6 +335,50 @@ This is useful because you don't need to know the final URL — Hwaro calculates
 > Quote text
 ```
 
+### Admonitions
+
+GitHub-style alert blocks render as styled callouts. Recognised types: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`.
+
+```markdown
+> [!NOTE]
+> Pay attention to this paragraph.
+
+> [!WARNING]
+>
+> Body can also live in its own paragraph.
+```
+
+The output is a `<div class="admonition admonition-{type}">` with a title paragraph (`<p class="admonition-title">`) followed by the body. Style it from your CSS — Hwaro emits semantic markup only.
+
+Disable by setting `admonitions = false` under `[markdown]` in `config.toml`.
+
+### Custom Heading IDs
+
+Append `{#custom-id}` to a heading line to override the auto-generated slug. Useful when you want stable anchor URLs that don't break on title edits.
+
+```markdown
+## Installation Guide {#install}
+```
+
+Renders as `<h2 id="install">Installation Guide</h2>`. The TOC and any `[link](#install)` will use the custom id.
+
+Allowed id characters: letters, digits, `_`, `-`, `:`. The id must start with a letter.
+
+Disable by setting `heading_ids = false` under `[markdown]` in `config.toml`.
+
+### Definition Lists
+
+```markdown
+Term
+: Definition body
+
+Another term
+: Definition with **bold**, *italic*, `code`, [a link](https://example.com), and ~~strikethrough~~
+: A second definition for the same term
+```
+
+Inline Markdown works inside both terms and definitions. Raw HTML is escaped for safety.
+
 ## Asset Colocation
 
 You can keep related assets (images, PDFs, etc.) in the same directory as your content file. This is known as a **Page Bundle**.

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -8,6 +8,8 @@ private def make_config(**opts) : Hwaro::Models::MarkdownConfig
   config.definition_lists = opts[:definition_lists]? || false
   config.mermaid = opts[:mermaid]? || false
   config.math = opts[:math]? || false
+  config.admonitions = opts[:admonitions]? || false
+  config.heading_ids = opts[:heading_ids]? || false
   config
 end
 
@@ -413,6 +415,186 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       content = "Term1\n: Def1\n\n\n\nTerm2\n: Def2"
       result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
       result.scan(/<dl>/).size.should eq(1)
+    end
+  end
+
+  describe "definition list inline markdown" do
+    it "renders bold markdown inside terms" do
+      content = "**Bold term**\n: Plain definition"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain("<dt><strong>Bold term</strong></dt>")
+    end
+
+    it "renders links inside definitions" do
+      content = "Term\n: See [docs](https://example.com)"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain(%(<a href="https://example.com">docs</a>))
+    end
+
+    it "renders italic and code spans inside definitions" do
+      content = "Term\n: *emphasis* and `inline code`"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain("<em>emphasis</em>")
+      result.should contain("<code>inline code</code>")
+    end
+
+    it "renders strikethrough inside definitions" do
+      content = "Term\n: ~~deprecated~~ feature"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain("<del>deprecated</del>")
+    end
+
+    it "still escapes raw HTML alongside inline markdown" do
+      content = "Term\n: <b>raw</b> and **md bold**"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should contain("&lt;b&gt;raw&lt;/b&gt;")
+      result.should contain("<strong>md bold</strong>")
+    end
+
+    it "rejects unsafe link schemes" do
+      content = "Term\n: [click](javascript:alert(1))"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_definition_lists(content)
+      result.should_not contain("<a href")
+      result.should contain("[click]")
+    end
+  end
+
+  describe "admonitions" do
+    it "rewrites a single-line GitHub-style note" do
+      html = "<blockquote>\n<p>[!NOTE]\nUseful info here</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<div class="admonition admonition-note">))
+      result.should contain(%(<p class="admonition-title">Note</p>))
+      result.should contain("<p>Useful info here</p>")
+      result.should_not contain("<blockquote>")
+    end
+
+    it "handles separate-paragraph body for warning" do
+      html = "<blockquote>\n<p>[!WARNING]</p>\n<p>Body paragraph</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(admonition-warning))
+      result.should contain(%(<p class="admonition-title">Warning</p>))
+      result.should contain("<p>Body paragraph</p>")
+    end
+
+    it "supports title-only admonition with no body" do
+      html = "<blockquote>\n<p>[!TIP]</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(admonition-tip))
+      result.should contain(%(<p class="admonition-title">Tip</p>))
+      result.should_not contain("<blockquote>")
+    end
+
+    it "recognises all five GitHub admonition types" do
+      %w[NOTE TIP IMPORTANT WARNING CAUTION].each do |type|
+        html = "<blockquote>\n<p>[!#{type}]\nbody</p>\n</blockquote>"
+        result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+        result.should contain("admonition-#{type.downcase}")
+      end
+    end
+
+    it "leaves regular blockquotes untouched" do
+      html = "<blockquote>\n<p>Just a quote</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should eq(html)
+    end
+
+    it "ignores unknown admonition types" do
+      html = "<blockquote>\n<p>[!UNKNOWN]\nbody</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should eq(html)
+    end
+
+    it "is case-sensitive on the type token" do
+      html = "<blockquote>\n<p>[!note]\nbody</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should eq(html)
+    end
+  end
+
+  describe "heading ids" do
+    it "extracts id from `## Heading {#custom-id}`" do
+      content = "## My Heading {#custom-id}"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_heading_ids(content)
+      result.should eq("## My Heading <!--HID:custom-id-->")
+    end
+
+    it "preserves headings without an id marker" do
+      content = "## Plain heading"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_heading_ids(content)
+      result.should eq(content)
+    end
+
+    it "applies the marker to a rendered heading tag" do
+      html = "<h2>My Heading <!--HID:custom-->\n</h2>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_heading_ids(html)
+      result.should contain(%(<h2 id="custom">))
+      result.should_not contain("HID:")
+    end
+
+    it "replaces an existing id attribute" do
+      html = %(<h3 class="foo" id="auto-slug">Heading <!--HID:wanted--></h3>)
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_heading_ids(html)
+      result.should contain(%(id="wanted"))
+      result.should_not contain("auto-slug")
+      result.should contain(%(class="foo"))
+    end
+
+    it "handles each heading level h1-h6" do
+      (1..6).each do |level|
+        content = "#{"#" * level} Heading {#h#{level}}"
+        result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_heading_ids(content)
+        result.should contain("<!--HID:h#{level}-->")
+      end
+    end
+
+    it "renders end-to-end through Markdown.render" do
+      cfg = make_config(heading_ids: true)
+      html, _ = Hwaro::Processor::Markdown.render(
+        "## Section {#intro}\n\nBody text.",
+        markdown_config: cfg,
+      )
+      html.should contain(%(<h2 id="intro">))
+      html.should_not contain("HID:")
+    end
+
+    it "leaves heading-id syntax inside fenced code blocks alone" do
+      content = "```markdown\n## Example {#example}\n```\n\n## Real heading {#real}"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_heading_ids(content)
+      # Inside the code fence: untouched
+      result.should contain("## Example {#example}")
+      # Outside the code fence: marker injected
+      result.should contain("## Real heading <!--HID:real-->")
+    end
+
+    it "supports tilde-fenced code blocks" do
+      content = "~~~\n## Example {#x}\n~~~"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_heading_ids(content)
+      result.should contain("## Example {#x}")
+      result.should_not contain("HID:")
+    end
+  end
+
+  describe "admonitions end-to-end" do
+    it "renders `> [!NOTE]` blockquotes via Markdown.render" do
+      cfg = make_config(admonitions: true)
+      html, _ = Hwaro::Processor::Markdown.render(
+        "> [!NOTE]\n> Pay attention.",
+        markdown_config: cfg,
+      )
+      html.should contain(%(class="admonition admonition-note"))
+      html.should contain("Pay attention.")
+      html.should_not contain("<blockquote>")
+    end
+
+    it "leaves admonitions disabled when config flag is off" do
+      cfg = make_config
+      html, _ = Hwaro::Processor::Markdown.render(
+        "> [!NOTE]\n> body",
+        markdown_config: cfg,
+      )
+      html.should contain("<blockquote>")
+      html.should contain("[!NOTE]")
     end
   end
 end

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -573,6 +573,71 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       result.should contain("## Example {#x}")
       result.should_not contain("HID:")
     end
+
+    it "matches headings indented up to 3 spaces (CommonMark)" do
+      content = "   ## Indented heading {#deep}"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_heading_ids(content)
+      result.should eq("   ## Indented heading <!--HID:deep-->")
+    end
+
+    it "does not match a heading-like line indented 4+ spaces (code block)" do
+      content = "    ## Looks like heading {#nope}"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_heading_ids(content)
+      result.should eq(content)
+    end
+
+    it "strips {#id} syntax under safe mode and skips marker injection" do
+      content = "## Foo {#bar}"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_heading_ids(content, safe: true)
+      result.should eq("## Foo")
+      result.should_not contain("HID:")
+      result.should_not contain("{#")
+    end
+
+    it "leaves a clean heading end-to-end under safe mode" do
+      cfg = make_config(heading_ids: true)
+      cfg.safe = true
+      html, _ = Hwaro::Processor::Markdown.render(
+        "## Foo {#bar}\n",
+        safe: cfg.safe,
+        markdown_config: cfg,
+      )
+      html.should contain("Foo")
+      html.should_not contain("{#")
+      html.should_not contain("raw HTML omitted")
+    end
+  end
+
+  describe "heading ids (TOC dedup)" do
+    # Locks current pre-existing behaviour in markdown.cr: when an `existing_id`
+    # is detected on a heading (which now includes ones we set from `{#id}`),
+    # the TOC entry gets a deduped id but the rendered HTML keeps the original
+    # id verbatim. This means duplicate `{#id}` produce duplicate id attributes
+    # and a broken TOC anchor for the second entry. Pre-existing limitation —
+    # tracked separately from this PR.
+    it "produces duplicate ids in HTML when the user writes the same {#id} twice" do
+      cfg = make_config(heading_ids: true)
+      content = "## A {#x}\n\nbody\n\n## B {#x}\n\nbody2\n"
+      html, toc = Hwaro::Content::Processors::Markdown.new.render_with_anchors(
+        content, markdown_config: cfg)
+      html.scan(/<h2 id="x">/).size.should eq(2)
+      toc.size.should eq(2)
+      toc[0].id.should eq("x")
+      toc[1].id.should eq("x-1") # TOC dedup, even though the HTML id wasn't updated
+    end
+  end
+
+  describe "admonitions (limitations)" do
+    it "closes early on a nested blockquote (documented v1 limitation)" do
+      # Inner </blockquote> ends the lazy match, so the outer admonition body
+      # is truncated before the second </blockquote>. This locks the current
+      # behaviour; lifting the restriction would mean a nest-aware matcher.
+      html = "<blockquote>\n<p>[!NOTE]\nouter</p>\n<blockquote>\n<p>inner</p>\n</blockquote>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain("admonition-note")
+      # Trailing outer </blockquote> is left behind in the output.
+      result.scan(/<\/blockquote>/).size.should eq(1)
+    end
   end
 
   describe "admonitions end-to-end" do

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -16,7 +16,7 @@ module Hwaro
           result = preprocess_definition_lists(result) if config.definition_lists
           result = preprocess_footnotes(result) if config.footnotes
           result = preprocess_math(result) if config.math
-          result = preprocess_heading_ids(result) if config.heading_ids
+          result = preprocess_heading_ids(result, safe: config.safe) if config.heading_ids
           result
         end
 
@@ -273,17 +273,28 @@ module Hwaro
         # attribute in `postprocess_heading_ids`.
         # Restricting the id charset to `[A-Za-z][\w:-]*` keeps it valid as an
         # HTML id without further escaping.
-        HEADING_ID_RE = /^(\#{1,6})[ \t]+(.+?)[ \t]*\{\#([A-Za-z][\w:-]*)\}[ \t]*$/
+        # CommonMark allows up to 3 leading spaces before an ATX heading, which
+        # we capture and preserve so Markd still recognises the line as a heading.
+        HEADING_ID_RE = /^([ ]{0,3})(\#{1,6})[ \t]+(.+?)[ \t]*\{\#([A-Za-z][\w:-]*)\}[ \t]*$/
+
+        FENCE_BACKTICKS = "```"
+        FENCE_TILDES    = "~~~"
 
         # Walk lines and apply the heading-id transform only outside fenced
         # code blocks, so `## ... {#id}` shown inside a ```` ``` ```` example
         # in the docs renders verbatim.
-        def preprocess_heading_ids(content : String) : String
+        #
+        # Under Markd's safe mode, inline HTML comments are replaced with the
+        # placeholder `<!-- raw HTML omitted -->`, which would both lose the id
+        # *and* leak that placeholder into the heading text. In that case we
+        # strip the `{#id}` syntax silently — custom heading IDs are not
+        # supported alongside `markdown.safe = true`.
+        def preprocess_heading_ids(content : String, *, safe : Bool = false) : String
           return content unless content.includes?("{#")
 
           String.build do |io|
             in_fence = false
-            fence_char = '`'
+            fence_marker = FENCE_BACKTICKS
 
             content.each_line(chomp: false) do |line|
               stripped = line.lstrip
@@ -291,21 +302,25 @@ module Hwaro
               if in_fence
                 # A closing fence is a line whose first non-blank run is the
                 # same fence character repeated 3+ times.
-                if stripped.starts_with?(fence_char.to_s * 3)
+                if stripped.starts_with?(fence_marker)
                   in_fence = false
                 end
                 io << line
-              elsif stripped.starts_with?("```")
+              elsif stripped.starts_with?(FENCE_BACKTICKS)
                 in_fence = true
-                fence_char = '`'
+                fence_marker = FENCE_BACKTICKS
                 io << line
-              elsif stripped.starts_with?("~~~")
+              elsif stripped.starts_with?(FENCE_TILDES)
                 in_fence = true
-                fence_char = '~'
+                fence_marker = FENCE_TILDES
                 io << line
               elsif line.includes?("{#")
                 io << line.gsub(HEADING_ID_RE) do |_|
-                  "#{$1} #{$2.rstrip} <!--HID:#{$3}-->"
+                  if safe
+                    "#{$1}#{$2} #{$3.rstrip}"
+                  else
+                    "#{$1}#{$2} #{$3.rstrip} <!--HID:#{$4}-->"
+                  end
                 end
               else
                 io << line

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -1,4 +1,5 @@
 require "html"
+require "uri"
 require "../../models/config"
 require "../../utils/text_utils"
 
@@ -15,12 +16,17 @@ module Hwaro
           result = preprocess_definition_lists(result) if config.definition_lists
           result = preprocess_footnotes(result) if config.footnotes
           result = preprocess_math(result) if config.math
+          result = preprocess_heading_ids(result) if config.heading_ids
           result
         end
 
         # Post-process HTML after Markd rendering
         def postprocess(html : String, config : Models::MarkdownConfig) : String
           result = html
+          # Admonitions and heading_ids run before footnotes/mermaid so the rewritten
+          # blockquotes/headings carry stable ids before TOC extraction sees them.
+          result = postprocess_admonitions(result) if config.admonitions
+          result = postprocess_heading_ids(result) if config.heading_ids
           result = postprocess_footnotes(result) if config.footnotes
           result = postprocess_mermaid(result) if config.mermaid
           result
@@ -63,13 +69,13 @@ module Hwaro
                   break
                 end
 
-                result << "<dt>#{HTML.escape(term)}</dt>"
+                result << "<dt>#{render_inline_md(term)}</dt>"
                 i += 1
 
                 # Collect definitions for this term
                 while i < lines.size && lines[i].lstrip.starts_with?(": ")
                   definition = lines[i].lstrip.lchop(": ").strip
-                  result << "<dd>#{HTML.escape(definition)}</dd>"
+                  result << "<dd>#{render_inline_md(definition)}</dd>"
                   i += 1
                 end
 
@@ -210,6 +216,197 @@ module Hwaro
             code = $~[1].gsub("&amp;", "&")
             "<div class=\"mermaid\">#{code}</div>"
           end
+        end
+
+        # --- GitHub-style Admonitions ---
+        # Recognised types match GitHub's alert syntax.
+        ADMONITION_TYPES = {"NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"}
+
+        # Captures a blockquote whose first paragraph starts with `[!TYPE]`.
+        # Group 1: type token (uppercased). Group 2: the rest of the blockquote
+        # body, possibly starting with `</p>` (when the marker was on its own
+        # paragraph) or with the inline body content (when the marker shared a
+        # paragraph with body text via a soft break).
+        ADMONITION_BLOCKQUOTE_RE = /<blockquote>\s*<p>\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*(.*?)<\/blockquote>/m
+
+        # Post-processing: rewrite GitHub `> [!TYPE]` blockquotes as admonition divs.
+        # Note: the lazy match against `</blockquote>` means a nested blockquote
+        # inside the admonition will close the match early. Acceptable for v1 —
+        # GitHub admonitions don't support nested blockquotes either.
+        def postprocess_admonitions(html : String) : String
+          return html unless html.includes?("[!")
+
+          html.gsub(ADMONITION_BLOCKQUOTE_RE) do |_|
+            type = $1
+            rest = $2
+            type_lower = type.downcase
+            type_title = type[0].to_s + type[1..].downcase
+
+            body = if rest.lstrip.starts_with?("</p>")
+                     # Marker was alone on its paragraph; remaining content
+                     # already consists of well-formed block elements.
+                     rest.sub(/\A\s*<\/p>\s*/, "").strip
+                   elsif rest.strip.empty?
+                     # Title-only admonition with no body.
+                     ""
+                   else
+                     # Body text shared the marker's paragraph (soft break).
+                     # The closing </p> is already inside `rest`.
+                     "<p>#{rest.lstrip}".strip
+                   end
+
+            String.build do |str|
+              str << %(<div class="admonition admonition-#{type_lower}">\n)
+              str << %(<p class="admonition-title">#{type_title}</p>\n)
+              unless body.empty?
+                str << body
+                str << '\n'
+              end
+              str << "</div>"
+            end
+          end
+        end
+
+        # --- Custom Heading IDs ---
+        # `## My Heading {#custom-id}` → `## My Heading <!--HID:custom-id-->`
+        # The marker survives Markd rendering and is converted to an `id="..."`
+        # attribute in `postprocess_heading_ids`.
+        # Restricting the id charset to `[A-Za-z][\w:-]*` keeps it valid as an
+        # HTML id without further escaping.
+        HEADING_ID_RE = /^(\#{1,6})[ \t]+(.+?)[ \t]*\{\#([A-Za-z][\w:-]*)\}[ \t]*$/
+
+        # Walk lines and apply the heading-id transform only outside fenced
+        # code blocks, so `## ... {#id}` shown inside a ```` ``` ```` example
+        # in the docs renders verbatim.
+        def preprocess_heading_ids(content : String) : String
+          return content unless content.includes?("{#")
+
+          String.build do |io|
+            in_fence = false
+            fence_char = '`'
+
+            content.each_line(chomp: false) do |line|
+              stripped = line.lstrip
+
+              if in_fence
+                # A closing fence is a line whose first non-blank run is the
+                # same fence character repeated 3+ times.
+                if stripped.starts_with?(fence_char.to_s * 3)
+                  in_fence = false
+                end
+                io << line
+              elsif stripped.starts_with?("```")
+                in_fence = true
+                fence_char = '`'
+                io << line
+              elsif stripped.starts_with?("~~~")
+                in_fence = true
+                fence_char = '~'
+                io << line
+              elsif line.includes?("{#")
+                io << line.gsub(HEADING_ID_RE) do |_|
+                  "#{$1} #{$2.rstrip} <!--HID:#{$3}-->"
+                end
+              else
+                io << line
+              end
+            end
+          end
+        end
+
+        HEADING_TAG_FOR_HID_RE = /<(h[1-6])([^>]*)>(.*?)<\/\1>/m
+        HID_MARKER_RE          = /<!--HID:([A-Za-z][\w:-]*)-->/
+        EXISTING_ID_RE         = /\bid\s*=\s*"[^"]*"/i
+        ANY_ID_ATTR_PRESENT_RE = /\bid\s*=/i
+
+        def postprocess_heading_ids(html : String) : String
+          return html unless html.includes?("<!--HID:")
+
+          html.gsub(HEADING_TAG_FOR_HID_RE) do |match|
+            tag = $1
+            attrs = $2
+            inner = $3
+
+            if hid_match = inner.match(HID_MARKER_RE)
+              id = hid_match[1]
+              cleaned_inner = inner.sub(hid_match[0], "").rstrip
+
+              new_attrs = if attrs.matches?(ANY_ID_ATTR_PRESENT_RE)
+                            attrs.sub(EXISTING_ID_RE, %(id="#{id}"))
+                          else
+                            "#{attrs.rstrip} id=\"#{id}\""
+                          end
+
+              "<#{tag}#{new_attrs}>#{cleaned_inner}</#{tag}>"
+            else
+              match
+            end
+          end
+        end
+
+        # --- Inline Markdown Renderer ---
+        # Renders a small subset of inline markdown (code/image/link/bold/italic/
+        # strikethrough) in HTML-escaped text. Used by definition lists so that
+        # `**bold**`/`[link](url)`/`` `code` `` work inside <dt>/<dd> while raw
+        # HTML remains escaped. Mirrors the table-cell renderer in
+        # `table_parser.cr` to keep semantics consistent across both consumers.
+        INLINE_CODE_SPAN_RE         = /`([^`]+)`/
+        INLINE_IMAGE_RE             = /!\[([^\]]*)\]\(([^)]*)\)/
+        INLINE_LINK_RE              = /\[([^\]]+)\]\(([^)]*)\)/
+        INLINE_BOLD_ASTERISK_RE     = /\*\*(.+?)\*\*/
+        INLINE_BOLD_UNDERSCORE_RE   = /__(.+?)__/
+        INLINE_ITALIC_ASTERISK_RE   = /\*(.+?)\*/
+        INLINE_ITALIC_UNDERSCORE_RE = /(?<![a-zA-Z0-9])_(.+?)_(?![a-zA-Z0-9])/
+        INLINE_STRIKETHROUGH_RE     = /~~(.+?)~~/
+
+        private def render_inline_md(text : String) : String
+          result = HTML.escape(text)
+
+          code_spans = [] of String
+          result = result.gsub(INLINE_CODE_SPAN_RE) do
+            code_spans << $1
+            "\x00CODESPAN#{code_spans.size - 1}\x00"
+          end
+
+          result = result.gsub(INLINE_IMAGE_RE) do
+            alt = $1
+            url = $2
+            if safe_inline_url?(url)
+              %(<img src="#{HTML.escape(url)}" alt="#{HTML.escape(alt)}">)
+            else
+              "![#{alt}](#{url})"
+            end
+          end
+
+          result = result.gsub(INLINE_LINK_RE) do
+            link_text = $1
+            url = $2
+            if safe_inline_url?(url)
+              %(<a href="#{HTML.escape(url)}">#{link_text}</a>)
+            else
+              "[#{link_text}](#{url})"
+            end
+          end
+
+          result = result.gsub(INLINE_BOLD_ASTERISK_RE) { "<strong>#{$1}</strong>" }
+          result = result.gsub(INLINE_BOLD_UNDERSCORE_RE) { "<strong>#{$1}</strong>" }
+          result = result.gsub(INLINE_ITALIC_ASTERISK_RE) { "<em>#{$1}</em>" }
+          result = result.gsub(INLINE_ITALIC_UNDERSCORE_RE) { "<em>#{$1}</em>" }
+          result = result.gsub(INLINE_STRIKETHROUGH_RE) { "<del>#{$1}</del>" }
+
+          code_spans.each_with_index do |content, idx|
+            result = result.gsub("\x00CODESPAN#{idx}\x00", "<code>#{content}</code>")
+          end
+
+          result
+        end
+
+        private def safe_inline_url?(url : String) : Bool
+          stripped = url.strip.downcase
+          decoded = URI.decode(stripped)
+          return true if decoded.starts_with?("http://") || decoded.starts_with?("https://") || decoded.starts_with?("mailto:")
+          return true if decoded.starts_with?("/") || decoded.starts_with?("#") || decoded.starts_with?("./") || decoded.starts_with?("../")
+          !decoded.includes?(":")
         end
       end
     end

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -523,6 +523,8 @@ module Hwaro
       property mermaid : Bool          # If true, renders ```mermaid blocks as diagrams
       property math : Bool             # If true, enables math syntax ($...$ and $$...$$)
       property math_engine : String    # "katex" or "mathjax"
+      property admonitions : Bool      # If true, GitHub-style `> [!NOTE]` blockquotes become admonition <div>s
+      property heading_ids : Bool      # If true, `## Heading {#custom-id}` sets an explicit id
 
       def initialize
         @safe = false
@@ -534,6 +536,8 @@ module Hwaro
         @mermaid = false
         @math = false
         @math_engine = "katex"
+        @admonitions = true
+        @heading_ids = true
       end
     end
 
@@ -1197,6 +1201,8 @@ module Hwaro
         if engine = s["math_engine"]?.try(&.as_s?)
           config.markdown.math_engine = engine
         end
+        config.markdown.admonitions = bool_value(s["admonitions"]?, config.markdown.admonitions)
+        config.markdown.heading_ids = bool_value(s["heading_ids"]?, config.markdown.heading_ids)
       end
 
       private def self.load_series(config : Config)

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -684,6 +684,8 @@ module Hwaro
             # safe = false
             # lazy_loading = false
             # emoji = false
+            # admonitions = true
+            # heading_ids = true
 
             TOML
         else
@@ -698,6 +700,8 @@ module Hwaro
             safe = false          # If true, raw HTML in markdown will be stripped (replaced by comments)
             lazy_loading = false  # If true, automatically add loading="lazy" to img tags
             emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoji characters
+            admonitions = true    # If true, GitHub-style `> [!NOTE]` blockquotes render as admonitions
+            heading_ids = true    # If true, `## Heading {#custom-id}` sets an explicit id
 
             TOML
         end


### PR DESCRIPTION
## Summary

Bundles three small but high-impact Markdown extensions:

- **GitHub-style admonitions** — `> [!NOTE|TIP|IMPORTANT|WARNING|CAUTION]` blockquotes render as `<div class="admonition admonition-{type}">` with a title paragraph + body. Handles single-paragraph (`> [!NOTE]\n> body`), separate-paragraph, and title-only forms.
- **Custom heading IDs** — `## Heading {#custom-id}` sets an explicit `id`, used by anchors and the TOC. Fenced code blocks (` ``` ` / `~~~`) are skipped so doc examples render verbatim.
- **Definition list inline markdown** — `<dt>`/`<dd>` content now renders `**bold**`, `*italic*`, `` `code` ``, `[link](url)`, `![img](url)`, `~~strike~~`. Raw HTML is still escaped; `javascript:` URLs are still rejected.

Both new behaviours are gated by `[markdown]` config flags (`admonitions`, `heading_ids`), default `true`. New TOML snippet entries are added to scaffold output and `hwaro doctor`.

## Implementation notes

- Admonition rewrite is post-process (operates on Markd output) — nested blockquotes inside an admonition are not supported in v1; documented in the inline comment.
- Heading-id transform is preprocess: marker comment (`<!--HID:id-->`) injected on the heading line, postprocess applies the id to the rendered tag. Postprocess runs before TOC extraction so anchors line up.
- Inline-md helper used by definition lists mirrors the existing table-cell renderer in `table_parser.cr` so both behave consistently.

## Test plan

- [x] `crystal spec` — 4784 examples, 0 failures (24 new specs added)
- [x] `bin/hwaro build -i docs` — confirmed `## ... {#install}` inside a fenced code block renders verbatim, while real headings get the custom id
- [x] `just fix` clean
- [ ] Manual review of admonition CSS once a docs theme is updated