### PR TITLE
fix(security): keep deploy token out of build environment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,9 +36,9 @@ inputs:
     required: false
     default: "github.com"
   token:
-    description: "GitHub token for deployment (defaults to GITHUB_TOKEN)"
+    description: "GitHub token for deployment. Defaults to the workflow token when deploying; intentionally empty for build_only runs so it is not exposed to user build hooks. Pass an explicit value to override."
     required: false
-    default: ${{ github.token }}
+    default: ""
 
 runs:
   using: "composite"
@@ -54,6 +54,27 @@ runs:
         TAG="${TAG:-latest}"
         echo "image=ghcr.io/hahwul/hwaro:${TAG}" >> "$GITHUB_OUTPUT"
         echo "Using Hwaro image: ghcr.io/hahwul/hwaro:${TAG}"
+
+    - name: Resolve deploy token
+      id: token
+      shell: bash
+      env:
+        BUILD_ONLY: ${{ inputs.build_only }}
+        INPUT_TOKEN: ${{ inputs.token }}
+        WORKFLOW_TOKEN: ${{ github.token }}
+      run: |
+        # Only fall back to the workflow token when actually deploying.
+        # build_only runs receive no token by default so the value cannot
+        # be exfiltrated by user-controlled build hooks. See issue #550.
+        if [[ -n "$INPUT_TOKEN" ]]; then
+          TOKEN="$INPUT_TOKEN"
+        elif [[ "$BUILD_ONLY" != "true" ]]; then
+          TOKEN="$WORKFLOW_TOKEN"
+        else
+          TOKEN=""
+        fi
+        echo "::add-mask::$TOKEN"
+        echo "value=$TOKEN" >> "$GITHUB_OUTPUT"
 
     - name: Run Hwaro
       shell: bash
@@ -71,5 +92,5 @@ runs:
           -e BUILD_ONLY="${{ inputs.build_only }}" \
           -e REPOSITORY="${{ inputs.repository }}" \
           -e GITHUB_HOSTNAME="${{ inputs.github_hostname }}" \
-          -e INPUT_TOKEN="${{ inputs.token }}" \
+          -e INPUT_TOKEN="${{ steps.token.outputs.value }}" \
           "${{ steps.resolve.outputs.image }}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -29,19 +29,22 @@ else
     TARGET_REPOSITORY=${GITHUB_REPOSITORY}
 fi
 
-# Support both INPUT_TOKEN (from action inputs) and GITHUB_TOKEN
-if [[ -n "$INPUT_TOKEN" ]]; then
-    GITHUB_TOKEN=$INPUT_TOKEN
-fi
+# Support both INPUT_TOKEN (from action inputs) and GITHUB_TOKEN.
+# Keep the deploy credential in DEPLOY_TOKEN — a name user-defined build
+# hooks have no reason to read — and remove GITHUB_TOKEN from the build
+# environment so untrusted site config can't exfiltrate it. See issue #550.
+DEPLOY_TOKEN="${INPUT_TOKEN:-${GITHUB_TOKEN:-}}"
+unset INPUT_TOKEN
+unset GITHUB_TOKEN
 
-if [[ -z "$GITHUB_TOKEN" ]] && [[ "$BUILD_ONLY" == "false" ]]; then
-    echo "Error: GITHUB_TOKEN is required for deployment."
+if [[ -z "$DEPLOY_TOKEN" ]] && [[ "$BUILD_ONLY" == "false" ]]; then
+    echo "Error: a GitHub token is required for deployment."
     echo "Please set the token input or GITHUB_TOKEN environment variable."
     exit 1
 fi
 
 restore_og_cache() {
-    local remote_url="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@${GITHUB_HOSTNAME}/${TARGET_REPOSITORY}.git"
+    local remote_url="https://${GITHUB_ACTOR}:${DEPLOY_TOKEN}@${GITHUB_HOSTNAME}/${TARGET_REPOSITORY}.git"
     local og_dir="${OUT_DIR}/og-images"
 
     # Check if gh-pages branch exists on remote
@@ -95,7 +98,7 @@ main() {
     git config --global --unset-all http.extraheader 2>/dev/null || true
 
     # Restore OG image cache before building (requires token for remote access)
-    if [[ "$BUILD_ONLY" != "true" ]] && [[ -n "$GITHUB_TOKEN" ]]; then
+    if [[ "$BUILD_ONLY" != "true" ]] && [[ -n "$DEPLOY_TOKEN" ]]; then
         restore_og_cache
     fi
 
@@ -122,7 +125,7 @@ main() {
     # Deploy to GitHub Pages
     echo "Pushing artifacts to ${TARGET_REPOSITORY}:${PAGES_BRANCH}"
 
-    remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@${GITHUB_HOSTNAME}/${TARGET_REPOSITORY}.git"
+    remote_repo="https://${GITHUB_ACTOR}:${DEPLOY_TOKEN}@${GITHUB_HOSTNAME}/${TARGET_REPOSITORY}.git"
     remote_branch=$PAGES_BRANCH
 
     cd "${OUT_DIR}"


### PR DESCRIPTION
## Summary

- `action.yml`: stop defaulting `token` to `${{ github.token }}`. The composite step only falls back to the workflow token when the run actually deploys (`build_only != 'true'`) and masks the resolved value with `::add-mask::` before forwarding it to the container.
- `docker/entrypoint.sh`: move the credential into a local `DEPLOY_TOKEN` variable used by the OG cache restore and final `git push`, and `unset GITHUB_TOKEN` / `INPUT_TOKEN` before `hwaro build` runs so user-defined build hooks no longer inherit either.

Closes #550

## Threat model

A `build_only: true` run from a workflow that omits the `token` input still received `${{ github.token }}` by default. The entrypoint promoted that to `GITHUB_TOKEN`, and `hwaro` build hooks (intentional Hwaro feature, but shell-executed with the inherited env) could read it — so untrusted site config could exfiltrate the workflow token.

## Test plan

- [x] Shell dry-run of the new entrypoint logic confirms `GITHUB_TOKEN` / `INPUT_TOKEN` / `DEPLOY_TOKEN` are all empty in subprocess env while `DEPLOY_TOKEN` is still set for the parent script (for OG restore and `git push`).
- [x] `crystal spec spec/` — 4921 examples, 0 failures (no regression in unrelated suites).
- [ ] Smoke test via a real GitHub Actions workflow (requires merge to a tagged image)

## Notes

- `action.yml`'s `token` input description was updated to document the new default behavior. Callers who relied on the implicit `${{ github.token }}` for deploys are unaffected (the composite step provides it automatically). Callers who need a token during build_only must now pass it explicitly.