### PR TITLE
fix(amp): strip disallowed external stylesheets from AMP pages

### DIFF
--- a/spec/unit/amp_spec.cr
+++ b/spec/unit/amp_spec.cr
@@ -111,6 +111,25 @@ describe Hwaro::Content::Seo::Amp do
       result.should contain("text")
     end
 
+    it "strips disallowed external stylesheets but keeps font-provider links" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      config = Hwaro::Models::Config.new
+
+      html = "<html><head>" +
+             %(<link rel="stylesheet" href="/css/style.css">) +
+             %(<link rel="stylesheet" href="https://cdnjs.cloudflare.com/highlight.min.css">) +
+             %(<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">) +
+             "</head><body>x</body></html>"
+      result = Hwaro::Content::Seo::Amp.convert_to_amp(html, page, config)
+
+      # Disallowed stylesheets (site CSS, highlight.js CDN) are removed...
+      result.should_not contain("/css/style.css")
+      result.should_not contain("cdnjs.cloudflare.com")
+      # ...but allowlisted font-provider stylesheets stay.
+      result.should contain("fonts.googleapis.com")
+    end
+
     it "injects AMP boilerplate CSS" do
       page = Hwaro::Models::Page.new("test.md")
       page.url = "/test/"

--- a/src/content/seo/amp.cr
+++ b/src/content/seo/amp.cr
@@ -7,6 +7,18 @@ module Hwaro
   module Content
     module Seo
       class Amp
+        # Font providers AMP allows via `<link rel="stylesheet">`. Every other
+        # external stylesheet is disallowed and is stripped during conversion.
+        AMP_FONT_PROVIDERS = %w[
+          cloud.typography.com
+          fast.fonts.net
+          fonts.googleapis.com
+          use.typekit.net
+          maxcdn.bootstrapcdn.com
+          use.fontawesome.com
+          fonts.bunny.net
+        ]
+
         # Generate AMP versions of rendered pages.
         # Reads the already-rendered HTML files, converts to AMP-compliant HTML,
         # and writes them under the configured path prefix.
@@ -65,6 +77,20 @@ module Hwaro
           # Remove disallowed tags: <script> (except application/ld+json and amp scripts)
           # Use [\s\S]*? instead of .*? to match across newlines
           result = result.gsub(/<script(?![^>]*type=["']application\/ld\+json["'])(?![^>]*(?:async|custom-element|src=["']https:\/\/cdn\.ampproject\.org))[^>]*>[\s\S]*?<\/script>/mi, "")
+
+          # Remove disallowed external stylesheets. AMP forbids
+          # `<link rel="stylesheet">` except from allowlisted font providers;
+          # all other CSS must live in a single `<style amp-custom>`. Without
+          # this the site CSS and highlight.js/KaTeX CDN links make every AMP
+          # page fail validation.
+          result = result.gsub(/<link\b[^>]*>/i) do |tag|
+            if tag =~ /rel=["']stylesheet["']/i
+              href = tag.match(/href=["']([^"']*)["']/i).try(&.[1]) || ""
+              AMP_FONT_PROVIDERS.any? { |provider| href.includes?(provider) } ? tag : ""
+            else
+              tag
+            end
+          end
 
           # Remove style attributes and JS event handlers BEFORE element conversion
           # (so that container divs added by amp-img conversion aren't affected)


### PR DESCRIPTION
Cycle 5 (final) of the dogfooding sweep. Found by enabling `[amp]` and validating the output.

## Bug
AMP forbids `<link rel="stylesheet">` except from a small allowlist of font providers — all other CSS must be inlined into a single `<style amp-custom>`. The converter stripped `<script>`, inline `style=`, and `on*=` handlers and converted `<img>`/`<video>`/`<iframe>`, but left **every external stylesheet** untouched:

```
$ grep -o '<link[^>]*stylesheet[^>]*>' public/amp/posts/hello-world/index.html
<link rel="stylesheet" href="http://localhost:3000/css/style.css">
<link rel="stylesheet" href="https://cdnjs.cloudflare.com/.../highlight.js/.../github.min.css">
```

Both are disallowed → **every generated AMP page failed AMP validation** ("The tag 'link rel=stylesheet for fonts' is disallowed"), so Google would reject them.

## Fix
`convert_to_amp` now drops `<link rel="stylesheet">` whose href isn't an allowlisted font provider (Google Fonts, Typekit, Font Awesome, Bunny, …); font stylesheets are preserved. The scripts those stylesheets pair with (highlight.js, KaTeX) are already stripped by AMP, so dropping their CSS costs nothing.

## Verification
- New amp spec: site + CDN stylesheets stripped, a `fonts.googleapis.com` stylesheet kept. Full suite green (5038 examples, 0 failures).
- E2E (`[amp] enabled = true`): AMP post now has **0** disallowed `rel=stylesheet` links while keeping `<amp-img>`, amp-boilerplate, canonical, and the `rel="amphtml"` link on the source page.

## Also checked this session (no bug)
`redirect_to`, all built-in shortcodes (youtube/vimeo/gist/tweet/codepen/figure), `tool validate` / `unused-assets`, `lazy_loading = true` (markdown imgs get `loading="lazy"`), and that markdown-image pass-through is by-design (image processing is the `resize_image()` template helper).

---
This is the 5th and final PR of a 5-cycle dogfooding loop (#574 #575 #576 #577 + this).