### PR TITLE
perf(og-image): cache base layer + parallelize per-page renders

### DIFF
--- a/src/content/hooks/og_image_hooks.cr
+++ b/src/content/hooks/og_image_hooks.cr
@@ -39,6 +39,7 @@ module Hwaro
             ctx.output_dir,
             ctx.options.verbose,
             partial: ctx.partial_render,
+            parallel: ctx.options.parallel,
           )
         end
       end

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -2,6 +2,7 @@ require "base64"
 require "digest/sha256"
 require "file_utils"
 require "json"
+require "../../core/build/parallel"
 require "../../models/config"
 require "../../models/page"
 require "../../utils/logger"
@@ -50,6 +51,7 @@ module Hwaro
           output_dir : String,
           verbose : Bool = false,
           partial : Bool = false,
+          parallel : Bool = true,
         )
           ai = config.og.auto_image
           return unless ai.enabled
@@ -99,6 +101,17 @@ module Hwaro
             cached_bg = OgPngRenderer.load_image(bg_abs_path, WIDTH, HEIGHT) if bg_abs_path
           end
 
+          # Pre-render the config-only layers once. Per-page rendering
+          # then memcpy's this 3MB base buffer instead of redoing the
+          # background fill, optional background image blit, overlay,
+          # style pattern, and top accent bar on every page — work
+          # that dominates the per-page cost (the "gradient" pattern
+          # alone touches all 756,000 pixels in Crystal math).
+          base_layer = nil
+          if png_available
+            base_layer = OgPngRenderer.build_base_layer(config, bg_abs_path, cached_bg)
+          end
+
           img_dir = File.join(output_dir, ai.output_dir)
           Hwaro::Utils::FileSafe.mkdir_p(img_dir) unless Dir.exists?(img_dir)
 
@@ -123,15 +136,15 @@ module Hwaro
 
           generated = 0
           skipped = 0
+          ext = (format == "png" && png_available) ? "png" : "svg"
 
-          pages.each_with_index do |page, idx|
-            # Yield to other fibers every few PNG renders so a serve
-            # session that runs this in a background fiber doesn't starve
-            # its own HTTP accept loop. PNG encoding is pure CPU and
-            # never yields on its own; without this, requests sit on the
-            # OS backlog indefinitely while the deferred render pass
-            # runs.
-            Fiber.yield if idx > 0 && (idx & 0x07) == 0
+          # Pass 1 (sequential): work out the slug, hash the page, and
+          # short-circuit on a cache hit. The cache-hit path is just a
+          # hash + stat + property assignment, far too cheap to be worth
+          # parallelising. Only the cache-miss renders go into the
+          # worker pool below.
+          pending = [] of Tuple(Models::Page, String, String)
+          pages.each do |page|
             next if page.draft
             next if page.generated
             next unless page.render
@@ -146,11 +159,8 @@ module Hwaro
             page_hash = compute_page_hash(page)
             new_entries[slug] = page_hash
 
-            # Determine expected output file extension
-            ext = (format == "png" && png_available) ? "png" : "svg"
             expected_file = File.join(img_dir, "#{slug}.#{ext}")
 
-            # Skip if content unchanged, config unchanged, and file exists
             if !config_changed && old_entries[slug]? == page_hash && File.exists?(expected_file)
               page.image = "/#{ai.output_dir}/#{slug}.#{ext}"
               skipped += 1
@@ -158,28 +168,43 @@ module Hwaro
               next
             end
 
-            if format == "png" && png_available
-              png_filename = "#{slug}.png"
-              png_path = File.join(img_dir, png_filename)
-              if OgPngRenderer.render_png(page, config, png_path, logo_abs_path, bg_abs_path, font_ctx, cached_logo, cached_bg)
-                page.image = "/#{ai.output_dir}/#{png_filename}"
+            pending << {page, slug, expected_file}
+          end
+
+          # Pass 2 (parallel): render the cache-miss pages. Each worker
+          # owns its own pixel buffer and file path so there is no
+          # shared mutable state to guard. The stb bindings have no
+          # global state, and `page.image = ...` writes only to a page
+          # touched by exactly one worker. The font context, cached
+          # logo/bg, and base layer are read-only after build.
+          unless pending.empty?
+            config_struct = Hwaro::Core::Build::ParallelConfig.new(enabled: parallel)
+            processor = Hwaro::Core::Build::Parallel(Tuple(Models::Page, String, String), Bool).new(config_struct)
+            results = processor.process(pending) do |item, _idx|
+              page, slug, _expected = item
+              if format == "png" && png_available
+                png_filename = "#{slug}.png"
+                png_path = File.join(img_dir, png_filename)
+                if OgPngRenderer.render_png(page, config, png_path, logo_abs_path, bg_abs_path, font_ctx, cached_logo, cached_bg, base_layer)
+                  page.image = "/#{ai.output_dir}/#{png_filename}"
+                else
+                  # Fallback to SVG on render failure
+                  svg_filename = "#{slug}.svg"
+                  svg = render_svg(page, config, logo_data_uri, bg_data_uri)
+                  File.write(File.join(img_dir, svg_filename), svg)
+                  page.image = "/#{ai.output_dir}/#{svg_filename}"
+                  Logger.warn "  PNG render failed for #{slug}, falling back to SVG"
+                end
               else
