### PR TITLE
fix(og): contain band titles, warn on CJK tofu, fix empty social cards

### DIFF
--- a/spec/unit/og_image_spec.cr
+++ b/spec/unit/og_image_spec.cr
@@ -630,6 +630,23 @@ describe Hwaro::Content::Seo::OgImage do
     end
   end
 
+  describe "text & layout helpers" do
+    it "detects CJK / kana / hangul characters" do
+      Hwaro::Content::Seo::OgImage.contains_cjk?("Hello World").should be_false
+      Hwaro::Content::Seo::OgImage.contains_cjk?("café résumé").should be_false # Latin-1, covered
+      Hwaro::Content::Seo::OgImage.contains_cjk?("한글 제목").should be_true
+      Hwaro::Content::Seo::OgImage.contains_cjk?("日本語のタイトル").should be_true
+      Hwaro::Content::Seo::OgImage.contains_cjk?("Mixed 中文 text").should be_true
+    end
+
+    it "caps band title lines to what fits the fixed-height band" do
+      # BAND_HEIGHT is 200: a 52px line (+8 gap) fits 3 lines, a 60px line fits 2.
+      Hwaro::Content::Seo::OgImage.band_line_capacity(52).should eq(3)
+      Hwaro::Content::Seo::OgImage.band_line_capacity(60).should eq(2)
+      Hwaro::Content::Seo::OgImage.band_line_capacity(1000).should eq(1) # never zero
+    end
+  end
+
   describe "style predicates" do
     it "classifies geometric styles" do
       Hwaro::Content::Seo::OgImage.geometric?("split").should be_true

--- a/spec/unit/og_image_spec.cr
+++ b/spec/unit/og_image_spec.cr
@@ -645,6 +645,14 @@ describe Hwaro::Content::Seo::OgImage do
       Hwaro::Content::Seo::OgImage.band_line_capacity(60).should eq(2)
       Hwaro::Content::Seo::OgImage.band_line_capacity(1000).should eq(1) # never zero
     end
+
+    it "marks band title truncation with an ellipsis" do
+      lines = ["One", "Two", "Three", "Four"]
+      # 60px → capacity 2; the kept lines gain an ellipsis on the last one.
+      Hwaro::Content::Seo::OgImage.cap_band_title(lines, 60).should eq(["One", "Two…"])
+      # Within capacity → untouched, no ellipsis.
+      Hwaro::Content::Seo::OgImage.cap_band_title(["Only"], 60).should eq(["Only"])
+    end
   end
 
   describe "style predicates" do

--- a/spec/unit/opengraph_spec.cr
+++ b/spec/unit/opengraph_spec.cr
@@ -343,6 +343,8 @@ describe Hwaro::Models::OpenGraphConfig do
       )
 
       tags.should contain(%(<meta name="twitter:image" content="https://example.com/images/default-twitter.png">))
+      # default_image satisfies the image requirement, so the large card stays.
+      tags.should contain(%(<meta name="twitter:card" content="summary_large_image">))
     end
 
     it "does not include image tag when no image available" do

--- a/spec/unit/opengraph_spec.cr
+++ b/spec/unit/opengraph_spec.cr
@@ -248,12 +248,51 @@ describe Hwaro::Models::OpenGraphConfig do
       tags = config.twitter_tags(
         title: "My Page",
         description: nil,
-        image: nil,
+        image: "/images/card.png",
         base_url: "https://example.com"
       )
 
       tags.should contain(%(<meta name="twitter:card" content="summary_large_image">))
       tags.should contain(%(<meta name="twitter:title" content="My Page">))
+    end
+
+    it "downgrades summary_large_image to summary when there is no image" do
+      config = Hwaro::Models::OpenGraphConfig.new # defaults to summary_large_image
+      tags = config.twitter_tags(
+        title: "My Page",
+        description: nil,
+        image: nil,
+        base_url: "https://example.com"
+      )
+
+      # A large-image card with no image renders as a blank preview.
+      tags.should contain(%(<meta name="twitter:card" content="summary">))
+      tags.should_not contain("summary_large_image")
+    end
+
+    it "keeps summary_large_image when an image is present" do
+      config = Hwaro::Models::OpenGraphConfig.new
+      tags = config.twitter_tags(
+        title: "My Page",
+        description: nil,
+        image: "/images/card.png",
+        base_url: "https://example.com"
+      )
+
+      tags.should contain(%(<meta name="twitter:card" content="summary_large_image">))
+    end
+
+    it "respects a non-large card type even without an image" do
+      config = Hwaro::Models::OpenGraphConfig.new
+      config.twitter_card = "summary"
+      tags = config.twitter_tags(
+        title: "My Page",
+        description: nil,
+        image: nil,
+        base_url: "https://example.com"
+      )
+
+      tags.should contain(%(<meta name="twitter:card" content="summary">))
     end
 
     it "includes description when provided" do

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -19,6 +19,11 @@ module Hwaro
         WIDTH  = 1200
         HEIGHT =  630
 
