### PR TITLE
fix(og): default auto OG image format to PNG

### DIFF
--- a/spec/unit/og_image_spec.cr
+++ b/spec/unit/og_image_spec.cr
@@ -36,7 +36,7 @@ describe Hwaro::Models::AutoImageConfig do
       ai.pattern_scale.should eq(1.0)
       ai.background_image.should be_nil
       ai.overlay_opacity.should eq(0.45)
-      ai.format.should eq("svg")
+      ai.format.should eq("png")
       ai.font_path.should be_nil
       ai.accent_bars.should be_false
     end
@@ -688,6 +688,7 @@ describe Hwaro::Content::Seo::OgImage do
         config = Hwaro::Models::Config.new
         config.title = "My Site"
         config.og.auto_image.enabled = true
+        config.og.auto_image.format = "svg" # explicit SVG path coverage
 
         page = Hwaro::Models::Page.new("test.md")
         page.title = "My Post"
@@ -751,6 +752,7 @@ describe Hwaro::Content::Seo::OgImage do
       Dir.mktmpdir do |dir|
         config = Hwaro::Models::Config.new
         config.og.auto_image.enabled = true
+        config.og.auto_image.format = "svg" # pin SVG: asserts the .svg output path
         config.og.auto_image.output_dir = "social-images"
 
         page = Hwaro::Models::Page.new("test.md")
@@ -769,6 +771,7 @@ describe Hwaro::Content::Seo::OgImage do
       Dir.mktmpdir do |dir|
         config = Hwaro::Models::Config.new
         config.og.auto_image.enabled = true
+        config.og.auto_image.format = "svg" # pin SVG: asserts the .svg output paths
 
         page1 = Hwaro::Models::Page.new("a.md")
         page1.title = "First Post"
@@ -880,6 +883,7 @@ describe Hwaro::Content::Seo::OgImage do
         config = Hwaro::Models::Config.new
         config.title = "My Site"
         config.og.auto_image.enabled = true
+        config.og.auto_image.format = "svg" # pin SVG: asserts the .svg path + mtime
 
         page = Hwaro::Models::Page.new("test.md")
         page.title = "My Post"
@@ -908,6 +912,7 @@ describe Hwaro::Content::Seo::OgImage do
         config = Hwaro::Models::Config.new
         config.title = "My Site"
         config.og.auto_image.enabled = true
+        config.og.auto_image.format = "svg" # pin SVG: reads rendered text from the file
 
         page = Hwaro::Models::Page.new("test.md")
         page.title = "Original Title"
@@ -933,6 +938,7 @@ describe Hwaro::Content::Seo::OgImage do
         config = Hwaro::Models::Config.new
         config.title = "My Site"
         config.og.auto_image.enabled = true
+        config.og.auto_image.format = "svg" # pin SVG: compares rendered file contents
 
         page = Hwaro::Models::Page.new("test.md")
         page.title = "My Post"
@@ -957,6 +963,7 @@ describe Hwaro::Content::Seo::OgImage do
         config = Hwaro::Models::Config.new
         config.title = "My Site"
         config.og.auto_image.enabled = true
+        config.og.auto_image.format = "svg" # pin SVG: asserts the .svg path
 
         page = Hwaro::Models::Page.new("test.md")
         page.title = "My Post"

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -363,7 +363,11 @@ module Hwaro
         @pattern_scale = 1.0
         @background_image = nil
         @overlay_opacity = 0.45
-        @format = "svg"
+        # PNG is the default because social platforms (Facebook, X/Twitter,
+        # LinkedIn, Slack, Discord, iMessage) do not render SVG og:image —
+        # an SVG preview silently shows nothing. Generation falls back to SVG
+        # automatically if PNG font initialization is unavailable.
+        @format = "png"
         @font_path = nil
         @logo_position = "bottom-left"
         @text_panel = 0.0

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -593,7 +593,7 @@ module Hwaro
           # pattern_scale = 1.0
           # background_image = ""          # Background image file path (embedded as base64)
           # overlay_opacity = 0.45
-          # format = "svg"                 # svg or png
+          # format = "png"                 # png (default) or svg — social platforms don't render SVG og:image
           # text_panel = 0.0               # 0.0–0.6 — adds subtle panel behind text (recommended with modern styles)
           # accent_bars = false            # Draw thin top/bottom accent bars (off by default; set true to opt in)
           # lazy_generate = false          # If true, skip bulk OG generation during `hwaro serve`.


### PR DESCRIPTION
## Problem

Auto OG images defaulted to **SVG** (`@format = "svg"`). Enabling `[og.auto_image]` therefore emitted:

```html
<meta property="og:image" content=".../og-images/posts-hello-world.svg">
<meta name="twitter:image" content=".../og-images/posts-hello-world.svg">
```

But **Facebook, X/Twitter, LinkedIn, Slack, Discord and iMessage do not render SVG `og:image`** — social shares silently show no preview, defeating the entire purpose of the feature. (A tell-tale: with SVG the cache-bust hash was `?v=d41d8cd9`, the empty-string MD5.) The README already advertises "auto-generated OG images (**PNG**)", so the default also contradicted the docs.

## Fix

Default `format` to `png`.

- PNG rendering uses the bundled Latin fallback fonts (`png_available` is true out of the box) and **falls back to SVG automatically** if font init is unavailable, so the change is safe.
- CJK-heavy sites still get the existing "set `font_path` to a CJK-capable font" warning.
- `[og.auto_image]` is opt-in (`enabled = false` by default), so only users who turned the feature on are affected — and PNG is what they need.

Also updated the config-snippet comment (`# format = "png" … social platforms don't render SVG og:image`).

## Test

- Updated the default-value assertion to `png`.
- Pinned the SVG-specific specs (custom output dir, multi-page uniqueness, manifest skip/regenerate, content comparisons) to `format = "svg"` so they keep exercising the SVG path; the dedicated "png format" spec covers PNG.
- 474 examples across og/config/doctor/models suites pass.

## Possible follow-up

`doctor` could warn when `format = "svg"` is set explicitly while `og:image` points at the SVG, since that combination won't preview on social platforms.