### PR TITLE
fix(mt): tolerate EEXIST per component in FileSafe.mkdir_p

### DIFF
--- a/spec/unit/file_safe_spec.cr
+++ b/spec/unit/file_safe_spec.cr
@@ -1,0 +1,71 @@
+require "../spec_helper"
+require "../../src/utils/file_safe"
+
+describe Hwaro::Utils::FileSafe do
+  describe ".mkdir_p" do
+    it "creates a nested directory" do
+      Dir.mktmpdir do |root|
+        target = File.join(root, "a", "b", "c")
+        Hwaro::Utils::FileSafe.mkdir_p(target)
+        Dir.exists?(target).should be_true
+      end
+    end
+
+    it "is a no-op when the directory already exists" do
+      Dir.mktmpdir do |root|
+        target = File.join(root, "exists")
+        Dir.mkdir_p(target)
+        Hwaro::Utils::FileSafe.mkdir_p(target)
+        Dir.exists?(target).should be_true
+      end
+    end
+
+    it "raises when the path exists as a file" do
+      Dir.mktmpdir do |root|
+        path = File.join(root, "file")
+        File.write(path, "hi")
+        expect_raises(File::AlreadyExistsError) do
+          Hwaro::Utils::FileSafe.mkdir_p(path)
+        end
+      end
+    end
+
+    # Drives many fibers at the same shared parent so the per-component race
+    # window is exercised. Pre-fix, a worker could fail with EEXIST on a parent
+    # during both its first attempt and the retry's parent walk and surface
+    # "Unable to create directory: '…': File exists" to the caller.
+    it "tolerates concurrent creation of siblings under a shared parent" do
+      Dir.mktmpdir do |root|
+        # Multiple shared parents (deep tree) amplify the cascading race
+        # that the single-retry implementation could not absorb.
+        base = File.join(root, "ko", "development")
+
+        worker_count = 32
+        done = Channel(Exception?).new(worker_count)
+
+        worker_count.times do |i|
+          spawn do
+            begin
+              Hwaro::Utils::FileSafe.mkdir_p(File.join(base, "page_#{i}"))
+              done.send(nil)
+            rescue ex
+              done.send(ex)
+            end
+          end
+        end
+
+        errors = [] of Exception
+        worker_count.times do
+          if err = done.receive
+            errors << err
+          end
+        end
+
+        errors.should be_empty
+        worker_count.times do |i|
+          Dir.exists?(File.join(base, "page_#{i}")).should be_true
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/file_safe_spec.cr
+++ b/spec/unit/file_safe_spec.cr
@@ -31,9 +31,14 @@ describe Hwaro::Utils::FileSafe do
     end
 
     # Drives many fibers at the same shared parent so the per-component race
-    # window is exercised. Pre-fix, a worker could fail with EEXIST on a parent
-    # during both its first attempt and the retry's parent walk and surface
-    # "Unable to create directory: '…': File exists" to the caller.
+    # window is exercised. Pre-fix, EEXIST on a shared parent surfaced as
+    # "Unable to create directory: '…': File exists" because the wrapper's
+    # whole-call retry could re-race and the leaf-only fallback check was
+    # false.
+    #
+    # Note: meaningful only under `-Dpreview_mt`. In ST mode the syscalls
+    # serialize and the race window never opens, so this test still asserts
+    # the post-conditions but cannot catch an MT regression.
     it "tolerates concurrent creation of siblings under a shared parent" do
       Dir.mktmpdir do |root|
         # Multiple shared parents (deep tree) amplify the cascading race

--- a/src/utils/file_safe.cr
+++ b/src/utils/file_safe.cr
@@ -19,26 +19,35 @@ module Hwaro
       # Equivalent to `FileUtils.mkdir_p` but tolerates concurrent creation
       # of any path component. Safe to call from MT workers without an
       # external mutex.
+      #
+      # We walk parents ourselves so EEXIST is absorbed *per component*.
+      # Crystal's `Dir.mkdir_p` is `exists? → mkdir` for each parent and the
+      # leaf, so two workers calling `mkdir_p("/out/a/b/x")` and
+      # `mkdir_p("/out/a/b/y")` can race on every shared parent
+      # (`/out`, `/out/a`, `/out/a/b`). A single retry of the whole call
+      # isn't enough: the retry's parent walk can re-race on a *different*
+      # shared parent, raise again, and a post-hoc `Dir.exists?(leaf)` check
+      # is false because we never reached the leaf — so the EEXIST bubbles
+      # out and a render fails ("Unable to create directory: '…': File
+      # exists"). Tolerating EEXIST per component avoids the cascade.
       def self.mkdir_p(path : String | Path, mode : Int32 = 0o777) : Nil