+        # Emit the "CJK text but no CJK font" advisory at most once per process
+        # (the generate hook can run multiple times — e.g. --fast-start's
+        # deferred pass, or every rebuild in `serve`).
+        @@cjk_font_warning_shown = false
+
         LOGO_SIZE          =  48
         LOGO_MARGIN        =  80
         LOGO_TOP_Y         =  20
@@ -208,8 +213,9 @@ module Hwaro
             # The bundled/system fallback fonts cover only Latin scripts. Warn
             # once if any page has CJK text but no CJK-capable font is set, since
             # those titles would otherwise render as blank "tofu" boxes.
-            if png_available && ai.font_path.nil? &&
+            if png_available && !@@cjk_font_warning_shown && ai.font_path.nil? &&
                pages.any? { |p| contains_cjk?(p.title) || contains_cjk?(p.description || "") }
+              @@cjk_font_warning_shown = true
               Logger.warn "  OG images: page titles/descriptions contain CJK characters, " \
                           "but the bundled font covers only Latin scripts — they will render " \
                           "as blank boxes. Set [og.auto_image].font_path to a CJK-capable font " \
@@ -416,7 +422,7 @@ module Hwaro
           title_lines = word_wrap(page.title, chars_per_line)
           # The band style draws the title inside a fixed-height color band;
           # cap the lines so a long title can't overflow the band invisibly.
-          title_lines = title_lines.first(band_line_capacity(font_size)) if style == "band"
+          title_lines = cap_band_title(title_lines, font_size) if style == "band"
           desc_lines = word_wrap(page.description || "", desc_chars)
 
           title_block_height = title_lines.size * (font_size + 8)
