### PR TITLE
test(cli): cover tool subcommand wrappers

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -16,3 +16,24 @@ class Dir
     end
   end
 end
+
+# Run a block with human-readable Logger output captured, returning everything
+# written to the logger as a String. All global Logger state (io, level, quiet)
+# is saved and restored so examples cannot leak state into one another.
+def with_captured_log(&) : String
+  previous_io = Hwaro::Logger.io
+  previous_level = Hwaro::Logger.level
+  previous_quiet = Hwaro::Logger.quiet?
+  sink = IO::Memory.new
+  Hwaro::Logger.io = sink
+  Hwaro::Logger.level = Hwaro::Logger::Level::Info
+  Hwaro::Logger.quiet = false
+  begin
+    yield
+    sink.to_s
+  ensure
+    Hwaro::Logger.io = previous_io
+    Hwaro::Logger.level = previous_level
+    Hwaro::Logger.quiet = previous_quiet
+  end
+end

--- a/spec/unit/agents_md_command_spec.cr
+++ b/spec/unit/agents_md_command_spec.cr
@@ -1,0 +1,91 @@
+require "../spec_helper"
+
+# Capture human-readable Logger output while running a block, restoring all
+# global Logger state afterwards.
+private def capture_agents_md_log(&)
+  previous_io = Hwaro::Logger.io
+  previous_level = Hwaro::Logger.level
+  previous_quiet = Hwaro::Logger.quiet?
+  sink = IO::Memory.new
+  Hwaro::Logger.io = sink
+  Hwaro::Logger.level = Hwaro::Logger::Level::Info
+  Hwaro::Logger.quiet = false
+  begin
+    yield
+    sink.to_s
+  ensure
+    Hwaro::Logger.io = previous_io
+    Hwaro::Logger.level = previous_level
+    Hwaro::Logger.quiet = previous_quiet
+  end
+end
+
+# Command-level tests for `hwaro tool agents-md`.
+#
+# The generated content itself is exercised in spec/unit/defaults_agents_md_spec.cr;
+# these tests cover the command wrapper: metadata and the `--write` path
+# (local and remote) that persists AGENTS.md. The interactive overwrite prompt
+# (which reads stdin and may `exit`) is intentionally not exercised here.
+describe Hwaro::CLI::Commands::Tool::AgentsMdCommand do
+  describe ".metadata" do
+    it "reports the command name and description" do
+      meta = Hwaro::CLI::Commands::Tool::AgentsMdCommand.metadata
+      meta.name.should eq("agents-md")
+      meta.description.should_not be_empty
+    end
+
+    it "exposes the remote, local, write and force flags" do
+      meta = Hwaro::CLI::Commands::Tool::AgentsMdCommand.metadata
+      meta.flags.any? { |f| f.long == "--remote" }.should be_true
+      meta.flags.any? { |f| f.long == "--local" }.should be_true
+      meta.flags.any? { |f| f.long == "--write" }.should be_true
+      meta.flags.any? { |f| f.long == "--force" }.should be_true
+    end
+  end
+
+  describe "#run" do
+    it "writes the local AGENTS.md and logs success" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          output = capture_agents_md_log do
+            cmd = Hwaro::CLI::Commands::Tool::AgentsMdCommand.new
+            cmd.run(["--write"])
+          end
+
+          output.should contain("local mode")
+          File.exists?(File.join(dir, "AGENTS.md")).should be_true
+          File.read(File.join(dir, "AGENTS.md")).should eq(Hwaro::Services::Defaults::AgentsMd.content)
+        end
+      end
+    end
+
+    it "writes the remote AGENTS.md variant when --remote is given" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          output = capture_agents_md_log do
+            cmd = Hwaro::CLI::Commands::Tool::AgentsMdCommand.new
+            cmd.run(["--remote", "--write"])
+          end
+
+          output.should contain("remote mode")
+          File.read(File.join(dir, "AGENTS.md")).should eq(Hwaro::Services::Defaults::AgentsMd.remote_content)
+        end
+      end
+    end
+
+    it "overwrites an existing AGENTS.md when --force is given" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("AGENTS.md", "stale content")
+
+          capture_agents_md_log do
+            cmd = Hwaro::CLI::Commands::Tool::AgentsMdCommand.new
+            cmd.run(["--write", "--force"])
+          end
+
+          File.read(File.join(dir, "AGENTS.md")).should eq(Hwaro::Services::Defaults::AgentsMd.content)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/agents_md_command_spec.cr
+++ b/spec/unit/agents_md_command_spec.cr
@@ -1,25 +1,5 @@
 require "../spec_helper"
 
-# Capture human-readable Logger output while running a block, restoring all
-# global Logger state afterwards.
-private def capture_agents_md_log(&)
-  previous_io = Hwaro::Logger.io
-  previous_level = Hwaro::Logger.level
-  previous_quiet = Hwaro::Logger.quiet?
-  sink = IO::Memory.new
-  Hwaro::Logger.io = sink
-  Hwaro::Logger.level = Hwaro::Logger::Level::Info
-  Hwaro::Logger.quiet = false
-  begin
-    yield
-    sink.to_s
-  ensure
-    Hwaro::Logger.io = previous_io
-    Hwaro::Logger.level = previous_level
-    Hwaro::Logger.quiet = previous_quiet
-  end
-end
-
 # Command-level tests for `hwaro tool agents-md`.
 #
 # The generated content itself is exercised in spec/unit/defaults_agents_md_spec.cr;
@@ -47,7 +27,7 @@ describe Hwaro::CLI::Commands::Tool::AgentsMdCommand do
     it "writes the local AGENTS.md and logs success" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do
-          output = capture_agents_md_log do
+          output = with_captured_log do
             cmd = Hwaro::CLI::Commands::Tool::AgentsMdCommand.new
             cmd.run(["--write"])
           end
