### PR TITLE
fix(serve): republish overwritten content/ assets on the watch loop

### DIFF
--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -801,6 +801,62 @@ describe Hwaro::Services::ChangeSet do
       )
       cs.rebuild_strategy.should eq(:content_and_template)
     end
+
+    it "returns :content_files when only content assets changed" do
+      cs = Hwaro::Services::ChangeSet.new(
+        modified_content: [] of String,
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: [] of String,
+        removed_files: [] of String,
+        config_changed: false,
+        modified_content_files: ["content/projects/foo/cover.jpg"],
+      )
+      cs.rebuild_strategy.should eq(:content_files)
+    end
+  end
+
+  describe "#content_files_only?" do
+    it "returns true when only non-Markdown content assets changed" do
+      cs = Hwaro::Services::ChangeSet.new(
+        modified_content: [] of String,
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: [] of String,
+        removed_files: [] of String,
+        config_changed: false,
+        modified_content_files: ["content/projects/foo/cover.jpg"],
+      )
+      cs.content_files_only?.should be_true
+      cs.empty?.should be_false
+    end
+
+    it "returns false when a markdown file also changed" do
+      cs = Hwaro::Services::ChangeSet.new(
+        modified_content: ["content/projects/foo/index.md"],
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: [] of String,
+        removed_files: [] of String,
+        config_changed: false,
+        modified_content_files: ["content/projects/foo/cover.jpg"],
+      )
+      cs.content_files_only?.should be_false
+    end
+
+    it "returns false when a structural change is present" do
+      cs = Hwaro::Services::ChangeSet.new(
+        modified_content: [] of String,
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: ["content/projects/bar/new.jpg"],
+        removed_files: [] of String,
+        config_changed: false,
+        modified_content_files: ["content/projects/foo/cover.jpg"],
+      )
+      cs.content_files_only?.should be_false
+      cs.needs_full_rebuild?.should be_true
+    end
   end
 
   describe "#description" do
@@ -1065,6 +1121,44 @@ describe "Server#detect_changes" do
     cs.modified_templates.should be_empty
     cs.content_incremental?.should be_true
   end
+
+  it "routes overwritten non-Markdown content files into modified_content_files (gh#530)" do
+    server = Hwaro::Services::Server.new
+    t1 = Time.utc(2025, 1, 1, 0, 0, 0)
+    t2 = Time.utc(2025, 1, 1, 0, 0, 5)
+
+    old = {"content/projects/foo/cover.jpg" => t1}
+    new_m = {"content/projects/foo/cover.jpg" => t2}
+
+    cs = server.test_detect_changes(old, new_m)
+    cs.modified_content_files.should eq(["content/projects/foo/cover.jpg"])
+    cs.modified_content.should be_empty
+    cs.modified_static.should be_empty
+    cs.added_files.should be_empty
+    cs.content_files_only?.should be_true
+    cs.rebuild_strategy.should eq(:content_files)
+  end
+
+  it "separates markdown and image changes under the same content directory" do
+    server = Hwaro::Services::Server.new
+    t1 = Time.utc(2025, 1, 1, 0, 0, 0)
+    t2 = Time.utc(2025, 1, 1, 0, 0, 5)
+
+    old = {
+      "content/projects/foo/index.md"  => t1,
+      "content/projects/foo/cover.jpg" => t1,
+    }
+    new_m = {
+      "content/projects/foo/index.md"  => t2,
+      "content/projects/foo/cover.jpg" => t2,
+    }
+
+    cs = server.test_detect_changes(old, new_m)
+    cs.modified_content.should eq(["content/projects/foo/index.md"])
+    cs.modified_content_files.should eq(["content/projects/foo/cover.jpg"])
+    cs.content_files_only?.should be_false
+    cs.content_incremental?.should be_true
+  end
 end
 
 describe "Builder incremental methods" do
@@ -1132,6 +1226,109 @@ describe "Builder incremental methods" do
             output_dir,
             false
           )
