### PR TITLE
feat(serve): add --fast-start to defer non-priority pages

### DIFF
--- a/spec/unit/phases_render_spec.cr
+++ b/spec/unit/phases_render_spec.cr
@@ -31,6 +31,10 @@ module Hwaro::Core::Build
     def test_build_global_vars(site : Models::Site)
       build_global_vars(site)
     end
+
+    def test_split_priority_pages(pages : Array(Models::Page), count : Int32)
+      split_priority_pages(pages, count)
+    end
   end
 end
 
@@ -362,6 +366,100 @@ describe Hwaro::Core::Build::Phases::Render do
       first_sub = subsections.first.raw.as(Hash)
       first_sub["name"].raw.should eq("posts/cli-series")
       first_sub["pages_count"].raw.should eq(1)
+    end
+  end
+
+  # `split_priority_pages` underpins `--fast-start` — it picks the page
+  # subset that gets rendered before the dev server binds the port and
+  # defers the rest to a background fiber. Wrong partitioning either
+  # makes ready-time regress (too many pages priority) or makes obvious
+  # URLs 404 until the background finishes (homepage in deferred).
+  describe "#split_priority_pages" do
+    it "returns everything as priority when total page count is <= count" do
+      builder = Hwaro::Core::Build::Builder.new
+      pages = [
+        Hwaro::Models::Page.new("a.md"),
+        Hwaro::Models::Page.new("b.md"),
+      ]
+      priority, deferred = builder.test_split_priority_pages(pages, 5)
+      priority.should eq(pages)
+      deferred.empty?.should be_true
+    end
+
+    it "always puts section index pages in priority regardless of date" do
+      builder = Hwaro::Core::Build::Builder.new
+      home = Hwaro::Models::Page.new("_index.md")
+      home.is_index = true
+      home.date = nil
+
+      section_idx = Hwaro::Models::Page.new("posts/_index.md")
+      section_idx.is_index = true
+      section_idx.date = Time.utc(2000, 1, 1)
+
+      recent = Hwaro::Models::Page.new("posts/new.md")
+      recent.date = Time.utc(2026, 5, 1)
+
+      old = Hwaro::Models::Page.new("posts/old.md")
+      old.date = Time.utc(2024, 1, 1)
+
+      undated = Hwaro::Models::Page.new("about.md")
+      undated.date = nil
+
+      pages = [home, section_idx, recent, old, undated]
+      priority, deferred = builder.test_split_priority_pages(pages, 1)
+
+      priority.includes?(home).should be_true
+      priority.includes?(section_idx).should be_true
+      # With count=1 only the most recent regular post is included
+      priority.includes?(recent).should be_true
+      priority.includes?(old).should be_false
+      priority.includes?(undated).should be_false
+      # Deferred must contain exactly the leftovers
+      deferred.sort_by(&.path).should eq([old, undated].sort_by(&.path))
+    end
+
+    it "sorts regular pages by date descending, nil-dated pages last" do
+      builder = Hwaro::Core::Build::Builder.new
+      a = Hwaro::Models::Page.new("a.md")
+      a.date = Time.utc(2026, 5, 1)
+      b = Hwaro::Models::Page.new("b.md")
+      b.date = Time.utc(2024, 1, 1)
+      c = Hwaro::Models::Page.new("c.md")
+      c.date = nil
+      d = Hwaro::Models::Page.new("d.md")
+      d.date = Time.utc(2025, 6, 1)
+
+      pages = [b, c, a, d] # input order intentionally scrambled
+      priority, deferred = builder.test_split_priority_pages(pages, 2)
+      # Top 2 by date desc: a (2026), d (2025)
+      priority.includes?(a).should be_true
+      priority.includes?(d).should be_true
+      priority.size.should eq(2)
+      # nil-dated falls into deferred ahead of dated b? No — both deferred
+      deferred.includes?(b).should be_true
+      deferred.includes?(c).should be_true
+    end
+
+    it "preserves the original input order in the priority list" do
+      builder = Hwaro::Core::Build::Builder.new
+      a = Hwaro::Models::Page.new("a.md")
+      a.date = Time.utc(2026, 5, 1)
+      b = Hwaro::Models::Page.new("b.md")
+      b.is_index = true
+      c = Hwaro::Models::Page.new("c.md")
+      c.date = Time.utc(2024, 1, 1)
+
+      pages = [a, b, c] # b is section index, a is most recent
+      priority, _deferred = builder.test_split_priority_pages(pages, 1)
+      # Priority should contain a and b, ordered as they appeared in input
+      priority.should eq([a, b])
+    end
+
+    it "handles an empty input gracefully" do
+      builder = Hwaro::Core::Build::Builder.new
+      priority, deferred = builder.test_split_priority_pages([] of Hwaro::Models::Page, 5)
+      priority.empty?.should be_true
+      deferred.empty?.should be_true
     end
   end
 end