@@ -62,7 +42,7 @@ describe Hwaro::CLI::Commands::Tool::AgentsMdCommand do
     it "writes the remote AGENTS.md variant when --remote is given" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do
-          output = capture_agents_md_log do
+          output = with_captured_log do
             cmd = Hwaro::CLI::Commands::Tool::AgentsMdCommand.new
             cmd.run(["--remote", "--write"])
           end
@@ -78,7 +58,7 @@ describe Hwaro::CLI::Commands::Tool::AgentsMdCommand do
         Dir.cd(dir) do
           File.write("AGENTS.md", "stale content")
 
-          capture_agents_md_log do
+          with_captured_log do
             cmd = Hwaro::CLI::Commands::Tool::AgentsMdCommand.new
             cmd.run(["--write", "--force"])
           end

--- a/spec/unit/ci_command_spec.cr
+++ b/spec/unit/ci_command_spec.cr
@@ -1,0 +1,76 @@
+require "../spec_helper"
+
+# Capture human-readable Logger output while running a block, restoring all
+# global Logger state afterwards.
+private def capture_ci_log(&)
+  previous_io = Hwaro::Logger.io
+  previous_level = Hwaro::Logger.level
+  previous_quiet = Hwaro::Logger.quiet?
+  sink = IO::Memory.new
+  Hwaro::Logger.io = sink
+  Hwaro::Logger.level = Hwaro::Logger::Level::Info
+  Hwaro::Logger.quiet = false
+  begin
+    yield
+    sink.to_s
+  ensure
+    Hwaro::Logger.io = previous_io
+    Hwaro::Logger.level = previous_level
+    Hwaro::Logger.quiet = previous_quiet
+  end
+end
+
+# Command-level tests for `hwaro tool ci` (deprecated alias for
+# `tool platform github-pages`).
+#
+# The CIConfig service is exercised in spec/unit/ci_config_spec.cr; these tests
+# cover the command wrapper: metadata, the deprecation warning, and writing the
+# generated workflow file. Paths that call `exit` (missing/unsupported
+# provider, refusing to overwrite) are intentionally not exercised here.
+describe Hwaro::CLI::Commands::Tool::CICommand do
+  describe ".metadata" do
+    it "reports the command name and description" do
+      meta = Hwaro::CLI::Commands::Tool::CICommand.metadata
+      meta.name.should eq("ci")
+      meta.description.should_not be_empty
+    end
+
+    it "lists every supported provider as a positional choice" do
+      meta = Hwaro::CLI::Commands::Tool::CICommand.metadata
+      Hwaro::Services::CIConfig::SUPPORTED_PROVIDERS.each do |provider|
+        meta.positional_choices.should contain(provider)
+      end
+    end
+  end
+
+  describe "#run" do
+    it "emits a deprecation warning and writes the workflow file" do
+      Dir.mktmpdir do |dir|
+        out_path = File.join(dir, "deploy.yml")
+
+        output = capture_ci_log do
+          cmd = Hwaro::CLI::Commands::Tool::CICommand.new
+          cmd.run(["github-actions", "-o", out_path])
+        end
+
+        output.should contain("DEPRECATED")
+        output.should contain("Generated")
+        File.exists?(out_path).should be_true
+        File.read(out_path).should_not be_empty
+      end
+    end
+
+    it "auto-detects the workflow path and creates intermediate directories" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          capture_ci_log do
+            cmd = Hwaro::CLI::Commands::Tool::CICommand.new
+            cmd.run(["github-actions"])
+          end
+
+          File.exists?(File.join(dir, ".github", "workflows", "deploy.yml")).should be_true
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/ci_command_spec.cr
+++ b/spec/unit/ci_command_spec.cr
@@ -1,25 +1,5 @@
 require "../spec_helper"
 
-# Capture human-readable Logger output while running a block, restoring all
-# global Logger state afterwards.
-private def capture_ci_log(&)
-  previous_io = Hwaro::Logger.io
-  previous_level = Hwaro::Logger.level
-  previous_quiet = Hwaro::Logger.quiet?
-  sink = IO::Memory.new
-  Hwaro::Logger.io = sink
-  Hwaro::Logger.level = Hwaro::Logger::Level::Info
-  Hwaro::Logger.quiet = false
-  begin
-    yield
-    sink.to_s
-  ensure
-    Hwaro::Logger.io = previous_io
-    Hwaro::Logger.level = previous_level
-    Hwaro::Logger.quiet = previous_quiet
-  end
-end
-
 # Command-level tests for `hwaro tool ci` (deprecated alias for
 # `tool platform github-pages`).
 #
@@ -48,7 +28,7 @@ describe Hwaro::CLI::Commands::Tool::CICommand do
       Dir.mktmpdir do |dir|
         out_path = File.join(dir, "deploy.yml")
 
-        output = capture_ci_log do
+        output = with_captured_log do
           cmd = Hwaro::CLI::Commands::Tool::CICommand.new
           cmd.run(["github-actions", "-o", out_path])
         end
@@ -63,7 +43,7 @@ describe Hwaro::CLI::Commands::Tool::CICommand do
     it "auto-detects the workflow path and creates intermediate directories" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do
-          capture_ci_log do
+          with_captured_log do
             cmd = Hwaro::CLI::Commands::Tool::CICommand.new
             cmd.run(["github-actions"])
           end

