### PR TITLE
fix(transform): populate page.lower/page.higher for page bundles

### DIFF
--- a/spec/unit/phases_transform_spec.cr
+++ b/spec/unit/phases_transform_spec.cr
@@ -126,6 +126,40 @@ describe Hwaro::Core::Build::Phases::Transform do
       page_b.lower.should eq(page_a)
       page_b.higher.should be_nil
     end
+
+    it "links page bundles alongside single-file pages (issue #539)" do
+      options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+
+      section = make_section("posts/_index.md", "posts")
+      section.is_index = true
+      section.weight = 1
+      section.sort_by = "weight"
+
+      # Single-file page
+      foo = make_page("posts/foo.md", "posts")
+      foo.title = "Foo"
+      foo.weight = 1
+      # Page bundle (index.md) — also has is_index = true for URL generation,
+      # but should still receive lower/higher links.
+      bar = make_page("posts/bar/index.md", "posts")
+      bar.title = "Bar"
+      bar.weight = 2
+      bar.is_index = true
+
+      ctx.sections = [section]
+      ctx.pages = [foo, bar]
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_link_page_navigation(ctx)
+
+      # Flat order: section index → foo (weight 1) → bar (weight 2)
+      foo.lower.should eq(section)
+      foo.higher.should eq(bar)
+
+      bar.lower.should eq(foo)
+      bar.higher.should be_nil
+    end
   end
 
   describe "#populate_taxonomies / #rebuild_taxonomies" do

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -41,10 +41,14 @@ module Hwaro::Core::Build::Phases::Transform
     sections_by_path = {} of String => Models::Section
     ctx.sections.each { |s| sections_by_path[s.section] = s }
 
-    # Group non-index pages by section
+    # Group pages by section. `ctx.pages` only contains regular pages and
+    # page-bundle leaves (`index.md`) — section indexes (`_index.md`) live
+    # in `ctx.sections` and are interleaved separately by
+    # `flatten_section_tree`. Page bundles set `is_index = true` for URL
+    # generation, but for navigation they're ordinary pages within their
+    # parent section.
     pages_by_section = {} of String => Array(Models::Page)
     ctx.pages.each do |page|
-      next if page.is_index
       section = page.section
       pages_by_section[section] ||= [] of Models::Page
       pages_by_section[section] << page
@@ -70,7 +74,6 @@ module Hwaro::Core::Build::Phases::Transform
     # Add any orphan pages not belonging to any section
     section_names = sections_by_path.keys.to_set
     ctx.pages.each do |page|
-      next if page.is_index
       next if section_names.includes?(page.section)
       flat_list << page unless flat_list.includes?(page)
     end
@@ -254,7 +257,6 @@ module Hwaro::Core::Build::Phases::Transform
 
     pages_by_section = {} of String => Array(Models::Page)
     site.pages.each do |page|
-      next if page.is_index
       section = page.section
       pages_by_section[section] ||= [] of Models::Page
       pages_by_section[section] << page
@@ -275,7 +277,6 @@ module Hwaro::Core::Build::Phases::Transform
 
     section_names = sections_by_path.keys.to_set
     site.pages.each do |page|
-      next if page.is_index
       next if section_names.includes?(page.section)
       flat_list << page unless flat_list.includes?(page)
     end


### PR DESCRIPTION
## Summary
- Navigation linker in `transform.cr` skipped any page with `is_index = true`, but `ctx.pages` only ever contains regular files and page-bundle leaves (`index.md`); section indexes (`_index.md`) live in `ctx.sections`. The filter was silently excluding page bundles, so `page.lower`/`page.higher` were always nil for `content/posts/bar/index.md` while working for `content/posts/foo.md`.
- Dropped the four `next if page.is_index` guards in `link_page_navigation` and `relink_navigation_for_sections`. Page bundles now sort alongside single-file pages within their parent section.
- Added a regression spec reproducing the exact scenario from the issue.

Closes #539

## Test plan
- [x] `crystal spec spec/unit/phases_transform_spec.cr` — 13 examples, 0 failures (includes new bundle case)
- [x] `crystal spec spec/unit/` — 4549 examples, 0 failures