### PR TITLE
perf(serve): make --fast-start actually fast — defer heavy BeforeRender hooks

### DIFF
--- a/spec/functional/fast_start_serve_spec.cr
+++ b/spec/functional/fast_start_serve_spec.cr
@@ -1,0 +1,123 @@
+require "./support/build_helper"
+require "http/client"
+
+# Process-level smoke test for `hwaro serve --fast-start`.
+#
+# Guards against the accept-loop starvation regression: under
+# `--fast-start` the deferred-render fiber does ~seconds of pure-CPU
+# work (PNG OG image encoding, image resize) right after the server
+# starts. If the deferred fiber runs before `server.listen` enters its
+# accept loop — or if a CPU-bound hook never yields — TCP connects
+# succeed via the OS backlog but HTTP responses never come back.
+#
+# This test spawns the real built binary so it exercises the actual
+# scheduler-level interaction. It's intentionally a single coarse
+# assertion: the server must produce an HTTP 200 within a couple of
+# seconds of emitting the ready signal.
+#
+# Skips when `bin/hwaro` isn't present (e.g. running `crystal spec`
+# without a prior `shards build`). In CI, the build step runs first
+# so the binary is always available.
+private HWARO_BIN = File.expand_path("../../bin/hwaro", __DIR__)
+
+private def fast_start_serve_available? : Bool
+  return false unless File.exists?(HWARO_BIN)
+  File::Info.executable?(HWARO_BIN)
+end
+
+private def pick_free_port : Int32
+  # Open ephemeral, read the assigned port, close. Race against another
+  # process grabbing it before `hwaro serve` binds is theoretically
+  # possible but vanishingly small for a unit-spec timeframe.
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  server.close
+  port
+end
+
+private def wait_for_ready(stdout : IO, deadline : Time)
+  loop do
+    raise "timed out waiting for hwaro serve ready signal" if Time.utc > deadline
+    line = stdout.gets(chomp: true)
+    return if line && line.includes?("hwaro serve: ready url=")
+  end
+end
+
+# Build a site with enough pages that `--fast-start` actually defers
+# rendering. The default `fast_start_count` is 20 — we generate 40 so
+# at least 20 pages land in the deferred bucket and the BeforeRender
+# hooks have non-trivial work to do on the deferred pass.
+private def make_fast_start_site(dir : String)
+  File.write(File.join(dir, "config.toml"), <<-TOML)
+    title = "FS Test"
+    base_url = "http://127.0.0.1"
+
+    [og.auto_image]
+    enabled = true
+    format = "svg"
+    TOML
+
+  FileUtils.mkdir_p(File.join(dir, "content"))
+  FileUtils.mkdir_p(File.join(dir, "templates"))
+
+  File.write(File.join(dir, "content", "_index.md"), "---\ntitle: Home\n---\nhome")
+
+  (1..40).each do |i|
+    File.write(
+      File.join(dir, "content", "post-#{i}.md"),
+      "---\ntitle: Post #{i}\ndate: 2025-01-#{(i % 28) + 1}\n---\nbody #{i}"
+    )
+  end
+
+  File.write(File.join(dir, "templates", "page.html"), "<html><body>{{ page.title }}</body></html>")
+  File.write(File.join(dir, "templates", "index.html"), "<html><body>{{ page.title }}</body></html>")
+end
+
+describe "hwaro serve --fast-start" do
+  it "answers HTTP requests immediately after emitting the ready signal" do
+    pending! "bin/hwaro not built — run `shards build -Dpreview_mt` first" unless fast_start_serve_available?
+
+    Dir.mktmpdir do |dir|
+      make_fast_start_site(dir)
+
+      port = pick_free_port
+
+      stdout_r, stdout_w = IO.pipe
+      stderr_r, stderr_w = IO.pipe
+
+      process = Process.new(
+        HWARO_BIN,
+        args: ["serve", "--fast-start", "--port", port.to_s, "--no-live-reload"],
+        chdir: dir,
+        input: Process::Redirect::Close,
+        output: stdout_w,
+        error: stderr_w,
+      )
+
+      begin
+        # The ready signal must arrive within a few seconds for a
+        # 40-page site even on a slow CI runner. Generous deadline to
+        # avoid flakes; the real assertion is what happens after.
+        wait_for_ready(stdout_r, Time.utc + 30.seconds)
+
+        # Race the request against the deferred pass. Without the
+        # accept-loop-starvation fix this would block until the
+        # deferred render completes (or timeout).
+        client = HTTP::Client.new("127.0.0.1", port)
+        client.read_timeout = 5.seconds
+        client.connect_timeout = 2.seconds
+        response = client.get("/")
+        client.close
+        response.status_code.should eq(200)
+      ensure
+        process.terminate(graceful: true) rescue nil
+        # Don't leave a zombie if terminate didn't take.
+        spawn { process.wait rescue nil }
+        stdout_w.close rescue nil
+        stderr_w.close rescue nil
+        stdout_r.close rescue nil
+        stderr_r.close rescue nil
+      end
+    end
+  end
+end

