### PR TITLE
fix(scaffold): wire blog posts section to post.html template

### DIFF
--- a/spec/unit/scaffolds_blog_spec.cr
+++ b/spec/unit/scaffolds_blog_spec.cr
@@ -82,4 +82,25 @@ describe Hwaro::Services::Scaffolds::Blog do
       content.should contain(%(template = "archives"))
     end
   end
+
+  describe "posts" do
+    # The blog scaffold ships a post.html with an <article> layout, a
+    # post-meta block (publish date) and series navigation, but posts
+    # inherit their template from the section's `page_template`. Without
+    # this wiring every post fell back to the bare page.html — rendering
+    # no date, no meta and no series nav, and edits to post.html had no
+    # effect at all.
+    it "wires the posts section to templates/post.html" do
+      scaffold = Hwaro::Services::Scaffolds::Blog.new
+      scaffold.content_files["posts/_index.md"].should contain(%(page_template = "post"))
+      scaffold.template_files["post.html"]?.should_not be_nil
+    end
+
+    it "ships a post.html that renders the publish date" do
+      scaffold = Hwaro::Services::Scaffolds::Blog.new
+      tpl = scaffold.template_files["post.html"].not_nil!
+      tpl.should contain("post-meta")
+      tpl.should contain("page.date")
+    end
+  end
 end

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -1105,6 +1105,9 @@ module Hwaro
             +++
             title = "Posts"
             description = "An index of every published blog post."
+            # Child pages of this section render with templates/post.html
+            # (article layout with publish date, meta, and series navigation).
+            page_template = "post"
             +++
 
             Browse all blog posts below.


### PR DESCRIPTION
## Problem

The `blog` scaffold ships a polished `templates/post.html` — an `<article>` layout with a `post-meta` block (publish date) and series navigation — but it was **never used**. Every post rendered with the bare `page.html` instead:

```
hwaro init s --scaffold blog && cd s && hwaro build
# public/posts/hello-world/index.html  <main> = just <h1> + content + footer
```

Result: **posts show no date, no meta, no series nav** out of the box. The date survives only in invisible JSON-LD. And because `post.html` is dead, a user who edits it to customize their post layout sees **zero effect** — very confusing.

## Cause

A leaf page inherits its template from its section's `page_template` (resolved in `determine_template`). The scaffold's `content/posts/_index.md` never set `page_template`, so posts fell through to the default `page` template.

## Fix

Set `page_template = "post"` in the scaffold's `posts/_index.md`. (The scaffold already uses the same mechanism for `archives.md` via `template = "archives"`, so it's an established pattern.) After the fix, posts render the article header, `<time>` publish date, and series nav from `post.html`.

## Test

Added unit specs asserting `posts/_index.md` wires `page_template = "post"` and that `post.html` exists and renders the publish date. Existing scaffold + link-integrity specs stay green.