-        Dir.mkdir_p(path, mode)
-      rescue File::AlreadyExistsError
-        # Two workers calling `mkdir_p("/out/posts/a")` and
-        # `mkdir_p("/out/posts/b")` can race on the shared parent `/out/posts`:
-        # both pass the `Dir.exists?` precondition (`/out/posts` is absent),
-        # both descend, both call `mkdir("/out/posts")`, and the loser gets
-        # EEXIST on the parent — even though its own leaf hasn't been created
-        # yet. So a single retry is enough: on the second attempt `/out/posts`
-        # now exists (whoever won the race created it), and `mkdir_p` skips
-        # that step and only creates the leaf the caller actually asked for.
-        begin
-          Dir.mkdir_p(path, mode)
-        rescue ex : File::AlreadyExistsError
-          # Genuinely repeated EEXIST after retry: surface only when the
-          # final target *still* isn't a directory. Otherwise the
-          # post-condition `mkdir_p` promises ("path exists as a directory")
-          # already holds and we treat as success.
-          raise ex unless Dir.exists?(path)
+        path = path.is_a?(Path) ? path : Path.new(path)
+        return if Dir.exists?(path)
+
+        path.each_parent do |parent|
+          mkdir_tolerant(parent, mode)
         end
+        mkdir_tolerant(path, mode)
+      end
+
+      # Create a single directory, treating "already exists as a directory"
+      # as success. Anything else (including the path existing as a file)
+      # propagates.
+      private def self.mkdir_tolerant(path : Path, mode : Int32) : Nil
+        return if Dir.exists?(path)
+        Dir.mkdir(path, mode)
+      rescue ex : File::AlreadyExistsError
+        raise ex unless Dir.exists?(path)
       end
     end
   end

--- a/src/utils/file_safe.cr
+++ b/src/utils/file_safe.cr
@@ -31,7 +31,7 @@ module Hwaro
       # out and a render fails ("Unable to create directory: '…': File
       # exists"). Tolerating EEXIST per component avoids the cascade.
       def self.mkdir_p(path : String | Path, mode : Int32 = 0o777) : Nil
-        path = path.is_a?(Path) ? path : Path.new(path)
+        path = Path.new(path)
         return if Dir.exists?(path)
 
         path.each_parent do |parent|


### PR DESCRIPTION
## Summary

- `Hwaro::Utils::FileSafe.mkdir_p` now walks parents itself and absorbs `EEXIST` *per component*, instead of relying on Crystal's `Dir.mkdir_p` with a whole-call retry.
- Fixes intermittent `Render failed for ...: Unable to create directory: '...': File exists` during `hwaro build` / `hwaro serve` on multilingual sites with multiple pages sharing a parent path.

## Why

Parallel render workers writing to sibling output paths (`/ko/development/page1`, `/ko/development/page2`, …) race on every shared parent. The old wrapper deferred to `Dir.mkdir_p` and retried the whole call once — but the retry's parent walk can re-race on a *different* shared parent, raise again, and the post-hoc `Dir.exists?(leaf)` check is `false` because the walk never reached the leaf. The `File::AlreadyExistsError` bubbled out to the render worker and surfaced as a `HWARO_E_TEMPLATE` failure.

Reproduced reliably with 64 fibers under `-Dpreview_mt`:

```
OLD failures: 129   # 50 trials × 64 fibers on a 5-level shared tree
NEW failures: 0
```

The new implementation walks `each_parent` and creates each component with a `Dir.mkdir` that tolerates `AlreadyExistsError` as long as the path ends up being a directory — anything else (e.g. the path existing as a file) still propagates.

## Test plan

- [x] `crystal spec spec/unit/` — 4580 examples, 0 failures
- [x] New `spec/unit/file_safe_spec.cr` covers: nested mkdir, idempotency, file-collision raises, concurrent-sibling race
- [x] 50 × 64-fiber stress harness under `-Dpreview_mt`: old code 129 failures → new code 0 failures
- [x] 10 consecutive `hwaro build -i docs` against the reproducing 128-page noir site: all clean
- [x] `crystal tool format --check` + `ameba` clean

Closes the intermittent `Unable to create directory` race reported when running `hwaro serve -i docs` on a multilingual site.