### PR TITLE
fix(convert): preserve calendar day for local dates

### DIFF
--- a/spec/unit/frontmatter_converter_spec.cr
+++ b/spec/unit/frontmatter_converter_spec.cr
@@ -734,4 +734,63 @@ describe Hwaro::Services::ConversionResult do
     result.skipped_count.should eq(3)
     result.error_count.should eq(1)
   end
+
+  describe ".serialize_time" do
+    # A TOML/YAML local date (e.g. `2026-05-20`) parses to midnight in the local
+    # zone. Forcing it through `to_rfc3339` (UTC) rolls the day back in any
+    # positive-offset zone; these cases must keep the calendar day regardless of
+    # the zone the value was parsed in.
+    it "keeps the calendar day for a positive-offset midnight (no UTC rollback)" do
+      time = Time.local(2026, 5, 20, 0, 0, 0, location: Time::Location.fixed(9 * 3600))
+      Hwaro::Services::FrontmatterConverter.serialize_time(time).should eq("2026-05-20")
+    end
+
+    it "emits a bare date for a UTC midnight (no spurious time component)" do
+      time = Time.utc(2026, 5, 20, 0, 0, 0)
+      Hwaro::Services::FrontmatterConverter.serialize_time(time).should eq("2026-05-20")
+    end
+
+    it "keeps the calendar day for a negative-offset midnight" do
+      time = Time.local(2026, 5, 20, 0, 0, 0, location: Time::Location.fixed(-5 * 3600))
+      Hwaro::Services::FrontmatterConverter.serialize_time(time).should eq("2026-05-20")
+    end
+
+    it "preserves genuine timestamps as RFC 3339" do
+      time = Time.utc(2026, 5, 20, 1, 30, 0)
+      Hwaro::Services::FrontmatterConverter.serialize_time(time).should eq("2026-05-20T01:30:00Z")
+    end
+  end
+
+  describe "date round-trip" do
+    # Regression: converting a file's frontmatter format must not shift a
+    # date-only value by a day or graft a spurious time onto it.
+    it "preserves a TOML local date when converting to YAML" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "post.md")
+        File.write(file_path, "+++\ntitle = \"Post\"\ndate = 2026-05-20\n+++\n\n# Content")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::YAML).should be_true
+
+        converted = File.read(file_path)
+        converted.should contain("2026-05-20")
+        converted.should_not contain("2026-05-20T") # no time-of-day grafted on
+        converted.should_not contain("2026-05-19")  # no day rollback
+      end
+    end
+
+    it "preserves a TOML local date when converting to JSON" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "post.md")
+        File.write(file_path, "+++\ntitle = \"Post\"\ndate = 2026-05-20\n+++\n\n# Content")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::JSON).should be_true
+
+        converted = File.read(file_path)
+        converted.should contain("\"date\": \"2026-05-20\"")
+        converted.should_not contain("2026-05-19")
+      end
+    end
+  end
 end

--- a/src/services/frontmatter_converter.cr
+++ b/src/services/frontmatter_converter.cr
@@ -335,6 +335,23 @@ module Hwaro
         root.to_pretty_json
       end
 
+      # Serialize a frontmatter date/time value without corrupting the calendar day.
+      #
+      # Frontmatter dates are commonly written as TOML/YAML *local dates* such as
+      # `2026-05-20`, which parse to midnight in the local time zone. Rendering
+      # those through `to_rfc3339` (always UTC) rolls the day back in any
+      # positive-offset zone — e.g. in KST `2026-05-20` becomes
+      # `2026-05-19T15:00:00Z`, silently shifting the post's date on a format
+      # round-trip. When the value carries no time-of-day we emit a bare
+      # `YYYY-MM-DD` date and keep the day; genuine timestamps round-trip as RFC 3339.
+      def self.serialize_time(time : Time) : String
+        if time.hour == 0 && time.minute == 0 && time.second == 0 && time.nanosecond == 0
+          time.to_s("%Y-%m-%d")
+        else
+          time.to_rfc3339
+        end
+      end
+
       private def yaml_any_to_json_any(yaml : YAML::Any) : JSON::Any
         raw = yaml.raw
         case raw
