### PR TITLE
feat(minify): make --minify actually shrink HTML without breaking pages

### DIFF
--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -228,15 +228,15 @@ The build output is identical — streaming only affects memory usage during the
 
 **About `--minify`:**
 
-The minify flag performs conservative optimization on generated files:
+The minify flag shrinks generated files while keeping them visually identical to the un-minified output:
 
-- **HTML**: Removes comments and trailing whitespace, collapses excessive blank lines. Preserves all indentation, newlines, inter-tag whitespace, and content structure.
+- **HTML**: Removes comments (preserves conditional comments, SSI directives, `<!-- more -->`), strips trailing whitespace, and collapses inter-tag whitespace. Whitespace between two block-level tags (e.g. `</p>\n<p>`) is removed entirely; whitespace between an inline neighbor (e.g. `<a>x</a> <a>y</a>`) is collapsed to a single space so the visible gap is preserved.
 - **JSON**: Removes whitespace and newlines for compact output.
 - **XML**: Removes whitespace between tags for smaller file sizes.
 
-Code blocks (`<pre>`, `<code>`) and script/style content are always preserved intact.
+Whitespace-sensitive elements — `<pre>`, `<code>`, `<textarea>`, `<script>`, `<style>`, `<svg>`, `<math>`, `<noscript>` — are extracted before any whitespace pass and restored verbatim, so their contents are never touched.
 
-**HTML minification is intentionally conservative.** Prior attempts at aggressive HTML reduction (stripping indentation, collapsing whitespace between tags, etc.) caused content-rendering regressions even with `<pre>`/`<script>`/`<style>` protection. If you need aggressive HTML minification for deployment, post-process the output of `public/` with a dedicated minifier (e.g. `html-minifier-terser`, `minify-html`) rather than relying on `--minify`.
+For more aggressive output shrinking (attribute quoting, entity collapsing, etc.) post-process `public/` with a dedicated tool such as `html-minifier-terser` or `minify-html`.
 
 **About `--cache` (Incremental Build):**
 

--- a/spec/unit/html_minifier_spec.cr
+++ b/spec/unit/html_minifier_spec.cr
@@ -179,6 +179,23 @@ describe Hwaro::Utils::HtmlMinifier do
         result.should contain("<pre>third</pre>")
       end
 
+      it "does not let a literal <script> string inside <style> derail extraction" do
+        # `<style>` is extracted before `<script>` precisely so the
+        # script pass cannot mis-pair a real `</script>` elsewhere
+        # with a `<script>` text fragment that lived inside CSS.
+        html = "<style>p::before { content: \"<script>\" }</style>\n<p>hi</p>\n<script>real()</script>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("<style>p::before { content: \"<script>\" }</style>")
+        result.should contain("<script>real()</script>")
+        result.should contain("<p>hi</p>")
+      end
+
+      it "preserves XML comments inside <svg>" do
+        html = "<div>\n  <svg><!-- generator note --><circle/></svg>\n</div>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("<!-- generator note -->")
+      end
+
       it "cleans template-induced whitespace inside pre/code" do
         # The protection covers <pre> first, so its content is opaque
         # afterward. Whitespace inside the <code> alone (without a
@@ -186,6 +203,27 @@ describe Hwaro::Utils::HtmlMinifier do
         html = "<pre><code>x\n  y</code></pre>"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
         result.should contain("x\n  y")
+      end
+    end
+
+    describe "edge cases" do
+      it "treats uppercase tag names the same as lowercase" do
+        html = "<DIV>\n  <P>hi</P>\n</DIV>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<DIV><P>hi</P></DIV>")
+      end
+
+      it "collapses whitespace around self-closing void elements between blocks" do
+        html = "<head>\n  <meta charset=\"utf-8\"/>\n  <link rel=\"icon\" href=\"x\"/>\n</head>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<head><meta charset=\"utf-8\"/><link rel=\"icon\" href=\"x\"/></head>")
+      end
+
+      it "preserves DOCTYPE and collapses whitespace before <html>" do
+        html = "<!doctype html>\n<html>\n  <head></head>\n</html>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should start_with("<!doctype html>")
+        result.should contain("<html><head></head></html>")
       end
     end
 

