### PR TITLE
feat(serve): custom response headers via --header and [serve.headers]

### DIFF
--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -292,6 +292,7 @@ hwaro serve -i /path/to/my-site -p 8080
 | --no-error-overlay | Disable in-browser error overlay (default: enabled) |
 | --live-reload | Enable browser live reload on file changes (default: enabled; kept for backwards compatibility) |
 | --no-live-reload | Disable browser live reload on file changes |
+| --header "NAME: VALUE" | Add custom response header (repeatable). Merged with `[serve.headers]` from `config.toml` (CLI wins). Only affects `hwaro serve`. |
 | --cache | Enable build caching (skip unchanged files) |
 | --stream | Enable streaming build to reduce memory usage |
 | --memory-limit SIZE | Memory limit for streaming build (e.g. `2G`, `512M`) |
@@ -317,6 +318,26 @@ Live reload is **enabled by default**. The server injects a small WebSocket clie
 Pass `--no-live-reload` to disable this behaviour (useful for testing production-like delivery locally). The `--live-reload` flag is kept as a no-op alias for backwards compatibility with existing invocations.
 
 When `-i` is specified, the server operates as if you had `cd`-ed into the given directory — watching and serving from that project root.
+
+**Custom response headers (`--header` / `[serve.headers]`):**
+
+Use this to reproduce headers that your production reverse-proxy, CDN, or static hosting sets (security headers, `Cache-Control`, custom CORS, etc.) so you can test locally before deploying the static output.
+
+```toml
+[serve.headers]
+X-Frame-Options = "SAMEORIGIN"
+X-Content-Type-Options = "nosniff"
+Referrer-Policy = "strict-origin-when-cross-origin"
+# Cache-Control = "public, max-age=3600"
+```
+
+```bash
+hwaro serve --header "X-Custom: foo" --header "Cache-Control: no-store"
+```
+
+- CLI `--header` values win over the same key in `config.toml`.
+- Headers are injected on **every** dev-server response (HTML, assets, 404s, redirects, live-reload injected pages).
+- This feature only affects `hwaro serve`. The files written to `public/` are untouched.
 
 ### deploy
 

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -1218,6 +1218,50 @@ describe Hwaro::Models::Config do
   end
 
   # ---------------------------------------------------------------------------
+  # Serve (dev server) configuration
+  # ---------------------------------------------------------------------------
+
+  describe "serve configuration" do
+    it "has default (empty) serve headers" do
+      config = Hwaro::Models::Config.new
+      config.serve.headers.should eq({} of String => String)
+    end
+
+    it "loads custom serve headers from TOML" do
+      config = load_config(<<-TOML)
+        title = "Test"
+        base_url = "http://localhost"
+
+        [serve.headers]
+        X-Frame-Options = "SAMEORIGIN"
+        X-Content-Type-Options = "nosniff"
+        Referrer-Policy = "strict-origin-when-cross-origin"
+        TOML
+
+      config.serve.headers["X-Frame-Options"].should eq("SAMEORIGIN")
+      config.serve.headers["X-Content-Type-Options"].should eq("nosniff")
+      config.serve.headers.size.should eq(3)
+    end
+
+    it "ignores non-string values and dangerous header names (colon)" do
+      config = load_config(<<-TOML)
+        title = "Test"
+        base_url = "http://localhost"
+
+        [serve.headers]
+        "Good-Header" = "safe-value"
+        "Bad:Name" = "x"
+        ignored = 123
+        also_ignored = ["array", "not", "string"]
+        TOML
+
+      config.serve.headers.has_key?("Good-Header").should be_true
+      config.serve.headers.has_key?("Bad:Name").should be_false
+      config.serve.headers.size.should eq(1)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Markdown
   # ---------------------------------------------------------------------------
 

--- a/spec/unit/serve_command_spec.cr
+++ b/spec/unit/serve_command_spec.cr
@@ -203,6 +203,42 @@ describe Hwaro::CLI::Commands::ServeCommand do
       build_options.fast_start.should be_true
       build_options.fast_start_count.should eq(5)
     end