--- a/spec/unit/serve_command_spec.cr
+++ b/spec/unit/serve_command_spec.cr
@@ -163,6 +163,46 @@ describe Hwaro::CLI::Commands::ServeCommand do
       build_options.memory_limit.should eq("2G")
       build_options.streaming?.should be_true
     end
+
+    it "defaults fast_start to false" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options([] of String)
+      options.fast_start.should be_false
+      options.fast_start_count.should eq(20)
+    end
+
+    it "enables fast_start when --fast-start is passed" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options(["--fast-start"])
+      options.fast_start.should be_true
+      options.fast_start_count.should eq(20)
+    end
+
+    it "parses --fast-start-count and implies --fast-start" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options(["--fast-start-count", "50"])
+      options.fast_start.should be_true
+      options.fast_start_count.should eq(50)
+    end
+
+    it "raises HwaroError(HWARO_E_USAGE) when --fast-start-count is not a positive integer" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+
+      ["0", "-1", "abc", ""].each do |bad|
+        err = expect_raises(Hwaro::HwaroError) do
+          cmd.test_parse_options(["--fast-start-count", bad])
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      end
+    end
+
+    it "propagates fast_start fields to build options" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options(["--fast-start", "--fast-start-count", "5"])
+      build_options = options.to_build_options
+      build_options.fast_start.should be_true
+      build_options.fast_start_count.should eq(5)
+    end
   end
 
   describe "#run" do

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -32,6 +32,8 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--cache", description: "Enable build caching (skip unchanged files)"),
           FlagInfo.new(short: nil, long: "--stream", description: "Enable streaming build to reduce memory usage"),
           FlagInfo.new(short: nil, long: "--memory-limit", description: "Memory limit for streaming build (e.g. 2G, 512M)", takes_value: true, value_hint: "SIZE"),
+          FlagInfo.new(short: nil, long: "--fast-start", description: "Render homepage + latest N pages first, then background-render the rest"),
+          FlagInfo.new(short: nil, long: "--fast-start-count", description: "Number of recent pages to render up front with --fast-start (default: 20)", takes_value: true, value_hint: "N"),
 
           # Server
           FlagInfo.new(short: "-b", long: "--bind", description: "Bind address (default: 127.0.0.1)", takes_value: true, value_hint: "HOST"),
@@ -105,6 +107,8 @@ module Hwaro
           cache = false
           stream = false
           memory_limit = ENV["HWARO_MEMORYLIMIT"]? || nil
+          fast_start = false
+          fast_start_count = 20
 
           # Server
           host = "127.0.0.1"
@@ -154,6 +158,19 @@ module Hwaro
             parser.on("--cache", "Enable build caching (skip unchanged files)") { cache = true }
             parser.on("--stream", "Enable streaming build to reduce memory usage") { stream = true }
             parser.on("--memory-limit SIZE", "Memory limit for streaming build (e.g. 2G, 512M)") { |size| memory_limit = size }
+            parser.on("--fast-start", "Render homepage + latest N pages first, then background-render the rest") { fast_start = true }
+            parser.on("--fast-start-count N", "Number of recent pages to render up front with --fast-start (default: 20)") do |n|
+              parsed = n.to_i?
+              if parsed.nil? || parsed < 1
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "Invalid --fast-start-count value: #{n}",
+                  hint: "Pass a positive integer, e.g. --fast-start-count 50.",
+                )
+              end
+              fast_start_count = parsed
+              fast_start = true
+            end
 
             # Server
             parser.on("-b HOST", "--bind HOST", "Bind address (default: 127.0.0.1)") { |h| host = h }
