### PR TITLE
chore: convert inline rescues to typed begin/rescue blocks

### DIFF
--- a/src/content/hooks/image_hooks.cr
+++ b/src/content/hooks/image_hooks.cr
@@ -360,8 +360,16 @@ module Hwaro
         # Verify that a source path resolves within the expected base directory.
         # Uses File.realpath to resolve symlinks before the boundary check.
         private def safe_path?(path : String, base : String) : Bool
-          resolved = File.realpath(path) rescue return false
-          resolved_base = File.realpath(base) rescue File.expand_path(base)
+          resolved = begin
+            File.realpath(path)
+          rescue File::Error
+            return false
+          end
+          resolved_base = begin
+            File.realpath(base)
+          rescue File::Error
+            File.expand_path(base)
+          end
           resolved == resolved_base || resolved.starts_with?(resolved_base + "/")
         end
 

--- a/src/content/processors/filters/i18n_filter.cr
+++ b/src/content/processors/filters/i18n_filter.cr
@@ -53,7 +53,11 @@ module Hwaro
 
             # Pluralize filter: {{ count | pluralize("item", "items") }}
             env.filters["pluralize"] = Crinja.filter({singular: "", plural: ""}) do
-              count = target.as_number.to_i rescue 0
+              count = begin
+                target.as_number.to_i
+              rescue Exception
+                0
+              end
               singular = arguments["singular"].to_s
               plural = arguments["plural"].to_s
               count == 1 ? singular : plural

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -388,7 +388,8 @@ module Hwaro
               hint: "Check JSON frontmatter object at start of file",
             )
           end
-          return unless json_fm.as_h?
+          fm_hash = json_fm.as_h?
+          return unless fm_hash
 
           date = parse_time(json_fm["date"]?.try(&.as_s?))
           updated = parse_time(json_fm["updated"]?.try(&.as_s?))
@@ -396,7 +397,7 @@ module Hwaro
 
           extra = {} of String => Models::ExtraValue
           unknown_keys = [] of String
-          json_fm.as_h.each do |key, value|
+          fm_hash.each do |key, value|
             next if KNOWN_FRONT_MATTER_KEYS.includes?(key)
             if key == "extra" && (inner = value.as_h?)
               inner.each do |inner_key, inner_value|
@@ -409,7 +410,7 @@ module Hwaro
           end
           warn_typo_keys(unknown_keys, file_path)
 
-          front_matter_keys = json_fm.as_h.keys
+          front_matter_keys = fm_hash.keys
           taxonomies = extract_taxonomies(json_fm, front_matter_keys)
           tags = fm_string_array(json_fm, "tags")
           taxonomies["tags"] = tags if tags.present?

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -506,7 +506,11 @@ module Hwaro
               # Resolve symlinks BEFORE boundary check to prevent TOCTOU attacks.
               project_root = File.realpath(Dir.current)
               resolved = File.expand_path(path, project_root)
-              resolved = File.realpath(resolved) rescue nil
+              resolved = begin
+                File.realpath(resolved)
+              rescue File::Error
+                nil
+              end
 
               if resolved &&
                  (resolved == project_root || resolved.starts_with?(project_root + "/")) &&

--- a/src/content/seo/og_png_renderer.cr
+++ b/src/content/seo/og_png_renderer.cr
@@ -368,7 +368,11 @@ module Hwaro
         # Parse "#RRGGBB" to 0xRRGGBB
         def self.parse_hex_color(hex : String) : UInt32
           hex = hex.lchop("#")
-          hex.to_u32(16) rescue 0x000000_u32
+          begin
+            hex.to_u32(16)
+          rescue ArgumentError
+            0x000000_u32
+          end
         end
 
         # Fill a solid rectangle

--- a/src/services/content_stats.cr
+++ b/src/services/content_stats.cr
@@ -67,7 +67,11 @@ module Hwaro
         monthly = {} of String => Int32
 
         published_items.each do |item|