+
+    it "parses --header and stores in options.headers (CLI only at parse time)" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options(["--header", "X-Test: hello", "--header", "Cache-Control=no-store"])
+      options.headers["X-Test"].should eq("hello")
+      options.headers["Cache-Control"].should eq("no-store")
+      options.headers.size.should eq(2)
+    end
+
+    it "supports --header with = separator and whitespace" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options(["--header", "X-Foo = bar baz"])
+      options.headers["X-Foo"].should eq("bar baz")
+    end
+
+    it "raises on invalid --header (empty key)" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      err = expect_raises(Hwaro::HwaroError) do
+        cmd.test_parse_options(["--header", ": value"])
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+    end
+
+    it "raises on --header containing control characters (CRLF injection guard)" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      # Pass the flag and the bad value as two separate argv elements (the value itself contains \n)
+      err = expect_raises(Hwaro::HwaroError) do
+        cmd.test_parse_options(["--header", "X-Bad: foo\nbar"])
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+
+      err2 = expect_raises(Hwaro::HwaroError) do
+        cmd.test_parse_options(["--header", "X-Bad2: foo\r\nX-Inject: evil"])
+      end
+      err2.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+    end
   end
 
   describe "#run" do

--- a/spec/unit/serve_command_spec.cr
+++ b/spec/unit/serve_command_spec.cr
@@ -226,6 +226,16 @@ describe Hwaro::CLI::Commands::ServeCommand do
       err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
     end
 
+    it "handles bare --header token (no separator) gracefully instead of IndexError" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      err = expect_raises(Hwaro::HwaroError) do
+        cmd.test_parse_options(["--header", "JustKeyNoValue"])
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      # Use to_s because Exception#message is String? in the base class
+      err.message.to_s.should contain("Invalid --header value")
+    end
+
     it "raises on --header containing control characters (CRLF injection guard)" do
       cmd = Hwaro::CLI::Commands::ServeCommand.new
       # Pass the flag and the bad value as two separate argv elements (the value itself contains \n)

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -258,12 +258,21 @@ module Hwaro
             key, value = s.split(":", 2)
           elsif s.includes?("=")
             key, value = s.split("=", 2)
+          elsif s =~ /\s/
+            # Only treat as "key value" if there actually is whitespace.
+            parts = s.split(/\s+/, 2)
+            key = parts[0]? || ""
+            value = parts[1]? || ""
           else
-            # fallback: first whitespace
-            key, value = s.split(/\s+/, 2)
+            # Bare token with no separator at all (e.g. --header "Foo").
+            # This used to cause an IndexError on parallel assignment before the
+            # safe split. Now we give the user the same friendly error as other
+            # malformed inputs (addresses Copilot review feedback on #556).
+            key = ""
+            value = ""
           end
           key = key.strip
-          value = (value || "").strip
+          value = value.strip
 
           if key.empty?
             raise Hwaro::HwaroError.new(

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -4,6 +4,7 @@ require "../../config/options/serve_options"
 require "../../services/server/server"
 require "../../utils/errors"
 require "../../utils/logger"
+require "../../models/config"
 
 module Hwaro
   module CLI
@@ -43,6 +44,7 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--no-error-overlay", description: "Disable error overlay in browser"),
           FlagInfo.new(short: nil, long: "--live-reload", description: "Enable live reload on file changes (default: enabled; kept for backwards compatibility)"),
           FlagInfo.new(short: nil, long: "--no-live-reload", description: "Disable live reload on file changes"),
+          FlagInfo.new(short: nil, long: "--header", description: "Add custom response header for dev server (repeatable, e.g. --header 'X-Foo: bar')", takes_value: true, value_hint: "NAME: VALUE"),
 
           # Skip options
           SKIP_OG_IMAGE_FLAG,
@@ -88,6 +90,20 @@ module Hwaro
             Dir.cd(input_dir)
           end
 
+          # Enrich CLI headers with [serve.headers] from config.toml (now in the correct
+          # directory after any -i/--input chdir). CLI values win on duplicate keys.
+          # This must happen after Dir.cd so `hwaro serve -i /other/project` reads the
+          # right config. We deliberately do not load config earlier in parse_options.
+          begin
+            cfg = Models::Config.load(env: options.env)
+            final = cfg.serve.headers.dup
+            options.headers.each { |k, v| final[k] = v } # CLI wins
+            options.headers = final
+          rescue Hwaro::HwaroError
+            # Missing/invalid config — the build inside Server will emit the proper
+            # classified error. We just proceed with whatever --header the user gave.
+          end
+
           Services::Server.new.run(options)
         end
 
@@ -117,6 +133,10 @@ module Hwaro
           access_log = false
           error_overlay = true
           live_reload = true
+
+          # CLI-provided headers only. Config [serve.headers] is merged later in #run
+          # (after any -i chdir) so that `hwaro serve -i other/dir` works correctly.
+          headers = {} of String => String
 
           # Skip options
           skip_og_image = false
@@ -180,6 +200,10 @@ module Hwaro
             parser.on("--no-error-overlay", "Disable error overlay in browser") { error_overlay = false }
             parser.on("--live-reload", "Enable live reload on file changes (default: enabled; kept for backwards compatibility)") { live_reload = true }
             parser.on("--no-live-reload", "Disable live reload on file changes") { live_reload = false }
+            parser.on("--header NAME:VALUE", "Add custom response header (repeatable)") do |h|
+              key, value = parse_header(h)
+              headers[key] = value
+            end
 
             # Skip options
             CLI.register_flag(parser, SKIP_OG_IMAGE_FLAG) { |_| skip_og_image = true }
@@ -220,7 +244,46 @@ module Hwaro
             json: json_output,
             fast_start: fast_start,
             fast_start_count: fast_start_count,
+            headers: headers,
           )}