--- a/spec/unit/export_command_spec.cr
+++ b/spec/unit/export_command_spec.cr
@@ -1,0 +1,90 @@
+require "../spec_helper"
+
+# Capture human-readable Logger output while running a block, restoring all
+# global Logger state afterwards.
+private def capture_export_log(&)
+  previous_io = Hwaro::Logger.io
+  previous_level = Hwaro::Logger.level
+  previous_quiet = Hwaro::Logger.quiet?
+  sink = IO::Memory.new
+  Hwaro::Logger.io = sink
+  Hwaro::Logger.level = Hwaro::Logger::Level::Info
+  Hwaro::Logger.quiet = false
+  begin
+    yield
+    sink.to_s
+  ensure
+    Hwaro::Logger.io = previous_io
+    Hwaro::Logger.level = previous_level
+    Hwaro::Logger.quiet = previous_quiet
+  end
+end
+
+# Command-level tests for `hwaro tool export`.
+#
+# The exporters themselves are exercised in spec/unit/exporters/*; these tests
+# cover the command wrapper: metadata, target validation, target → exporter
+# dispatch, and the success logging path.
+describe Hwaro::CLI::Commands::Tool::ExportCommand do
+  describe ".metadata" do
+    it "reports the command name and description" do
+      meta = Hwaro::CLI::Commands::Tool::ExportCommand.metadata
+      meta.name.should eq("export")
+      meta.description.should_not be_empty
+    end
+
+    it "declares a target-type positional argument" do
+      meta = Hwaro::CLI::Commands::Tool::ExportCommand.metadata
+      meta.positional_args.should eq(["target-type"])
+    end
+
+    it "lists hugo and jekyll as supported targets" do
+      meta = Hwaro::CLI::Commands::Tool::ExportCommand.metadata
+      meta.positional_choices.should eq(["hugo", "jekyll"])
+    end
+
+    it "exposes the output flag" do
+      meta = Hwaro::CLI::Commands::Tool::ExportCommand.metadata
+      meta.flags.any? { |f| f.long == "--output" }.should be_true
+    end
+  end
+
+  describe "#run argument validation" do
+    it "raises a usage error when no target type is given" do
+      cmd = Hwaro::CLI::Commands::Tool::ExportCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run([] of String) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("missing <target-type>")
+    end
+
+    it "raises a usage error for an unknown target type" do
+      cmd = Hwaro::CLI::Commands::Tool::ExportCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["gatsby"]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unknown target type")
+    end
+  end
+
+  describe "#run success path" do
+    it "exports content to hugo and logs a completion summary" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(content_dir)
+        File.write(
+          File.join(content_dir, "post.md"),
+          "+++\ntitle = \"My Post\"\ndate = 2024-01-15T10:00:00Z\n+++\n\nHello world\n"
+        )
+
+        output = capture_export_log do
+          cmd = Hwaro::CLI::Commands::Tool::ExportCommand.new
+          cmd.run(["hugo", "-c", content_dir, "-o", output_dir])
+        end
+
+        output.should contain("Exporting to hugo")
+        output.should contain("Export complete")
+        File.exists?(File.join(output_dir, "content", "post.md")).should be_true
+      end
+    end
+  end
+end

--- a/spec/unit/export_command_spec.cr
+++ b/spec/unit/export_command_spec.cr
@@ -1,25 +1,5 @@
 require "../spec_helper"
 
-# Capture human-readable Logger output while running a block, restoring all
-# global Logger state afterwards.
-private def capture_export_log(&)
-  previous_io = Hwaro::Logger.io
-  previous_level = Hwaro::Logger.level
-  previous_quiet = Hwaro::Logger.quiet?
-  sink = IO::Memory.new
-  Hwaro::Logger.io = sink
-  Hwaro::Logger.level = Hwaro::Logger::Level::Info
-  Hwaro::Logger.quiet = false
-  begin
-    yield
-    sink.to_s
-  ensure
-    Hwaro::Logger.io = previous_io
-    Hwaro::Logger.level = previous_level
-    Hwaro::Logger.quiet = previous_quiet
-  end
-end
-
 # Command-level tests for `hwaro tool export`.
 #
 # The exporters themselves are exercised in spec/unit/exporters/*; these tests
@@ -76,7 +56,7 @@ describe Hwaro::CLI::Commands::Tool::ExportCommand do
           "+++\ntitle = \"My Post\"\ndate = 2024-01-15T10:00:00Z\n+++\n\nHello world\n"
         )
 
-        output = capture_export_log do
+        output = with_captured_log do
           cmd = Hwaro::CLI::Commands::Tool::ExportCommand.new
           cmd.run(["hugo", "-c", content_dir, "-o", output_dir])
         end