+        end
+      end
+    end
+  end
+
+  describe "#copy_changed_content_files" do
+    it "republishes an in-place overwritten image (gh#530)" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "content", "projects", "foo"))
+        FileUtils.mkdir_p(File.join(dir, "templates"))
+
+        File.write(File.join(dir, "config.toml"), <<-TOML
+          title = "Test"
+          base_url = "http://localhost"
+
+          [content.files]
+          allow_extensions = ["jpg", "png"]
+          TOML
+        )
+        File.write(File.join(dir, "templates", "page.html"), "{{ content }}")
+        File.write(File.join(dir, "content", "projects", "foo", "_index.md"),
+          "---\ntitle: Foo\n---\n")
+        File.write(File.join(dir, "content", "projects", "foo", "cover.jpg"), "OLD")
+
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+          options = Hwaro::Config::Options::BuildOptions.new
+          builder.run(options)
+
+          published = File.join(dir, "public", "projects", "foo", "cover.jpg")
+          File.read(published).should eq("OLD")
+
+          # Simulate the bug repro: overwrite the image in place, then ask
+          # the watcher's republish path to update output.
+          File.write(File.join(dir, "content", "projects", "foo", "cover.jpg"), "NEW")
+          builder.copy_changed_content_files(
+            ["content/projects/foo/cover.jpg"],
+            File.join(dir, "public"),
+            false,
+          )
+
+          File.read(published).should eq("NEW")
+        end
+      end
+    end
+
+    it "refuses to publish files whose extension isn't allowed" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "content"))
+        FileUtils.mkdir_p(File.join(dir, "templates"))
+
+        File.write(File.join(dir, "config.toml"), <<-TOML
+          title = "Test"
+          base_url = "http://localhost"
+
+          [content.files]
+          allow_extensions = ["jpg"]
+          TOML
+        )
+        File.write(File.join(dir, "templates", "page.html"), "{{ content }}")
+        File.write(File.join(dir, "content", "secret.psd"), "binary")
+
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+          options = Hwaro::Config::Options::BuildOptions.new
+          builder.run(options)
+
+          builder.copy_changed_content_files(
+            ["content/secret.psd"],
+            File.join(dir, "public"),
+            false,
+          )
+
+          File.exists?(File.join(dir, "public", "secret.psd")).should be_false
+        end
+      end
+    end
+
+    it "is a no-op when content.files is disabled" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "content"))
+        FileUtils.mkdir_p(File.join(dir, "templates"))
+
+        File.write(File.join(dir, "config.toml"),
+          "title = \"Test\"\nbase_url = \"http://localhost\"\n")
+        File.write(File.join(dir, "templates", "page.html"), "{{ content }}")
+        File.write(File.join(dir, "content", "cover.jpg"), "bytes")
+
+        Dir.cd(dir) do
+          builder = Hwaro::Core::Build::Builder.new
+          Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+          options = Hwaro::Config::Options::BuildOptions.new
+          builder.run(options)
+
+          builder.copy_changed_content_files(
+            ["content/cover.jpg"],
+            File.join(dir, "public"),
+            false,
+          )
+
+          File.exists?(File.join(dir, "public", "cover.jpg")).should be_false
         end
       end
     end

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -727,6 +727,34 @@ describe Hwaro::Services::ChangeSet do
       merged = cs1.merge(cs2)
       merged.removed_files.should eq(["content/old.md", "content/other.md"])
     end
+
+    it "merges modified_content_files with deduplication" do
+      cs1 = Hwaro::Services::ChangeSet.new(
+        modified_content: [] of String,
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: [] of String,
+        removed_files: [] of String,
+        config_changed: false,
+        modified_content_files: ["content/projects/a/cover.jpg"],
+      )
+      cs2 = Hwaro::Services::ChangeSet.new(
+        modified_content: [] of String,
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: [] of String,
+        removed_files: [] of String,
+        config_changed: false,
+        modified_content_files: ["content/projects/a/cover.jpg", "content/projects/b/cover.png"],
+      )
+
+      merged = cs1.merge(cs2)
+      merged.modified_content_files.should eq([
+        "content/projects/a/cover.jpg",
+        "content/projects/b/cover.png",
+      ])
+      merged.content_files_only?.should be_true
+    end
   end
 
   describe "#rebuild_strategy" do

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -537,8 +537,11 @@ module Hwaro
         #
         # Skips files whose extension isn't permitted by `[content.files]`, so
         # the watcher can't smuggle a `.md` or a disallowed type into output.
-        # Falls back to a full build when the config hasn't been loaded yet
-        # (cold serve), since there's no allowlist to check against.
+        # No-ops when `[content.files]` isn't enabled — nothing was published
+        # in the first place, so there's nothing to refresh. (`@config` is nil
+        # only before the initial build, which `Server#run_with_options`
+        # already performs before spawning the watcher, so the watcher always
+        # sees a loaded config.)
         def copy_changed_content_files(changed_files : Array(String), output_dir : String, verbose : Bool = false)
           config = @config
           unless config && config.content_files.enabled?

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -530,6 +530,49 @@ module Hwaro
           Logger.success "Copied #{copied} static file(s)." if copied > 0
         end
 
