### PR TITLE
fix(build): write .html aliases to that exact path, not a directory

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"be0760eb-5892-4cc9-9267-7790184e7a66","pid":64423,"procStart":"Sun May 31 07:24:16 2026","acquiredAt":1780215712948}

--- a/spec/functional/build_integration_spec.cr
+++ b/spec/functional/build_integration_spec.cr
@@ -401,6 +401,26 @@ describe "Build Integration: Redirects" do
       alias2.should contain("url=/new-page/")
     end
   end
+
+  it "writes .html aliases to that exact path instead of appending index.html" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "new-page.md" => "---\ntitle: New Page\naliases:\n  - /promo.html\n  - /docs/guide.html\n---\nNew content",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+    ) do
+      # Alias is written as a file at that exact path...
+      File.file?("public/promo.html").should be_true
+      File.read("public/promo.html").should contain("url=/new-page/")
+      File.file?("public/docs/guide.html").should be_true
+
+      # ...not a directory `promo.html/` with an index.html inside it
+      # (the previous behaviour blindly appended /index.html).
+      Dir.exists?("public/promo.html").should be_false
+      File.exists?("public/promo.html/index.html").should be_false
+    end
+  end
 end
 
 # ---------------------------------------------------------------------------

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -674,7 +674,16 @@ module Hwaro::Core::Build::Phases::Render
   private def generate_aliases(page : Models::Page, output_dir : String, verbose : Bool)
     page.aliases.each do |alias_path|
       alias_clean = Utils::PathUtils.sanitize_path(alias_path.lchop("/"))
-      dest_path = File.join(output_dir, alias_clean, "index.html")
+      # An alias that already names an HTML file (`/legacy.html`,
+      # `/old/index.html`) is written to that exact path; only "pretty"
+      # aliases (`/old/`) get an `index.html` appended. Previously every
+      # alias got `/index.html` tacked on, so `/legacy/index.html` became
+      # the directory `legacy/index.html/` with an `index.html` inside.
+      dest_path = if alias_clean.ends_with?(".html") || alias_clean.ends_with?(".htm")
+                    File.join(output_dir, alias_clean)
+                  else
+                    File.join(output_dir, alias_clean, "index.html")
+                  end
       next unless Utils::OutputGuard.within_output_dir?(dest_path, output_dir)
 
       ensure_dir(File.dirname(dest_path))


### PR DESCRIPTION
Cycle 3 of the dogfooding sweep. Found while testing content lifecycle + aliases.

## Bug
`generate_aliases` appended `/index.html` to **every** alias, so an alias that already names an HTML file produced a *directory* with an `index.html` inside it:

| alias | before | expected |
|---|---|---|
| `/legacy/index.html` | `public/legacy/index.html/index.html` | `public/legacy/index.html` |
| `/promo.html` | `public/promo.html/index.html` | `public/promo.html` |
| `/docs/guide.html` | `public/docs/guide.html/index.html` | `public/docs/guide.html` |

So a Hugo-style `aliases = ["/old-name.html"]` (common when migrating from a `.html`-URL site) silently produced a broken redirect at the wrong location.

## Fix
An alias ending in `.html`/`.htm` is written to that exact path; only "pretty" aliases (`/old/`) still get an `index.html` appended. Covers page and section aliases (shared method).

## Verification
- New build-integration spec: `.html` aliases are files (not directories), pretty aliases unchanged. Full suite green (5036 examples, 0 failures).
- E2E: `aliases = ["/promo.html", "/docs/guide.html", "/legacy/index.html"]` → each is a redirect **file** at the exact path; `/old-home/` still → `old-home/index.html`; no `promo.html/` directory.

(Also checked in the same session: `draft` / future-dated / `expires` content all correctly excluded by default and included with their flags — no issues there.)