### PR TITLE
fix: honor multilingual in full-config + default-theme & DX papercuts

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -898,6 +898,23 @@ describe Hwaro::Services::Creator do
         end
       end
 
+      it "does not double the dir when a slash-path's leading segment matches --section" do
+        # Regression: `hwaro new posts/foo -s posts` (no .md extension) used to
+        # join the section onto a path that already carried it, producing
+        # content/posts/posts/foo.md.
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+            options = Hwaro::Config::Options::NewOptions.new(
+              path: "posts/foo", title: "Foo", section: "posts")
+            Hwaro::Services::Creator.new.run(options)
+
+            File.exists?("content/posts/foo.md").should be_true
+            Dir.exists?("content/posts/posts").should be_false
+          end
+        end
+      end
+
       it "does not warn when the path has no leading directory (section provides it)" do
         Dir.mktmpdir do |dir|
           Dir.cd(dir) do

--- a/spec/unit/initializer_spec.cr
+++ b/spec/unit/initializer_spec.cr
@@ -19,6 +19,21 @@ describe Hwaro::Services::Initializer do
       end
     end
 
+    it "exposes math and mermaid toggles in the default [markdown] config" do
+      # Discoverability: the balanced default config listed emoji/task_lists/
+      # footnotes but omitted math/mermaid, so users couldn't tell the
+      # features existed.
+      Dir.mktmpdir do |dir|
+        target = File.join(dir, "mysite")
+        Hwaro::Services::Initializer.new.run(target)
+
+        config = File.read(File.join(target, "config.toml"))
+        config.should contain("mermaid =")
+        config.should contain("math =")
+        config.should contain("math_engine =")
+      end
+    end
+
     it "creates target directory if it does not exist" do
       Dir.mktmpdir do |dir|
         target = File.join(dir, "new", "nested", "site")
@@ -316,6 +331,24 @@ describe Hwaro::Services::Initializer do
           File.exists?(File.join(target, "content", "index.md")).should be_true
           # Second language content (with lang suffix)
           File.exists?(File.join(target, "content", "index.ko.md")).should be_true
+        end
+      end
+
+      it "enables languages in --full-config mode (regression: full config dropped multilingual)" do
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+          Hwaro::Services::Initializer.new.run(
+            target,
+            multilingual_languages: ["en", "ko"],
+            full_config: true
+          )
+
+          config_content = File.read(File.join(target, "config.toml"))
+          # Must be the real, *uncommented* block — not the placeholder.
+          config_content.should contain("default_language = \"en\"")
+          config_content.should contain("[languages.ko]")
+          config_content.should_not contain("# default_language = \"en\"")
+          config_content.should_not contain("# [languages.ko]")
         end
       end
 

--- a/spec/unit/scaffolds_book_spec.cr
+++ b/spec/unit/scaffolds_book_spec.cr
@@ -240,8 +240,8 @@ private class TestBaseScaffold < Hwaro::Services::Scaffolds::Base
     {} of String => String
   end
 
-  def config_content(skip_taxonomies : Bool = false) : String
-    minimal_config_content(skip_taxonomies)
+  def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
+    minimal_config_content(skip_taxonomies, multilingual_languages)
   end
 end
 

--- a/spec/unit/scaffolds_spec.cr
+++ b/spec/unit/scaffolds_spec.cr
@@ -67,6 +67,16 @@ describe Hwaro::Services::Scaffolds::Simple do
       files.has_key?("header.html").should be_true
     end
 
+    it "styles tables, images, and blockquotes in the default header CSS" do
+      # Regression: the default theme shipped no table/img/blockquote rules,
+      # so markdown tables rendered borderless and images could overflow.
+      header = Hwaro::Services::Scaffolds::Simple.new.template_files["header.html"]
+      header.should contain("table {")
+      header.should contain("border-collapse")
+      header.should contain("blockquote {")
+      header.should contain("img {")
+    end
+
     it "includes footer.html" do
       scaffold = Hwaro::Services::Scaffolds::Simple.new
       files = scaffold.template_files

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -147,7 +147,10 @@ module Hwaro
             filename = File.basename(path)
             full_path = File.join("content", section, filename)
           elsif path