--- a/spec/unit/html_minifier_spec.cr
+++ b/spec/unit/html_minifier_spec.cr
@@ -23,28 +23,6 @@ describe Hwaro::Utils::HtmlMinifier do
       result.should contain("<!-- more -->")
     end
 
-    it "collapses excessive blank lines" do
-      html = "<p>Hello</p>\n\n\n\n\n<p>World</p>"
-      result = Hwaro::Utils::HtmlMinifier.minify(html)
-      result.should_not contain("\n\n\n")
-      result.should contain("<p>Hello</p>")
-      result.should contain("<p>World</p>")
-    end
-
-    it "cleans whitespace inside pre/code blocks" do
-      html = "<pre>\n  <code>content</code>\n</pre>"
-      result = Hwaro::Utils::HtmlMinifier.minify(html)
-      result.should contain("<pre><code")
-      result.should contain("</code></pre>")
-    end
-
-    it "cleans pre blocks with attributes" do
-      html = "<pre class=\"highlight\">\n  <code>content</code>\n</pre>"
-      result = Hwaro::Utils::HtmlMinifier.minify(html)
-      result.should contain("<pre class=\"highlight\"><code")
-      result.should contain("</code></pre>")
-    end
-
     it "strips surrounding whitespace" do
       html = "  \n  <p>Hello</p>  \n  "
       result = Hwaro::Utils::HtmlMinifier.minify(html)
@@ -53,6 +31,10 @@ describe Hwaro::Utils::HtmlMinifier do
 
     it "handles empty string" do
       Hwaro::Utils::HtmlMinifier.minify("").should eq("")
+    end
+
+    it "handles whitespace-only content" do
+      Hwaro::Utils::HtmlMinifier.minify("   \n\n\n   ").should eq("")
     end
 
     it "handles html with no minifiable content" do
@@ -78,13 +60,6 @@ describe Hwaro::Utils::HtmlMinifier do
       result.should_not contain("comment")
     end
 
-    it "preserves content inside pre/code blocks unchanged" do
-      html = "<pre><code>  line1\n  line2\n  line3</code></pre>"
-      result = Hwaro::Utils::HtmlMinifier.minify(html)
-      result.should contain("line1")
-      result.should contain("line2")
-    end
-
     it "handles nested comments edge case" do
       html = "<p>A</p><!-- outer <!-- inner --> --><p>B</p>"
       result = Hwaro::Utils::HtmlMinifier.minify(html)
@@ -92,66 +67,55 @@ describe Hwaro::Utils::HtmlMinifier do
       result.should contain("<p>B</p>")
     end
 
-    it "collapses exactly 3 blank lines to 2" do
-      html = "<p>A</p>\n\n\n<p>B</p>"
-      result = Hwaro::Utils::HtmlMinifier.minify(html)
-      result.should eq("<p>A</p>\n\n<p>B</p>")
-    end
-
-    it "preserves 2 blank lines unchanged" do
-      html = "<p>A</p>\n\n<p>B</p>"
-      result = Hwaro::Utils::HtmlMinifier.minify(html)
-      result.should eq("<p>A</p>\n\n<p>B</p>")
-    end
-
-    it "handles multiple pre blocks" do
-      html = "<pre>\n  <code>first</code>\n</pre>\n<p>gap</p>\n<pre>\n  <code>second</code>\n</pre>"
-      result = Hwaro::Utils::HtmlMinifier.minify(html)
-      result.should contain("<pre><code")
-      result.should contain("first")
-      result.should contain("second")
-    end
-
-    it "handles comments adjacent to preserved more marker" do
-      html = "<!-- remove this --><!-- more -->"
-      result = Hwaro::Utils::HtmlMinifier.minify(html)
-      result.should_not contain("remove this")
-      result.should contain("<!-- more -->")
-    end
-
-    it "handles whitespace-only content" do
-      Hwaro::Utils::HtmlMinifier.minify("   \n\n\n   ").should eq("")
-    end
-
-    describe "trailing whitespace" do
-      it "strips trailing spaces from each line" do
-        html = "<p>A</p>   \n<p>B</p>\t\t\n<p>C</p>"
+    describe "block-level whitespace collapse" do
+      it "strips whitespace between two block-level tags" do
+        html = "<div>\n  <p>indented</p>\n</div>"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
-        result.should eq("<p>A</p>\n<p>B</p>\n<p>C</p>")
+        result.should eq("<div><p>indented</p></div>")
       end
 