@@ -201,6 +218,8 @@ module Hwaro
             stream: stream,
             memory_limit: memory_limit,
             json: json_output,
+            fast_start: fast_start,
+            fast_start_count: fast_start_count,
           )}
         end
       end

--- a/src/config/options/build_options.cr
+++ b/src/config/options/build_options.cr
@@ -27,6 +27,13 @@ module Hwaro
         # already-processed resized images (see `ImageHooks#process_images`
         # mtime-skip logic, which only works when destinations survive).
         property preserve_output : Bool
+        # When set (dev-server only), render only the homepage + the N most
+        # recent pages on the initial pass; the remaining pages are stashed
+        # on the Builder and rendered by a background fiber after the server
+        # is already serving. Drops "ready" time on large sites from O(all)
+        # to O(N). Always paired with `fast_start_count`.
+        property fast_start : Bool
+        property fast_start_count : Int32
 
         def initialize(
           @output_dir : String = "public",
@@ -50,6 +57,8 @@ module Hwaro
           @skip_og_image : Bool = false,
           @skip_image_processing : Bool = false,
           @preserve_output : Bool = false,
+          @fast_start : Bool = false,
+          @fast_start_count : Int32 = 20,
         )
         end
 

--- a/src/config/options/serve_options.cr
+++ b/src/config/options/serve_options.cr
@@ -24,6 +24,8 @@ module Hwaro
         property stream : Bool
         property memory_limit : String?
         property json : Bool
+        property fast_start : Bool
+        property fast_start_count : Int32
 
         def initialize(
           @host : String = "127.0.0.1",
@@ -48,6 +50,8 @@ module Hwaro
           @stream : Bool = false,
           @memory_limit : String? = nil,
           @json : Bool = false,
+          @fast_start : Bool = false,
+          @fast_start_count : Int32 = 20,
         )
         end
 
@@ -76,6 +80,8 @@ module Hwaro
             env: @env,
             skip_og_image: @skip_og_image,
             skip_image_processing: @skip_image_processing,
+            fast_start: @fast_start,
+            fast_start_count: @fast_start_count,
           )
         end
       end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -532,7 +532,7 @@ module Hwaro
         # during the initial Generate phase.
         def render_deferred(options : Config::Options::BuildOptions) : Int32
           pages = @deferred_pages
-          return 0 unless pages && !pages.empty?
+          return 0 if pages.nil? || pages.empty?
 
           site = @site
           templates = @templates

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -562,7 +562,9 @@ module Hwaro
 
           # Refresh feeds / sitemap / search now that every page has rendered
           # content. Without this, feed descriptions and the search index
-          # only cover the priority subset.
+          # only cover the priority subset. Per-taxonomy RSS feeds and tag
+          # listing pages pull from `page.content` too, so they have to be
+          # regenerated for the same reason — matches `run_rerender`.
           all_pages = (site.pages + site.sections).as(Array(Models::Page))
           seo_tasks = [
             -> { Content::Seo::Sitemap.generate(all_pages, site, output_dir, verbose); nil },
@@ -571,7 +573,12 @@ module Hwaro
             -> { Content::Search.generate(all_pages, site.config, output_dir, verbose); nil },
           ] of Proc(Nil)
           ParallelHelper.execute(seo_tasks, options.parallel)
+          Content::Taxonomies.generate(site, output_dir, templates, verbose)
 
+          # Persist cache updates from the deferred pass. The initial build
+          # already saved once; without this second save, killing the server
+          # before any watch rebuild loses the deferred pages' cache entries
+          # and the next `--cache` cold start has to re-render them.
           cache.save if options.cache
 
           # Clear the stash so a second call is a no-op and subsequent

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -118,6 +118,10 @@ module Hwaro
         @created_dirs_mutex : Mutex = Mutex.new
         # Unified cache manager for all cache layers
         @cache_manager : CacheManager = CacheManager.new
+        # Pages stashed by `--fast-start` during the initial build so the
+        # dev server can render them in a background fiber after the
+        # "ready" signal has been emitted. Nil outside of fast-start mode.
+        @deferred_pages : Array(Models::Page)? = nil
 
         def initialize
           @lifecycle = Lifecycle::Manager.new