-            full_path = File.join("content", section, path)
+            # When the path already carries the section dir (`new posts/foo
+            # -s posts`), don't join it twice into `content/posts/posts/foo`.
+            relative = path.starts_with?("#{section}/") ? path : File.join(section, path)
+            full_path = File.join("content", relative)
             full_path += ".md" unless full_path.ends_with?(".md")
           else
             # No path given; title must be supplied via --title.

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -130,7 +130,7 @@ module Hwaro
         if minimal_config
           config_content = scaffold.minimal_config_content(skip_taxonomies, multilingual_languages)
         elsif full_config
-          config_content = scaffold.config_content(skip_taxonomies)
+          config_content = scaffold.config_content(skip_taxonomies, multilingual_languages)
         else
           config_content = build_balanced_default_config(scaffold, skip_taxonomies, is_multilingual, multilingual_languages)
         end
@@ -620,7 +620,10 @@ module Hwaro
           io << "emoji = true\n"
           io << "task_lists = true\n"
           io << "definition_lists = true\n"
-          io << "footnotes = true\n\n"
+          io << "footnotes = true\n"
+          io << "mermaid = false        # Render ```mermaid code blocks as diagrams (loads mermaid.js)\n"
+          io << "math = false           # Inline ($...$) and block ($$...$$) math (loads math_engine)\n"
+          io << "math_engine = \"katex\"  # \"katex\" or \"mathjax\"\n\n"
         end
 
         str

--- a/src/services/scaffolds/bare.cr
+++ b/src/services/scaffolds/bare.cr
@@ -55,7 +55,7 @@ module Hwaro
         # when `--include-taxonomies` is set; we still ship the taxonomy
         # templates below so users can wire them up later by adding
         # `[[taxonomies]]` entries themselves.
-        def config_content(skip_taxonomies : Bool = false) : String
+        def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
           config = String.build do |str|
             str << base_config
             str << plugins_config

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -203,8 +203,11 @@ module Hwaro
             MD
         end
 
-        # Returns the config.toml content
-        abstract def config_content(skip_taxonomies : Bool = false) : String
+        # Returns the config.toml content. `multilingual_languages` (from
+        # `--include-multilingual`) is threaded through so the full config
+        # emits a real, enabled `[languages]` block instead of the commented
+        # placeholder.
+        abstract def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
 
         # Returns the site title used in config (overridable per scaffold)
         protected def config_title : String
@@ -472,6 +475,11 @@ module Hwaro
               code { background: var(--bg-subtle); padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.85em; font-family: ui-monospace, "SFMono-Regular", Consolas, monospace; }
               pre { background: var(--bg-subtle); padding: 1rem; border-radius: 6px; overflow-x: auto; border: 1px solid var(--border); }
               pre code { background: none; padding: 0; }
+              img { max-width: 100%; height: auto; }
+              blockquote { margin: 1em 0; padding: 0.25rem 1rem; color: var(--text-muted); border-left: 3px solid var(--border); }
+              table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.95em; }
+              th, td { border: 1px solid var(--border); padding: 0.5rem 0.75rem; text-align: left; }
+              th { background: var(--bg-subtle); font-weight: 600; }
 
               /* Components */
               ul.section-list { list-style: none; padding: 0; margin: 1.5rem 0; }
@@ -526,7 +534,35 @@ module Hwaro
             TOML
         end
 
