### PR TITLE
feat(minify): shrink HTML further with block-aware + intra-tag whitespace collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- `hwaro build --minify` now collapses whitespace adjacent to *any* block-level neighbour (not just block-to-block) and shrinks runs of whitespace inside tag openings with a quote-aware scan. Indented templates like `<header>\n  <a>...</a>\n</header>` and multi-line attribute lists like `<a\n  href=…\n  class=…>` shrink further while inline siblings (`<a>x</a> <a>y</a>`), text content, and the contents of `<pre>`/`<code>`/`<script>`/`<style>`/`<svg>`/`<math>`/`<textarea>`/`<noscript>` stay byte-identical. Protected-block placeholders carry their original display class so a `<pre>` adjacent to a `<div>` is also stripped while a `<code>` between two inline siblings still keeps a space on each side.
+
 ## v0.14.1
 
 ### Fixed

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -230,7 +230,7 @@ The build output is identical — streaming only affects memory usage during the
 
 The minify flag shrinks generated files while keeping them visually identical to the un-minified output:
 
-- **HTML**: Removes comments (preserves conditional comments, SSI directives, `<!-- more -->`), strips trailing whitespace, and collapses inter-tag whitespace. Whitespace between two block-level tags (e.g. `</p>\n<p>`) is removed entirely; whitespace between an inline neighbor (e.g. `<a>x</a> <a>y</a>`) is collapsed to a single space so the visible gap is preserved.
+- **HTML**: Removes comments (preserves conditional comments, SSI directives, `<!-- more -->`), strips trailing whitespace, collapses intra-tag whitespace (runs between attributes shrink to one space, quoted attribute values stay untouched), and collapses inter-tag whitespace by neighbour classification. If either neighbour is a block-level element the whitespace is stripped entirely (browsers collapse whitespace at the start, end, or between block siblings anyway); only when *both* neighbours are inline is a single space kept so the visible gap of `<a>x</a> <a>y</a>` is preserved.
 - **JSON**: Removes whitespace and newlines for compact output.
 - **XML**: Removes whitespace between tags for smaller file sizes.
 

--- a/spec/unit/html_minifier_spec.cr
+++ b/spec/unit/html_minifier_spec.cr
@@ -285,16 +285,6 @@ describe Hwaro::Utils::HtmlMinifier do
         result.should eq("<a href=\"/x\">link</a>")
       end
 
-      it "collapses newlines between attributes spanning multiple lines" do
-        html = "<svg\n  width=\"10\"\n  height=\"10\"\n  viewBox=\"0 0 10 10\">x</svg>"
-        result = Hwaro::Utils::HtmlMinifier.minify(html)
-        # <svg> is protected — its body is opaque — but the *opening*
-        # tag is part of the protected match too, so it survives
-        # untouched. The collapse below confirms a non-protected
-        # multi-line tag gets squashed.
-        result.should contain("<svg")
-      end
-
       it "collapses multi-line attribute lists on a normal tag" do
         html = "<a\n  href=\"/x\"\n  class=\"y\"\n  data-x=\"1\"\n>link</a>"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
@@ -341,6 +331,22 @@ describe Hwaro::Utils::HtmlMinifier do
         html = "<meta charset=\"utf-8\"   />"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
         result.should eq("<meta charset=\"utf-8\"/>")
+      end
+
+      it "preserves UTF-8 in attribute values when stripping space before />" do
+        # Regression: a prior implementation used char-indexed
+        # `body[0, body.bytesize - 2]` to drop the trailing ` /`,
+        # which over-ran the string for multi-byte UTF-8 and left
+        # a stray `/` in the output.
+        html = "<img alt=\"안녕 세계\"   />"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<img alt=\"안녕 세계\"/>")
+      end
+
+      it "preserves UTF-8 in attribute values when collapsing inter-attribute whitespace" do
+        html = "<a   title=\"안녕\"   class=\"y\">x</a>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<a title=\"안녕\" class=\"y\">x</a>")
       end
     end
 

--- a/spec/unit/html_minifier_spec.cr
+++ b/spec/unit/html_minifier_spec.cr
@@ -112,10 +112,25 @@ describe Hwaro::Utils::HtmlMinifier do
         result.should eq("<a>x</a> <a>y</a>")
       end
 