--- a/spec/unit/import_command_spec.cr
+++ b/spec/unit/import_command_spec.cr
@@ -1,0 +1,136 @@
+require "../spec_helper"
+
+# Capture human-readable Logger output while running a block, restoring all
+# global Logger state afterwards.
+private def capture_import_log(&)
+  previous_io = Hwaro::Logger.io
+  previous_level = Hwaro::Logger.level
+  previous_quiet = Hwaro::Logger.quiet?
+  sink = IO::Memory.new
+  Hwaro::Logger.io = sink
+  Hwaro::Logger.level = Hwaro::Logger::Level::Info
+  Hwaro::Logger.quiet = false
+  begin
+    yield
+    sink.to_s
+  ensure
+    Hwaro::Logger.io = previous_io
+    Hwaro::Logger.level = previous_level
+    Hwaro::Logger.quiet = previous_quiet
+  end
+end
+
+# Command-level tests for `hwaro tool import`.
+#
+# The individual importers are exercised in spec/unit/importers/*; these tests
+# cover the command wrapper itself: metadata, argument validation, the
+# source-type → importer dispatch, the source-specific hints, and the
+# success/skip logging paths.
+describe Hwaro::CLI::Commands::Tool::ImportCommand do
+  describe ".metadata" do
+    it "reports the command name and description" do
+      meta = Hwaro::CLI::Commands::Tool::ImportCommand.metadata
+      meta.name.should eq("import")
+      meta.description.should_not be_empty
+    end
+
+    it "declares source-type and path positional arguments" do
+      meta = Hwaro::CLI::Commands::Tool::ImportCommand.metadata
+      meta.positional_args.should eq(["source-type", "path"])
+    end
+
+    it "lists every supported importer as a positional choice" do
+      meta = Hwaro::CLI::Commands::Tool::ImportCommand.metadata
+      %w[wordpress jekyll hugo notion obsidian hexo astro eleventy].each do |source|
+        meta.positional_choices.should contain(source)
+      end
+    end
+
+    it "exposes the output and force flags" do
+      meta = Hwaro::CLI::Commands::Tool::ImportCommand.metadata
+      meta.flags.any? { |f| f.long == "--output" }.should be_true
+      meta.flags.any? { |f| f.long == "--force" }.should be_true
+    end
+  end
+
+  describe "#run argument validation" do
+    it "raises a usage error when no source type is given" do
+      cmd = Hwaro::CLI::Commands::Tool::ImportCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run([] of String) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("missing <source-type>")
+    end
+
+    it "raises a usage error for an unknown source type" do
+      cmd = Hwaro::CLI::Commands::Tool::ImportCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["bloggertool", "/tmp/x"]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unknown source type")
+    end
+
+    it "raises a usage error when the path is missing" do
+      cmd = Hwaro::CLI::Commands::Tool::ImportCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["jekyll"]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("missing <path>")
+    end
+
+    it "includes a source-specific hint when nothing importable is found" do
+      Dir.mktmpdir do |dir|
+        # An empty directory: jekyll importer finds no _posts/, reports 0 items.
+        cmd = Hwaro::CLI::Commands::Tool::ImportCommand.new
+        ex = expect_raises(Hwaro::HwaroError) { cmd.run(["jekyll", dir, "-o", File.join(dir, "out")]) }
+        ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        ex.message.to_s.should contain("no importable content found")
+        ex.hint.to_s.should contain("_posts/")
+      end
+    end
+  end
+
+  describe "#run success path" do
+    it "imports Jekyll posts and logs a completion summary" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "_posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "2024-01-15-hello-world.md"),
+          "---\ntitle: \"Hello World\"\n---\nFirst post body.\n"
+        )
+        output_dir = File.join(dir, "out")
+
+        output = capture_import_log do
+          cmd = Hwaro::CLI::Commands::Tool::ImportCommand.new
+          cmd.run(["jekyll", dir, "-o", output_dir])
+        end
+
+        output.should contain("Importing from jekyll")
+        output.should contain("Import complete")
+        File.exists?(File.join(output_dir, "posts", "hello-world.md")).should be_true
+      end
+    end
+
+    it "warns about skipped files when the destination already exists" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "_posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "2024-01-15-hello-world.md"),
+          "---\ntitle: \"Hello World\"\n---\nFirst post body.\n"
+        )
+        output_dir = File.join(dir, "out")
+
+        cmd = Hwaro::CLI::Commands::Tool::ImportCommand.new
+        capture_import_log { cmd.run(["jekyll", dir, "-o", output_dir]) }
+
+        # Second run without --force: the destination exists, so it is skipped.
+        output = capture_import_log do
+          cmd2 = Hwaro::CLI::Commands::Tool::ImportCommand.new
+          cmd2.run(["jekyll", dir, "-o", output_dir])
+        end
+
+        output.should contain("skipped")
+        output.should contain("--force")
+      end
+    end
+  end
+end

--- a/spec/unit/import_command_spec.cr
+++ b/spec/unit/import_command_spec.cr
@@ -1,25 +1,5 @@
 require "../spec_helper"
 
-# Capture human-readable Logger output while running a block, restoring all
-# global Logger state afterwards.
-private def capture_import_log(&)
-  previous_io = Hwaro::Logger.io
-  previous_level = Hwaro::Logger.level
-  previous_quiet = Hwaro::Logger.quiet?
-  sink = IO::Memory.new
-  Hwaro::Logger.io = sink
-  Hwaro::Logger.level = Hwaro::Logger::Level::Info
-  Hwaro::Logger.quiet = false
-  begin
-    yield
-    sink.to_s
-  ensure
-    Hwaro::Logger.io = previous_io
-    Hwaro::Logger.level = previous_level
-    Hwaro::Logger.quiet = previous_quiet
-  end
-end
-
 # Command-level tests for `hwaro tool import`.
 #
 # The individual importers are exercised in spec/unit/importers/*; these tests
@@ -98,7 +78,7 @@ describe Hwaro::CLI::Commands::Tool::ImportCommand do
         )
         output_dir = File.join(dir, "out")
 
-        output = capture_import_log do
+        output = with_captured_log do
           cmd = Hwaro::CLI::Commands::Tool::ImportCommand.new
           cmd.run(["jekyll", dir, "-o", output_dir])
         end
@@ -120,10 +100,10 @@ describe Hwaro::CLI::Commands::Tool::ImportCommand do
         output_dir = File.join(dir, "out")
 
         cmd = Hwaro::CLI::Commands::Tool::ImportCommand.new
-        capture_import_log { cmd.run(["jekyll", dir, "-o", output_dir]) }
+        with_captured_log { cmd.run(["jekyll", dir, "-o", output_dir]) }
 
         # Second run without --force: the destination exists, so it is skipped.
-        output = capture_import_log do
+        output = with_captured_log do
           cmd2 = Hwaro::CLI::Commands::Tool::ImportCommand.new
           cmd2.run(["jekyll", dir, "-o", output_dir])
         end

--- a/spec/unit/platform_command_spec.cr
+++ b/spec/unit/platform_command_spec.cr
@@ -1,25 +1,5 @@
 require "../spec_helper"
 