+        # Republish non-Markdown content assets (images, etc.) to the output
+        # directory, preserving their path relative to `content/`. Mirrors what
+        # the full build does via the raw-files path in the Write phase, but
+        # only touches the files the watcher actually flagged as changed.
+        #
+        # Skips files whose extension isn't permitted by `[content.files]`, so
+        # the watcher can't smuggle a `.md` or a disallowed type into output.
+        # Falls back to a full build when the config hasn't been loaded yet
+        # (cold serve), since there's no allowlist to check against.
+        def copy_changed_content_files(changed_files : Array(String), output_dir : String, verbose : Bool = false)
+          config = @config
+          unless config && config.content_files.enabled?
+            Logger.debug "  Content-file republish skipped — content.files not enabled."
+            return
+          end
+
+          copied = 0
+          changed_files.each do |src_path|
+            next unless File.exists?(src_path)
+            next if File.directory?(src_path)
+
+            relative = begin
+              Path[src_path].relative_to("content").to_s
+            rescue ArgumentError
+              src_path.lchop("content/")
+            end
+
+            next unless config.content_files.publish?(relative)
+
+            dest_path = File.join(output_dir, relative)
+            unless Utils::OutputGuard.within_output_dir?(dest_path, output_dir)
+              Logger.warn "Skipping content file outside output directory: #{relative}"
+              next
+            end
+
+            FileUtils.mkdir_p(File.dirname(dest_path))
+            FileUtils.cp(src_path, dest_path)
+            Logger.action :copy, dest_path, :blue if verbose
+            copied += 1
+          end
+          Logger.success "Copied #{copied} content file(s)." if copied > 0
+        end
+
         def run(
           output_dir : String = "public",
           base_url : String? = nil,

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -156,11 +156,16 @@ module Hwaro
 
     # Categorised set of file-system changes detected by the watcher.
     #
-    # Changes are split into four buckets so the server can pick the
+    # Changes are split into five buckets so the server can pick the
     # cheapest rebuild strategy.
     struct ChangeSet
       # Content files (.md under content/) that were *modified* (not added/deleted)
       getter modified_content : Array(String)
+      # Non-Markdown files under content/ (images and other assets published
+      # via `[content.files] allow_extensions`) that were *modified*. These
+      # are not pages — they're copied 1:1 to the output dir on rebuild, so
+      # they can't ride the incremental page pipeline.
+      getter modified_content_files : Array(String)
       # Template files that were *modified*
       getter modified_templates : Array(String)
       # Static files that were *modified*
@@ -179,12 +184,14 @@ module Hwaro
         @added_files : Array(String),
         @removed_files : Array(String),
         @config_changed : Bool,
+        @modified_content_files : Array(String) = [] of String,
       )
       end
 
       # True when the change set is empty (nothing actually changed)
       def empty? : Bool
         @modified_content.empty? &&
+          @modified_content_files.empty? &&
           @modified_templates.empty? &&
           @modified_static.empty? &&
           @added_files.empty? &&
@@ -203,6 +210,7 @@ module Hwaro
       def templates_only? : Bool
         !@modified_templates.empty? &&
           @modified_content.empty? &&
+          @modified_content_files.empty? &&
           @modified_static.empty? &&
           @added_files.empty? &&
           @removed_files.empty? &&
@@ -213,7 +221,20 @@ module Hwaro
       def static_only? : Bool
         !@modified_static.empty? &&
           @modified_content.empty? &&
+          @modified_content_files.empty? &&
           @modified_templates.empty? &&
+          @added_files.empty? &&
+          @removed_files.empty? &&
+          !@config_changed
+      end
+
+      # True when only non-Markdown content files were modified — just
+      # republish them, no markdown re-parsing, no template re-render.
+      def content_files_only? : Bool
+        !@modified_content_files.empty? &&
+          @modified_content.empty? &&
+          @modified_templates.empty? &&
+          @modified_static.empty? &&
           @added_files.empty? &&
           @removed_files.empty? &&
           !@config_changed
@@ -260,6 +281,7 @@ module Hwaro
 
         ChangeSet.new(
           modified_content: (@modified_content + other.modified_content).uniq,
+          modified_content_files: (@modified_content_files + other.modified_content_files).uniq,
           modified_templates: (@modified_templates + other.modified_templates).uniq,
           modified_static: (@modified_static + other.modified_static).uniq,
           added_files: net_added,
@@ -280,6 +302,8 @@ module Hwaro
           :incremental
         elsif static_only?
           :static
+        elsif content_files_only?
+          :content_files
         else
           :full
         end
@@ -289,6 +313,7 @@ module Hwaro
       def description : String
         parts = [] of String
         parts << "#{@modified_content.size} content" unless @modified_content.empty?
+        parts << "#{@modified_content_files.size} content-asset" unless @modified_content_files.empty?
         parts << "#{@modified_templates.size} template" unless @modified_templates.empty?
         parts << "#{@modified_static.size} static" unless @modified_static.empty?
         parts << "#{@added_files.size} added" unless @added_files.empty?
@@ -532,6 +557,7 @@ module Hwaro
         new_mtimes : Hash(String, Time),
       ) : ChangeSet
         modified_content = [] of String