-      it "strips trailing whitespace even inside pre blocks (no visual effect)" do
-        html = "<pre><code>line1   \nline2\t</code></pre>"
+      it "strips whitespace between adjacent block-level siblings" do
+        html = "<p>A</p>\n<p>B</p>"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
-        result.should contain("line1\nline2")
-        result.should_not match(/line1 +\n/)
+        result.should eq("<p>A</p><p>B</p>")
+      end
+
+      it "collapses deeply indented block markup" do
+        html = "<html>\n  <head>\n    <title>T</title>\n  </head>\n  <body>\n    <p>Hi</p>\n  </body>\n</html>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<html><head><title>T</title></head><body><p>Hi</p></body></html>")
+      end
+
+      it "strips whitespace between adjacent <meta> tags in <head>" do
+        html = "<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"x\">\n</head>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<head><meta charset=\"utf-8\"><meta name=\"x\"></head>")
       end
     end
 
-    describe "conservative guarantees (things it must NOT do)" do
-      # Prior attempts to strip these broke content rendering. The flag
-      # is contractually conservative — these assertions pin that down.
-
-      it "does not collapse whitespace between tags" do
+    describe "inline whitespace preservation" do
+      it "preserves a single space between adjacent inline siblings" do
         html = "<span>x</span> <span>y</span>"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
         result.should eq("<span>x</span> <span>y</span>")
       end
 
-      it "does not strip leading whitespace from lines (preserves indentation)" do
-        html = "<div>\n  <p>indented</p>\n</div>"
+      it "collapses whitespace runs between inline siblings to a single space" do
+        html = "<a>x</a>     <a>y</a>"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
-        result.should eq("<div>\n  <p>indented</p>\n</div>")
+        result.should eq("<a>x</a> <a>y</a>")
+      end
+
+      it "collapses newlines between inline siblings to a single space" do
+        html = "<a>x</a>\n  <a>y</a>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<a>x</a> <a>y</a>")
+      end
+
+      it "keeps a single space when an inline neighbor sits next to a block neighbor" do
+        html = "<p>\n  <span>only</span>\n</p>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<p> <span>only</span> </p>")
       end
 
       it "does not collapse whitespace runs in body text" do
@@ -160,16 +124,82 @@ describe Hwaro::Utils::HtmlMinifier do
         result.should contain("two  spaces")
       end
 
-      it "preserves inline whitespace inside pre/code blocks" do
-        html = "<pre><code>  leading\n    indented\n  outdented</code></pre>"
+      it "does not introduce whitespace where there was none" do
+        html = "<a>x</a><b>y</b>"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
-        result.should contain("  leading\n    indented\n  outdented")
+        result.should eq("<a>x</a><b>y</b>")
+      end
+    end
+
+    describe "protected blocks (whitespace-sensitive elements)" do
+      it "preserves content inside <pre><code> unchanged" do
+        html = "<pre><code>  line1\n    line2\n  line3</code></pre>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("  line1\n    line2\n  line3")
       end
 
