### PR TITLE
fix(scaffold): emit JSON-LD structured data in default themes

### DIFF
--- a/spec/unit/scaffolds_spec.cr
+++ b/spec/unit/scaffolds_spec.cr
@@ -77,6 +77,20 @@ describe Hwaro::Services::Scaffolds::Simple do
       header.should contain("img {")
     end
 
+    it "wires JSON-LD structured data into the header of SEO scaffolds" do
+      # Regression: the engine generates JSON-LD and exposes it as `{{ jsonld }}`,
+      # but no scaffold included it, so the advertised structured-data feature
+      # produced nothing out of the box.
+      {
+        Hwaro::Services::Scaffolds::Simple.new,
+        Hwaro::Services::Scaffolds::Blog.new,
+        Hwaro::Services::Scaffolds::Docs.new,
+        Hwaro::Services::Scaffolds::Book.new,
+      }.each do |scaffold|
+        scaffold.template_files["header.html"].should contain("{{ jsonld }}")
+      end
+    end
+
     it "includes footer.html" do
       scaffold = Hwaro::Services::Scaffolds::Simple.new
       files = scaffold.template_files

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -335,6 +335,7 @@ module Hwaro
               <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
               <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
               {{ og_all_tags }}
+              {{ jsonld }}
               {{ hreflang_tags }}
               #{styles}
               {{ highlight_css }}

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -140,6 +140,7 @@ module Hwaro
               <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
               <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
               {{ og_all_tags }}
+              {{ jsonld }}
               {{ hreflang_tags }}
               #{styles}
               {{ highlight_css }}

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -134,6 +134,7 @@ module Hwaro
               <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
               <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
               {{ og_all_tags }}
+              {{ jsonld }}
               {{ hreflang_tags }}
               #{styles}
               {{ highlight_css }}

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -170,6 +170,7 @@ module Hwaro
               <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
               <link rel="icon" type="image/svg+xml" href="{{ base_url }}/favicon.svg">
               {{ og_all_tags }}
+              {{ jsonld }}
               {{ hreflang_tags }}
               #{styles}
               {{ highlight_css }}


### PR DESCRIPTION
Cycle 4 of the dogfooding sweep. Found while auditing SEO output of a built blog.

## Bug
The build generates JSON-LD (`Article`, `BreadcrumbList`, `FAQPage`, `HowTo`, `WebSite`, `Organization`) and exposes it to templates as `{{ jsonld }}` — but **no built-in scaffold included it**. So the README's "JSON-LD structured data (Article, FAQ, HowTo, Organization, Person)" produced **zero** `application/ld+json` in any default theme; pages shipped OG tags but no structured data.

```
$ hwaro init blog --scaffold blog && hwaro build
$ grep -c 'application/ld+json' public/posts/hello-world/index.html
0            # ← before
```

## Fix
Add `{{ jsonld }}` to the `<head>` of the `simple` / `blog` / `docs` / `book` headers, right after `{{ og_all_tags }}`. `bare` stays markup-only by design; the `*-dark` variants inherit from their light parents.

## Verification
- Scaffold spec asserts the SEO scaffolds wire in `{{ jsonld }}`. Full suite green (5037 examples, 0 failures).
- E2E on a fresh `blog` site: a post now emits valid `Article` + `BreadcrumbList`, the homepage emits `Article` (parsed as JSON, no errors).

## Also checked this session (no bug)
RSS/Atom + sitemap are well-formed with CJK + `& < > "` titles and correctly escaped; `feeds.limit` honored (10 items); `tool check-links` accurate. Pagination is off-by-default (intended — no `[pagination]` in scaffold config).