+        end
+
+        # Parse "Name: Value" or "Name=Value" or "Name Value" into {name, value}.
+        # Header names are case-insensitive per HTTP spec; we preserve the
+        # casing the user gave us (common convention is Title-Case).
+        private def parse_header(raw : String) : {String, String}
+          s = raw.strip
+          # Try "key: value", "key = value", "key value"
+          if s.includes?(":")
+            key, value = s.split(":", 2)
+          elsif s.includes?("=")
+            key, value = s.split("=", 2)
+          else
+            # fallback: first whitespace
+            key, value = s.split(/\s+/, 2)
+          end
+          key = key.strip
+          value = (value || "").strip
+
+          if key.empty?
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "Invalid --header value: #{raw.inspect}",
+              hint: "Use the form --header 'X-Foo: bar' or --header 'X-Foo=bar'.",
+            )
+          end
+
+          # Prevent HTTP response splitting / header injection attacks.
+          # Control characters (especially CR/LF) in names or values are dangerous.
+          if key.each_char.any? { |c| c.ascii_control? || c == ':' } || value.each_char.any?(&.ascii_control?)
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "Invalid characters in --header: #{raw.inspect}",
+              hint: "Header names and values must not contain control characters, newlines, or colons in the name.",
+            )
+          end
+
+          {key, value}
         end
       end
     end

--- a/src/config/options/serve_options.cr
+++ b/src/config/options/serve_options.cr
@@ -26,6 +26,8 @@ module Hwaro
         property json : Bool
         property fast_start : Bool
         property fast_start_count : Int32
+        # Custom response headers to inject during serve (from config.toml [serve.headers] + CLI --header)
+        property headers : Hash(String, String)
 
         def initialize(
           @host : String = "127.0.0.1",
@@ -52,6 +54,7 @@ module Hwaro
           @json : Bool = false,
           @fast_start : Bool = false,
           @fast_start_count : Int32 = 20,
+          @headers : Hash(String, String) = {} of String => String,
         )
         end
 

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -524,6 +524,27 @@ module Hwaro
       end
     end
 
+    # Serve (development server) configuration
+    #
+    # Currently used to configure custom response headers that are injected
+    # on every request while running `hwaro serve`. This makes it easy to
+    # reproduce production reverse-proxy / CDN header behaviour locally.
+    class ServeConfig
+      # Custom HTTP response headers applied to *all* responses during
+      # `hwaro serve` (including 404s, redirects, and static assets).
+      #
+      # Example in config.toml:
+      #   [serve.headers]
+      #   X-Frame-Options = "SAMEORIGIN"
+      #   X-Content-Type-Options = "nosniff"
+      #   Referrer-Policy = "strict-origin-when-cross-origin"
+      property headers : Hash(String, String)
+
+      def initialize
+        @headers = {} of String => String
+      end
+    end
+
     # Markdown parser configuration
     # Maps to Markd::Options for controlling markdown parsing behavior
     class MarkdownConfig