-                # Fallback to SVG on render failure
                 svg_filename = "#{slug}.svg"
                 svg = render_svg(page, config, logo_data_uri, bg_data_uri)
                 File.write(File.join(img_dir, svg_filename), svg)
                 page.image = "/#{ai.output_dir}/#{svg_filename}"
-                Logger.warn "  PNG render failed for #{slug}, falling back to SVG"
               end
-            else
-              svg_filename = "#{slug}.svg"
-              svg = render_svg(page, config, logo_data_uri, bg_data_uri)
-              File.write(File.join(img_dir, svg_filename), svg)
-              page.image = "/#{ai.output_dir}/#{svg_filename}"
+              Logger.debug "  OG image: #{page.image}" if verbose
+              true
             end
-
-            generated += 1
-            Logger.debug "  OG image: #{page.image}" if verbose
+            generated = results.count(&.success)
           end
 
           save_manifest(manifest_path, config_hash, new_entries)

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -143,7 +143,7 @@ module Hwaro
           # hash + stat + property assignment, far too cheap to be worth
           # parallelising. Only the cache-miss renders go into the
           # worker pool below.
-          pending = [] of Tuple(Models::Page, String, String)
+          pending = [] of Tuple(Models::Page, String)
           pages.each do |page|
             next if page.draft
             next if page.generated
@@ -168,7 +168,7 @@ module Hwaro
               next
             end
 
-            pending << {page, slug, expected_file}
+            pending << {page, slug}
           end
 
           # Pass 2 (parallel): render the cache-miss pages. Each worker
@@ -179,9 +179,9 @@ module Hwaro
           # logo/bg, and base layer are read-only after build.
           unless pending.empty?
             config_struct = Hwaro::Core::Build::ParallelConfig.new(enabled: parallel)
-            processor = Hwaro::Core::Build::Parallel(Tuple(Models::Page, String, String), Bool).new(config_struct)
+            processor = Hwaro::Core::Build::Parallel(Tuple(Models::Page, String), Bool).new(config_struct)
             results = processor.process(pending) do |item, _idx|
-              page, slug, _expected = item
+              page, slug = item
               if format == "png" && png_available
                 png_filename = "#{slug}.png"
                 png_path = File.join(img_dir, png_filename)
@@ -202,6 +202,14 @@ module Hwaro
                 page.image = "/#{ai.output_dir}/#{svg_filename}"
               end
               Logger.debug "  OG image: #{page.image}" if verbose
+              # Yield after each render so a `serve` session running this
+              # in a background fiber doesn't starve its own HTTP accept
+              # loop. PNG encoding is pure CPU and never yields on its
+              # own; under MT with a saturated worker pool, or in the
+              # sequential path (parallel: false, or a single pending
+              # item), nothing else in this block would otherwise hand
+              # control back to the scheduler.
+              Fiber.yield
               true
             end
             generated = results.count(&.success)

--- a/src/content/seo/og_png_renderer.cr
+++ b/src/content/seo/og_png_renderer.cr
@@ -201,9 +201,61 @@ module Hwaro
           nil
         end
 
+        # Pre-render the config-only layers (background fill, background
+        # image + overlay, style pattern, top accent bar) into a reusable
+        # RGBA buffer that can be memcpy'd into each per-page pixel
+        # buffer. On large sites these layers account for the bulk of
+        # the per-page cost — the "gradient" pattern alone touches every
+        # one of the 756,000 pixels in Crystal-level math — so doing
+        # them once per build instead of once per page is the largest
+        # single win in PNG OG generation.
+        #
+        # Z-order is preserved: the original render order is bg → bg
+        # image → pattern → top bar → text → logo → bottom bar, and the
+        # remaining per-page work (text, logo, bottom bar) is layered
+        # on top of this base in the same order.
+        def self.build_base_layer(
+          config : Models::Config,
+          bg_image_path : String? = nil,
+          cached_bg : CachedImage? = nil,
+        ) : Bytes
+          ai = config.og.auto_image
+          is_minimal = ai.style == "minimal"
+          bg_color = parse_hex_color(ai.background)
+          accent_color = parse_hex_color(ai.accent_color)
+
+          base = Bytes.new(WIDTH * HEIGHT * CHANNELS)
+          pixels = base.to_unsafe
+
+          fill_rect(pixels, 0, 0, WIDTH, HEIGHT, bg_color)
+
+          if bg_image_path
+            if cbg = cached_bg
+              blit_cached_image(pixels, cbg, 0, 0)
+            else
+              composite_image(pixels, bg_image_path, 0, 0, WIDTH, HEIGHT)
+            end
+            fill_rect_alpha(pixels, 0, 0, WIDTH, HEIGHT, bg_color, ai.overlay_opacity)
+          end
+
+          render_pattern(pixels, ai.style, accent_color, ai.pattern_opacity, ai.pattern_scale)
+
+          unless is_minimal
+            fill_rect(pixels, 0, 0, WIDTH, 6, accent_color)
+          end
+
+          base
+        end
+
         # Render OG image directly to PNG file. Returns true on success.
         # Accepts optional pre-loaded CachedImage for logo/background to avoid
         # repeated decode+resize when generating many pages.