-          content = File.read(item.path) rescue next
+          content = begin
+            File.read(item.path)
+          rescue File::Error
+            next
+          end
 
           body = extract_body(content)
           wc = count_words(body)

--- a/src/services/content_stats.cr
+++ b/src/services/content_stats.cr
@@ -69,7 +69,7 @@ module Hwaro
         published_items.each do |item|
           content = begin
             File.read(item.path)
-          rescue File::Error
+          rescue IO::Error
             next
           end
 

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -978,7 +978,11 @@ module Hwaro
       # Auto-generate a deploy command for known cloud URL schemes.
       # Returns nil if the scheme is not recognized.
       private def auto_command_for_url(url : String, source_dir : String) : String?
-        uri = URI.parse(url) rescue return
+        uri = begin
+          URI.parse(url)
+        rescue URI::Error
+          return
+        end
         case uri.scheme
         when "s3"
           "aws s3 sync {source}/ {url} --delete"

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -44,9 +44,17 @@ module Hwaro
           # Only attempt realpath if the path exists on disk; otherwise skip
           # the redirect entirely so non-existent traversal paths cannot
           # bypass the boundary check (realpath returns nil for missing paths).
-          public_real = File.realpath(@public_dir) rescue @public_dir
+          public_real = begin
+            File.realpath(@public_dir)
+          rescue File::Error
+            @public_dir
+          end
           resolved = if File.exists?(fs_path.to_s)
-                       File.realpath(fs_path) rescue nil
+                       begin
+                         File.realpath(fs_path)
+                       rescue File::Error
+                         nil
+                       end
                      end
           if resolved && (resolved == public_real || resolved.starts_with?(public_real + "/")) && Dir.exists?(resolved)
             context.response.status_code = 301

--- a/src/services/unused_assets.cr
+++ b/src/services/unused_assets.cr
@@ -127,7 +127,11 @@ module Hwaro
         end
 
         scan_files.each do |file|
-          text = File.read(file) rescue next
+          text = begin
+            File.read(file)
+          rescue File::Error
+            next
+          end
           text.scan(ext_pattern) do |match|
             refs << match[0]
           end

--- a/src/services/unused_assets.cr
+++ b/src/services/unused_assets.cr
@@ -129,7 +129,7 @@ module Hwaro
         scan_files.each do |file|
           text = begin
             File.read(file)
-          rescue File::Error
+          rescue IO::Error
             next
           end
           text.scan(ext_pattern) do |match|


### PR DESCRIPTION
## Summary

Production-quality cleanup with **no behavior change**. Continues the direction set in #548 ("Crystal inline `rescue` cannot take a type, so unintentionally swallowed every exception including programmer errors") to the remaining inline rescues outside Crinja-filter context.

- **Security-relevant paths** (path-traversal checks) — `server.cr`, `template.cr#load_data`, `image_hooks.cr#safe_path?`: inline `File.realpath(...) rescue ...` → `begin/rescue File::Error/end`. Prior inline form swallowed any exception including programmer errors.
- **Best-effort I/O and parsing** — `deployer.cr#auto_command_for_url` (`URI::Error`), `content_stats.cr` / `unused_assets.cr` (`File::Error`), `og_png_renderer.cr#parse_hex_color` (`ArgumentError`).
- **`i18n_filter.cr#pluralize`** — inline `rescue 0` → explicit `begin/rescue Exception/end`. Kept broad per the filter convention documented in #548; the explicit block makes the deliberate broad catch visible.
- **`markdown.cr#extract_from_json`** — cache `json_fm.as_h?` once instead of recomputing `as_h` three times.

Untouched (intentionally): Crinja filter broad `rescue Exception` blocks in `collection_filter.cr`/`math_filter.cr`/`i18n_filter.cr` and chained inline rescues in `date_filter.cr` — these are the documented filter-context convention from #548.

## Test plan

- [x] `crystal tool format --check` — clean
- [x] `ameba` — 346 inspected, 0 failures
- [x] `crystal spec` — 4921 examples, 0 failures
- [x] `bin/hwaro build -i docs` — 220 files, clean exit