### PR TITLE
fix(security): sanitize redirect_to output path

### DIFF
--- a/spec/functional/build_integration_spec.cr
+++ b/spec/functional/build_integration_spec.cr
@@ -362,6 +362,22 @@ describe "Build Integration: Redirects" do
     end
   end
 
+  it "does not write redirect_to output outside output_dir" do
+    # Regression for #549: previously, a content file whose frontmatter
+    # `path` traversed upward could cause the redirect writer to drop
+    # index.html outside output_dir (a sibling of `public/`).
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "evil.md" => "---\ntitle: PoC\npath: \"../escape-poc-549\"\nredirect_to: /\n---\n",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+    ) do
+      Dir.exists?("escape-poc-549").should be_false
+      File.exists?("escape-poc-549/index.html").should be_false
+    end
+  end
+
   it "generates alias redirect pages" do
     build_site(
       BASIC_CONFIG,

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -527,7 +527,14 @@ module Hwaro::Core::Build::Phases::Render
     redirect_url = page.redirect_to
     return unless redirect_url
 
-    output_path = File.join(output_dir, page.url.lchop("/"), "index.html")
+    url_path = Utils::PathUtils.sanitize_path(page.url.lchop("/"))
+    candidate = File.join(output_dir, url_path, "index.html")
+    output_path = Utils::OutputGuard.safe_output_path(candidate, output_dir)
+    unless output_path
+      Logger.warn "Skipping redirect outside output directory: #{candidate}"
+      return
+    end
+
     ensure_dir(Path[output_path].dirname.to_s)
     File.write(output_path, Utils::RedirectHtml.full_redirect(redirect_url))
     Logger.action :create, output_path if verbose


### PR DESCRIPTION
## Summary

- Route `generate_redirect_page` through `PathUtils.sanitize_path` and `OutputGuard.safe_output_path`, mirroring `get_output_path`.
- Skip writing if the candidate path still resolves outside `output_dir`.
- Add a regression test that asserts a `path` with `..` traversal cannot drop `index.html` as a sibling of `output_dir`.

Closes #549

## Test plan

- [x] `crystal spec spec/functional/build_integration_spec.cr` (86 examples pass, including the new traversal regression)
- [x] `crystal spec spec/` (full suite: 4921 examples, 0 failures)
- [x] Manual PoC with `path = "../../hwaro-poc-549"` + `redirect_to = "/"` no longer escapes; the file lands safely inside `public/`