-        protected def multilingual_config : String
+        protected def multilingual_config(multilingual_languages : Array(String) = [] of String) : String
+          # When `--include-multilingual` requested 2+ languages, emit a real,
+          # enabled languages block so the full config honors the flag (gh: the
+          # full-config path used to drop multilingual entirely, leaving
+          # `.ko.md` variants routed as literal `/about.ko/` pages).
+          if multilingual_languages.size > 1
+            default_lang = multilingual_languages.first
+            lang_blocks = multilingual_languages.map_with_index do |lang, index|
+              "  [languages.#{lang}]\n" \
+              "  language_name = \"#{language_display_name(lang)}\"\n" \
+              "  weight = #{index + 1}\n" \
+              "  generate_feed = true\n" \
+              "  build_search_index = true"
+            end
+            return String.build do |str|
+              str << "\n"
+              str << "# =============================================================================\n"
+              str << "# Multilingual\n"
+              str << "# =============================================================================\n"
+              str << "# Language variants use filename suffixes:\n"
+              str << "# - content/about.md -> /about/\n"
+              str << "# - content/about.ko.md -> /ko/about/\n\n"
+              str << "default_language = \"#{default_lang}\"\n\n"
+              str << "[languages]\n"
+              str << lang_blocks.join("\n\n")
+              str << "\n\n"
+            end
+          end
+
           <<-TOML
 
             # =============================================================================

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -78,13 +78,13 @@ module Hwaro
           files
         end
 
-        def config_content(skip_taxonomies : Bool = false) : String
+        def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
           config = String.build do |str|
             # Site basics
             str << base_config(config_title, config_description)
 
             # Content & Processing
-            str << multilingual_config
+            str << multilingual_config(multilingual_languages)
             str << plugins_config
             str << content_files_config
             str << highlight_config

--- a/src/services/scaffolds/blog_dark.cr
+++ b/src/services/scaffolds/blog_dark.cr
@@ -22,13 +22,13 @@ module Hwaro
           "github-dark"
         end
 
-        def config_content(skip_taxonomies : Bool = false) : String
+        def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
           config = String.build do |str|
             # Site basics
             str << base_config(config_title, config_description)
 
             # Content & Processing
-            str << multilingual_config
+            str << multilingual_config(multilingual_languages)
             str << plugins_config
             str << content_files_config
             str << highlight_dark_config

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -80,10 +80,10 @@ module Hwaro
         # template from being emitted as dead chrome (it's also dropped
         # from `template_files`). Users who want taxonomies can copy from
         # the simple/blog scaffolds.
-        def config_content(skip_taxonomies : Bool = false) : String
+        def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
           config = String.build do |str|
             str << base_config(config_title, config_description)
-            str << multilingual_config
+            str << multilingual_config(multilingual_languages)
             str << plugins_config
             str << content_files_config
             str << highlight_config

--- a/src/services/scaffolds/book_dark.cr
+++ b/src/services/scaffolds/book_dark.cr
@@ -21,10 +21,10 @@ module Hwaro
           "github-dark"
         end
 
-        def config_content(skip_taxonomies : Bool = false) : String
+        def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
           config = String.build do |str|
             str << base_config(config_title, config_description)
-            str << multilingual_config
+            str << multilingual_config(multilingual_languages)
             str << plugins_config
             str << content_files_config
             str << highlight_dark_config

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -115,13 +115,13 @@ module Hwaro
           files
         end
 
-        def config_content(skip_taxonomies : Bool = false) : String
+        def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
           config = String.build do |str|
             # Site basics
             str << base_config(config_title, config_description)
 
             # Content & Processing
-            str << multilingual_config
+            str << multilingual_config(multilingual_languages)
             str << plugins_config
             str << content_files_config
             str << highlight_config

--- a/src/services/scaffolds/docs_dark.cr
+++ b/src/services/scaffolds/docs_dark.cr
@@ -21,13 +21,13 @@ module Hwaro
           "github-dark"
         end
 
-        def config_content(skip_taxonomies : Bool = false) : String
+        def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
           config = String.build do |str|
             # Site basics
             str << base_config(config_title, config_description)
 
             # Content & Processing
-            str << multilingual_config
+            str << multilingual_config(multilingual_languages)
             str << plugins_config
             str << content_files_config
             str << highlight_dark_config