-      it "keeps a single space when an inline neighbor sits next to a block neighbor" do
+      it "strips whitespace when an inline neighbor sits at a block boundary" do
+        # Browsers collapse leading/trailing whitespace inside a block
+        # parent, so `<p>\n  <span>only</span>\n</p>` and
+        # `<p><span>only</span></p>` render identically.
         html = "<p>\n  <span>only</span>\n</p>"
         result = Hwaro::Utils::HtmlMinifier.minify(html)
-        result.should eq("<p> <span>only</span> </p>")
+        result.should eq("<p><span>only</span></p>")
+      end
+
+      it "strips whitespace when an inline closer butts against a block closer" do
+        html = "<div>text<a>x</a>\n</div>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<div>text<a>x</a></div>")
+      end
+
+      it "strips whitespace when a block opener is followed by an inline child" do
+        html = "<li>\n  <a href=\"x\">link</a>\n</li>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<li><a href=\"x\">link</a></li>")
       end
 
       it "does not collapse whitespace runs in body text" do
@@ -204,6 +219,36 @@ describe Hwaro::Utils::HtmlMinifier do
         result = Hwaro::Utils::HtmlMinifier.minify(html)
         result.should contain("x\n  y")
       end
+
+      it "strips whitespace between a block tag and a protected-block sibling" do
+        # <pre> is whitespace-sensitive (protected) AND a block element.
+        # Indentation between an outer block and a <pre> placeholder
+        # should be removed since <pre>'s body is opaque and both
+        # neighbours are block.
+        html = "<div>\n  <pre>x</pre>\n</div>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<div><pre>x</pre></div>")
+      end
+
+      it "keeps one space between two inline protected siblings" do
+        # <code> placeholders are inline. Two inline neighbours keep a
+        # single space.
+        html = "<p><code>a</code>   <code>b</code></p>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<p><code>a</code> <code>b</code></p>")
+      end
+
+      it "strips whitespace between an inline tag and an inline protected sibling at a block boundary" do
+        # `<button>` (inline) wraps an `<svg>` (inline, protected). The
+        # surrounding `<div>` is block, so whitespace between `<div>`
+        # and `<button>` collapses; whitespace inside `<button>`
+        # around the `<svg>` stays one space (inline neighbours).
+        html = "<div>\n  <button>\n    <svg><path/></svg>\n    label\n  </button>\n</div>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("<div><button>")
+        result.should contain("<svg><path/></svg>")
+        result.should_not contain("\n  <button")
+      end
     end
 
     describe "edge cases" do
@@ -224,6 +269,78 @@ describe Hwaro::Utils::HtmlMinifier do
         result = Hwaro::Utils::HtmlMinifier.minify(html)
         result.should start_with("<!doctype html>")
         result.should contain("<html><head></head></html>")
+      end
+    end
+
+    describe "intra-tag whitespace collapse" do
+      it "collapses runs of whitespace between attributes to a single space" do
+        html = "<a   href=\"/x\"   class=\"y\">link</a>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<a href=\"/x\" class=\"y\">link</a>")
+      end
+
+      it "strips trailing whitespace before the closing >" do
+        html = "<a href=\"/x\"   >link</a>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<a href=\"/x\">link</a>")
+      end
+
+      it "collapses newlines between attributes spanning multiple lines" do
+        html = "<svg\n  width=\"10\"\n  height=\"10\"\n  viewBox=\"0 0 10 10\">x</svg>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        # <svg> is protected — its body is opaque — but the *opening*
+        # tag is part of the protected match too, so it survives
+        # untouched. The collapse below confirms a non-protected
+        # multi-line tag gets squashed.
+        result.should contain("<svg")
+      end
+
+      it "collapses multi-line attribute lists on a normal tag" do
+        html = "<a\n  href=\"/x\"\n  class=\"y\"\n  data-x=\"1\"\n>link</a>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<a href=\"/x\" class=\"y\" data-x=\"1\">link</a>")
+      end
+
+      it "preserves whitespace inside quoted attribute values" do
+        html = "<a title=\"two  spaces\"   class=\"y\">link</a>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<a title=\"two  spaces\" class=\"y\">link</a>")
+      end
+
+      it "preserves single-quoted attribute values verbatim" do
+        html = "<a data-x='hello  world'   data-y='1'>x</a>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<a data-x='hello  world' data-y='1'>x</a>")
+      end
+
+      it "handles tags with no attributes unchanged" do
+        html = "<div><p>x</p></div>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<div><p>x</p></div>")
+      end
+
+      it "does not touch text content between tags" do
+        html = "<p>two  spaces  and  more</p>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<p>two  spaces  and  more</p>")
+      end
+
+      it "leaves DOCTYPE unchanged" do
+        html = "<!DOCTYPE html><html><head></head></html>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should start_with("<!DOCTYPE html>")
+      end
+
+      it "handles tags containing > inside a quoted attribute value" do
+        html = "<a title=\"x > y\"   class=\"z\">link</a>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<a title=\"x > y\" class=\"z\">link</a>")
+      end
+
+      it "collapses whitespace before /> on void elements" do
+        html = "<meta charset=\"utf-8\"   />"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<meta charset=\"utf-8\"/>")
       end
     end
 