-      it "preserves single newline between block elements" do
-        html = "<p>A</p>\n<p>B</p>"
+      it "preserves inline <code> whitespace exactly" do
+        html = "<p>Use <code>two   spaces</code> here</p>"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
-        result.should eq("<p>A</p>\n<p>B</p>")
+        result.should contain("<code>two   spaces</code>")
+      end
+
+      it "preserves <textarea> content as-is" do
+        html = "<form>\n  <textarea>line 1\n  line 2\nline 3</textarea>\n</form>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("<textarea>line 1\n  line 2\nline 3</textarea>")
+      end
+
+      it "preserves <script> body unchanged" do
+        html = "<head>\n  <script>\n    if (a < b) {\n      foo();\n    }\n  </script>\n</head>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("if (a < b) {\n      foo();\n    }")
+      end
+
+      it "preserves <style> body unchanged" do
+        html = "<head><style>\n  .x {\n    color: red;\n  }\n</style></head>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain(".x {\n    color: red;\n  }")
+      end
+
+      it "preserves <svg> subtree unchanged" do
+        html = "<div>\n  <svg width=\"10\">\n    <text x=\"0\" y=\"0\">hi</text>\n  </svg>\n</div>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("<svg width=\"10\">\n    <text x=\"0\" y=\"0\">hi</text>\n  </svg>")
+      end
+
+      it "does not pair an opening <pre> with a different protected closer" do
+        # Regression: prior alternation-based regex could match
+        # `<pre>...</script>` across a mix of protected tags. With per-tag
+        # passes each tag's content is captured independently.
+        html = "<pre>first</pre>\n<script>second</script>\n<pre>third</pre>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("<pre>first</pre>")
+        result.should contain("<script>second</script>")
+        result.should contain("<pre>third</pre>")
+      end
+
+      it "cleans template-induced whitespace inside pre/code" do
+        # The protection covers <pre> first, so its content is opaque
+        # afterward. Whitespace inside the <code> alone (without a
+        # surrounding <pre>) is preserved verbatim too.
+        html = "<pre><code>x\n  y</code></pre>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("x\n  y")
+      end
+    end
+
+    describe "trailing and blank-line whitespace" do
+      it "strips trailing spaces from each line" do
+        html = "<div>A</div>   \n<div>B</div>\t\t\n<div>C</div>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<div>A</div><div>B</div><div>C</div>")
+      end
+
+      it "collapses runs of blank lines" do
+        html = "<p>A</p>\n\n\n\n<p>B</p>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<p>A</p><p>B</p>")
       end
     end
   end

--- a/src/cli/metadata.cr
+++ b/src/cli/metadata.cr
@@ -50,7 +50,7 @@ module Hwaro
     DRAFTS_FLAG                = FlagInfo.new(short: "-d", long: "--drafts", description: "Include draft content")
     INCLUDE_EXPIRED_FLAG       = FlagInfo.new(short: nil, long: "--include-expired", description: "Include expired content")
     INCLUDE_FUTURE_FLAG        = FlagInfo.new(short: nil, long: "--include-future", description: "Include future-dated content")
-    MINIFY_FLAG                = FlagInfo.new(short: nil, long: "--minify", description: "Minify JSON/XML output and conservatively trim HTML (comments, trailing whitespace, blank lines)")
+    MINIFY_FLAG                = FlagInfo.new(short: nil, long: "--minify", description: "Minify HTML/JSON/XML output (strips comments and inter-tag whitespace; preserves pre/code/script/style/svg)")
     BASE_URL_FLAG              = FlagInfo.new(short: nil, long: "--base-url", description: "Override base_url from config.toml", takes_value: true, value_hint: "URL")
     SKIP_CACHE_BUSTING_FLAG    = FlagInfo.new(short: nil, long: "--skip-cache-busting", description: "Disable cache busting query parameters on CSS/JS resources")
     SKIP_OG_IMAGE_FLAG         = FlagInfo.new(short: nil, long: "--skip-og-image", description: "Skip auto OG image generation")

--- a/src/utils/html_minifier.cr
+++ b/src/utils/html_minifier.cr
@@ -1,62 +1,141 @@
 # HTML minification utilities
 #
