### PR TITLE
fix(serve): emit ACAO:* so localhost/127.0.0.1 fetches don't break

### DIFF
--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -246,6 +246,63 @@ describe Hwaro::Services::NotFoundHandler do
   end
 end
 
+describe Hwaro::Services::DevCorsHandler do
+  it "sets Access-Control-Allow-Origin on a normal request and passes through" do
+    handler = Hwaro::Services::DevCorsHandler.new
+    dummy = DummyHandler.new
+    handler.next = dummy
+
+    request = HTTP::Request.new("GET", "/search_index.json")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler.call(context)
+
+    response.headers["Access-Control-Allow-Origin"].should eq("*")
+    dummy.called.should be_true
+  end
+
+  it "short-circuits OPTIONS preflight with 204 and CORS headers" do
+    handler = Hwaro::Services::DevCorsHandler.new
+    dummy = DummyHandler.new
+    handler.next = dummy
+
+    request = HTTP::Request.new(
+      "OPTIONS",
+      "/search_index.json",
+      HTTP::Headers{"Access-Control-Request-Headers" => "content-type"},
+    )
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler.call(context)
+
+    response.status_code.should eq(204)
+    response.headers["Access-Control-Allow-Origin"].should eq("*")
+    response.headers["Access-Control-Allow-Methods"].should eq("GET, HEAD, OPTIONS")
+    response.headers["Access-Control-Allow-Headers"].should eq("content-type")
+    response.headers["Access-Control-Max-Age"].should eq("86400")
+    dummy.called.should be_false
+  end
+
+  it "falls back to * for Access-Control-Allow-Headers when preflight omits the request" do
+    handler = Hwaro::Services::DevCorsHandler.new
+    dummy = DummyHandler.new
+    handler.next = dummy
+
+    request = HTTP::Request.new("OPTIONS", "/search_index.json")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler.call(context)
+
+    response.headers["Access-Control-Allow-Headers"].should eq("*")
+  end
+end
+
 describe Hwaro::Services::ChangeSet do
   describe "#empty?" do
     it "returns true when nothing changed" do

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -80,6 +80,34 @@ module Hwaro
       end
     end
 
+    # Emits `Access-Control-Allow-Origin: *` on every dev-server response so
+    # a site loaded via one local hostname can still `fetch()` resources
+    # served under another — the canonical example being `localhost:3000`
+    # in the address bar while `{{ base_url }}` was baked as
+    # `http://127.0.0.1:3000` (the default bind). Same-origin policy treats
+    # those as different origins and would otherwise block the fetch.
+    #
+    # Dev-only: the built output is untouched. Matches what other SSG dev
+    # servers do (Zola, Hugo).
+    class DevCorsHandler
+      include HTTP::Handler
+
+      def call(context)
+        context.response.headers["Access-Control-Allow-Origin"] = "*"
+
+        if context.request.method == "OPTIONS"
+          requested_headers = context.request.headers["Access-Control-Request-Headers"]?
+          context.response.headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
+          context.response.headers["Access-Control-Allow-Headers"] = requested_headers || "*"
+          context.response.headers["Access-Control-Max-Age"] = "86400"
+          context.response.status_code = 204
+          return
+        end
+
+        call_next(context)
+      end
+    end
+
     # `HTTP::StaticFileHandler` derives `Content-Type` from the file
     # extension via `MIME.from_extension` and writes it without a
     # charset parameter — so `robots.txt` / `llms.txt` / sitemap and
@@ -319,6 +347,12 @@ module Hwaro
 
         handlers = [] of HTTP::Handler
         handlers << HTTP::LogHandler.new if access_log
+        # Set CORS headers first so they apply to every downstream response,
+        # including 301 redirects from IndexRewriteHandler and 404s from
+        # NotFoundHandler. Without this, opening the site via `localhost`
+        # while base_url is baked as `127.0.0.1` (or vice versa) makes
+        # browser fetch() calls fail same-origin checks.
+        handlers << DevCorsHandler.new
         # Run before StaticFileHandler so we can append `; charset=utf-8`
         # to text-shaped Content-Type headers after the static handler
         # sets them — Crystal's `HTTP::Server::Response` buffers the


### PR DESCRIPTION
## Summary
- `hwaro serve` binds to `127.0.0.1` and bakes that into `base_url`, so a template doing `fetch(\"{{ base_url }}/search_index.json\")` fails CORS when the developer opens the site via `localhost:3000` (different origin under SOP).
- Add a dev-only `DevCorsHandler` that sets `Access-Control-Allow-Origin: *` on every response and answers OPTIONS preflight with 204. Built output is untouched.
- Wired before `IndexRewriteHandler` / `StaticFileHandler` / `NotFoundHandler`, so redirects and 404s also carry the header.

Implements option 1 from #531 — matches what other SSG dev servers do (Zola, Hugo).

Fixes #531

## Test plan
- [x] `crystal spec spec/unit/server_spec.cr` (4 new cases for `DevCorsHandler`, 110 examples pass)
- [x] `crystal spec spec/unit` — full unit suite passes (4491 examples)
- [x] Manual smoke test:
  - `GET /` → 200 with `Access-Control-Allow-Origin: *`
  - `GET /missing` → 404 with `Access-Control-Allow-Origin: *`
  - `OPTIONS /` with `Access-Control-Request-Headers: content-type` → 204 with `ACAO:*`, `Allow-Methods: GET, HEAD, OPTIONS`, `Allow-Headers: content-type`, `Max-Age: 86400`