### PR TITLE
fix(scaffold): render markdown in the alert shortcode body

### DIFF
--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../../src/core/build/builder"
+require "../../src/content/processors/filters/html_filter"
 
 # Reopen Builder to expose private methods for testing
 module Hwaro::Core::Build
@@ -72,6 +73,19 @@ describe Hwaro::Core::Build::Builder do
       content = "{% note(type=\"warning\") %}This is important{% end %}"
       result = builder.test_process_shortcodes_jinja(content, templates, context, crinja_env_override: env)
       result.should contain("<div class=\"note\">This is important</div>")
+    end
+
+    it "renders markdown in a block shortcode body via markdownify (the scaffold alert pattern)" do
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      Hwaro::Content::Processors::Filters::HtmlFilters.register(env)
+      templates = {"shortcodes/alert" => "<div class=\"alert\">{{ body | markdownify }}</div>"}
+      context = {} of String => Crinja::Value
+
+      content = "{% alert(type=\"info\") %}This is **bold** text{% end %}"
+      result = builder.test_process_shortcodes_jinja(content, templates, context, crinja_env_override: env)
+      result.should contain("<strong>bold</strong>")
+      result.should_not contain("**bold**")
     end
 
     it "accepts named closers like {% endnote %}" do

--- a/spec/unit/defaults_templates_spec.cr
+++ b/spec/unit/defaults_templates_spec.cr
@@ -50,7 +50,7 @@ describe Hwaro::Services::Defaults::TemplateSamples do
     it "returns a string containing expected tags" do
       alert = Hwaro::Services::Defaults::TemplateSamples.alert
       alert.should contain("{{ type | upper }}")
-      alert.should contain("{{ body }}")
+      alert.should contain("{{ body | markdownify }}")
     end
   end
 

--- a/spec/unit/scaffolds_book_spec.cr
+++ b/spec/unit/scaffolds_book_spec.cr
@@ -262,11 +262,10 @@ describe Hwaro::Services::Scaffolds::Base do
     it "ships the shared alert shortcode" do
       files = TestBaseScaffold.new.shortcode_files
       files.has_key?("shortcodes/alert.html").should be_true
-      # Alert shortcode references body and type via Jinja. The `{{ type`
-      # substring is intentionally truncated — the source uses
-      # `{{ type | upper }}`, and the partial form matches both the filtered
-      # and unfiltered forms.
-      files["shortcodes/alert.html"].should contain("{{ body }}")
+      # Alert shortcode references body and type via Jinja. The body is
+      # piped through `markdownify` so markdown inside the alert renders;
+      # `{{ type` is truncated to match `{{ type | upper }}`.
+      files["shortcodes/alert.html"].should contain("{{ body | markdownify }}")
       files["shortcodes/alert.html"].should contain("{{ type")
     end
   end

--- a/spec/unit/scaffolds_spec.cr
+++ b/spec/unit/scaffolds_spec.cr
@@ -91,6 +91,20 @@ describe Hwaro::Services::Scaffolds::Simple do
       end
     end
 
+    it "markdownifies the alert shortcode body so markdown inside alerts renders" do
+      # Regression: the alert shortcode emitted `{{ body }}` verbatim, so
+      # `{% alert %}**bold**{% end %}` rendered the literal `**bold**` instead
+      # of `<strong>bold</strong>`.
+      {
+        Hwaro::Services::Scaffolds::Simple.new,
+        Hwaro::Services::Scaffolds::Blog.new,
+        Hwaro::Services::Scaffolds::Docs.new,
+        Hwaro::Services::Scaffolds::Book.new,
+      }.each do |scaffold|
+        scaffold.shortcode_files["shortcodes/alert.html"].should contain("body | markdownify")
+      end
+    end
+
     it "includes footer.html" do
       scaffold = Hwaro::Services::Scaffolds::Simple.new
       files = scaffold.template_files

--- a/src/services/defaults/templates.cr
+++ b/src/services/defaults/templates.cr
@@ -93,7 +93,7 @@ module Hwaro
         def self.alert : String
           <<-HTML
             <div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
-              <strong>{{ type | upper }}:</strong> {{ body }}
+              <strong>{{ type | upper }}:</strong> {{ body | markdownify }}
             </div>
             HTML
         end

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -309,10 +309,15 @@ module Hwaro
         end
 
         # Common shortcode: alert (Jinja2 syntax)
+        #
+        # The body is piped through `markdownify` so markdown written inside
+        # the alert — **bold**, `code`, [links](…) — renders as HTML instead
+        # of appearing as literal markup. (Crinja autoescaping is off here, the
+        # same way `{{ content }}` emits rendered HTML.)
         protected def alert_shortcode : String
           <<-HTML
             <div class="alert" style="padding: 1rem; border: 1px solid #ddd; background-color: #f9f9f9; border-left: 5px solid #0070f3; margin: 1rem 0;">
-              <strong>{{ type | upper }}:</strong> {{ body }}
+              <strong>{{ type | upper }}:</strong> {{ body | markdownify }}
             </div>
             HTML
         end


### PR DESCRIPTION
## Problem

The built-in `alert` shortcode emitted its body verbatim through `{{ body }}`, so markdown written *inside* an alert appeared as literal markup:

```md
{% alert(type="info") %}This is **bold** and a [link](/x){% end %}
```

rendered as:

```html
<strong>INFO:</strong> This is **bold** and a [link](/x)
```

(visible literal `**bold**` / `[link](/x)`). Confirmed in a built site — the asterisks show on the page.

## Fix

Pipe the body through the existing `markdownify` filter:

```diff
- <strong>{{ type | upper }}:</strong> {{ body }}
+ <strong>{{ type | upper }}:</strong> {{ body | markdownify }}
```

Crinja autoescaping is off in this engine (templates opt into escaping with `| e`, and `{{ content }}` already emits rendered HTML), so the markdownified HTML is emitted as-is.

Applied to both copies so they stay consistent:
- `scaffolds/base.cr` `alert_shortcode` (shipped by `hwaro init`)
- `defaults/templates.cr` `TemplateSamples.alert` (reference sample)

## Test

- Unit: all four SEO scaffolds ship `{{ body | markdownify }}` in `shortcodes/alert.html`; updated the base + defaults sample assertions.
- End-to-end: a new `#process_shortcodes_jinja` spec runs `{% alert %}**bold**{% end %}` through the real builder + filters and asserts the output contains `<strong>bold</strong>` and not `**bold**`.

246 examples across the shortcode/scaffold/filter suites pass.