-# Provides conservative HTML minification that only removes
-# clearly unnecessary content while preserving meaningful whitespace.
+# Aggressively shrinks rendered HTML while staying visually equivalent
+# to the input. Two ideas keep it safe:
 #
-# Conservative-by-default is a deliberate choice: prior attempts at
-# aggressive whitespace collapsing (leading-whitespace strip, inter-tag
-# whitespace collapse, etc.) broke content rendering even with
-# `<pre>/<textarea>/<script>/<style>` protection. If more aggressive
-# output shrinking is required, post-process with an external tool.
+#   1. Whitespace-sensitive elements (<pre>, <textarea>, <script>,
+#      <style>, <code>, <svg>, <math>, <noscript>) are extracted as
+#      opaque blocks before any whitespace pass touches the document
+#      and restored verbatim at the end. Each tag is handled in its
+#      own pass so a stray alternation in non-greedy matching can't
+#      pair an open <pre> with a close </script>.
 #
-# Operations:
-# - Clean up template-induced whitespace inside <pre> blocks
-# - Remove HTML comments (preserving conditional and <!--more--> markers)
-# - Strip trailing whitespace from each line
-# - Collapse excessive blank lines
+#   2. Inter-tag whitespace is collapsed by classifying both
+#      neighboring tag names. Between two block-level tags whitespace
+#      is removed entirely; otherwise it collapses to a single space,
+#      preserving the visible gap between adjacent inline elements
+#      (e.g. `<a>x</a> <a>y</a>`).
+#
+# What is NOT done: variable renaming, attribute rewriting, or
+# entity collapsing. For more aggressive output shrinking, post-process
+# with a dedicated tool (`html-minifier-terser`, `minify-html`).
 
 module Hwaro
   module Utils
     module HtmlMinifier
       extend self
 