--- a/src/cli/metadata.cr
+++ b/src/cli/metadata.cr
@@ -50,7 +50,7 @@ module Hwaro
     DRAFTS_FLAG                = FlagInfo.new(short: "-d", long: "--drafts", description: "Include draft content")
     INCLUDE_EXPIRED_FLAG       = FlagInfo.new(short: nil, long: "--include-expired", description: "Include expired content")
     INCLUDE_FUTURE_FLAG        = FlagInfo.new(short: nil, long: "--include-future", description: "Include future-dated content")
-    MINIFY_FLAG                = FlagInfo.new(short: nil, long: "--minify", description: "Minify HTML/JSON/XML output (strips comments and inter-tag whitespace; preserves pre/code/script/style/svg)")
+    MINIFY_FLAG                = FlagInfo.new(short: nil, long: "--minify", description: "Minify HTML/JSON/XML output (strips comments, intra-tag and inter-tag whitespace by neighbour class; preserves pre/code/script/style/svg/math/textarea/noscript)")
     BASE_URL_FLAG              = FlagInfo.new(short: nil, long: "--base-url", description: "Override base_url from config.toml", takes_value: true, value_hint: "URL")
     SKIP_CACHE_BUSTING_FLAG    = FlagInfo.new(short: nil, long: "--skip-cache-busting", description: "Disable cache busting query parameters on CSS/JS resources")
     SKIP_OG_IMAGE_FLAG         = FlagInfo.new(short: nil, long: "--skip-og-image", description: "Skip auto OG image generation")

--- a/src/utils/html_minifier.cr
+++ b/src/utils/html_minifier.cr
@@ -1,33 +1,51 @@
 # HTML minification utilities
 #
 # Aggressively shrinks rendered HTML while staying visually equivalent
-# to the input. Two ideas keep it safe:
+# to the input. The contract:
 #
 #   1. Whitespace-sensitive elements (<pre>, <textarea>, <script>,
 #      <style>, <code>, <svg>, <math>, <noscript>) are extracted as
-#      opaque blocks before any whitespace pass touches the document
-#      and restored verbatim at the end. Each tag is handled in its
-#      own pass so a stray alternation in non-greedy matching can't
-#      pair an open <pre> with a close </script>.
+#      opaque, typed placeholders before any whitespace pass touches
+#      the document and restored verbatim at the end. Each tag is
+#      handled in its own pass so a stray alternation in non-greedy
+#      matching can't pair an open <pre> with a close </script>.
+#      Placeholders carry the element's default display classification
+#      (block or inline) so the whitespace collapse can treat the
+#      sealed block as if it were still its original tag for the
+#      purpose of deciding whether neighbouring whitespace is visible.
 #
-#   2. Inter-tag whitespace is collapsed by classifying both
-#      neighboring tag names. Between two block-level tags whitespace
-#      is removed entirely; otherwise it collapses to a single space,
-#      preserving the visible gap between adjacent inline elements
-#      (e.g. `<a>x</a> <a>y</a>`).
+#   2. Inter-token whitespace is collapsed by classifying both
+#      neighbours (tags or placeholders) by HTML default display.
+#      If either neighbour is a block-level tag the whitespace is
+#      stripped entirely (browsers collapse whitespace at the start,
+#      end, or between block siblings). Only when both neighbours are
+#      inline do we keep a single space so adjacent inline siblings
+#      like `<a>x</a> <a>y</a>` keep their visible gap.
 #