-# Capture human-readable Logger output while running a block, restoring all
-# global Logger state afterwards.
-private def capture_platform_log(&)
-  previous_io = Hwaro::Logger.io
-  previous_level = Hwaro::Logger.level
-  previous_quiet = Hwaro::Logger.quiet?
-  sink = IO::Memory.new
-  Hwaro::Logger.io = sink
-  Hwaro::Logger.level = Hwaro::Logger::Level::Info
-  Hwaro::Logger.quiet = false
-  begin
-    yield
-    sink.to_s
-  ensure
-    Hwaro::Logger.io = previous_io
-    Hwaro::Logger.level = previous_level
-    Hwaro::Logger.quiet = previous_quiet
-  end
-end
-
 # Command-level tests for `hwaro tool platform`.
 #
 # The PlatformConfig service is exercised in spec/unit/platform_config_spec.cr;
@@ -58,7 +38,7 @@ describe Hwaro::CLI::Commands::Tool::PlatformCommand do
           File.write("config.toml", "title = \"Test Site\"\nbase_url = \"https://example.com\"\n")
           out_path = File.join(dir, "netlify.toml")
 
-          output = capture_platform_log do
+          output = with_captured_log do
             cmd = Hwaro::CLI::Commands::Tool::PlatformCommand.new
             cmd.run(["netlify", "-o", out_path])
           end
@@ -75,7 +55,7 @@ describe Hwaro::CLI::Commands::Tool::PlatformCommand do
         Dir.cd(dir) do
           File.write("config.toml", "title = \"Test Site\"\n")
 
-          capture_platform_log do
+          with_captured_log do
             cmd = Hwaro::CLI::Commands::Tool::PlatformCommand.new
             cmd.run(["github-pages"])
           end
@@ -90,7 +70,7 @@ describe Hwaro::CLI::Commands::Tool::PlatformCommand do
         Dir.cd(dir) do
           out_path = File.join(dir, "netlify.toml")
 
-          output = capture_platform_log do
+          output = with_captured_log do
             cmd = Hwaro::CLI::Commands::Tool::PlatformCommand.new
             cmd.run(["netlify", "-o", out_path])
           end

--- a/spec/unit/platform_command_spec.cr
+++ b/spec/unit/platform_command_spec.cr
@@ -1,0 +1,104 @@
+require "../spec_helper"
+
+# Capture human-readable Logger output while running a block, restoring all
+# global Logger state afterwards.
+private def capture_platform_log(&)
+  previous_io = Hwaro::Logger.io
+  previous_level = Hwaro::Logger.level
+  previous_quiet = Hwaro::Logger.quiet?
+  sink = IO::Memory.new
+  Hwaro::Logger.io = sink
+  Hwaro::Logger.level = Hwaro::Logger::Level::Info
+  Hwaro::Logger.quiet = false
+  begin
+    yield
+    sink.to_s
+  ensure
+    Hwaro::Logger.io = previous_io
+    Hwaro::Logger.level = previous_level
+    Hwaro::Logger.quiet = previous_quiet
+  end
+end
+
+# Command-level tests for `hwaro tool platform`.
+#
+# The PlatformConfig service is exercised in spec/unit/platform_config_spec.cr;
+# these tests cover the command wrapper: metadata, writing the generated file
+# to disk, and the warning emitted when run outside a Hwaro project (no
+# config.toml). Paths that call `exit` (missing/unsupported platform, refusing
+# to overwrite) are intentionally not exercised here since `exit` would abort
+# the spec process.
+describe Hwaro::CLI::Commands::Tool::PlatformCommand do
+  describe ".metadata" do
+    it "reports the command name and description" do
+      meta = Hwaro::CLI::Commands::Tool::PlatformCommand.metadata
+      meta.name.should eq("platform")
+      meta.description.should_not be_empty
+    end
+
+    it "lists every supported platform as a positional choice" do
+      meta = Hwaro::CLI::Commands::Tool::PlatformCommand.metadata
+      Hwaro::Services::PlatformConfig::SUPPORTED_PLATFORMS.each do |platform|
+        meta.positional_choices.should contain(platform)
+      end
+    end
+
+    it "exposes the output, stdout and force flags" do
+      meta = Hwaro::CLI::Commands::Tool::PlatformCommand.metadata
+      meta.flags.any? { |f| f.long == "--output" }.should be_true
+      meta.flags.any? { |f| f.long == "--stdout" }.should be_true
+      meta.flags.any? { |f| f.long == "--force" }.should be_true
+    end
+  end
+
+  describe "#run" do
+    it "writes the generated config to the requested output path" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", "title = \"Test Site\"\nbase_url = \"https://example.com\"\n")
+          out_path = File.join(dir, "netlify.toml")
+
+          output = capture_platform_log do
+            cmd = Hwaro::CLI::Commands::Tool::PlatformCommand.new
+            cmd.run(["netlify", "-o", out_path])
+          end
+
+          output.should contain("Generated")
+          File.exists?(out_path).should be_true
+          File.read(out_path).should_not be_empty
+        end
+      end
+    end
+
+    it "creates intermediate directories for nested workflow paths" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", "title = \"Test Site\"\n")
+
+          capture_platform_log do
+            cmd = Hwaro::CLI::Commands::Tool::PlatformCommand.new
+            cmd.run(["github-pages"])
+          end
+
+          File.exists?(File.join(dir, ".github", "workflows", "deploy.yml")).should be_true
+        end
+      end
+    end
+
+    it "warns when run without a config.toml" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          out_path = File.join(dir, "netlify.toml")
+
+          output = capture_platform_log do
+            cmd = Hwaro::CLI::Commands::Tool::PlatformCommand.new
+            cmd.run(["netlify", "-o", out_path])
+          end
+
+          output.should contain("config.toml not found")
+          File.exists?(out_path).should be_true
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/stats_command_spec.cr
+++ b/spec/unit/stats_command_spec.cr
@@ -1,25 +1,5 @@
 require "../spec_helper"
 