@@ -750,6 +771,7 @@ module Hwaro
       property default_language : String
       property languages : Hash(String, LanguageConfig)
       property build : BuildConfig
+      property serve : ServeConfig
       property markdown : MarkdownConfig
       property series : SeriesConfig
       property related : RelatedConfig
@@ -783,6 +805,7 @@ module Hwaro
         @default_language = "en"
         @languages = {} of String => LanguageConfig
         @build = BuildConfig.new
+        @serve = ServeConfig.new
         @markdown = MarkdownConfig.new
         @series = SeriesConfig.new
         @related = RelatedConfig.new
@@ -914,6 +937,7 @@ module Hwaro
         load_taxonomies(config)
         load_languages(config)
         load_build(config)
+        load_serve(config)
         load_markdown(config)
         load_series(config)
         load_related(config)
@@ -1246,6 +1270,23 @@ module Hwaro
           end
           if post_hooks = hooks_section["post"]?.try(&.as_a?)
             config.build.hooks.post = post_hooks.compact_map(&.as_s?)
+          end
+        end
+      end
+
+      private def self.load_serve(config : Config)
+        return unless s = config.raw["serve"]?.try(&.as_h?)
+
+        if headers_table = s["headers"]?.try(&.as_h?)
+          headers_table.each do |name, value|
+            next unless str = value.as_s?
+            # Drop obviously dangerous values (CRLF, other controls) coming from config.
+            # This is defense-in-depth; a bad config.toml should ideally be caught by
+            # the user or by `hwaro doctor`, but we refuse to emit split responses.
+            next if name.each_char.any? { |c| c.ascii_control? || c == ':' } ||
+                    str.each_char.any?(&.ascii_control?)
+
+            config.serve.headers[name] = str
           end
         end
       end

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -22,6 +22,7 @@ module Hwaro
         "highlight"        => {description: "Syntax highlighting (Highlight.js)", snippet: -> { highlight(commented: true) }},
         "og"               => {description: "OpenGraph & Twitter Cards", snippet: -> { og(commented: true) }},
         "search"           => {description: "Client-side search index", snippet: -> { search(commented: true) }},
+        "serve"            => {description: "Development server options (custom response headers)", snippet: -> { serve(commented: true) }},
         "pagination"       => {description: "Pagination settings", snippet: -> { pagination(commented: true) }},
         "series"           => {description: "Series grouping", snippet: -> { series(commented: true) }},
         "related"          => {description: "Related posts", snippet: -> { related(commented: true) }},
@@ -935,6 +936,44 @@ module Hwaro
             # pattern = "^.+\\.css$"
             # cacheControl = "max-age=31536000"
             # gzip = true