+        #
+        # When `base_layer` is given, the config-only layers (background,
+        # pattern, top accent bar) are memcpy'd from it instead of being
+        # re-rendered per page. Callers that render many pages should
+        # build the base layer once via `build_base_layer` and pass it
+        # in here.
         def self.render_png(
           page : Models::Page,
           config : Models::Config,
@@ -213,6 +265,7 @@ module Hwaro
           font_ctx : FontContext? = nil,
           cached_logo : CachedImage? = nil,
           cached_bg : CachedImage? = nil,
+          base_layer : Bytes? = nil,
         ) : Bool
           ai = config.og.auto_image
           is_minimal = ai.style == "minimal"
@@ -228,26 +281,32 @@ module Hwaro
           return false if pixels.null?
 
           begin
-            # 1. Fill background
-            fill_rect(pixels, 0, 0, WIDTH, HEIGHT, bg_color)
+            if base = base_layer
+              # Fast path: the config-only layers (steps 1–4) are
+              # already baked into `base`; memcpy them in.
+              base.to_unsafe.copy_to(pixels, base.size)
+            else
+              # 1. Fill background
+              fill_rect(pixels, 0, 0, WIDTH, HEIGHT, bg_color)
 
-            # 2. Background image (if configured)
-            if bg_image_path
-              if cbg = cached_bg
-                blit_cached_image(pixels, cbg, 0, 0)
-              else
-                composite_image(pixels, bg_image_path, 0, 0, WIDTH, HEIGHT)
+              # 2. Background image (if configured)
+              if bg_image_path
+                if cbg = cached_bg
+                  blit_cached_image(pixels, cbg, 0, 0)
+                else
+                  composite_image(pixels, bg_image_path, 0, 0, WIDTH, HEIGHT)
+                end
+                # Overlay
+                fill_rect_alpha(pixels, 0, 0, WIDTH, HEIGHT, bg_color, ai.overlay_opacity)
               end
-              # Overlay
-              fill_rect_alpha(pixels, 0, 0, WIDTH, HEIGHT, bg_color, ai.overlay_opacity)
-            end
 
-            # 3. Style pattern
-            render_pattern(pixels, ai.style, accent_color, ai.pattern_opacity, ai.pattern_scale)
+              # 3. Style pattern
+              render_pattern(pixels, ai.style, accent_color, ai.pattern_opacity, ai.pattern_scale)
 
-            # 4. Accent bar at top
-            unless is_minimal
-              fill_rect(pixels, 0, 0, WIDTH, 6, accent_color)
+              # 4. Accent bar at top
+              unless is_minimal
+                fill_rect(pixels, 0, 0, WIDTH, 6, accent_color)
+              end
             end
 
             # 5. Render text


### PR DESCRIPTION
## Summary

- Pre-render the config-only OG layers (bg fill, bg image + overlay, style pattern, top accent bar) into a reusable `Bytes` buffer once per build, then `memcpy` into each per-page pixel buffer. Z-order is preserved — text → logo → bottom bar still layer on top in the original order.
- Split the per-page loop into a serial cache-check pass and a parallel render pass dispatched through the existing `Hwaro::Core::Build::Parallel` worker pool.
- The stb bindings have no global state, and the font context / cached images / base layer are read-only after build, so workers do not share mutable state.

## Why

The `fill_rect` alone was touching all 756,000 pixels in Crystal math on every page, and the `gradient` pattern doubled that. On large sites this was the single dominant cost of an OG-enabled build (the existing `og_image_hooks.cr` comment already calls out ~20s for 1k pages). Both pieces of work are now amortised once per build and the remaining per-page work runs in parallel.

## Benchmark (200 pages, PNG mode)

| Style       | Baseline | This PR | Speedup |
|-------------|---------:|--------:|--------:|
| `default`   | 6056 ms  | 1345 ms | 4.5×    |
| `gradient`  | 6151 ms  |  932 ms | 6.6×    |

## Test plan

- [x] `just test` — all 4921 specs pass
- [x] OG-specific specs (`og_image_spec.cr`, `og_png_renderer_spec.cr`, `og_image_hooks_spec.cr`) — 80 examples pass
- [x] `bin/hwaro build -i docs` — 64 OG PNGs produced, valid `PNG image data, 1200 x 630, 8-bit/color RGBA, non-interlaced`
- [x] Benchmarked before/after on a 200-page site with both `default` and `gradient` styles