### PR TITLE
fix(build): apply section page_template to child pages

### DIFF
--- a/spec/unit/phases_render_spec.cr
+++ b/spec/unit/phases_render_spec.cr
@@ -8,8 +8,9 @@ module Hwaro::Core::Build
       get_output_path(page, output_dir)
     end
 
-    def test_determine_template(page : Models::Page, templates : Hash(String, String))
-      determine_template(page, templates)
+    def test_determine_template(page : Models::Page, templates : Hash(String, String),
+                                site : Models::Site = Models::Site.new(Models::Config.new))
+      determine_template(page, templates, site)
     end
 
     def test_filter_changed_pages(pages, output_dir, cache)
@@ -114,6 +115,52 @@ describe Hwaro::Core::Build::Phases::Render do
       templates = {"page" => "p"}
       builder.test_determine_template(page, templates).should eq("page")
       page.build_warnings.any?(&.includes?("missing")).should be_true
+    end
+
+    it "inherits the parent section's page_template for child pages" do
+      builder = Hwaro::Core::Build::Builder.new
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      section = Hwaro::Models::Section.new("guide/_index.md")
+      section.section = "guide"
+      section.page_template = "doc-page"
+      site.sections << section
+      site.build_lookup_index
+
+      page = Hwaro::Models::Page.new("guide/intro.md")
+      page.section = "guide"
+      templates = {"page" => "p", "doc-page" => "d"}
+      builder.test_determine_template(page, templates, site).should eq("doc-page")
+    end
+
+    it "lets a page-level template override the section page_template" do
+      builder = Hwaro::Core::Build::Builder.new
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      section = Hwaro::Models::Section.new("guide/_index.md")
+      section.section = "guide"
+      section.page_template = "doc-page"
+      site.sections << section
+      site.build_lookup_index
+
+      page = Hwaro::Models::Page.new("guide/intro.md")
+      page.section = "guide"
+      page.template = "landing"
+      templates = {"page" => "p", "doc-page" => "d", "landing" => "l"}
+      builder.test_determine_template(page, templates, site).should eq("landing")
+    end
+
+    it "falls back to 'page' when the section page_template is not a real template" do
+      builder = Hwaro::Core::Build::Builder.new
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      section = Hwaro::Models::Section.new("guide/_index.md")
+      section.section = "guide"
+      section.page_template = "doc-page"
+      site.sections << section
+      site.build_lookup_index
+
+      page = Hwaro::Models::Page.new("guide/intro.md")
+      page.section = "guide"
+      templates = {"page" => "p"}
+      builder.test_determine_template(page, templates, site).should eq("page")
     end
   end
 

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -296,7 +296,7 @@ module Hwaro::Core::Build::Phases::Render
               crinja_env_override: env, template_cache_override: tmpl_cache, error_overlay: error_overlay, profiler: profiler)
             if profiler && page_start
               elapsed_ms = (Time.instant - page_start).total_milliseconds
-              template_name = determine_template(page, templates)
+              template_name = determine_template(page, templates, site)
               profiler.record_template(template_name, page.content.bytesize.to_i64, elapsed_ms)
             end
             source_path = File.join("content", page.path)
@@ -313,7 +313,7 @@ module Hwaro::Core::Build::Phases::Render
             error_mutex.synchronize do
               failures << {page_path: page.path, message: ex.message.to_s}
             end
-            Logger.debug "  Template: #{determine_template(page, templates)}, Section: #{page.section}"
+            Logger.debug "  Template: #{determine_template(page, templates, site)}, Section: #{page.section}"
             Logger.debug "  Backtrace: #{ex.backtrace?.try(&.first(3).join("\n    ")) || "unavailable"}"
             results.send(false)
           end
@@ -414,7 +414,7 @@ module Hwaro::Core::Build::Phases::Render
       render_page(page, site, templates, output_dir, minify, highlight, safe, verbose, global_vars, error_overlay: error_overlay, profiler: profiler)
       if profiler && page_start
         elapsed_ms = (Time.instant - page_start).total_milliseconds
-        template_name = determine_template(page, templates)
+        template_name = determine_template(page, templates, site)
         profiler.record_template(template_name, page.content.bytesize.to_i64, elapsed_ms)
       end
       source_path = File.join("content", page.path)
@@ -511,7 +511,7 @@ module Hwaro::Core::Build::Phases::Render
       toc_headers = [] of Models::TocHeader
     end
 
-    template_name = determine_template(page, templates)
+    template_name = determine_template(page, templates, site)
     template_content = templates[template_name]? || templates["page"]?
     Logger.debug "Rendering #{page.path} (section=#{page.section.empty? ? "<root>" : page.section}, index=#{page.is_index}) using template '#{template_name}'" if verbose
 
@@ -641,7 +641,7 @@ module Hwaro::Core::Build::Phases::Render
     Logger.action :create, output_path if verbose
   end
 
-  private def determine_template(page : Models::Page, templates : Hash(String, String)) : String
+  private def determine_template(page : Models::Page, templates : Hash(String, String), site : Models::Site) : String
     if custom = page.template
       return custom if templates.has_key?(custom)
       msg = "Custom template '#{custom}' not found for #{page.path}. Falling back to default."
@@ -655,6 +655,17 @@ module Hwaro::Core::Build::Phases::Render
 
     if page.is_index && page.section.empty? && templates.has_key?("index")
       return "index"
+    end
+
+    # Inherit the parent section's default template (`page_template`) for regular
+    # child pages that did not set an explicit `template`. Sections render with
+    # their own "section" template (handled above), so they are excluded here.
+    unless page.is_a?(Models::Section)
+      if section = site.sections_by_name[page.section]?
+        if pt = section.effective_page_template
+          return pt if templates.has_key?(pt)
+        end
+      end
     end
 
     "page"


### PR DESCRIPTION
## Problem

`page_template` on a section's `_index.md` is documented as the **default template for child pages** ([docs/content/writing/sections.md](https://github.com/hahwul/hwaro/blob/main/docs/content/writing/sections.md)):

> ```toml
> title = "Docs"
> page_template = "doc-page"
> ```
> All pages use `doc-page.html` template and sort by weight.

In practice it was a **no-op**. `determine_template` only checked the page's own `template`, then `section`/`index`, then fell back to `page`. It never consulted the parent section's `page_template`, and `Section#effective_page_template` was dead code.

### Reproduction
```toml
# content/guide/_index.md
page_template = "doc-page"
```
`content/guide/intro.md` rendered with `page.html`, not `doc-page.html`.

### Side effect
This is also why the **blog scaffold's `post.html`** (which contains `<time>{{ page.date }}</time>` and the post-meta block) was never used — posts rendered via `page.html`, so the post date/meta never appeared. With this fix a section can opt its children into `post.html`.

## Fix
In `determine_template`, when a non-section page sets no explicit `template`, resolve the parent section via `site.sections_by_name[page.section]` and use its `effective_page_template` (only if that template actually exists).

Precedence preserved:
1. Page-level `template` (front matter) — highest
2. `section` template for Section pages
3. `index` template for the root index
4. **NEW:** parent section's `page_template` for child pages
5. `page` fallback

## Tests
Added regression specs:
- child page inherits the section's `page_template`
- page-level `template` overrides the section default
- falls back to `page` when the configured `page_template` doesn't exist

Targeted spec `crystal spec spec/unit/phases_render_spec.cr` → 30 examples, 0 failures. `crystal tool format --check` and ameba clean.