-# What is NOT done: variable renaming, attribute rewriting, or
-# entity collapsing. For more aggressive output shrinking, post-process
-# with a dedicated tool (`html-minifier-terser`, `minify-html`).
+#   3. Whitespace *inside* tag openings is collapsed with a
+#      quote-aware scan: runs of whitespace between attributes
+#      shrink to a single space and trailing whitespace before the
+#      closing `>` is stripped. Quoted attribute values are passed
+#      through untouched so `title="x  y"` retains its inner spacing.
+#
+# What is NOT done: variable renaming, attribute-value rewriting,
+# or entity collapsing. For more aggressive output shrinking,
+# post-process with a dedicated tool (`html-minifier-terser`,
+# `minify-html`).
 
 module Hwaro
   module Utils
     module HtmlMinifier
       extend self
 
-      # HTML block-level elements. Whitespace between two block-level
-      # neighbors has no visual effect (the user agent renders them on
-      # separate lines anyway), so it is safe to strip entirely.
+      # HTML block-level elements. Whitespace adjacent to a block-level
+      # neighbour has no visual effect:
+      #   * between two block siblings the user agent renders them on
+      #     separate lines anyway,
+      #   * leading whitespace inside a block parent is collapsed by
+      #     the browser before the first inline child,
+      #   * trailing whitespace before a block close is collapsed
+      #     after the last inline child.
       # Anything not listed here is treated as inline, where whitespace
       # between siblings collapses to a single rendered space and must
       # therefore be kept as one literal space.
@@ -37,7 +55,7 @@ module Hwaro
         "div", "dl", "dt", "fieldset", "figcaption", "figure",
         "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6",
         "head", "header", "hgroup", "hr", "html", "iframe",
-        "li", "link", "main", "meta", "nav", "noscript",
+        "li", "link", "main", "menu", "meta", "nav", "noscript",
         "ol", "p", "picture", "pre", "script", "section",
         "source", "style", "summary", "table", "tbody", "td",
         "tfoot", "th", "thead", "title", "tr", "track", "ul",
@@ -55,30 +73,40 @@ module Hwaro
       # before the `script` pass runs.
       PROTECTED_TAGS = %w[pre textarea style script code svg math noscript]
 
+      # Classification of protected tags by default HTML display so
+      # the inter-token whitespace pass can treat sealed blocks as if
+      # they were their original tag.
+      PROTECTED_INLINE = Set{"code", "svg", "math", "textarea"}
+
       # Sentinel format for protected blocks. `\x00` is illegal in HTML,