-# Capture human-readable Logger output while running a block, restoring all
-# global Logger state afterwards.
-private def capture_stats_log(&)
-  previous_io = Hwaro::Logger.io
-  previous_level = Hwaro::Logger.level
-  previous_quiet = Hwaro::Logger.quiet?
-  sink = IO::Memory.new
-  Hwaro::Logger.io = sink
-  Hwaro::Logger.level = Hwaro::Logger::Level::Info
-  Hwaro::Logger.quiet = false
-  begin
-    yield
-    sink.to_s
-  ensure
-    Hwaro::Logger.io = previous_io
-    Hwaro::Logger.level = previous_level
-    Hwaro::Logger.quiet = previous_quiet
-  end
-end
-
 # Command-level tests for `hwaro tool stats`.
 #
 # The ContentStats service is exercised in spec/unit/content_stats_spec.cr;
@@ -43,7 +23,7 @@ describe Hwaro::CLI::Commands::Tool::StatsCommand do
   describe "#run" do
     it "reports when no content is found" do
       Dir.mktmpdir do |dir|
-        output = capture_stats_log do
+        output = with_captured_log do
           cmd = Hwaro::CLI::Commands::Tool::StatsCommand.new
           cmd.run(["-c", dir])
         end
@@ -62,7 +42,7 @@ describe Hwaro::CLI::Commands::Tool::StatsCommand do
           "---\ntitle: Second\ndate: 2024-02-20\ntags:\n  - crystal\n---\nMore content with several words inside.\n"
         )
 
-        output = capture_stats_log do
+        output = with_captured_log do
           cmd = Hwaro::CLI::Commands::Tool::StatsCommand.new
           cmd.run(["-c", dir])
         end

--- a/spec/unit/stats_command_spec.cr
+++ b/spec/unit/stats_command_spec.cr
@@ -1,0 +1,80 @@
+require "../spec_helper"
+
+# Capture human-readable Logger output while running a block, restoring all
+# global Logger state afterwards.
+private def capture_stats_log(&)
+  previous_io = Hwaro::Logger.io
+  previous_level = Hwaro::Logger.level
+  previous_quiet = Hwaro::Logger.quiet?
+  sink = IO::Memory.new
+  Hwaro::Logger.io = sink
+  Hwaro::Logger.level = Hwaro::Logger::Level::Info
+  Hwaro::Logger.quiet = false
+  begin
+    yield
+    sink.to_s
+  ensure
+    Hwaro::Logger.io = previous_io
+    Hwaro::Logger.level = previous_level
+    Hwaro::Logger.quiet = previous_quiet
+  end
+end
+
+# Command-level tests for `hwaro tool stats`.
+#
+# The ContentStats service is exercised in spec/unit/content_stats_spec.cr;
+# these tests cover the command wrapper's metadata and its human-readable
+# rendering of the statistics (overview, word counts, tags, monthly buckets).
+describe Hwaro::CLI::Commands::Tool::StatsCommand do
+  describe ".metadata" do
+    it "reports the command name and description" do
+      meta = Hwaro::CLI::Commands::Tool::StatsCommand.metadata
+      meta.name.should eq("stats")
+      meta.description.should_not be_empty
+    end
+
+    it "exposes the content-dir and json flags" do
+      meta = Hwaro::CLI::Commands::Tool::StatsCommand.metadata
+      meta.flags.any? { |f| f.long == "--content-dir" }.should be_true
+      meta.flags.any? { |f| f.long == "--json" }.should be_true
+    end
+  end
+
+  describe "#run" do
+    it "reports when no content is found" do
+      Dir.mktmpdir do |dir|
+        output = capture_stats_log do
+          cmd = Hwaro::CLI::Commands::Tool::StatsCommand.new
+          cmd.run(["-c", dir])
+        end
+        output.should contain("No content found")
+      end
+    end
+
+    it "renders an overview, word counts, tags and monthly frequency" do
+      Dir.mktmpdir do |dir|
+        File.write(
+          File.join(dir, "first.md"),
+          "---\ntitle: First\ndate: 2024-01-10\ntags:\n  - crystal\n  - web\n---\nHello world here are some words.\n"
+        )
+        File.write(
+          File.join(dir, "second.md"),
+          "---\ntitle: Second\ndate: 2024-02-20\ntags:\n  - crystal\n---\nMore content with several words inside.\n"
+        )
+
+        output = capture_stats_log do
+          cmd = Hwaro::CLI::Commands::Tool::StatsCommand.new
+          cmd.run(["-c", dir])
+        end
+
+        output.should contain("Content statistics")
+        output.should contain("Overview:")
+        output.should contain("Total:")
+        output.should contain("Word Count")
+        output.should contain("Tags")
+        output.should contain("crystal")
+        output.should contain("Monthly Publishing")
+      end
+    end
+  end
+end

--- a/spec/unit/unused_assets_command_spec.cr
+++ b/spec/unit/unused_assets_command_spec.cr
@@ -1,25 +1,5 @@
 require "../spec_helper"
 
-# Capture human-readable Logger output while running a block, restoring all
-# global Logger state afterwards.
-private def capture_unused_log(&)
-  previous_io = Hwaro::Logger.io
-  previous_level = Hwaro::Logger.level
-  previous_quiet = Hwaro::Logger.quiet?
-  sink = IO::Memory.new
-  Hwaro::Logger.io = sink
-  Hwaro::Logger.level = Hwaro::Logger::Level::Info
-  Hwaro::Logger.quiet = false
-  begin
-    yield
-    sink.to_s
-  ensure
-    Hwaro::Logger.io = previous_io
-    Hwaro::Logger.level = previous_level
-    Hwaro::Logger.quiet = previous_quiet
-  end
-end
-
 # Command-level tests for `hwaro tool unused-assets`.
 #
 # The UnusedAssets service is exercised in spec/unit/unused_assets_spec.cr;