+
+            TOML
+        end
+      end
+
+      def self.serve(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+            # =============================================================================
+            # Serve (Development Server) (Optional)
+            # =============================================================================
+            # Custom response headers injected on every request while running
+            # `hwaro serve`. Extremely useful for reproducing production
+            # reverse-proxy, CDN, or security header behaviour locally.
+
+            # [serve.headers]
+            # X-Frame-Options = "SAMEORIGIN"
+            # X-Content-Type-Options = "nosniff"
+            # Referrer-Policy = "strict-origin-when-cross-origin"
+            # # Cache-Control = "public, max-age=3600"
+
+            TOML
+        else
+          <<-TOML
+
+            # =============================================================================
+            # Serve (Development Server) (Optional)
+            # =============================================================================
+            # Custom response headers injected on every request while running
+            # `hwaro serve`. Extremely useful for reproducing production
+            # reverse-proxy, CDN, or security header behaviour locally.
+
+            [serve.headers]
+            X-Frame-Options = "SAMEORIGIN"
+            X-Content-Type-Options = "nosniff"
+            Referrer-Policy = "strict-origin-when-cross-origin"
+            # Cache-Control = "public, max-age=3600"
 
             TOML
         end

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -650,6 +650,10 @@ module Hwaro
         protected def deployment_config : String
           ConfigSnippets.deployment
         end
+
+        protected def serve_config : String
+          ConfigSnippets.serve
+        end
       end
     end
   end

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -650,10 +650,6 @@ module Hwaro
         protected def deployment_config : String
           ConfigSnippets.deployment
         end
-
-        protected def serve_config : String
-          ConfigSnippets.serve
-        end
       end
     end
   end

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -162,6 +162,34 @@ module Hwaro
       end
     end
 
+    # Injects user-provided custom response headers on every dev-server response.
+    #
+    # Runs *after* `call_next` so the configured headers always win over any
+    # headers set by built-in handlers (DevCorsHandler, CharsetHandler, 404
+    # handler, redirect Location from IndexRewriteHandler, etc.). This gives
+    # predictable "what I put in [serve.headers] is what the browser receives"
+    # behaviour — exactly what users need when reproducing production server
+    # configuration locally.
+    class CustomHeadersHandler
+      include HTTP::Handler
+
+      def initialize(@headers : Hash(String, String))
+      end
+
+      def call(context)
+        call_next(context)
+
+        # Apply after all other handlers so user values override built-ins
+        # (including Content-Type adjustments and dev CORS headers).
+        @headers.each do |name, value|
+          # Final guard: never emit control characters in headers even if they
+          # somehow made it through config/CLI validation.
+          next if name.each_char.any?(&.ascii_control?) || value.each_char.any?(&.ascii_control?)
+          context.response.headers[name] = value
+        end
+      end
+    end
+
     # Categorised set of file-system changes detected by the watcher.
     #
     # Changes are split into five buckets so the server can pick the
@@ -357,15 +385,15 @@ module Hwaro
 
       def run(options : Config::Options::ServeOptions)
         build_options = options.to_build_options
-        run_with_options(options.host, options.port, options.open_browser, options.access_log, options.live_reload, build_options, options.json)
+        run_with_options(options.host, options.port, options.open_browser, options.access_log, options.live_reload, build_options, options.json, options.headers)
       end
 
       def run(host : String = "127.0.0.1", port : Int32 = 3000, drafts : Bool = false)
         build_options = Config::Options::BuildOptions.new(drafts: drafts)
-        run_with_options(host, port, false, false, false, build_options, false)
+        run_with_options(host, port, false, false, false, build_options, false, {} of String => String)
       end
 
-      private def run_with_options(host : String, port : Int32, open_browser : Bool, access_log : Bool, live_reload : Bool, build_options : Config::Options::BuildOptions, json_output : Bool = false)
+      private def run_with_options(host : String, port : Int32, open_browser : Bool, access_log : Bool, live_reload : Bool, build_options : Config::Options::BuildOptions, json_output : Bool = false, headers : Hash(String, String) = {} of String => String)
         if build_options.fast_start
           Logger.info "Performing fast-start initial build (priority pages only)..."
         else
@@ -401,6 +429,10 @@ module Hwaro
         # response until first flush, so post-call_next header edits
         # take effect for typical dev-site responses.
         handlers << CharsetHandler.new
+        # User-provided headers (from config + CLI). Placed here so:
+        # - it wraps IndexRewrite / LiveReloadInject (catches their early returns)
+        # - it runs after DevCors + Charset on the return path (user values win)
+        handlers << CustomHeadersHandler.new(headers) unless headers.empty?
         if live_reload
           lr_handler = LiveReloadHandler.new
           @live_reload_handler = lr_handler


### PR DESCRIPTION
Adds support for setting custom HTTP response headers during `hwaro serve`.

### Motivation
While the final site is static, many production deployments (CDN, reverse proxy, hosting platform) inject security headers, Cache-Control, CORS rules, etc. Being able to reproduce those headers locally makes testing much more realistic.

### Changes
- `[serve.headers]` table in `config.toml` (under new `ServeConfig`)
- Repeatable `--header "Name: Value"` CLI flag
- `CustomHeadersHandler` placed so user headers win over dev-builtins (CORS, charset, 404, redirects, live-reload injection)
- **Important fix during review**: header loading now correctly respects `-i /path` (was loading from wrong directory before)
- Strong sanitization: control characters (incl. CR/LF) are rejected in both CLI and config paths to prevent header injection / response splitting
- Full test coverage additions + updated docs + `doctor --fix` support

### Usage
```toml
[serve.headers]
X-Frame-Options = "SAMEORIGIN"
Referrer-Policy = "strict-origin-when-cross-origin"
```

```bash
hwaro serve --header "Cache-Control: public, max-age=3600"
```

CLI takes precedence over config for the same key.

All headers are applied to *every* response served by the dev server.