--- a/spec/unit/og_image_spec.cr
+++ b/spec/unit/og_image_spec.cr
@@ -791,6 +791,77 @@ describe Hwaro::Content::Seo::OgImage do
       config_hash.should eq("")
       entries.should be_empty
     end
+
+    # Default `partial: false` truncates the manifest each pass so
+    # entries for pages that no longer exist don't accumulate. Without
+    # this, an `--fast-start` regression that started writing partial
+    # manifests in full builds would leak slugs forever — the cache
+    # check `old_entries[slug]? == page_hash` would keep matching
+    # against stale entries and the on-disk OG file for a removed
+    # page would never get cleaned up.
+    it "prunes manifest entries for pages no longer in the input (full mode)" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.title = "My Site"
+        config.og.auto_image.enabled = true
+
+        page_a = Hwaro::Models::Page.new("a.md")
+        page_a.title = "A"
+        page_a.url = "/a/"
+        page_a.render = true
+
+        page_b = Hwaro::Models::Page.new("b.md")
+        page_b.title = "B"
+        page_b.url = "/b/"
+        page_b.render = true
+
+        Hwaro::Content::Seo::OgImage.generate([page_a, page_b], config, dir)
+
+        manifest_path = File.join(dir, "og-images", ".og_manifest.json")
+        entries = JSON.parse(File.read(manifest_path))["entries"].as_h
+        entries.has_key?("a").should be_true
+        entries.has_key?("b").should be_true
+
+        # Second pass with only page_a — page_b's manifest entry must drop.
+        page_a.image = nil
+        Hwaro::Content::Seo::OgImage.generate([page_a], config, dir)
+
+        entries = JSON.parse(File.read(manifest_path))["entries"].as_h
+        entries.has_key?("a").should be_true
+        entries.has_key?("b").should be_false
+      end
+    end
+
+    # Partial mode is the `--fast-start` two-pass path: the priority
+    # pass writes a manifest, the deferred pass writes another for the
+    # remainder. The second call must NOT truncate the first call's
+    # entries, otherwise the next cold start would re-render every
+    # priority page's OG image from scratch.
+    it "accumulates manifest entries across calls (partial mode)" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.title = "My Site"
+        config.og.auto_image.enabled = true
+
+        priority_page = Hwaro::Models::Page.new("home.md")
+        priority_page.title = "Home"
+        priority_page.url = "/"
+        priority_page.render = true
+
+        deferred_page = Hwaro::Models::Page.new("old.md")
+        deferred_page.title = "Old Post"
+        deferred_page.url = "/old/"
+        deferred_page.render = true
+
+        Hwaro::Content::Seo::OgImage.generate([priority_page], config, dir, partial: true)
+        Hwaro::Content::Seo::OgImage.generate([deferred_page], config, dir, partial: true)
+
+        manifest_path = File.join(dir, "og-images", ".og_manifest.json")
+        entries = JSON.parse(File.read(manifest_path))["entries"].as_h
+        entries.has_key?("home").should be_true # slugified from title since "/" yields empty URL slug
+        entries.has_key?("old").should be_true
+      end
+    end
   end
 
   describe ".split_into_segments" do

--- a/spec/unit/phases_render_spec.cr
+++ b/spec/unit/phases_render_spec.cr
@@ -386,14 +386,16 @@ describe Hwaro::Core::Build::Phases::Render do
       deferred.empty?.should be_true
     end
 
-    it "always puts section index pages in priority regardless of date" do
+    it "always puts shallow section index pages in priority regardless of date" do
       builder = Hwaro::Core::Build::Builder.new
-      home = Hwaro::Models::Page.new("_index.md")
+      home = Hwaro::Models::Section.new("_index.md")
       home.is_index = true
+      home.section = ""
       home.date = nil
 
-      section_idx = Hwaro::Models::Page.new("posts/_index.md")
+      section_idx = Hwaro::Models::Section.new("posts/_index.md")
       section_idx.is_index = true