+        modified_content_files = [] of String
         modified_templates = [] of String
         modified_static = [] of String
         added_files = [] of String
@@ -546,7 +572,7 @@ module Hwaro
             if path == "config.toml"
               config_changed = true
             else
-              classify_modified(path, modified_content, modified_templates, modified_static)
+              classify_modified(path, modified_content, modified_content_files, modified_templates, modified_static)
             end
           else
             # New file (exists now, didn't before)
@@ -563,6 +589,7 @@ module Hwaro
 
         ChangeSet.new(
           modified_content: modified_content,
+          modified_content_files: modified_content_files,
           modified_templates: modified_templates,
           modified_static: modified_static,
           added_files: added_files,
@@ -572,14 +599,24 @@ module Hwaro
       end
 
       # Put a modified path into the right bucket.
+      #
+      # Non-Markdown files under `content/` (images, PDFs, anything copied via
+      # `[content.files] allow_extensions`) used to land in `content` and then
+      # get silently dropped by `run_incremental` because they have no `Page`
+      # entry. They now go into their own bucket and are republished verbatim.
       private def classify_modified(
         path : String,
         content : Array(String),
+        content_files : Array(String),
         templates : Array(String),
         static : Array(String),
       )
         if path.starts_with?("content/")
-          content << path
+          if path.downcase.ends_with?(".md")
+            content << path
+          else
+            content_files << path
+          end
         elsif path.starts_with?("templates/")
           templates << path
         elsif path.starts_with?("static/")
@@ -603,11 +640,22 @@ module Hwaro
           @builder.run_incremental_then_rerender(changeset.modified_content, build_options)
         when :static
           copy_static(changeset, build_options)
+        when :content_files
+          copy_content_files(changeset, build_options)
         end
 
         # Copy static files if they changed alongside content/template changes
         if strategy != :static && strategy != :full && !changeset.modified_static.empty?
           copy_static(changeset, build_options)
+        end
+
+        # Republish non-Markdown content assets whenever they accompany any
+        # rebuild that wasn't a full one. A full build already re-copies them
+        # via the ReadContent → Write raw-files path; for incremental,
+        # templates-only, and static-only strategies, the watcher has to do
+        # it explicitly or the served bytes stay stale (issue #530).
+        if strategy != :content_files && strategy != :full && !changeset.modified_content_files.empty?
+          copy_content_files(changeset, build_options)
         end
 
         @live_reload_handler.try(&.notify_reload)
@@ -616,6 +664,11 @@ module Hwaro
       private def copy_static(changeset : ChangeSet, build_options : Config::Options::BuildOptions)
         output_dir = sanitize_output_dir(build_options.output_dir)
         @builder.copy_changed_static(changeset.modified_static, output_dir, build_options.verbose)
+      end
+
+      private def copy_content_files(changeset : ChangeSet, build_options : Config::Options::BuildOptions)
+        output_dir = sanitize_output_dir(build_options.output_dir)
+        @builder.copy_changed_content_files(changeset.modified_content_files, output_dir, build_options.verbose)
       end
 
       private def open_browser_url(url : String)


### PR DESCRIPTION
## Summary
- Closes #530. `hwaro serve` now reflects in-place image overwrites under `content/` without a restart.
- Non-Markdown files were silently dropped by `run_incremental` because they have no matching `Page`. They now route through a dedicated `:content_files` strategy that re-copies them via the same validation the full build uses.
- `Builder#copy_changed_content_files` re-checks `config.content_files.publish?` for every path, so the watcher can't smuggle disallowed extensions (e.g. `.psd`) or `.md` files into output.

Out-of-scope: when `[image_processing]` is enabled, resized variants (`cover_800w.jpg`, …) stay stale until the next full rebuild. The issue's repro only covers the base path; expanding to variants is a separate change.

## Test plan
- [x] `just test` (4842 examples, 0 failures) covers the new `ChangeSet` bucket, `content_files_only?`, `rebuild_strategy == :content_files`, `Server#detect_changes` routing for non-md content paths, and the `Builder#copy_changed_content_files` happy path / disallowed-extension / disabled-config branches.
- [x] Manual repro per the issue: cold-serve with `[content.files] allow_extensions = ["jpg"]`, `printf OLD > content/projects/foo/cover.jpg`, then `printf NEW > …` mid-session. Before fix: served `OLD` until restart. After fix: served `NEW` once the watch loop logs `Strategy: content_files`.