### PR TITLE
fix(markdown): apply heading id dedup to HTML, not just TOC

### DIFF
--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -609,21 +609,26 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
   end
 
   describe "heading ids (TOC dedup)" do
-    # Locks current pre-existing behaviour in markdown.cr: when an `existing_id`
-    # is detected on a heading (which now includes ones we set from `{#id}`),
-    # the TOC entry gets a deduped id but the rendered HTML keeps the original
-    # id verbatim. This means duplicate `{#id}` produce duplicate id attributes
-    # and a broken TOC anchor for the second entry. Pre-existing limitation —
-    # tracked separately from this PR.
-    it "produces duplicate ids in HTML when the user writes the same {#id} twice" do
+    it "de-duplicates identical custom IDs across both HTML and TOC" do
       cfg = make_config(heading_ids: true)
       content = "## A {#x}\n\nbody\n\n## B {#x}\n\nbody2\n"
       html, toc = Hwaro::Content::Processors::Markdown.new.render_with_anchors(
         content, markdown_config: cfg)
-      html.scan(/<h2 id="x">/).size.should eq(2)
+      html.scan(/<h2 id="x">/).size.should eq(1)
+      html.scan(/<h2 id="x-1">/).size.should eq(1)
       toc.size.should eq(2)
       toc[0].id.should eq("x")
-      toc[1].id.should eq("x-1") # TOC dedup, even though the HTML id wasn't updated
+      toc[1].id.should eq("x-1")
+    end
+
+    it "de-duplicates raw HTML headings that share an existing id" do
+      content = %(<h2 id="dup">First</h2>\n\n<h2 id="dup">Second</h2>\n)
+      html, toc = Hwaro::Content::Processors::Markdown.new.render_with_anchors(content)
+      html.scan(/id="dup"/).size.should eq(1)
+      html.should contain(%(id="dup-1"))
+      toc.size.should eq(2)
+      toc[0].id.should eq("dup")
+      toc[1].id.should eq("dup-1")
     end
   end
 

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -705,9 +705,17 @@ module Hwaro
               end
               stack.push(toc_item)
 
-              # Rebuild the tag, injecting id if it was missing
+              # Rebuild the tag. When the heading already had an id and the
+              # dedup loop didn't touch it, the original markup is returned
+              # verbatim. Otherwise we rewrite — either replacing a duplicated
+              # existing id with its suffixed form, or injecting a fresh id.
               if existing_id
-                match # Return unchanged
+                if id == existing_id
+                  match
+                else
+                  new_attrs = attrs.sub(ID_ATTR_REGEX, %(id="#{id}"))
+                  "<#{tag_name}#{new_attrs}>#{inner_html}</#{tag_name}>"
+                end
               else
                 "<#{tag_name}#{attrs} id=\"#{id}\">#{inner_html}</#{tag_name}>"
               end


### PR DESCRIPTION
## Summary

Fix a pre-existing bug in `markdown.cr#post_process_html` surfaced while reviewing #520:

When a heading already carried an `id` attribute — either from raw HTML or from a `{#custom-id}` annotation — the dedup loop computed a suffixed id for the TOC entry but returned the heading markup verbatim. The HTML therefore kept the duplicate `id`, and the corresponding TOC anchor (`#name-1`) pointed to nothing.

Now we rewrite the tag whenever the deduped id differs from the original, substituting the existing `id="..."` attribute via `ID_ATTR_REGEX`. Headings whose id wasn't touched by dedup are still returned unchanged.

## Test plan

- [x] Flips the test added in #520 that locked the buggy behaviour to assert the corrected output instead.
- [x] Adds a coverage test for two raw-HTML `<h2 id="dup">` siblings — the second now becomes `id="dup-1"` and the TOC entry matches.
- [x] `crystal spec` — 4791 examples, 0 failures.
- [x] `just fix` clean.