+      section_idx.section = "posts"
       section_idx.date = Time.utc(2000, 1, 1)
 
       recent = Hwaro::Models::Page.new("posts/new.md")
@@ -405,17 +407,72 @@ describe Hwaro::Core::Build::Phases::Render do
       undated = Hwaro::Models::Page.new("about.md")
       undated.date = nil
 
-      pages = [home, section_idx, recent, old, undated]
+      pages = [home.as(Hwaro::Models::Page), section_idx.as(Hwaro::Models::Page), recent, old, undated]
       priority, deferred = builder.test_split_priority_pages(pages, 1)
 
-      priority.includes?(home).should be_true
-      priority.includes?(section_idx).should be_true
+      priority.includes?(home.as(Hwaro::Models::Page)).should be_true
+      priority.includes?(section_idx.as(Hwaro::Models::Page)).should be_true
       # With count=1 only the most recent regular post is included
       priority.includes?(recent).should be_true
       priority.includes?(old).should be_false
       priority.includes?(undated).should be_false
       # Deferred must contain exactly the leftovers
-      deferred.sort_by(&.path).should eq([old, undated].sort_by(&.path))
+      deferred.sort_by(&.path).should eq([old.as(Hwaro::Models::Page), undated.as(Hwaro::Models::Page)].sort_by(&.path))
+    end
+
+    it "defers deeply nested section indexes — only depth ≤ 1 are auto-priority" do
+      builder = Hwaro::Core::Build::Builder.new
+      home = Hwaro::Models::Section.new("_index.md")
+      home.is_index = true
+      home.section = ""
+
+      top = Hwaro::Models::Section.new("archive/_index.md")
+      top.is_index = true
+      top.section = "archive"
+
+      deep = Hwaro::Models::Section.new("archive/dev/crystal/_index.md")
+      deep.is_index = true
+      deep.section = "archive/dev/crystal"
+
+      # Many regulars so depth-deep section can't sneak in via the recent-N fill.
+      regulars = (1..30).map do |i|
+        p = Hwaro::Models::Page.new("posts/p#{i}.md")
+        p.date = Time.utc(2026, 5, i)
+        p
+      end
+
+      pages = [home.as(Hwaro::Models::Page), top.as(Hwaro::Models::Page), deep.as(Hwaro::Models::Page)] + regulars.map(&.as(Hwaro::Models::Page))
+      priority, deferred = builder.test_split_priority_pages(pages, 5)
+
+      priority.includes?(home.as(Hwaro::Models::Page)).should be_true
+      priority.includes?(top.as(Hwaro::Models::Page)).should be_true
+      priority.includes?(deep.as(Hwaro::Models::Page)).should be_false
+      deferred.includes?(deep.as(Hwaro::Models::Page)).should be_true
+    end
+
+    it "treats `index.md` page bundles as regulars, not auto-priority" do
+      builder = Hwaro::Core::Build::Builder.new
+      home = Hwaro::Models::Section.new("_index.md")
+      home.is_index = true
+      home.section = ""
+
+      # A regular post that happens to use Hugo-style page-bundle layout —
+      # `is_index` is true on the underlying Page but it's still just a
+      # post, not a section listing. Must compete for the recent-N slot.
+      old_bundle = Hwaro::Models::Page.new("posts/2020/old/index.md")
+      old_bundle.is_index = true
+      old_bundle.date = Time.utc(2020, 1, 1)
+
+      new_post = Hwaro::Models::Page.new("posts/new.md")
+      new_post.date = Time.utc(2026, 5, 1)
+
+      pages = [home.as(Hwaro::Models::Page), old_bundle.as(Hwaro::Models::Page), new_post.as(Hwaro::Models::Page)]
+      priority, deferred = builder.test_split_priority_pages(pages, 1)
+
+      priority.includes?(home.as(Hwaro::Models::Page)).should be_true
+      priority.includes?(new_post).should be_true
+      priority.includes?(old_bundle.as(Hwaro::Models::Page)).should be_false
+      deferred.includes?(old_bundle.as(Hwaro::Models::Page)).should be_true
     end
 
     it "sorts regular pages by date descending, nil-dated pages last" do
@@ -444,15 +501,16 @@ describe Hwaro::Core::Build::Phases::Render do
       builder = Hwaro::Core::Build::Builder.new
       a = Hwaro::Models::Page.new("a.md")
       a.date = Time.utc(2026, 5, 1)