@@ -192,6 +196,8 @@ module Hwaro
             stream: options.stream,
             memory_limit: options.memory_limit,
             env: options.env,
+            fast_start: options.fast_start,
+            fast_start_count: options.fast_start_count,
           )
         end
 
@@ -508,6 +514,75 @@ module Hwaro
           end
         end
 
+        # Are there any pages stashed by `--fast-start` waiting to render?
+        # Server checks this to decide whether to spawn the background fiber.
+        def has_deferred_pages? : Bool
+          if pages = @deferred_pages
+            !pages.empty?
+          else
+            false
+          end
+        end
+
+        # Render pages that were skipped on the initial `--fast-start` build.
+        # Runs after the dev server is already serving the priority subset,
+        # so user-visible "ready" time stays bounded on large sites.
+        # Regenerates SEO/search files at the end since feeds and the search
+        # index pull from `page.content`, which was empty for deferred pages
+        # during the initial Generate phase.
+        def render_deferred(options : Config::Options::BuildOptions) : Int32
+          pages = @deferred_pages
+          return 0 unless pages && !pages.empty?
+
+          site = @site
+          templates = @templates
+          unless site && templates
+            Logger.warn "render_deferred called before initial build completed; skipping."
+            return 0
+          end
+
+          Logger.info "Fast-start: background-rendering #{pages.size} deferred page(s)..."
+          start_time = Time.instant
+
+          output_dir = options.output_dir
+          minify = options.minify
+          highlight = options.highlight && site.config.highlight.enabled
+          verbose = options.verbose
+          cache = @cache || Cache.new(enabled: false)
+
+          global_vars = build_global_vars(site, options.cache_busting)
+          @pages_by_path = build_pages_by_path(site)
+          renderable = pages.select(&.render)
+
+          count = if options.parallel && renderable.size > 1
+                    process_files_parallel(renderable, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: options.error_overlay)
+                  else
+                    process_files_sequential(renderable, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: options.error_overlay)
+                  end
+
+          # Refresh feeds / sitemap / search now that every page has rendered
+          # content. Without this, feed descriptions and the search index
+          # only cover the priority subset.
+          all_pages = (site.pages + site.sections).as(Array(Models::Page))
+          seo_tasks = [
+            -> { Content::Seo::Sitemap.generate(all_pages, site, output_dir, verbose); nil },
+            -> { Content::Seo::Feeds.generate(all_pages, site.config, output_dir, verbose); nil },
+            -> { Content::Seo::Llms.generate(site.config, all_pages, output_dir, verbose); nil },
+            -> { Content::Search.generate(all_pages, site.config, output_dir, verbose); nil },
+          ] of Proc(Nil)
+          ParallelHelper.execute(seo_tasks, options.parallel)
+
+          cache.save if options.cache
+
+          # Clear the stash so a second call is a no-op and subsequent
+          # watch-triggered full rebuilds start clean.
+          @deferred_pages = nil
+
+          elapsed = Time.instant - start_time
+          Logger.success "Fast-start: deferred render complete (#{count} pages in #{elapsed.total_milliseconds.round(2)}ms)."
+          count
+        end
+
         # Copy only the specified static files to the output directory.
         # Used by serve mode when only static files have changed.
         def copy_changed_static(changed_files : Array(String), output_dir : String, verbose : Bool = false)
@@ -594,6 +669,8 @@ module Hwaro
           stream : Bool = false,
           memory_limit : String? = nil,
           env : String? = nil,
+          fast_start : Bool = false,
+          fast_start_count : Int32 = 20,
         )
           # Load config once and reuse throughout the build.
           # `Models::Config.load` raises `HwaroError(HWARO_E_CONFIG)` directly
@@ -640,6 +717,8 @@ module Hwaro
             stream: stream,
             memory_limit: memory_limit,
             env: env,
+            fast_start: fast_start,
+            fast_start_count: fast_start_count,
           )
           if options.streaming?
             Logger.info "  Streaming mode enabled (batch size: #{options.batch_size})"

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -48,6 +48,21 @@ module Hwaro::Core::Build::Phases::Render
       end
     end
 