@@ -793,6 +799,17 @@ module Hwaro
         # drawn in the background color, renders invisibly off-band.
         def self.band_line_capacity(font_size : Int32) : Int32
           Math.max(1, BAND_HEIGHT // (font_size + 8))
+        end
+
+        # Cap a `band`-style title to the lines that fit the band, marking the
+        # last kept line with an ellipsis so the truncation is visible rather
+        # than silent.
+        def self.cap_band_title(lines : Array(String), font_size : Int32) : Array(String)
+          cap = band_line_capacity(font_size)
+          return lines if lines.size <= cap
+          capped = lines.first(cap)
+          capped[-1] = "#{capped[-1].rstrip}…"
+          capped
         end
 
         # Compute a hash of OG-relevant config properties.

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -204,6 +204,17 @@ module Hwaro
             unless png_available
               Logger.warn "  PNG format requested but font initialization failed. Falling back to SVG."
             end
+
+            # The bundled/system fallback fonts cover only Latin scripts. Warn
+            # once if any page has CJK text but no CJK-capable font is set, since
+            # those titles would otherwise render as blank "tofu" boxes.
+            if png_available && ai.font_path.nil? &&
+               pages.any? { |p| contains_cjk?(p.title) || contains_cjk?(p.description || "") }
+              Logger.warn "  OG images: page titles/descriptions contain CJK characters, " \
+                          "but the bundled font covers only Latin scripts — they will render " \
+                          "as blank boxes. Set [og.auto_image].font_path to a CJK-capable font " \
+                          "(e.g. Noto Sans CJK)."
+            end
           end
 
           # Resolve absolute paths for logo and background image
@@ -403,6 +414,9 @@ module Hwaro
           desc_chars = Math.max((text_w / (desc_size * 0.55)).to_i, 1)
 
           title_lines = word_wrap(page.title, chars_per_line)
+          # The band style draws the title inside a fixed-height color band;
+          # cap the lines so a long title can't overflow the band invisibly.
+          title_lines = title_lines.first(band_line_capacity(font_size)) if style == "band"
           desc_lines = word_wrap(page.description || "", desc_chars)
 
           title_block_height = title_lines.size * (font_size + 8)
@@ -764,6 +778,21 @@ module Hwaro
             (code >= 0x30A0 && code <= 0x30FF) || # Katakana
             (code >= 0xAC00 && code <= 0xD7AF) || # Hangul Syllables
             (code >= 0xFF00 && code <= 0xFFEF)    # Fullwidth Forms
+        end
+
+        # True if the text contains CJK ideographs, kana, hangul, or fullwidth
+        # forms — glyphs the bundled/system Latin fonts cannot render, so PNG
+        # OG images would show blank "tofu" boxes unless a CJK-capable
+        # `font_path` is configured.
+        def self.contains_cjk?(text : String) : Bool
+          text.each_char.any? { |c| cjk_char?(c) }
+        end
+
+        # How many title lines fit inside the fixed-height color band used by
+        # the `band` style. Beyond this the title overflows the band and, being
+        # drawn in the background color, renders invisibly off-band.
+        def self.band_line_capacity(font_size : Int32) : Int32
+          Math.max(1, BAND_HEIGHT // (font_size + 8))
         end
 
         # Compute a hash of OG-relevant config properties.

--- a/src/content/seo/og_png_renderer.cr
+++ b/src/content/seo/og_png_renderer.cr
@@ -454,7 +454,7 @@ module Hwaro
           title_lines = word_wrap_measured(bold_info, bold_scale, page.title, wrap_width)
           # The band style draws the title inside a fixed-height color band;
           # cap the lines so a long title can't overflow the band invisibly.
-          title_lines = title_lines.first(OgImage.band_line_capacity(font_size.to_i)) if ai.style == "band"
+          title_lines = OgImage.cap_band_title(title_lines, font_size.to_i) if ai.style == "band"
           desc_text = page.description || ""
           desc_lines = desc_text.empty? ? [] of String : word_wrap_measured(r_info, r_scale, desc_text, wrap_width)
 

--- a/src/content/seo/og_png_renderer.cr
+++ b/src/content/seo/og_png_renderer.cr
@@ -452,6 +452,9 @@ module Hwaro
                        end
 
           title_lines = word_wrap_measured(bold_info, bold_scale, page.title, wrap_width)
+          # The band style draws the title inside a fixed-height color band;
+          # cap the lines so a long title can't overflow the band invisibly.
+          title_lines = title_lines.first(OgImage.band_line_capacity(font_size.to_i)) if ai.style == "band"
           desc_text = page.description || ""
           desc_lines = desc_text.empty? ? [] of String : word_wrap_measured(r_info, r_scale, desc_text, wrap_width)
 

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -434,14 +434,21 @@ module Hwaro
         image : String?,
         base_url : String,
       ) : String
+        # A "summary_large_image" card with no image renders as a blank preview
+        # on most platforms, so downgrade to the plain "summary" card when this
+        # page resolves to no image (e.g. auto OG images disabled and no
+        # per-page or default image set).
+        img_url = resolve_image_url(image, base_url)
+        card = (@twitter_card == "summary_large_image" && img_url.nil?) ? "summary" : @twitter_card
+
         # See `og_tags` above for why subsequent lines are pre-indented.
         String.build(256) do |str|
-          str << %(<meta name="twitter:card" content="#{Utils::TextUtils.escape_xml(@twitter_card)}">\n  )
+          str << %(<meta name="twitter:card" content="#{Utils::TextUtils.escape_xml(card)}">\n  )
           str << %(<meta name="twitter:title" content="#{Utils::TextUtils.escape_xml(title)}">)
           if desc = description
             str << %(\n  <meta name="twitter:description" content="#{Utils::TextUtils.escape_xml(desc)}">)
           end
-          if img_url = resolve_image_url(image, base_url)
+          if img_url
             str << %(\n  <meta name="twitter:image" content="#{Utils::TextUtils.escape_xml(img_url)}">)
           end
           if site = @twitter_site


### PR DESCRIPTION
## Summary

Found by building a real site with `./bin/hwaro` (blog scaffold → build → serve → inspect rendered OG images). Three user-facing issues, each fixed with regression specs.

### 1. `band` style overflows with long titles
The `band` style draws the title **in the background color** inside a fixed-height color band. A title that wraps to 3–4 lines overflowed the band, so the off-band lines rendered bg-on-bg (invisible) and collided with the description.

**Fix:** cap title lines to what fits the band — `OgImage.band_line_capacity(font_size) = BAND_HEIGHT / (font_size + 8)` — in both the PNG and SVG renderers. Only affects titles that were already broken.

| before | after |
|---|---|
| 4 lines spilling above/below the band, clipped & overlapping the description | title fully contained in the band (2 lines @ 60px), description clear |

### 2. CJK titles render as blank "tofu" boxes, silently
The PNG renderer uses Latin-only bundled/system fonts with no per-glyph fallback, so Korean/Japanese/Chinese titles render as `□□□` — and the build reports success. A working escape hatch exists (`[og.auto_image].font_path`) but is undiscoverable.

**Fix:** warn once during generation when page text contains CJK and no `font_path` is set, pointing at the fix. Heuristic reuses the existing `cjk_char?` ranges (CJK/kana/hangul/fullwidth — exactly what the Latin fonts lack), so no false positives on Latin/accented text. Verified the `font_path` workaround renders CJK correctly.

### 3. `summary_large_image` card with no image → blank social preview
`twitter_tags` emitted `summary_large_image` unconditionally. The default scaffolds ship this card but no image (auto OG images are opt-in), so out-of-the-box social previews are blank.

**Fix:** downgrade to the plain `summary` card when a page resolves to no image. The large card is preserved whenever an image exists (per-page front matter, auto-generated OG image, or `og.default_image`).

## Testing
- `crystal spec` — **4971 examples, 0 failures** (5 new: `band_line_capacity`, `contains_cjk?`, twitter-card downgrade/preserve)
- `crystal tool format --check` — clean
- `ameba` — 0 failures
- `shards build -Dpreview_mt` — builds clean
- Manually verified all three against a generated site (band containment, CJK warning + `font_path` fix, card downgrade vs. preservation)