-      b = Hwaro::Models::Page.new("b.md")
+      b = Hwaro::Models::Section.new("b/_index.md")
       b.is_index = true
+      b.section = "b"
       c = Hwaro::Models::Page.new("c.md")
       c.date = Time.utc(2024, 1, 1)
 
-      pages = [a, b, c] # b is section index, a is most recent
+      pages = [a, b.as(Hwaro::Models::Page), c] # b is section index, a is most recent
       priority, _deferred = builder.test_split_priority_pages(pages, 1)
       # Priority should contain a and b, ordered as they appeared in input
-      priority.should eq([a, b])
+      priority.should eq([a, b.as(Hwaro::Models::Page)])
     end
 
     it "handles an empty input gracefully" do

--- a/src/content/hooks/image_hooks.cr
+++ b/src/content/hooks/image_hooks.cr
@@ -113,11 +113,23 @@ module Hwaro
           resolved_output = File.expand_path(output_dir)
 
           # Phase 1: Collect all image jobs (fast, single-threaded)
+          #
+          # Under `--fast-start`, only collect page-asset jobs for the
+          # priority subset and skip the (potentially thousands of) static
+          # and content-file globs entirely on the cold pass. The deferred
+          # render pass re-invokes this hook with priority_pages cleared so
+          # the full job set runs in the background. The `resize_image()`
+          # template helper falls back to the original URL on a cache miss,
+          # so priority pages render correctly even if their non-asset
+          # image references haven't been resized yet.
+          fast_start_priority = ctx.priority_pages
           jobs = [] of ImageJob
           seen = Set(String).new
-          collect_page_asset_jobs(ctx, output_dir, resolved_output, jobs, seen)
-          collect_content_file_jobs(config, output_dir, resolved_output, jobs, seen) if config.content_files.enabled?
-          collect_static_jobs(output_dir, resolved_output, jobs, seen)
+          collect_page_asset_jobs(ctx, output_dir, resolved_output, jobs, seen, fast_start_priority)
+          if fast_start_priority.nil?
+            collect_content_file_jobs(config, output_dir, resolved_output, jobs, seen) if config.content_files.enabled?
+            collect_static_jobs(output_dir, resolved_output, jobs, seen)
+          end
 
           return if jobs.empty?
 
@@ -257,8 +269,10 @@ module Hwaro
           resolved_output : String,
           jobs : Array(ImageJob),
           seen : Set(String),
+          priority_pages : Array(Models::Page)? = nil,
         )
-          ctx.all_pages.each do |page|
+          source = priority_pages || ctx.all_pages
+          source.each do |page|
             next if page.assets.empty?
 
             page_bundle_dir = File.dirname(page.path)

--- a/src/content/hooks/og_image_hooks.cr
+++ b/src/content/hooks/og_image_hooks.cr
@@ -26,8 +26,15 @@ module Hwaro
           end
           return unless site.config.og.auto_image.enabled
 
+          # When --fast-start is active, only generate images for the
+          # priority subset on the cold pass. The deferred render pass
+          # re-runs this hook for the rest. PNG OG generation is the
+          # single largest cost on big sites — rendering 700+ PNGs
+          # eats ~20s on a 1k-page site and is what made fast-start
+          # indistinguishable from a normal cold start.
+          pages = ctx.priority_pages || ctx.all_pages
           Content::Seo::OgImage.generate(
-            ctx.all_pages,
+            pages,
             site.config,
             ctx.output_dir,
             ctx.options.verbose,

--- a/src/content/hooks/og_image_hooks.cr
+++ b/src/content/hooks/og_image_hooks.cr
@@ -38,6 +38,7 @@ module Hwaro
             site.config,
             ctx.output_dir,
             ctx.options.verbose,
+            partial: ctx.partial_render,
           )
         end
       end

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -36,11 +36,20 @@ module Hwaro
         # Generate OG images for all pages that lack a custom image.
         # Sets page.image to the generated SVG path so that og:image
         # meta tags pick it up automatically.
+        #
+        # `partial` signals that the caller is only handing in a subset
+        # of the site's pages (e.g. `--fast-start` runs this once for
+        # the priority subset and again for the deferred remainder).
+        # In partial mode we accumulate manifest entries across calls
+        # rather than overwriting; in full mode (default) we still
+        # truncate so manifest entries — and the disk files they
+        # describe — for deleted pages get pruned naturally.
         def self.generate(
           pages : Array(Models::Page),
           config : Models::Config,
           output_dir : String,
           verbose : Bool = false,
+          partial : Bool = false,
         )
           ai = config.og.auto_image
           return unless ai.enabled
