### PR TITLE
fix(multilingual): stop duplicating default-language taxonomies under /<lang>/

### DIFF
--- a/spec/functional/multilingual_spec.cr
+++ b/spec/functional/multilingual_spec.cr
@@ -268,3 +268,56 @@ describe "Multilingual: Homepage per language" do
     end
   end
 end
+
+describe "Multilingual: Taxonomy output" do
+  it "emits default-language taxonomies at the root and non-default under a prefix, with no duplicate /<default_language>/ tree" do
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+      default_language = "en"
+
+      [[taxonomies]]
+      name = "tags"
+
+      [languages.en]
+      language_name = "English"
+      weight = 1
+      taxonomies = ["tags"]
+
+      [languages.ko]
+      language_name = "한국어"
+      weight = 2
+      taxonomies = ["tags"]
+      TOML
+
+    build_site(
+      config,
+      content_files: {
+        "blog/_index.md"    => "---\ntitle: Blog\n---\n",
+        "blog/_index.ko.md" => "---\ntitle: 블로그\n---\n",
+        "blog/post.md"      => "---\ntitle: Post\ntags:\n  - crystal\n---\nEnglish post",
+        "blog/post.ko.md"   => "---\ntitle: 포스트\ntags:\n  - crystal\n---\n한국어 포스트",
+      },
+      template_files: {
+        "page.html"          => "{{ content }}",
+        "section.html"       => "{{ content }}",
+        "taxonomy.html"      => "<h1>{{ taxonomy_name }}</h1>",
+        "taxonomy_term.html" => "<h1>{{ taxonomy_term }}</h1>",
+      },
+    ) do
+      # Default language (en) taxonomies live at the root.
+      File.exists?("public/tags/index.html").should be_true
+      File.exists?("public/tags/crystal/index.html").should be_true
+
+      # Non-default language (ko) taxonomies are language-prefixed.
+      File.exists?("public/ko/tags/index.html").should be_true
+      File.exists?("public/ko/tags/crystal/index.html").should be_true
+
+      # The default language must NOT also be duplicated under /en/ — that
+      # produced orphaned URLs (absent from the sitemap, no canonical).
+      File.exists?("public/en/tags/index.html").should be_false
+      File.exists?("public/en/tags/crystal/index.html").should be_false
+      Dir.exists?("public/en").should be_false
+    end
+  end
+end

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -35,6 +35,11 @@ module Hwaro
         # This closes the gap where non-default languages had no taxonomy UI at all.
         if config.multilingual?
           config.languages.each do |lang_code, lang_cfg|
+            # The default language is served at the site root, and its
+            # taxonomies were already emitted there by the call above. Emitting
+            # them again under `/<default_language>/` produces orphaned
+            # duplicate URLs (not in the sitemap, no canonical) — skip it.
+            next if lang_code == config.default_language
             next if lang_cfg.taxonomies.empty?
 
             # Build a filtered view of taxonomies for just this language's pages


### PR DESCRIPTION
## Problem

On a multilingual site (e.g. `--include-multilingual en,ko` with `en` as the default), taxonomy pages for the **default** language were emitted twice:

- at the site root — `/tags/`, `/categories/` (correct)
- **and again** under the default-language prefix — `/en/tags/`, `/en/categories/` (orphaned duplicates)

The `/en/...` copies were broken in several ways:
- **Not in `sitemap.xml`** — orphaned.
- **No `rel=canonical`** — two crawlable URLs serving near-identical content → duplicate-content SEO issue.
- **Inconsistent** — the `/en/` copy dropped the cross-language link to the `ko` post that the root copy included.
- `public/en/` had no `index.html` at all — just stray `tags/` + `categories/` trees.

Regular content pages for the default language were already emitted only at the root, so taxonomy output was also inconsistent with the rest of the site.

## Cause

`Taxonomies` first generates root taxonomies for the default language, then loops over `config.languages` to emit language-prefixed copies — but that loop included the **default** language, re-emitting what the root pass had already produced.

## Fix

Skip the default language in the per-language loop (it is already served at the root).

```crystal
config.languages.each do |lang_code, lang_cfg|
  next if lang_code == config.default_language  # already emitted at root
  ...
```

## Test

Added a functional spec asserting default-language taxonomies exist at the root, non-default ones under `/ko/`, and that **no** `/en/` taxonomy tree (or `public/en` dir) is produced. Verified the spec fails without the fix and passes with it. Full multilingual + taxonomy suites stay green.