-      # so the placeholder cannot collide with author content.
-      private PRESERVE_PREFIX = "\x00HW_HTML_P_"
-      private PRESERVE_SUFFIX = "\x00"
+      # so the placeholder cannot collide with author content. The
+      # `B`/`I` suffix lets the whitespace collapser look up the
+      # original element's display class without re-parsing the body.
+      private PRESERVE_PREFIX_BLOCK  = "\x00HW_HTML_PB_"
+      private PRESERVE_PREFIX_INLINE = "\x00HW_HTML_PI_"
+      private PRESERVE_SUFFIX        = "\x00"
 
       # Regex constants
       private REGEX_COMMENTS       = /<!--(?!\[if|#|\s*more\s*-->).*?-->/m
       private REGEX_TRAILING_SPACE = /[ \t]+$/m
-      # Match a complete tag immediately followed by whitespace and
-      # lookahead at the next tag. Captures:
-      #   $1 = "/" or "" on the prior tag
-      #   $2 = prior tag's name
-      #   $3 = prior tag's attribute slice (may contain a self-closing /)
-      #   $4 = whitespace run
-      #   $5 = "/" or "" on the next tag
-      #   $6 = next tag's name
+      # Match a structural token immediately followed by whitespace and
+      # lookahead at the next structural token. A "token" here is
+      # either a regular tag or one of our protected-block
+      # placeholders. Captures:
+      #   $1 = prior token (full text)
+      #   $2 = whitespace run
+      #   $3 = next token (full text, via lookahead)
       #
       # Known limitation: `[^>]*` does not understand quoted attribute
       # values, so a literal `>` inside an attribute (`title="x > y"`)
-      # is treated as the tag's end. Hwaro's rendered output does not
-      # produce such attributes in practice.
-      private REGEX_INTERTAG_WS    = /(<\/?)([A-Za-z][\w-]*)([^>]*)>(\s+)(?=<(\/?)([A-Za-z][\w-]*))/
+      # is treated as the tag's end. The intra-tag pass is quote-aware
+      # and runs first, but it cannot rewrite the value text itself —
+      # in those rare cases this pass simply leaves the surrounding
+      # whitespace untouched (the prior conservative behaviour).
+      private REGEX_INTERTOKEN_WS  = /(<\/?[A-Za-z][\w-]*[^>]*>|\x00HW_HTML_P[BI]_\d+\x00)(\s+)(?=(<\/?[A-Za-z][\w-]*[^>]*>|\x00HW_HTML_P[BI]_\d+\x00))/
+      private REGEX_TAG_NAME       = /^<\/?([A-Za-z][\w-]*)/
       private REGEX_BLANK_LINES    = /\n{2,}/
-      private REGEX_PRESERVE_TOKEN = /\x00HW_HTML_P_(\d+)\x00/
+      private REGEX_PRESERVE_TOKEN = /\x00HW_HTML_P[BI]_(\d+)\x00/
 
       # Minify the given HTML.
       #
@@ -93,7 +121,8 @@ module Hwaro
         result = protect_sensitive_blocks(html, preserves)
         result = result.gsub(REGEX_COMMENTS, "")
         result = result.gsub(REGEX_TRAILING_SPACE, "")
-        result = collapse_inter_tag_whitespace(result)
+        result = collapse_intra_tag_whitespace(result)
+        result = collapse_inter_token_whitespace(result)
         result = result.gsub(REGEX_BLANK_LINES, "\n")
         result = restore_sensitive_blocks(result, preserves)
         result.strip
@@ -108,6 +137,7 @@ module Hwaro
       private def protect_sensitive_blocks(html : String, preserves : Array(String)) : String
         result = html
         PROTECTED_TAGS.each do |tag|
+          prefix = PROTECTED_INLINE.includes?(tag) ? PRESERVE_PREFIX_INLINE : PRESERVE_PREFIX_BLOCK
           pattern = Regex.new(
             "<#{tag}\\b[^>]*>.*?</#{tag}\\s*>",
             Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE
@@ -115,7 +145,7 @@ module Hwaro
           result = result.gsub(pattern) do |match|
             idx = preserves.size
             preserves << match
-            "#{PRESERVE_PREFIX}#{idx}#{PRESERVE_SUFFIX}"
+            "#{prefix}#{idx}#{PRESERVE_SUFFIX}"
           end
         end
         result
@@ -128,24 +158,165 @@ module Hwaro
         end
       end
 
-      # Collapse whitespace between two tags according to neighbor type.
-      # Both block-level → strip entirely. Otherwise → single space, so
-      # adjacent inline siblings keep their visible gap.
-      private def collapse_inter_tag_whitespace(html : String) : String
-        html.gsub(REGEX_INTERTAG_WS) do
-          slash_prev = $1
-          name_prev = $2
-          attrs_prev = $3
-          # $4 = whitespace run (discarded)
-          name_next = $6
-
-          rebuilt = "#{slash_prev}#{name_prev}#{attrs_prev}>"
-          if BLOCK_TAGS.includes?(name_prev.downcase) && BLOCK_TAGS.includes?(name_next.downcase)
-            rebuilt
+      # Collapse whitespace between two structural tokens. The token
+      # classification distinguishes block from inline so we can:
+      #   * strip whitespace entirely when either neighbour is block
+      #     (leading inside block / trailing inside block / between
+      #     block siblings — all collapsed by browsers anyway), and
+      #   * keep a single space only when both neighbours are inline,
+      #     preserving the visible gap between adjacent inline elements
+      #     like `<a>x</a> <a>y</a>`.
+      private def collapse_inter_token_whitespace(html : String) : String
+        html.gsub(REGEX_INTERTOKEN_WS) do
+          prior = $1
+          # $2 = whitespace run (discarded except when we re-emit one space)
+          nxt = $3
+          if block_token?(prior) || block_token?(nxt)
+            prior
           else
-            "#{rebuilt} "
+            "#{prior} "
           end
         end
+      end
+
+      # True if the structural token is a block-level tag (or a
+      # placeholder for a protected element whose default display is
+      # block).
+      private def block_token?(token : String) : Bool
+        return true if token.starts_with?(PRESERVE_PREFIX_BLOCK)
+        return false if token.starts_with?(PRESERVE_PREFIX_INLINE)
+        if m = REGEX_TAG_NAME.match(token)
+          BLOCK_TAGS.includes?(m[1].downcase)
+        else
+          false
+        end
+      end
+
+      # Collapse whitespace runs *inside* tag openings to a single
+      # space, and strip whitespace immediately before the closing
+      # `>` or `/>`. The scan is quote-aware so attribute values
+      # like `title="x  y"` survive unchanged. Comments, DOCTYPEs
+      # (`<!...>`) and processing instructions (`<?...?>`) are
+      # ignored. Protected-block placeholders are also ignored
+      # (their bodies are already opaque).
+      private def collapse_intra_tag_whitespace(html : String) : String
+        return html if html.empty?
+        bytes = html.to_slice
+        n = bytes.size
+        String.build(n) do |io|
+          i = 0
+          while i < n
+            b = bytes[i]
+            if b == '<'.ord
+              if i + 1 < n && tag_start_byte?(bytes[i + 1])
+                tag_end = find_tag_end(bytes, i, n)
+                if tag_end >= 0
+                  emit_collapsed_tag(io, bytes, i, tag_end)
+                  i = tag_end + 1
+                  next
+                end
+              end
+            end
+            io.write_byte(b)
+            i += 1
+          end
+        end
+      end
+
+      # The byte immediately following `<` must look like the start of
+      # a real tag name or a closing tag. We deliberately exclude `!`
+      # (DOCTYPE / declarations) and `?` (processing instructions).
+      private def tag_start_byte?(b : UInt8) : Bool
+        return true if (b >= 'a'.ord && b <= 'z'.ord) || (b >= 'A'.ord && b <= 'Z'.ord)
+        b == '/'.ord
+      end
+
+      # Scan forward from `start` (pointing at `<`) to the matching
+      # `>` while respecting single- and double-quoted attribute
+      # values. Returns the index of the closing `>` or -1 if the
+      # tag is unterminated (in which case the caller falls back to
+      # emitting the byte literally and continues).
+      private def find_tag_end(bytes : Bytes, start : Int32, n : Int32) : Int32
+        i = start + 1
+        quote = 0_u8
+        while i < n
+          b = bytes[i]
+          if quote != 0_u8
+            quote = 0_u8 if b == quote
+          else
+            return i if b == '>'.ord
+            quote = b if b == '"'.ord || b == '\''.ord
+          end
+          i += 1
+        end
+        -1
+      end
+
+      # Write the tag at `bytes[start..tag_end]` to `io` with internal
+      # whitespace collapsed. The tag-name run is copied verbatim;
+      # then we collapse whitespace between attributes, preserve
+      # quoted values, and strip any trailing whitespace before the
+      # final `>` (or `/>` for self-closing).
+      private def emit_collapsed_tag(io : IO, bytes : Bytes, start : Int32, tag_end : Int32) : Nil
+        # Buffer the tag body (minus the closing `>`) into a slice so
+        # we can collapse and trim, then emit `>` at the end.
+        # We can't easily trim trailing whitespace from an already-
+        # written IO, so do it in a local buffer.
+        body = String.build(tag_end - start + 1) do |buf|
+          i = start
+          # Copy `<` (and optional `/`)
+          buf.write_byte(bytes[i])
+          i += 1
+          if i < tag_end && bytes[i] == '/'.ord
+            buf.write_byte(bytes[i])
+            i += 1
+          end
+          # Copy the tag name run.
+          while i < tag_end && (
+                  (bytes[i] >= 'a'.ord && bytes[i] <= 'z'.ord) ||
+                  (bytes[i] >= 'A'.ord && bytes[i] <= 'Z'.ord) ||
+                  (bytes[i] >= '0'.ord && bytes[i] <= '9'.ord) ||
+                  bytes[i] == '-'.ord || bytes[i] == ':'.ord
+                )
+            buf.write_byte(bytes[i])
+            i += 1
+          end
+          # Walk the attribute area collapsing whitespace and
+          # respecting quotes.
+          last_was_space = false
+          quote = 0_u8
+          while i < tag_end
+            b = bytes[i]
+            if quote != 0_u8
+              buf.write_byte(b)
+              quote = 0_u8 if b == quote
+              last_was_space = false
+            elsif b == ' '.ord || b == '\t'.ord || b == '\n'.ord || b == '\r'.ord
+              unless last_was_space
+                buf.write_byte(' '.ord.to_u8)
+                last_was_space = true
+              end
+            else
+              buf.write_byte(b)
+              quote = b if b == '"'.ord || b == '\''.ord
+              last_was_space = false
+            end
+            i += 1
+          end
+        end
+        # Drop trailing whitespace before the `>`. For self-closing
+        # tags `<br />` the `/` is the last byte of `body`; we then
+        # also strip the single space we inserted between the
+        # attributes and the `/` so the output is `<br/>`. That edge
+        # is only safe when the byte preceding the `/` is the space
+        # this pass inserted, never the tag name itself (no real
+        # input ever ends a tag-name with `/`).
+        body = body.rstrip
+        if body.ends_with?(" /")
+          body = body[0, body.bytesize - 2] + "/"
+        end
+        io << body
+        io.write_byte('>'.ord.to_u8)
       end
     end
   end

--- a/src/utils/html_minifier.cr
+++ b/src/utils/html_minifier.cr
@@ -307,14 +307,12 @@ module Hwaro
         # Drop trailing whitespace before the `>`. For self-closing
         # tags `<br />` the `/` is the last byte of `body`; we then
         # also strip the single space we inserted between the
-        # attributes and the `/` so the output is `<br/>`. That edge
-        # is only safe when the byte preceding the `/` is the space
-        # this pass inserted, never the tag name itself (no real
-        # input ever ends a tag-name with `/`).
+        # attributes and the `/` so the output is `<br/>`. `rchop`
+        # is suffix-equality (byte-safe), so it works even when
+        # the byte preceding the `" /"` is part of a multi-byte
+        # UTF-8 sequence inside a quoted attribute value.
         body = body.rstrip
-        if body.ends_with?(" /")
-          body = body[0, body.bytesize - 2] + "/"
-        end
+        body = body.rchop(" /") + "/" if body.ends_with?(" /")
         io << body
         io.write_byte('>'.ord.to_u8)
       end


### PR DESCRIPTION
## Summary

Builds on #545 with three additional safe shrinks to `Utils::HtmlMinifier`:

1. **Block-OR-block stripping** — inter-tag whitespace collapses whenever *either* neighbour is block-level (browsers already collapse whitespace at the start, end, or between block siblings). Single space kept only when both neighbours are inline, so `<a>x</a> <a>y</a>` still has its visible gap.
2. **Typed protected-block placeholders** — sealed `<pre>/<script>/<style>/<noscript>` carry a "block" marker; `<code>/<svg>/<math>/<textarea>` carry "inline." The inter-token pass treats them as their original tag for the purpose of deciding visibility.
3. **Quote-aware intra-tag whitespace collapse** — runs between attributes shrink to one space, trailing whitespace before `>` / `/>` is stripped. A byte-level state machine preserves quoted attribute values, including those containing `>`.

Measured on hwaro `docs/`: 1223 KB → 1077 KB HTML (~-12.0%, was ~-11.5%). `index.html` 24 KB → 16 KB.

## Test plan

- [x] `crystal spec` — 4919 examples pass (51 minifier specs, 16 new)
- [x] Stress-test page covering markdown, tables, code, math, mermaid, SVG, textarea, tricky attribute values, and embedded HTML in `<script>`/`<style>` round-trips visibly identically
- [x] All shipped scaffolds (`docs`, `blog`, `book`, `simple`, `bare`) + hwaro `docs/` — 126 pages total, **0 visible-text or tag-count differences** between plain and `--minify` outputs (block-boundary-aware diff)
- [x] `href` and `src` attribute values preserved across all pages
- [x] DOM tag-name counts identical
- [ ] (reviewer) Sanity-check rendered output of the docs site under `--minify` in a real browser

## Spec changes

- Updated `<p>\n  <span>only</span>\n</p>` → `<p><span>only</span></p>` (was `<p> <span>only</span> </p>`); the old assertion was over-conservative — leading whitespace inside a block is browser-collapsed anyway.
- New `intra-tag whitespace collapse` describe block covers attribute collapse, single- and double-quoted value preservation, `/>` trimming, multi-line attribute lists, and the `title="x > y"` edge case.
- New protected-block specs pin `<div>↔<pre>` (block↔protected-block), `<code>↔<code>` (inline↔inline-protected), and the `<button>↔<svg>` inline-around-protected case.

## Docs

- `--minify` CLI description in `src/cli/metadata.cr`
- Minify section in `docs/content/start/cli.md`
- `CHANGELOG.md` unreleased entry