@@ -98,12 +107,19 @@ module Hwaro
           config_hash = compute_config_hash(config)
           old_config_hash, old_entries = load_manifest(manifest_path)
           config_changed = old_config_hash != config_hash
-          # Start from the old manifest so partial passes (e.g.
-          # `--fast-start` calling `generate` once for the priority subset
-          # and again for the deferred subset) accumulate rather than
-          # truncate. When config changed, every entry is stale so the
-          # snapshot starts empty.
-          new_entries = config_changed ? ({} of String => String) : old_entries.dup
+          # In partial mode, start from the old manifest so a follow-up
+          # call (e.g. the `--fast-start` deferred pass) doesn't truncate
+          # the entries the previous call just wrote. In full mode we
+          # truncate so entries for deleted pages don't accumulate
+          # forever — the on-disk PNG/SVG for a removed page becomes
+          # orphaned, and the manifest growing unbounded across builds
+          # would defeat the cache-hit check by always "matching"
+          # stale slugs. Config-changed always truncates.
+          new_entries = if config_changed || !partial
+                          {} of String => String
+                        else
+                          old_entries.dup
+                        end
 
           generated = 0
           skipped = 0

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -97,13 +97,25 @@ module Hwaro
           manifest_path = File.join(img_dir, ".og_manifest.json")
           config_hash = compute_config_hash(config)
           old_config_hash, old_entries = load_manifest(manifest_path)
-          new_entries = {} of String => String
           config_changed = old_config_hash != config_hash
+          # Start from the old manifest so partial passes (e.g.
+          # `--fast-start` calling `generate` once for the priority subset
+          # and again for the deferred subset) accumulate rather than
+          # truncate. When config changed, every entry is stale so the
+          # snapshot starts empty.
+          new_entries = config_changed ? ({} of String => String) : old_entries.dup
 
           generated = 0
           skipped = 0
 
-          pages.each do |page|
+          pages.each_with_index do |page, idx|
+            # Yield to other fibers every few PNG renders so a serve
+            # session that runs this in a background fiber doesn't starve
+            # its own HTTP accept loop. PNG encoding is pure CPU and
+            # never yields on its own; without this, requests sit on the
+            # OS backlog indefinitely while the deferred render pass
+            # runs.
+            Fiber.yield if idx > 0 && (idx & 0x07) == 0
             next if page.draft
             next if page.generated
             next unless page.render

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -199,6 +199,10 @@ module Hwaro
             env: options.env,
             fast_start: options.fast_start,
             fast_start_count: options.fast_start_count,
+            skip_og_image: options.skip_og_image,
+            skip_image_processing: options.skip_image_processing,
+            preserve_output: options.preserve_output,
+            cache_busting: options.cache_busting,
           )
         end
 
@@ -531,6 +535,12 @@ module Hwaro
         # Regenerates SEO/search files at the end since feeds and the search
         # index pull from `page.content`, which was empty for deferred pages
         # during the initial Generate phase.
+        #
+        # Also runs the BeforeRender hooks for the remaining work the
+        # cold pass deferred — OG image generation for non-priority pages
+        # and image resizing for static/content_file globs + non-priority
+        # page assets. Without this step those images never get produced
+        # in a fast-start serve session until the user saves a file.
         def render_deferred(options : Config::Options::BuildOptions) : Int32
           pages = @deferred_pages
           return 0 if pages.nil? || pages.empty?
@@ -550,6 +560,26 @@ module Hwaro
           highlight = options.highlight && site.config.highlight.enabled
           verbose = options.verbose
           cache = @cache || Cache.new(enabled: false)
+
+          # Re-run the BeforeRender hooks against the full page set. The
+          # ctx carries no priority_pages this time, so OG image
+          # generation and image resizing process whatever the cold pass
+          # left undone. We construct a fresh context rather than reusing
+          # the original — the original's priority_pages would short-
+          # circuit the very hooks we want to fully execute here.
+          deferred_ctx = Lifecycle::BuildContext.new(options)
+          deferred_ctx.site = site
+          deferred_ctx.config = site.config
+          deferred_ctx.pages = site.pages
+          deferred_ctx.sections = site.sections
+          deferred_ctx.templates = templates
+          deferred_ctx.output_dir = output_dir
+          deferred_ctx.cache = @cache
+          deferred_ctx.priority_pages = nil
+
+          # Trigger BeforeRender hooks directly — we're not re-running the
+          # Render phase, just the prep work it would have done.
+          @lifecycle.trigger(Lifecycle::HookPoint::BeforeRender, deferred_ctx)
 
           global_vars = build_global_vars(site, options.cache_busting)
           @pages_by_path = build_pages_by_path(site)