@@ -56,7 +36,7 @@ describe Hwaro::CLI::Commands::Tool::UnusedAssetsCommand do
           "---\ntitle: Page\n---\n\n![Logo](/logo.png)\n"
         )
 
-        output = capture_unused_log do
+        output = with_captured_log do
           cmd = Hwaro::CLI::Commands::Tool::UnusedAssetsCommand.new
           cmd.run(["-c", content_dir, "-s", static_dir])
         end
@@ -80,7 +60,7 @@ describe Hwaro::CLI::Commands::Tool::UnusedAssetsCommand do
           "---\ntitle: Page\n---\n\nNo images referenced here.\n"
         )
 
-        output = capture_unused_log do
+        output = with_captured_log do
           cmd = Hwaro::CLI::Commands::Tool::UnusedAssetsCommand.new
           cmd.run(["-c", content_dir, "-s", static_dir])
         end

--- a/spec/unit/unused_assets_command_spec.cr
+++ b/spec/unit/unused_assets_command_spec.cr
@@ -1,0 +1,94 @@
+require "../spec_helper"
+
+# Capture human-readable Logger output while running a block, restoring all
+# global Logger state afterwards.
+private def capture_unused_log(&)
+  previous_io = Hwaro::Logger.io
+  previous_level = Hwaro::Logger.level
+  previous_quiet = Hwaro::Logger.quiet?
+  sink = IO::Memory.new
+  Hwaro::Logger.io = sink
+  Hwaro::Logger.level = Hwaro::Logger::Level::Info
+  Hwaro::Logger.quiet = false
+  begin
+    yield
+    sink.to_s
+  ensure
+    Hwaro::Logger.io = previous_io
+    Hwaro::Logger.level = previous_level
+    Hwaro::Logger.quiet = previous_quiet
+  end
+end
+
+# Command-level tests for `hwaro tool unused-assets`.
+#
+# The UnusedAssets service is exercised in spec/unit/unused_assets_spec.cr;
+# these tests cover the command wrapper's metadata and its rendering of the
+# scan summary, the "no unused assets" path, and the list of unused files.
+describe Hwaro::CLI::Commands::Tool::UnusedAssetsCommand do
+  describe ".metadata" do
+    it "reports the command name and description" do
+      meta = Hwaro::CLI::Commands::Tool::UnusedAssetsCommand.metadata
+      meta.name.should eq("unused-assets")
+      meta.description.should_not be_empty
+    end
+
+    it "exposes the static-dir, delete and json flags" do
+      meta = Hwaro::CLI::Commands::Tool::UnusedAssetsCommand.metadata
+      meta.flags.any? { |f| f.long == "--static-dir" }.should be_true
+      meta.flags.any? { |f| f.long == "--delete" }.should be_true
+      meta.flags.any? { |f| f.long == "--json" }.should be_true
+    end
+  end
+
+  describe "#run" do
+    it "reports when there are no unused assets" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        static_dir = File.join(dir, "static")
+        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(static_dir)
+
+        # A static asset that is referenced by content → not unused.
+        File.write(File.join(static_dir, "logo.png"), "binary")
+        File.write(
+          File.join(content_dir, "page.md"),
+          "---\ntitle: Page\n---\n\n![Logo](/logo.png)\n"
+        )
+
+        output = capture_unused_log do
+          cmd = Hwaro::CLI::Commands::Tool::UnusedAssetsCommand.new
+          cmd.run(["-c", content_dir, "-s", static_dir])
+        end
+
+        output.should contain("Scanning for unused assets")
+        output.should contain("No unused assets found")
+      end
+    end
+
+    it "lists unused files and a scan summary" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        static_dir = File.join(dir, "static")
+        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(static_dir)
+
+        # An asset nothing references → reported as unused.
+        File.write(File.join(static_dir, "orphan.png"), "binary")
+        File.write(
+          File.join(content_dir, "page.md"),
+          "---\ntitle: Page\n---\n\nNo images referenced here.\n"
+        )
+
+        output = capture_unused_log do
+          cmd = Hwaro::CLI::Commands::Tool::UnusedAssetsCommand.new
+          cmd.run(["-c", content_dir, "-s", static_dir])
+        end
+
+        output.should contain("Total assets:")
+        output.should contain("Unused files:")
+        output.should contain("orphan.png")
+      end
+    end
+  end
+end