--- a/src/services/scaffolds/remote.cr
+++ b/src/services/scaffolds/remote.cr
@@ -69,7 +69,7 @@ module Hwaro
           {} of String => String
         end
 
-        def config_content(skip_taxonomies : Bool = false) : String
+        def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
           @config_data
         end
 

--- a/src/services/scaffolds/simple.cr
+++ b/src/services/scaffolds/simple.cr
@@ -48,13 +48,13 @@ module Hwaro
           files
         end
 
-        def config_content(skip_taxonomies : Bool = false) : String
+        def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
           config = String.build do |str|
             # Site basics
             str << base_config
 
             # Content & Processing
-            str << multilingual_config
+            str << multilingual_config(multilingual_languages)
             str << plugins_config
             str << content_files_config
             str << highlight_config


### PR DESCRIPTION
Found while dogfooding `hwaro init` / `serve` / `new` end-to-end (build a multilingual site, design it, look for papercuts). Four independent fixes, each with a regression spec.

## 1. `--full-config` silently dropped `--include-multilingual` (bug)
`hwaro init X --full-config --include-multilingual en,ko` generated a `config.toml` whose `[languages]` / `default_language` stayed **commented out**, so multilingual routing never turned on:

| | before | after |
|---|---|---|
| `content/about.ko.md` | `/about.ko/` (literal page) | `/ko/about/` |
| `content/posts/_index.ko.md` | `/posts/_index.ko/` (broken) | `/ko/posts/` |

The config's own comment promised `/ko/about/` while the build produced `/about.ko/`. Default & `--minimal-config` paths already honored the flag — only `--full-config` dropped it.

**Root cause:** the `full_config` branch in `initializer.cr` called `scaffold.config_content(skip_taxonomies)` *without* the requested languages, so the full config always emitted the static commented `multilingual_config` placeholder.

**Fix:** thread `multilingual_languages` through `config_content` → `multilingual_config` (scaffolds are shared singletons in the registry, so a parameter — not instance state) and emit a real, enabled block when 2+ languages are requested. No-flag and single-language full configs are unchanged.

## 2. Default `simple` theme had no table / image / blockquote CSS (design gap)
The default scaffold's inline header CSS styled headings/code/pagination but shipped **no `table`, `th/td`, `border-collapse`, `img`, or `blockquote` rules** — markdown tables rendered borderless and cramped, and large images could overflow the 720px container. (`blog`/`docs` themes already styled these.) Added the rules to the shared header template.

## 3. `math` / `mermaid` were undiscoverable in the default config
The balanced default `[markdown]` block listed `emoji`/`task_lists`/`definition_lists`/`footnotes` but omitted `math`/`mermaid`, so a user editing it had no hint the features exist (the README advertises them; the full config already lists them). Added `mermaid` / `math` / `math_engine` (commented defaults).

## 4. `hwaro new posts/foo -s posts` doubled the directory
When the path's leading segment already matched `--section`, the section was joined again → `content/posts/posts/foo.md`. Now skipped: `content/posts/foo.md`. The `.md` form and the mismatch-warning path were already correct and are unchanged.

## Verification
- New regression specs for all four fixes; **full unit suite green (4644 examples, 0 failures)**.
- E2E: regenerated sites across `simple`/`blog`/`docs`/`book` × `--full-config`/default/minimal — multilingual now routes to `/ko/...`, `doctor` clean, no duplicate `[languages]` section.

## Notes
- No CHANGELOG entry — this repo updates CHANGELOG at release time, not per-PR.
- No linked issue (none of the 3 open issues match these).
- Bundled per request; happy to split into focused PRs if you'd prefer.

## Deferred (intentionally out of scope — behavioral/opinionated)
- CLI dir-flag inconsistency: `build`/`serve` use `-i`, `doctor`/`tool` use `-c` only.
- `doctor` doesn't warn about orphaned `*.<lang>.md` variants when i18n is off (ties into #1).
- `/posts/` 404 when a section has children but no `_index.md` (no auto section index).