### PR TITLE
fix(seo): use WebSite JSON-LD for the homepage instead of an empty-headline Article

### DIFF
--- a/spec/functional/seo_spec.cr
+++ b/spec/functional/seo_spec.cr
@@ -405,3 +405,38 @@ describe "SEO: llms.txt content structure" do
     end
   end
 end
+
+describe "SEO: JSON-LD by page type" do
+  it "emits WebSite for the homepage (not an Article with an empty headline) and Article for titled pages" do
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+      description = "A site about things"
+      TOML
+
+    build_site(
+      config,
+      content_files: {
+        # Homepage with an empty title, exactly like the default scaffold.
+        "index.md"     => "+++\ntitle = \"\"\n+++\nWelcome",
+        "blog/_index.md" => "---\ntitle: Blog\n---\n",
+        "blog/post.md" => "---\ntitle: My Post\ndate: 2026-01-01\n---\nBody",
+      },
+      template_files: {
+        "page.html"    => "{{ jsonld }}",
+        "section.html" => "{{ jsonld }}",
+      },
+    ) do
+      home = File.read("public/index.html")
+      home.should contain(%("@type":"WebSite"))
+      # The homepage must not be an Article, and must never carry an empty headline.
+      home.should_not contain(%("@type":"Article"))
+      home.should_not contain(%("headline":""))
+
+      # A normal titled page still gets a proper Article with a real headline.
+      post = File.read("public/blog/post/index.html")
+      post.should contain(%("@type":"Article"))
+      post.should contain(%("headline":"My Post"))
+    end
+  end
+end

--- a/spec/functional/seo_spec.cr
+++ b/spec/functional/seo_spec.cr
@@ -418,9 +418,9 @@ describe "SEO: JSON-LD by page type" do
       config,
       content_files: {
         # Homepage with an empty title, exactly like the default scaffold.
-        "index.md"     => "+++\ntitle = \"\"\n+++\nWelcome",
+        "index.md"       => "+++\ntitle = \"\"\n+++\nWelcome",
         "blog/_index.md" => "---\ntitle: Blog\n---\n",
-        "blog/post.md" => "---\ntitle: My Post\ndate: 2026-01-01\n---\nBody",
+        "blog/post.md"   => "---\ntitle: My Post\ndate: 2026-01-01\n---\nBody",
       },
       template_files: {
         "page.html"    => "{{ jsonld }}",

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1557,15 +1557,31 @@ module Hwaro::Core::Build::Phases::Render
     }
     vars["seo"] = Crinja::Value.new(seo_obj)
 
-    # JSON-LD structured data — generate breadcrumb only when needed
-    jsonld_article = Content::Seo::JsonLd.article(page, config)
+    # JSON-LD structured data.
+    #
+    # The homepage is a WebSite, not an Article — and because the scaffold
+    # homepage ships an empty title, emitting an Article there produced an
+    # invalid empty `headline`. Use the WebSite schema for the homepage, and
+    # for any other untitled page skip the Article entirely rather than emit
+    # one with an empty headline.
+    is_homepage = page.is_index && page.section.empty?
+    jsonld_article = if is_homepage || page.title.empty?
+                       ""
+                     else
+                       Content::Seo::JsonLd.article(page, config)
+                     end
     needs_breadcrumb = !page.ancestors.empty? || !page.is_index
     jsonld_breadcrumb = needs_breadcrumb ? Content::Seo::JsonLd.breadcrumb(page, config) : ""
 
     # Extended schema types (FAQ, HowTo) auto-detected from extra.schema_type
     jsonld_extra = Content::Seo::JsonLd.for_page(page, config)
 
-    jsonld_parts = [jsonld_article]
+    jsonld_parts = [] of String
+    if is_homepage
+      jsonld_home_website = Content::Seo::JsonLd.website(config)
+      jsonld_parts << jsonld_home_website unless jsonld_home_website.empty?
+    end
+    jsonld_parts << jsonld_article unless jsonld_article.empty?
     jsonld_parts << jsonld_breadcrumb unless jsonld_breadcrumb.empty?
     jsonld_parts << jsonld_extra unless jsonld_extra.empty?
     jsonld_all = jsonld_parts.join("\n")


### PR DESCRIPTION
## Problem

Every page got an `Article` JSON-LD block injected into `{{ jsonld }}`, including the homepage and section list pages. Since the default scaffold homepage ships `title = ""`, the homepage emitted **invalid** structured data:

```html
<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"","url":"http://localhost:3000/",...}</script>
```

- A homepage is **not** an Article.
- An empty `headline` is invalid per Google's Article structured-data guidelines.
- It was internally inconsistent: the OG tags already emit `og:type="website"` for the homepage.

`JsonLd.website()` already existed (and `jsonld_website` was even computed) but no theme used it — `{{ jsonld }}` only carried Article + breadcrumb + extra.

## Fix

In the render phase's JSON-LD aggregation:
- **Homepage** (`page.is_index && page.section.empty?`) → emit the **WebSite** schema (includes the sitelinks `SearchAction` when search is enabled) instead of an Article.
- **Any other untitled page** → skip the Article rather than emit an empty `headline`.
- **Titled pages** → unchanged (Article with a real headline).

## Test

Added a functional spec: the homepage emits `"@type":"WebSite"`, never `"@type":"Article"` and never `"headline":""`; a titled page still emits an Article with the correct headline. Verified the spec fails without the fix. SEO + JSON-LD suites (38 examples) stay green.