### PR TITLE
fix(build): validate --memory-limit range

### DIFF
--- a/spec/unit/build_options_spec.cr
+++ b/spec/unit/build_options_spec.cr
@@ -116,5 +116,33 @@ describe Hwaro::Config::Options::BuildOptions do
         opts.batch_size
       end
     end
+
+    it "raises on a zero memory limit instead of silently using a batch of 1" do
+      opts = Hwaro::Config::Options::BuildOptions.new(memory_limit: "0")
+      expect_raises(Exception, /Invalid memory limit: 0\. Must be a positive size/) do
+        opts.batch_size
+      end
+    end
+
+    it "raises on a zero memory limit with a unit suffix" do
+      opts = Hwaro::Config::Options::BuildOptions.new(memory_limit: "0G")
+      expect_raises(Exception, /Invalid memory limit: 0G/) do
+        opts.batch_size
+      end
+    end
+
+    it "raises a friendly error on an overflowing memory limit (not 'Arithmetic overflow')" do
+      opts = Hwaro::Config::Options::BuildOptions.new(memory_limit: "999999999999999999999G")
+      expect_raises(Exception, /Memory limit too large/) do
+        opts.batch_size
+      end
+    end
+
+    it "raises a friendly error on an overflowing plain-bytes memory limit" do
+      opts = Hwaro::Config::Options::BuildOptions.new(memory_limit: "99999999999999999999999999")
+      expect_raises(Exception, /Memory limit too large/) do
+        opts.batch_size
+      end
+    end
   end
 end

--- a/src/config/options/build_options.cr
+++ b/src/config/options/build_options.cr
@@ -88,18 +88,30 @@ module Hwaro
         end
 
         private def parse_memory_limit(value : String) : Int64
-          case value.strip
-          when /^(\d+(?:\.\d+)?)\s*[Gg]$/
-            ($1.to_f * 1024 * 1024 * 1024).to_i64
-          when /^(\d+(?:\.\d+)?)\s*[Mm]$/
-            ($1.to_f * 1024 * 1024).to_i64
-          when /^(\d+(?:\.\d+)?)\s*[Kk]$/
-            ($1.to_f * 1024).to_i64
-          when /^(\d+)$/
-            $1.to_i64
-          else
-            raise "Invalid memory limit format: #{value}. Use format like '2G', '512M', or '256K'."
+          bytes =
+            case value.strip
+            when /^(\d+(?:\.\d+)?)\s*[Gg]$/
+              $1.to_f * 1024 * 1024 * 1024
+            when /^(\d+(?:\.\d+)?)\s*[Mm]$/
+              $1.to_f * 1024 * 1024
+            when /^(\d+(?:\.\d+)?)\s*[Kk]$/
+              $1.to_f * 1024
+            when /^(\d+)$/
+              $1.to_f
+            else
+              raise "Invalid memory limit format: #{value}. Use format like '2G', '512M', or '256K'."
+            end
+
+          # Validate the resolved size before narrowing to Int64 so callers get a
+          # clear message instead of a degenerate batch size (0 -> batch of 1) or
+          # a raw "Arithmetic overflow" from `.to_i64` on an enormous value.
+          if bytes < 1
+            raise "Invalid memory limit: #{value}. Must be a positive size like '2G', '512M', or '256K'."
+          elsif bytes >= Int64::MAX.to_f
+            raise "Memory limit too large: #{value}. Maximum is #{Int64::MAX} bytes (~8 EiB)."
           end
+
+          bytes.to_i64
         end
       end
     end


### PR DESCRIPTION
## Problem

`--memory-limit` mishandled two edge inputs:

```bash
hwaro build --stream --memory-limit 0
# silently accepted -> 0 bytes -> batch_size clamped to 1 (degenerate, looks valid)

hwaro build --stream --memory-limit 999999999999999999999G
# Error: Arithmetic overflow   ← raw OverflowError from .to_i64, no guidance
```

`parse_memory_limit` computed `($1.to_f * 1024**n).to_i64` per branch. A zero
value passed straight through (`0` matches `/^(\d+)$/`), and an enormous value
overflowed `.to_i64`, raising the unhelpful `Arithmetic overflow`.

## Fix
Resolve the size to a `Float64` first, then validate before narrowing to `Int64`:
- `bytes < 1` → `Invalid memory limit: …. Must be a positive size…`
- `bytes >= Int64::MAX` → `Memory limit too large: …. Maximum is … bytes (~8 EiB).`

Valid sizes and the existing `Invalid memory limit format` path (`abc`, `-1`, empty) are unchanged.

### After
| input | before | after |
|-------|--------|-------|
| `0`, `0G`, `0K` | accepted → batch of 1 | `Invalid memory limit: …. Must be a positive size…` |
| `999…G`, huge plain bytes | `Arithmetic overflow` | `Memory limit too large: …. Maximum is … bytes (~8 EiB).` |
| `2G`, `512M`, `100K`, `100`, `1.5G` | ok | ok (unchanged) |
| `abc`, `-1`, `""` | format error | format error (unchanged) |

## Tests
Added specs for zero (bare + unit-suffixed) and overflowing (unit + plain-bytes) limits. `crystal spec spec/unit/build_options_spec.cr` → 18 examples, 0 failures. Format + ameba clean.