-      # Regex constants for HTML minification
-      private REGEX_PRE_OPEN       = /<pre([^>]*)>\s*<code/
-      private REGEX_PRE_CLOSE      = /<\/code>\s*<\/pre>/
+      # HTML block-level elements. Whitespace between two block-level
+      # neighbors has no visual effect (the user agent renders them on
+      # separate lines anyway), so it is safe to strip entirely.
+      # Anything not listed here is treated as inline, where whitespace
+      # between siblings collapses to a single rendered space and must
+      # therefore be kept as one literal space.
+      BLOCK_TAGS = Set{
+        "address", "article", "aside", "base", "blockquote", "body",
+        "caption", "col", "colgroup", "dd", "details", "dialog",
+        "div", "dl", "dt", "fieldset", "figcaption", "figure",
+        "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6",
+        "head", "header", "hgroup", "hr", "html", "iframe",
+        "li", "link", "main", "meta", "nav", "noscript",
+        "ol", "p", "picture", "pre", "script", "section",
+        "source", "style", "summary", "table", "tbody", "td",
+        "tfoot", "th", "thead", "title", "tr", "track", "ul",
+        "video", "audio", "canvas",
+      }
+
+      # Tags whose content must be preserved verbatim. Extracted into
+      # placeholders before any whitespace pass and restored afterward.
+      # `code` is included because inline-code snippets often carry
+      # whitespace that authors expect to ship unchanged.
+      PROTECTED_TAGS = %w[pre textarea script style code svg math noscript]
+
+      # Sentinel format for protected blocks. `\x00` is illegal in HTML,
+      # so the placeholder cannot collide with author content.
+      private PRESERVE_PREFIX = "\x00HW_HTML_P_"
+      private PRESERVE_SUFFIX = "\x00"
+
+      # Regex constants
       private REGEX_COMMENTS       = /<!--(?!\[if|#|\s*more\s*-->).*?-->/m
       private REGEX_TRAILING_SPACE = /[ \t]+$/m
-      private REGEX_BLANK_LINES    = /\n{3,}/
+      # Match a complete tag immediately followed by whitespace and
+      # lookahead at the next tag. Captures:
+      #   $1 = "/" or "" on the prior tag
+      #   $2 = prior tag's name
+      #   $3 = prior tag's attribute slice (may contain a self-closing /)
+      #   $4 = whitespace run
+      #   $5 = "/" or "" on the next tag
+      #   $6 = next tag's name
+      private REGEX_INTERTAG_WS    = /(<\/?)([A-Za-z][\w-]*)([^>]*)>(\s+)(?=<(\/?)([A-Za-z][\w-]*))/
+      private REGEX_BLANK_LINES    = /\n{2,}/
+      private REGEX_PRESERVE_TOKEN = /\x00HW_HTML_P_(\d+)\x00/
 
-      # Perform conservative HTML minification
-      #
-      # Only removes: HTML comments, trailing whitespace on lines, excessive blank lines
-      # Preserves: all meaningful whitespace, newlines, indentation structure
+      # Minify the given HTML.
       #
       # Example:
-      #   minify("<p>Hello</p>\n\n\n\n<p>World</p>")  # => "<p>Hello</p>\n\n<p>World</p>"
+      #   minify("<div>\n  <p>Hello</p>\n</div>")
+      #   # => "<div><p>Hello</p></div>"
       #
+      #   minify("<span>x</span>\n<span>y</span>")
+      #   # => "<span>x</span> <span>y</span>"
       def minify(html : String) : String
-        # Clean up template-induced whitespace inside pre blocks
-        # This handles cases like: <pre>\n  <code>content</code>\n</pre>
-        # Converting to: <pre><code>content</code></pre>
-        cleaned = html
-          .gsub(REGEX_PRE_OPEN, "<pre\\1><code")
-          .gsub(REGEX_PRE_CLOSE, "</code></pre>")
+        preserves = [] of String
+        result = protect_sensitive_blocks(html, preserves)
+        result = result.gsub(REGEX_COMMENTS, "")
+        result = result.gsub(REGEX_TRAILING_SPACE, "")
+        result = collapse_inter_tag_whitespace(result)
+        result = result.gsub(REGEX_BLANK_LINES, "\n")
+        result = restore_sensitive_blocks(result, preserves)
+        result.strip
+      end
 
-        # Remove HTML comments (but not conditional comments like <!--[if IE]>)
-        # Also preserve <!-- more --> markers used for content summaries
-        minified = cleaned.gsub(REGEX_COMMENTS, "")
+      # Extract whitespace-sensitive elements one tag at a time. A
+      # single regex with alternation in the open/close tag (e.g.
+      # `<(pre|script)>...</(pre|script)>`) does not enforce that both
+      # sides reference the same tag, which let prior implementations
+      # pair `<pre>` openers with `</script>` closers when the document
+      # mixed both. One pass per tag avoids that whole class of bug.
+      private def protect_sensitive_blocks(html : String, preserves : Array(String)) : String
+        result = html
+        PROTECTED_TAGS.each do |tag|
+          pattern = Regex.new(
+            "<#{tag}\\b[^>]*>.*?</#{tag}\\s*>",
+            Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE
+          )
+          result = result.gsub(pattern) do |match|
+            idx = preserves.size
+            preserves << match
+            "#{PRESERVE_PREFIX}#{idx}#{PRESERVE_SUFFIX}"
+          end
+        end
+        result
+      end
 
-        # Strip trailing whitespace from each line. Trailing spaces have no
-        # rendering effect in HTML anywhere — including inside <pre>, where
-        # line-ending whitespace is invisible — so this is safe regardless
-        # of context.
-        minified = minified.gsub(REGEX_TRAILING_SPACE, "")
+      private def restore_sensitive_blocks(html : String, preserves : Array(String)) : String
+        html.gsub(REGEX_PRESERVE_TOKEN) do
+          idx = $1.to_i
+          idx < preserves.size ? preserves[idx] : $0
+        end
+      end
 
-        # Collapse 3+ consecutive blank lines to 2
-        minified = minified.gsub(REGEX_BLANK_LINES, "\n\n")
+      # Collapse whitespace between two tags according to neighbor type.
+      # Both block-level → strip entirely. Otherwise → single space, so
+      # adjacent inline siblings keep their visible gap.
+      private def collapse_inter_tag_whitespace(html : String) : String
+        html.gsub(REGEX_INTERTAG_WS) do
+          slash_prev = $1
+          name_prev = $2
+          attrs_prev = $3
+          # $4 = whitespace run (discarded)
+          name_next = $6
 
-        minified.strip
+          rebuilt = "#{slash_prev}#{name_prev}#{attrs_prev}>"
+          if BLOCK_TAGS.includes?(name_prev.downcase) && BLOCK_TAGS.includes?(name_next.downcase)
+            rebuilt
+          else
+            "#{rebuilt} "
+          end
+        end
       end
     end
   end

--- a/src/utils/html_minifier.cr
+++ b/src/utils/html_minifier.cr
@@ -48,7 +48,12 @@ module Hwaro
       # placeholders before any whitespace pass and restored afterward.
       # `code` is included because inline-code snippets often carry
       # whitespace that authors expect to ship unchanged.
-      PROTECTED_TAGS = %w[pre textarea script style code svg math noscript]
+      #
+      # Order matters: a `<style>` body may legitimately contain the
+      # literal string `<script>` (e.g. `content: "<script>"`), so
+      # `style` is extracted first to remove that text from view
+      # before the `script` pass runs.
+      PROTECTED_TAGS = %w[pre textarea style script code svg math noscript]
 
       # Sentinel format for protected blocks. `\x00` is illegal in HTML,
       # so the placeholder cannot collide with author content.
@@ -66,6 +71,11 @@ module Hwaro
       #   $4 = whitespace run
       #   $5 = "/" or "" on the next tag
       #   $6 = next tag's name
+      #
+      # Known limitation: `[^>]*` does not understand quoted attribute
+      # values, so a literal `>` inside an attribute (`title="x > y"`)
+      # is treated as the tag's end. Hwaro's rendered output does not
+      # produce such attributes in practice.
       private REGEX_INTERTAG_WS    = /(<\/?)([A-Za-z][\w-]*)([^>]*)>(\s+)(?=<(\/?)([A-Za-z][\w-]*))/
       private REGEX_BLANK_LINES    = /\n{2,}/
       private REGEX_PRESERVE_TOKEN = /\x00HW_HTML_P_(\d+)\x00/


### PR DESCRIPTION
## Summary

- Make `--minify` perform aggressive-but-safe HTML minification: strip whitespace between block-level neighbors, collapse to a single space between any inline neighbor, and preserve `<pre>/<textarea>/<script>/<style>/<code>/<svg>/<math>/<noscript>` content verbatim.
- Fix the two bugs that sank prior aggressive attempts (1eff5fb introduced → 9e87263 reverted): (1) alternation in the protected-tag regex did not enforce open/close pairing, so a `<pre>` could match a `</script>` — each tag is now protected in its own pass; (2) inline siblings lost their visible gap — neighbor type is now classified before stripping.
- Update help text and docs to describe the new behavior.

## Result

Measured on the docs site:

| | Without `--minify` | With `--minify` | Δ |
|---|---|---|---|
| Total HTML | 1223 KB | 1082 KB | **-11.5%** |
| `index.html` | 24 KB | 19 KB | -21% |

Tag counts for `p/div/span/a/code/pre/script/style/li/tr/td/h1-3/link/meta` match before/after — DOM is preserved.

## Test plan

- [x] `crystal spec` — full suite (4898 examples, 0 failures)
- [x] `crystal spec spec/unit/html_minifier_spec.cr` — 30 examples covering block collapse, inline preservation, all protected tags, mixed-tag regression
- [x] `crystal tool format` + `ameba` — clean
- [x] Build the docs site with and without `--minify`, diff rendered output, confirm tag counts match
- [x] Spot-check code-heavy pages (`start/cli/index.html`): `<pre><code>` blocks and inline `<code>` whitespace shipped verbatim

Closes #411.