--- a/spec/unit/validate_command_spec.cr
+++ b/spec/unit/validate_command_spec.cr
@@ -1,0 +1,79 @@
+require "../spec_helper"
+
+# Capture human-readable Logger output while running a block, restoring all
+# global Logger state afterwards.
+private def capture_validate_log(&)
+  previous_io = Hwaro::Logger.io
+  previous_level = Hwaro::Logger.level
+  previous_quiet = Hwaro::Logger.quiet?
+  sink = IO::Memory.new
+  Hwaro::Logger.io = sink
+  Hwaro::Logger.level = Hwaro::Logger::Level::Info
+  Hwaro::Logger.quiet = false
+  begin
+    yield
+    sink.to_s
+  ensure
+    Hwaro::Logger.io = previous_io
+    Hwaro::Logger.level = previous_level
+    Hwaro::Logger.quiet = previous_quiet
+  end
+end
+
+# Command-level tests for `hwaro tool validate`.
+#
+# The ContentValidator service is exercised in spec/unit/content_validator_spec.cr;
+# these tests cover the command wrapper's metadata and its rendering of the
+# "no issues" and "issues grouped by file with a summary" paths.
+describe Hwaro::CLI::Commands::Tool::ValidateCommand do
+  describe ".metadata" do
+    it "reports the command name and description" do
+      meta = Hwaro::CLI::Commands::Tool::ValidateCommand.metadata
+      meta.name.should eq("validate")
+      meta.description.should_not be_empty
+    end
+
+    it "exposes the content-dir and json flags" do
+      meta = Hwaro::CLI::Commands::Tool::ValidateCommand.metadata
+      meta.flags.any? { |f| f.long == "--content-dir" }.should be_true
+      meta.flags.any? { |f| f.long == "--json" }.should be_true
+    end
+  end
+
+  describe "#run" do
+    it "reports a clean result for well-formed content" do
+      Dir.mktmpdir do |dir|
+        File.write(
+          File.join(dir, "good.md"),
+          "---\ntitle: A Good Post\ndescription: A perfectly fine description for SEO purposes.\ndate: 2024-01-10\n---\n\n# A Good Post\n\nThis post has a healthy amount of body text so the validator is satisfied that it is a real article and not an empty stub document.\n"
+        )
+
+        output = capture_validate_log do
+          cmd = Hwaro::CLI::Commands::Tool::ValidateCommand.new
+          cmd.run(["-c", dir])
+        end
+
+        output.should contain("Validating content")
+        output.should contain("No issues found")
+      end
+    end
+
+    it "groups issues by file and prints a summary when problems exist" do
+      Dir.mktmpdir do |dir|
+        # Missing title triggers a validation issue.
+        File.write(
+          File.join(dir, "bad.md"),
+          "---\ndescription: no title here\n---\n\nShort.\n"
+        )
+
+        output = capture_validate_log do
+          cmd = Hwaro::CLI::Commands::Tool::ValidateCommand.new
+          cmd.run(["-c", dir])
+        end
+
+        output.should contain("bad.md")
+        output.should match(/Found \d+ error/)
+      end
+    end
+  end
+end

--- a/spec/unit/validate_command_spec.cr
+++ b/spec/unit/validate_command_spec.cr
@@ -1,25 +1,5 @@
 require "../spec_helper"
 
-# Capture human-readable Logger output while running a block, restoring all
-# global Logger state afterwards.
-private def capture_validate_log(&)
-  previous_io = Hwaro::Logger.io
-  previous_level = Hwaro::Logger.level
-  previous_quiet = Hwaro::Logger.quiet?
-  sink = IO::Memory.new
-  Hwaro::Logger.io = sink
-  Hwaro::Logger.level = Hwaro::Logger::Level::Info
-  Hwaro::Logger.quiet = false
-  begin
-    yield
-    sink.to_s
-  ensure
-    Hwaro::Logger.io = previous_io
-    Hwaro::Logger.level = previous_level
-    Hwaro::Logger.quiet = previous_quiet
-  end
-end
-
 # Command-level tests for `hwaro tool validate`.
 #
 # The ContentValidator service is exercised in spec/unit/content_validator_spec.cr;
@@ -48,7 +28,7 @@ describe Hwaro::CLI::Commands::Tool::ValidateCommand do
           "---\ntitle: A Good Post\ndescription: A perfectly fine description for SEO purposes.\ndate: 2024-01-10\n---\n\n# A Good Post\n\nThis post has a healthy amount of body text so the validator is satisfied that it is a real article and not an empty stub document.\n"
         )
 
-        output = capture_validate_log do
+        output = with_captured_log do
           cmd = Hwaro::CLI::Commands::Tool::ValidateCommand.new
           cmd.run(["-c", dir])
         end
@@ -66,13 +46,16 @@ describe Hwaro::CLI::Commands::Tool::ValidateCommand do
           "---\ndescription: no title here\n---\n\nShort.\n"
         )
 
-        output = capture_validate_log do
+        output = with_captured_log do
           cmd = Hwaro::CLI::Commands::Tool::ValidateCommand.new
           cmd.run(["-c", dir])
         end
 
+        # The offending file is listed and a count summary is printed. We assert
+        # on the summary line shape rather than a specific severity so the test
+        # does not break if the validator reclassifies this issue.
         output.should contain("bad.md")
-        output.should match(/Found \d+ error/)
+        output.should match(/Found \d+ error\(s\), \d+ warning\(s\), \d+ info\(s\)/)
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds command-level specs for eight `hwaro tool` subcommands whose command classes had **no direct test coverage**. The underlying services (`ContentStats`, `ContentValidator`, `UnusedAssets`, importers/exporters, `PlatformConfig`, `CIConfig`) were already well tested, but each command **wrapper's own `run` logic** was not exercised:

- argument validation and usage errors
- source/target type → service dispatch
- error branches (including the source-specific hints)
- human-readable Logger output formatting
- file-writing paths (and intermediate directory creation)

## New specs (+44 examples)

| Spec | Covers |
|------|--------|
| `import_command_spec.cr` | metadata, 4 validation branches (missing/unknown source, missing path, no importable content + hint), jekyll import success + skip warning |
| `export_command_spec.cr` | metadata, target validation, hugo export success |
| `stats_command_spec.cr` | metadata, "no content" + full stats rendering (overview/word counts/tags/monthly) |
| `validate_command_spec.cr` | metadata, clean result + per-file grouping & summary |
| `unused_assets_command_spec.cr` | metadata, "no unused" + unused file listing |
| `platform_command_spec.cr` | metadata, file write, nested dir creation, missing-config.toml warning |
| `agents_md_command_spec.cr` | metadata, local/remote `--write`, `--force` overwrite |
| `ci_command_spec.cr` | metadata, deprecation warning + workflow file generation |

## Conventions

- Capture human-readable output by swapping `Logger.io` to an `IO::Memory`, saving/restoring `level` and `quiet`.
- Use `Dir.cd(tmp) do … end` blocks for CWD-dependent paths.
- Intentionally skip branches that call `exit()` (which would abort the spec process); these are noted in comments.

## Verification

- `crystal spec`: **5029 examples, 0 failures** (was 4985)
- `crystal tool format --check`: clean
- `ameba`: clean