@@ -679,6 +709,10 @@ module Hwaro
           env : String? = nil,
           fast_start : Bool = false,
           fast_start_count : Int32 = 20,
+          skip_og_image : Bool = false,
+          skip_image_processing : Bool = false,
+          preserve_output : Bool = false,
+          cache_busting : Bool = true,
         )
           # Load config once and reuse throughout the build.
           # `Models::Config.load` raises `HwaroError(HWARO_E_CONFIG)` directly
@@ -727,6 +761,10 @@ module Hwaro
             env: env,
             fast_start: fast_start,
             fast_start_count: fast_start_count,
+            skip_og_image: skip_og_image,
+            skip_image_processing: skip_image_processing,
+            preserve_output: preserve_output,
+            cache_busting: cache_busting,
           )
           if options.streaming?
             Logger.info "  Streaming mode enabled (batch size: #{options.batch_size})"

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -576,6 +576,12 @@ module Hwaro
           deferred_ctx.output_dir = output_dir
           deferred_ctx.cache = @cache
           deferred_ctx.priority_pages = nil
+          # Still a partial pass — the priority pass just wrote OG
+          # manifest entries we must not truncate. Without this flag the
+          # deferred pass would overwrite `.og_manifest.json` with only
+          # its own slugs and the next cold start would re-render every
+          # priority page's OG image from scratch.
+          deferred_ctx.partial_render = true
 
           # Trigger BeforeRender hooks directly — we're not re-running the
           # Render phase, just the prep work it would have done.

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -66,14 +66,22 @@ module Hwaro::Core::Build::Phases::Render
       @deferred_pages = deferred
       if !deferred.empty?
         Logger.info "  Fast-start: rendering #{priority.size} priority page(s) up front, deferring #{deferred.size} for background render."
+        # NOTE — both `priority_pages` and `partial_render` are consumed
+        # by BeforeRender hooks below (`og_image:generate`,
+        # `image:resize`). Don't move these assignments after
+        # `run_phase` or those hooks will fall back to the all-pages
+        # path and `--fast-start` becomes a no-op again.
         ctx.priority_pages = priority
+        ctx.partial_render = true
       else
         ctx.priority_pages = nil
+        ctx.partial_render = false
       end
       pages_to_build = priority
     else
       @deferred_pages = nil
       ctx.priority_pages = nil
+      ctx.partial_render = false
     end
 
     profiler.start_phase("Render")

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -52,15 +52,28 @@ module Hwaro::Core::Build::Phases::Render
     # pass and stash the rest on the Builder so a background fiber in
     # `serve` can render them after the server is already accepting
     # connections. Has no effect outside of `hwaro serve --fast-start`.
+    #
+    # Critically, the priority set is published on `ctx.priority_pages`
+    # BEFORE BeforeRender hooks run so OG image generation and image
+    # resizing (the dominant cost on large sites) only run for the
+    # priority subset on the cold pass. Without this they iterated
+    # `ctx.all_pages` and ate the savings the render-phase filter was
+    # supposed to deliver — fast-start was indistinguishable from a
+    # normal serve cold start. The background pass re-runs those hooks
+    # for the rest, then renders the deferred pages.
     if ctx.options.fast_start
       priority, deferred = split_priority_pages(pages_to_build, ctx.options.fast_start_count)
       @deferred_pages = deferred
       if !deferred.empty?
         Logger.info "  Fast-start: rendering #{priority.size} priority page(s) up front, deferring #{deferred.size} for background render."
+        ctx.priority_pages = priority
+      else
+        ctx.priority_pages = nil
       end
       pages_to_build = priority
     else
       @deferred_pages = nil
+      ctx.priority_pages = nil
     end
 
     profiler.start_phase("Render")
@@ -80,11 +93,21 @@ module Hwaro::Core::Build::Phases::Render
     result
   end
 
