### PR TITLE
fix(multilingual): expose translations on section.pages items

### DIFF
--- a/spec/functional/multilingual_spec.cr
+++ b/spec/functional/multilingual_spec.cr
@@ -88,6 +88,32 @@ describe "Multilingual: Translation links" do
   end
 end
 
+describe "Multilingual: section.pages translations" do
+  it "exposes translations on each page in section.pages (#540)" do
+    build_site(
+      MULTILINGUAL_CONFIG,
+      content_files: {
+        "posts/_index.md"       => "---\ntitle: Posts\n---\n",
+        "posts/_index.ko.md"    => "---\ntitle: 포스트\n---\n",
+        "posts/foo/index.md"    => "---\ntitle: Foo\n---\nEN foo",
+        "posts/foo/index.ko.md" => "---\ntitle: 푸\n---\nKO foo",
+      },
+      template_files: {
+        "page.html" => "{% set section = get_section(path=page.section) %}" \
+                       "SIB={% for p in section.pages %}" \
+                       "[{{ p.url }} t={% for t in p.translations %}{{ t.code }}:{{ t.url }},{% endfor %}]" \
+                       "{% endfor %}",
+      },
+    ) do
+      en_html = File.read("public/posts/foo/index.html")
+      # Sibling page in section.pages must expose the same translations
+      # as the page itself does (gh#540). The previously broken output
+      # was `t=` (empty); the fix populates both language entries.
+      en_html.should contain("t=en:/posts/foo/,ko:/ko/posts/foo/,")
+    end
+  end
+end
+
 describe "Multilingual: Section list isolation" do
   it "section_list only shows pages of the same language" do
     build_site(

--- a/spec/functional/multilingual_spec.cr
+++ b/spec/functional/multilingual_spec.cr
@@ -105,11 +105,14 @@ describe "Multilingual: section.pages translations" do
                        "{% endfor %}",
       },
     ) do
-      en_html = File.read("public/posts/foo/index.html")
       # Sibling page in section.pages must expose the same translations
       # as the page itself does (gh#540). The previously broken output
       # was `t=` (empty); the fix populates both language entries.
+      en_html = File.read("public/posts/foo/index.html")
       en_html.should contain("t=en:/posts/foo/,ko:/ko/posts/foo/,")
+
+      ko_html = File.read("public/ko/posts/foo/index.html")
+      ko_html.should contain("t=en:/posts/foo/,ko:/ko/posts/foo/,")
     end
   end
 end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -806,6 +806,15 @@ module Hwaro::Core::Build::Phases::Render
       end
       @cache_manager.record_miss("page_crinja_value")
       begin
+        translations = p.translations.map do |t|
+          Crinja::Value.new({
+            "code"       => Crinja::Value.new(t.code),
+            "url"        => Crinja::Value.new(t.url),
+            "title"      => Crinja::Value.new(t.title),
+            "is_current" => Crinja::Value.new(t.is_current),
+            "is_default" => Crinja::Value.new(t.is_default),
+          })
+        end
         val = Crinja::Value.new({
           "path"         => Crinja::Value.new(p.path),
           "title"        => Crinja::Value.new(p.title),
@@ -821,6 +830,7 @@ module Hwaro::Core::Build::Phases::Render
           "generated"    => Crinja::Value.new(p.generated),
           "in_sitemap"   => Crinja::Value.new(p.in_sitemap),
           "language"     => Crinja::Value.new(p.language || default_language),
+          "translations" => Crinja::Value.new(translations),
           "weight"       => Crinja::Value.new(p.weight),
           "summary"      => Crinja::Value.new(p.summary_html || p.effective_summary || ""),
           "word_count"   => Crinja::Value.new(p.word_count),

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1160,29 +1160,19 @@ module Hwaro::Core::Build::Phases::Render
     lang_prefix = page_language != default_lang && config.multilingual? ? "/#{page_language}" : ""
     vars["lang_prefix"] = Crinja::Value.new(lang_prefix)
 
-    translations = page.translations.map do |t|
-      Crinja::Value.new(
-        {
-          "code"       => Crinja::Value.new(t.code),
-          "url"        => Crinja::Value.new(t.url),
-          "title"      => Crinja::Value.new(t.title),
-          "is_current" => Crinja::Value.new(t.is_current),
-          "is_default" => Crinja::Value.new(t.is_default),
-        }
-      )
-    end
-    vars["page_translations"] = Crinja::Value.new(translations)
-
     # Generate permalink only if not already set
     page.generate_permalink(config.base_url) unless page.permalink
 
-    # Reuse cached Crinja arrays for tags/authors/assets/extra (avoids per-page .map allocation)
+    # Reuse cached Crinja arrays for tags/authors/assets/extra/translations
+    # (avoids per-page .map allocation)
     cached_page_val = cached_page_crinja_value(page, default_lang)
     cached_raw = cached_page_val.raw.as(Hash)
     tags_crinja = cached_raw["tags"].as(Crinja::Value)
     authors_crinja = cached_raw["authors"].as(Crinja::Value)
     assets_crinja = cached_raw["assets"].as(Crinja::Value)
     extra_crinja = cached_raw["extra"].as(Crinja::Value)
+    translations_crinja = cached_raw["translations"].as(Crinja::Value)
+    vars["page_translations"] = translations_crinja
 
     # Reuse cached Crinja::Value for lower/higher pages
     lower_obj = page.lower.try { |l| cached_page_crinja_value(l, default_lang) }
@@ -1222,7 +1212,7 @@ module Hwaro::Core::Build::Phases::Render
       "generated"    => Crinja::Value.new(page.generated),
       "in_sitemap"   => Crinja::Value.new(page.in_sitemap),
       "language"     => Crinja::Value.new(page_language),
-      "translations" => Crinja::Value.new(translations),
+      "translations" => translations_crinja,
       # New properties
       "authors"         => authors_crinja,
       "tags"            => tags_crinja,
@@ -1493,7 +1483,7 @@ module Hwaro::Core::Build::Phases::Render
       "twitter_site"    => Crinja::Value.new(config.og.twitter_site || ""),
       "twitter_creator" => Crinja::Value.new(config.og.twitter_creator || ""),
       "fb_app_id"       => Crinja::Value.new(config.og.fb_app_id || ""),
-      "hreflang"        => Crinja::Value.new(translations),
+      "hreflang"        => translations_crinja,
     }
     vars["seo"] = Crinja::Value.new(seo_obj)
 


### PR DESCRIPTION
## Summary
- `cached_page_crinja_value` omitted the `translations` field, so every consumer that reuses the cache (`section.pages`, `get_section(...).pages`, `series_pages`, `related_posts`, the global `pages` array) saw empty translation arrays even though `page.translations` on the current page was fully populated.
- Mirror the same `TranslationLink` → Crinja shape used by the page object into the cached value so sibling/related pages expose the same data.

## Test plan
- [x] `crystal spec spec/functional/multilingual_spec.cr spec/unit/multilingual_spec.cr spec/unit/multilingual_utils_spec.cr spec/functional/seo_obj_spec.cr spec/functional/site_vars_spec.cr` — 51/51 pass
- [x] `crystal spec spec/functional/build_integration_spec.cr spec/functional/cache_spec.cr` — 96/96 pass (Crinja value caching unaffected)
- [x] New regression test asserts `section.pages[*].translations` matches `page.translations` shape

Fixes #540