### PR TITLE
fix(search): scope multilingual search to the current language

### DIFF
--- a/spec/unit/search_spec.cr
+++ b/spec/unit/search_spec.cr
@@ -228,6 +228,55 @@ describe Hwaro::Content::Search do
       end
     end
 
+    it "tags each entry with its language (defaults to default_language)" do
+      config = Hwaro::Models::Config.new
+      config.search.enabled = true
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.title = "Test"
+      page.url = "/test/"
+      page.draft = false
+      page.raw_content = "Content"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Search.generate([page], config, output_dir)
+
+        content = File.read(File.join(output_dir, "search.json"))
+        content.should contain(%("lang":"en"))
+      end
+    end
+
+    it "excludes pages of a language whose build_search_index is false" do
+      config = Hwaro::Models::Config.new
+      config.search.enabled = true
+      config.default_language = "en"
+      config.languages["en"] = Hwaro::Models::LanguageConfig.new("en")
+      ko = Hwaro::Models::LanguageConfig.new("ko")
+      ko.build_search_index = false
+      config.languages["ko"] = ko
+
+      en_page = Hwaro::Models::Page.new("about.md")
+      en_page.title = "About"
+      en_page.url = "/about/"
+      en_page.draft = false
+      en_page.raw_content = "English"
+
+      ko_page = Hwaro::Models::Page.new("about.ko.md")
+      ko_page.title = "소개"
+      ko_page.url = "/ko/about/"
+      ko_page.language = "ko"
+      ko_page.draft = false
+      ko_page.raw_content = "한국어"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Search.generate([en_page, ko_page], config, output_dir)
+
+        content = File.read(File.join(output_dir, "search.json"))
+        content.should contain("About")
+        content.should_not contain("소개")
+      end
+    end
+
     it "prepends base_url path to URLs for subpath deployments" do
       config = Hwaro::Models::Config.new
       config.search.enabled = true

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -40,6 +40,17 @@ module Hwaro
           end
         end
 
+        # Multilingual: honor each language's `build_search_index` toggle so a
+        # language opted out is excluded from the index. Pages without an
+        # explicit language fall back to the default language.
+        if config.multilingual?
+          default_lang = config.default_language
+          search_pages.reject! do |page|
+            lang_config = config.language(page.language || default_lang)
+            lang_config ? !lang_config.build_search_index : false
+          end
+        end
+
         if search_pages.empty?
           Logger.info "  No pages to include in search index."
           return
@@ -121,6 +132,10 @@ module Hwaro
 
           # Always include URL even if not in fields list
           data["url"] = base_path + page.url unless data.has_key?("url")
+
+          # Always include the page language so the client can scope results
+          # to the current language (mirrors per-language feeds).
+          data["lang"] = page.language || config.default_language
 
           data
         end

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -749,9 +749,11 @@ module Hwaro
                   return;
                 }
                 var q = query.trim().toLowerCase();
+                var pageLang = document.documentElement.lang || '';
                 var results = [];
                 for (var i = 0; i < searchData.length; i++) {
                   var item = searchData[i];
+                  if (pageLang && item.lang && item.lang !== pageLang) continue;
                   var titleIdx = item.title.toLowerCase().indexOf(q);
                   var contentIdx = item.content.toLowerCase().indexOf(q);
                   if (titleIdx !== -1 || contentIdx !== -1) {

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -1113,9 +1113,11 @@ module Hwaro
                   return;
                 }
                 var q = query.trim().toLowerCase();
+                var pageLang = document.documentElement.lang || '';
                 var results = [];
                 for (var i = 0; i < searchData.length; i++) {
                   var item = searchData[i];
+                  if (pageLang && item.lang && item.lang !== pageLang) continue;
                   var titleIdx = item.title.toLowerCase().indexOf(q);
                   var contentIdx = item.content.toLowerCase().indexOf(q);
                   if (titleIdx !== -1 || contentIdx !== -1) {

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -870,9 +870,11 @@ module Hwaro
                   return;
                 }
                 var q = query.trim().toLowerCase();
+                var pageLang = document.documentElement.lang || '';
                 var results = [];
                 for (var i = 0; i < searchData.length; i++) {
                   var item = searchData[i];
+                  if (pageLang && item.lang && item.lang !== pageLang) continue;
                   var titleIdx = item.title.toLowerCase().indexOf(q);
                   var contentIdx = item.content.toLowerCase().indexOf(q);
                   if (titleIdx !== -1 || contentIdx !== -1) {


### PR DESCRIPTION
Cycle 2 of a dogfooding sweep. On a multilingual site (`en` + `ko`) the search box returned results from **both** languages.

## Bug
`Search.generate` flattened every page into a single root `search.json` with no language marker:
- A `/ko/` visitor searching got mixed `en` + `ko` results (7 + 7 in my repro).
- The per-language `build_search_index` key — documented as *"Include in search index"* and already loaded from TOML (`config_spec` covers parsing) — was **never consumed**, so opting a language out did nothing.
- Feeds are already per-language (`/ko/rss.xml`); search was the odd one out.

## Fix
- **search.cr**: tag each entry with its `lang` (page language → falls back to `default_language`), and honor `build_search_index` by dropping pages whose language opted out.
- **blog / docs / book scaffolds**: the search box filters `searchData` to the current page's `document.documentElement.lang` (the scaffolds already emit per-page `<html lang>`), so each language only sees its own pages. `*-dark` variants inherit this from their light parents.

## Verification
- New search specs: `lang` field present, and `build_search_index = false` excludes that language. Full unit suite green (4690 examples, 0 failures).
- E2E: rebuilt a `blog --full-config --include-multilingual en,ko` site → `search.json` entries now carry `lang` (en×7, ko×7); rendered `/js/search.js` filters on `document.documentElement.lang`.
- Non-multilingual sites unchanged (single language ⇒ no filtering).

## Note
Kept a single index with a `lang` field + client-side filter (matches the docs' "Include in search index" wording and needs no path logic) rather than per-language `*/search.json` files. Happy to switch to per-language files if you'd prefer the feeds-style layout.