-  # Pick a "priority" subset of pages for fast-start: every section index
-  # (so the homepage and any top-level list pages always come up first),
-  # plus the N most recent regular pages by `date` descending. Pages
-  # without a date sort last (they're typically standalone pages like
-  # /about/ that visitors don't land on first).
+  # Pick a "priority" subset of pages for fast-start: the homepage and
+  # shallow section indexes (depth ≤ 1) plus the N most recent regular
+  # pages by `date` descending. Pages without a date sort last.
+  #
+  # Earlier iterations included every `is_index` page, but on real sites
+  # that pulls in deeply-nested `_index.md` files (e.g.
+  # `archive/dev/crystal/_index.md`) plus every `index.md` page-bundle
+  # leaf — on a 1k-page site this ballooned the priority set to 200+
+  # pages and wiped out the win, since OG image generation and image
+  # resize were still running for the whole subset. Section listings
+  # for deep archive folders are exactly the pages users don't hit
+  # first; live-reload will refresh any tab parked on one once the
+  # background pass finishes.
+  PRIORITY_MAX_SECTION_DEPTH = 1
+
   protected def split_priority_pages(
     pages : Array(Models::Page),
     count : Int32,
@@ -95,7 +118,7 @@ module Hwaro::Core::Build::Phases::Render
     regulars = [] of Models::Page
 
     pages.each do |page|
-      if page.is_index
+      if priority_section_index?(page)
         priority << page
       else
         regulars << page
@@ -122,6 +145,18 @@ module Hwaro::Core::Build::Phases::Render
     priority_list = pages.select { |p| priority.includes?(p) }
     deferred_list = pages.reject { |p| priority.includes?(p) }
     {priority_list, deferred_list}
+  end
+
+  # Treat only the root section index and depth-1 section indexes as
+  # always-priority. `Page#is_index` is also true for `index.md`
+  # page-bundle leaves (regular posts that live alongside their
+  # assets) — those should compete with other regulars for the
+  # `fast_start_count` slots, not bypass the limit.
+  private def priority_section_index?(page : Models::Page) : Bool
+    return false unless page.is_a?(Models::Section)
+    section = page.section
+    return true if section.empty?
+    section.count('/') < PRIORITY_MAX_SECTION_DEPTH
   end
 
   private def render_streaming(

--- a/src/core/lifecycle/context.cr
+++ b/src/core/lifecycle/context.cr
@@ -53,6 +53,13 @@ module Hwaro
         # Track build statistics
         property stats : BuildStats
 
+        # When `--fast-start` is active, this is populated with the subset of
+        # pages the initial pass should process (homepage + recent N + section
+        # indexes). BeforeRender hooks (OG image, image resize) consult this to
+        # skip work for the deferred subset; the background render pass clears
+        # it and re-runs those hooks for the rest. Nil outside of fast-start.
+        property priority_pages : Array(Models::Page)?
+
         @all_pages_cache : Array(Models::Page)?
 
         def initialize(@options : Config::Options::BuildOptions)

--- a/src/core/lifecycle/context.cr
+++ b/src/core/lifecycle/context.cr
@@ -60,6 +60,14 @@ module Hwaro
         # it and re-runs those hooks for the rest. Nil outside of fast-start.
         property priority_pages : Array(Models::Page)?
 
+        # True when the current run only handles a subset of the site's
+        # pages — set on both passes of a `--fast-start` session
+        # (priority + deferred). Hooks that persist per-page state
+        # (e.g. the OG image manifest) use this to skip the "truncate
+        # entries for missing pages" prune, so the second pass doesn't
+        # wipe the first pass's writes.
+        property partial_render : Bool = false
+
         @all_pages_cache : Array(Models::Page)?
 
         def initialize(@options : Config::Options::BuildOptions)

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -453,11 +453,36 @@ module Hwaro
         # watcher proceeds.
         deferred_done = Channel(Nil).new
         fast_start_pending = build_options.fast_start && @builder.has_deferred_pages?
+
+        # Run `server.listen` in its own fiber so the accept loop is
+        # already established before we kick off the heavy deferred
+        # render. With fast-start the deferred fiber does ~20s of mostly
+        # pure-CPU work (PNG OG image encoding + image resize); if we
+        # spawned it first and only then called `server.listen` from the
+        # main fiber, the cooperative scheduler would pick the deferred
+        # fiber at the first yield and the accept loop would never get
+        # to run — TCP connects succeeded (OS-level backlog) but HTTP
+        # responses sat indefinitely.
+        listen_done = Channel(Nil).new
+        spawn do
+          begin
+            server.listen
+          ensure
+            listen_done.close
+          end
+        end
+
         if fast_start_pending
           deferred_options = build_options.dup
           deferred_options.preserve_output = true
           deferred_options.fast_start = false
           spawn do
+            # Yield once so the listen fiber spawned just above has a
+            # chance to enter its accept loop before we start
+            # CPU-saturating work. The accept loop itself yields on the
+            # first `accept?` call, so once it's running the deferred
+            # fiber can coexist with it.
+            Fiber.yield
             begin
               @builder.render_deferred(deferred_options)
               @live_reload_handler.try(&.notify_reload)
@@ -482,7 +507,9 @@ module Hwaro
         end
 
         emit_ready_signal(host, port, json_output)
-        server.listen
+        # Block the main fiber on the listen fiber's completion so the
+        # process stays alive for the lifetime of the server.
+        listen_done.receive?
       end
 
       # Emit a single deterministic, machine-parseable line indicating the

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -477,12 +477,18 @@ module Hwaro
           deferred_options.preserve_output = true
           deferred_options.fast_start = false
           spawn do
-            # Yield once so the listen fiber spawned just above has a
-            # chance to enter its accept loop before we start
-            # CPU-saturating work. The accept loop itself yields on the
-            # first `accept?` call, so once it's running the deferred
-            # fiber can coexist with it.
-            Fiber.yield
+            # Block until the listen fiber has actually entered the
+            # accept loop. `HTTP::Server#listening?` flips to true
+            # synchronously inside `#listen`, just before the accept
+            # fiber is spawned, so once we observe it the accept path
+            # is guaranteed to be live. Polling with `Fiber.yield` (not
+            # `sleep`) keeps the wait sub-microsecond on a quiet
+            # scheduler. A single `Fiber.yield` was *probabilistically*
+            # enough in practice but offered no ordering guarantee
+            # under `-Dpreview_mt` work-stealing.
+            until server.listening?
+              Fiber.yield
+            end
             begin
               @builder.render_deferred(deferred_options)
               @live_reload_handler.try(&.notify_reload)


### PR DESCRIPTION
## Summary

`--fast-start` was supposed to keep dev-server cold-start time bounded on large sites, but in practice it filtered only the Render block — the `BeforeRender` hooks (OG image generation, image resize) still iterated `ctx.all_pages` and consumed ~95% of the time. On hahwul.com (1063 pages, 734 PNG OG images) `--fast-start` was indistinguishable from a normal serve cold start (~22s).

This PR makes `--fast-start` actually fast.

### Profile (hahwul.com cold start)

| | Before | After |
|---|---|---|
| Time-to-ready (`hwaro serve --fast-start`) | **21.7s** | **2.6s** (8× faster) |
| Priority pages rendered up-front | 228 | 25 |
| OG images rendered up-front | 734 | 25 |
| HTTP responsiveness during deferred pass | TCP connects, HTTP timed out | sub-ms |

### What changed

- **Defer BeforeRender hooks to the background fiber.** Priority subset is now published on `BuildContext#priority_pages` before hooks run; `og_image_hooks` and `image_hooks` process only that subset on the cold pass. The background pass re-triggers the hooks for the remainder.
- **Tighten the priority set.** `split_priority_pages` now keeps only depth-≤1 section indexes plus the recent-N regulars. Hugo-style `index.md` page-bundle leaves no longer bypass `fast_start_count`. Priority dropped 228 → 25 on the test site.
- **OG manifest accumulates across partial passes** so the priority/deferred split doesn't truncate it.
- **Fix accept-loop starvation under fast-start.** `server.listen` now runs in its own fiber and the deferred fiber yields once before starting heavy work; without this the cooperative scheduler picked the deferred fiber at the first yield, the accept loop never ran, and HTTP requests piled up behind the OS-level TCP backlog. The OG image loop also yields every 8 pages so pure-CPU PNG encoding doesn't monopolize a worker.
- **Fix silent flag-drop bug** in `Builder#run(BuildOptions)` — `skip_og_image`, `skip_image_processing`, `preserve_output`, and `cache_busting` were dropped on delegation to the keyword `run(...)`.

## Test plan

- [x] `crystal spec -Dpreview_mt` — 4888 examples, 0 failures
- [x] `ameba src/` — 0 issues
- [x] `crystal tool format` — clean
- [x] Manual: `hwaro serve --fast-start` on hahwul.com — ready in 2.6s, priority pages serve sub-ms during deferred render, deferred pages serve correctly once background pass completes, OG `<meta>` tags reference real images on both priority and deferred HTML