+    # Fast-start mode: render only homepage + most recent N pages on this
+    # pass and stash the rest on the Builder so a background fiber in
+    # `serve` can render them after the server is already accepting
+    # connections. Has no effect outside of `hwaro serve --fast-start`.
+    if ctx.options.fast_start
+      priority, deferred = split_priority_pages(pages_to_build, ctx.options.fast_start_count)
+      @deferred_pages = deferred
+      if !deferred.empty?
+        Logger.info "  Fast-start: rendering #{priority.size} priority page(s) up front, deferring #{deferred.size} for background render."
+      end
+      pages_to_build = priority
+    else
+      @deferred_pages = nil
+    end
+
     profiler.start_phase("Render")
     result = @lifecycle.run_phase(Lifecycle::Phase::Render, ctx) do
       global_vars = build_global_vars(site, ctx.options.cache_busting)
@@ -63,6 +78,50 @@ module Hwaro::Core::Build::Phases::Render
     end
     profiler.end_phase
     result
+  end
+
+  # Pick a "priority" subset of pages for fast-start: every section index
+  # (so the homepage and any top-level list pages always come up first),
+  # plus the N most recent regular pages by `date` descending. Pages
+  # without a date sort last (they're typically standalone pages like
+  # /about/ that visitors don't land on first).
+  protected def split_priority_pages(
+    pages : Array(Models::Page),
+    count : Int32,
+  ) : {Array(Models::Page), Array(Models::Page)}
+    return {pages, [] of Models::Page} if pages.size <= count
+
+    priority = Set(Models::Page).new
+    regulars = [] of Models::Page
+
+    pages.each do |page|
+      if page.is_index
+        priority << page
+      else
+        regulars << page
+      end
+    end
+
+    # Sort by date descending, nil dates last
+    regulars.sort! do |a, b|
+      ad = a.date
+      bd = b.date
+      if ad && bd
+        bd <=> ad
+      elsif ad
+        -1
+      elsif bd
+        1
+      else
+        0
+      end
+    end
+
+    regulars.first(count).each { |p| priority << p }
+
+    priority_list = pages.select { |p| priority.includes?(p) }
+    deferred_list = pages.reject { |p| priority.includes?(p) }
+    {priority_list, deferred_list}
   end
 
   private def render_streaming(

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -442,6 +442,16 @@ module Hwaro
         # subset immediately. Notify the browser via live-reload when the
         # background pass finishes so any tab parked on a not-yet-rendered
         # URL automatically refreshes once its HTML is on disk.
+        #
+        # `deferred_done` gates the file watcher: starting the watcher
+        # before the deferred fiber returns would let a save-triggered
+        # incremental rebuild race with the deferred render, both fibers
+        # mutating shared Builder state (`@pages_by_path`,
+        # `@page_crinja_value_cache`, `@cache`, …) at IO yield points.
+        # The channel is closed once the deferred pass finishes (or
+        # immediately if there's nothing to defer), at which point the
+        # watcher proceeds.
+        deferred_done = Channel(Nil).new
         fast_start_pending = build_options.fast_start && @builder.has_deferred_pages?
         if fast_start_pending
           deferred_options = build_options.dup
@@ -455,11 +465,19 @@ module Hwaro
               Logger.error "[Fast-start] Background render failed: #{ex.message}"
               Logger.debug "[Fast-start] Backtrace: #{ex.backtrace?.try(&.first(5).join("\n    ")) || "unavailable"}"
               @live_reload_handler.try(&.notify_build_error(ex.message || "Background render failed"))
+            ensure
+              deferred_done.close
             end
           end
+        else
+          deferred_done.close
         end
 
         spawn do
+          # Block here — not in a sleep loop — until the deferred fiber
+          # signals completion. `receive?` on a closed channel returns
+          # `nil` without blocking.
+          deferred_done.receive?
           watch_for_changes(watch_options)
         end
 

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -358,7 +358,11 @@ module Hwaro
       end
 
       private def run_with_options(host : String, port : Int32, open_browser : Bool, access_log : Bool, live_reload : Bool, build_options : Config::Options::BuildOptions, json_output : Bool = false)
-        Logger.info "Performing initial build..."
+        if build_options.fast_start
+          Logger.info "Performing fast-start initial build (priority pages only)..."
+        else
+          Logger.info "Performing initial build..."
+        end
         @builder.run(build_options)
 
         # Watch-triggered rebuilds should preserve the already-built output
@@ -367,6 +371,11 @@ module Hwaro
         # serve honest about fresh state.
         watch_options = build_options.dup
         watch_options.preserve_output = true
+        # Once the deferred pages have been rendered we don't want subsequent
+        # watch-triggered rebuilds to also defer — that would re-stash the
+        # same pages on every file save. Fast-start is a cold-start only
+        # optimisation.
+        watch_options.fast_start = false
 
         output_dir = sanitize_output_dir(build_options.output_dir)
 
@@ -425,6 +434,28 @@ module Hwaro
           spawn do
             sleep 0.5.seconds
             open_browser_url(url)
+          end
+        end
+
+        # If fast-start stashed pages on the builder, render them in the
+        # background so the dev server can start serving the priority
+        # subset immediately. Notify the browser via live-reload when the
+        # background pass finishes so any tab parked on a not-yet-rendered
+        # URL automatically refreshes once its HTML is on disk.
+        fast_start_pending = build_options.fast_start && @builder.has_deferred_pages?
+        if fast_start_pending
+          deferred_options = build_options.dup
+          deferred_options.preserve_output = true
+          deferred_options.fast_start = false
+          spawn do
+            begin
+              @builder.render_deferred(deferred_options)
+              @live_reload_handler.try(&.notify_reload)
+            rescue ex
+              Logger.error "[Fast-start] Background render failed: #{ex.message}"
+              Logger.debug "[Fast-start] Backtrace: #{ex.backtrace?.try(&.first(5).join("\n    ")) || "unavailable"}"
+              @live_reload_handler.try(&.notify_build_error(ex.message || "Background render failed"))
+            end
           end
         end
 


### PR DESCRIPTION
## Summary
- Add `--fast-start` (with `--fast-start-count N`, default 20) to `hwaro serve`. The initial build renders every section index (homepage included) plus the N most recent pages by date, emits the ready signal, then background-renders the rest in a fiber.
- Live-reload fires when the deferred pass completes so a tab sitting on a not-yet-rendered URL auto-refreshes once its HTML lands on disk.
- Watch-loop rebuilds and `hwaro build` are unaffected — the option is dev-server cold-start only and resets after the deferred pass. Composes with `--cache`: second runs skip unchanged priority pages and only newly-edited deferred pages re-render.

### Why
Large sites pay full-render cost before the port is bound, which dominates ready time when most pages aren't what the developer is editing. Existing `--cache` only helps on the second run; `--fast-start` cuts cold-start ready time on the first run too.

### Implementation notes
- `BuildOptions` / `ServeOptions` gain `fast_start` + `fast_start_count` (propagated through `Builder.run(options)` so the render phase sees them).
- In `execute_render_phase`, when `fast_start` is set, pages are partitioned by `split_priority_pages` (section indexes ∪ N latest by `date` desc, nil-dates last); the remainder is stashed on `Builder#@deferred_pages`.
- `Builder#render_deferred(options)` reuses cached `@site` / `@templates` / `@cache` and regenerates sitemap / feeds / llms.txt / search index (those pull from `page.content`, which was empty for deferred pages during the initial Generate phase).
- `Server` spawns the background fiber after `bind_tcp` but before `listen`, and clears `fast_start` from `watch_options` so save-triggered rebuilds don't re-defer.

## Test plan
- [x] `crystal spec spec/unit/{build_options,serve_options,serve_command,server,builder_orchestration,builder_orchestration_run}_spec.cr spec/functional/build_integration_spec.cr` — all green
- [x] `hwaro serve --fast-start --fast-start-count 2` against `testapp/`: initial render of 6/12 pages in 37ms, ready signal, then deferred 6/12 + SEO regenerated in 18ms in the background fiber
- [x] `hwaro build` (no flag) still produces 12/12 pages — non-fast-start path untouched
- [ ] Manual: visit a deferred URL immediately after ready signal — currently returns 404 until the background fiber finishes (on-demand render is a follow-up)