@@ -344,7 +361,7 @@ module Hwaro
         when Float32 then JSON::Any.new(raw.to_f64)
         when Float64 then JSON::Any.new(raw)
         when String  then JSON::Any.new(raw)
-        when Time    then JSON::Any.new(raw.to_rfc3339)
+        when Time    then JSON::Any.new(FrontmatterConverter.serialize_time(raw))
         when Nil     then JSON::Any.new(nil)
         when Array
           arr = yaml.as_a.map { |v| yaml_any_to_json_any(v) }
@@ -368,7 +385,7 @@ module Hwaro
         when Int64   then JSON::Any.new(raw)
         when Float64 then JSON::Any.new(raw)
         when String  then JSON::Any.new(raw)
-        when Time    then JSON::Any.new(raw.to_rfc3339)
+        when Time    then JSON::Any.new(FrontmatterConverter.serialize_time(raw))
         when Array
           arr = raw.map do |item|
             item.is_a?(TOML::Any) ? toml_any_to_json_any(item) : JSON::Any.new(item.to_s)
@@ -513,7 +530,7 @@ module Hwaro
           when Float32, Float64
             raw.to_s
           when Time
-            raw.to_rfc3339
+            FrontmatterConverter.serialize_time(raw)
           when Array
             items = value.as_a.map { |v| to_toml_value(v) }
             "[#{items.join(", ")}]"
@@ -564,7 +581,7 @@ module Hwaro
         when Bool
           YAML::Any.new(raw)
         when Time
-          YAML::Any.new(raw.to_rfc3339)
+          YAML::Any.new(FrontmatterConverter.serialize_time(raw))
         when Array
           arr = raw.map { |item|
             if item.is_a?(TOML::Any)


### PR DESCRIPTION
## Problem

`hwaro tool convert` shifts unquoted (native) TOML/YAML **local dates** back by a day in any positive-offset time zone, silently corrupting post dates on a format round-trip.

### Reproduction (under `TZ=Asia/Seoul`)
```toml
# content/posts/d.md
date = 2026-05-20
```
```bash
hwaro tool convert to-yaml   # date: "2026-05-19T15:00:00Z"   ← rolled back to the 19th
hwaro tool convert to-toml   # date = "2026-05-19T15:00:00Z"
```
The build output follows: `sitemap.xml` `<lastmod>` flips from `2026-05-20` to **`2026-05-19`**.

### Root cause
Every `Time` was serialized with `to_rfc3339`, which always renders in UTC. A TOML/YAML *local date* (`2026-05-20`, no time, no offset) parses to **midnight in the local zone**, so the UTC rendering rolls the calendar day back (KST midnight = `15:00Z` the previous day) and grafts a spurious time component on.

## Fix
Add `FrontmatterConverter.serialize_time`:
- value has **no time-of-day** → emit a bare `YYYY-MM-DD` (keeps the calendar day in any zone)
- genuine timestamp → still `to_rfc3339` (instant preserved)

Applied at all four `Time` serialization points: TOML→YAML, TOML→JSON, YAML→JSON, YAML→TOML.

### After (under `TZ=Asia/Seoul`)
| value | before | after |
|-------|--------|-------|
| `date = 2026-05-20` | `2026-05-19T15:00:00Z` | `2026-05-20` |
| `updated = 2026-05-20T10:30:00+09:00` | `2026-05-20T01:30:00Z` | `2026-05-20T01:30:00Z` (unchanged — same instant) |

## Tests
- `.serialize_time` unit cases with **fixed** +09:00 / −05:00 / UTC offsets — timezone-independent, prove no day rollback.
- `convert_file` round-trip coverage for to-YAML and to-JSON asserting no day shift and no grafted time.

`crystal spec spec/unit/frontmatter_converter_spec.cr` → 59 examples, 0 failures under both `TZ=UTC` and `TZ=Asia/Seoul`. Format + ameba clean.