### PR TITLE
fix(scaffold): render the table of contents in the docs and book themes

### DIFF
--- a/spec/functional/toc_obj_spec.cr
+++ b/spec/functional/toc_obj_spec.cr
@@ -90,4 +90,28 @@ describe "TOC: toc_obj.headers exposes structured header data" do
       html.should contain("my-section")
     end
   end
+
+  # The scaffolds (docs/book) render the TOC with the guarded wrapper
+  # `{% if toc %}<nav class="...-toc">{{ toc }}</nav>{% endif %}`. Verify the
+  # wrapper appears with a header link when toc is on, and is omitted when off.
+  it "renders the guarded toc wrapper only when toc is enabled" do
+    build_site(
+      TOC_CONFIG,
+      content_files: {
+        "on.md"  => "+++\ntitle = \"On\"\ntoc = true\ninsert_anchor_links = true\n+++\n## Alpha\n## Beta\n",
+        "off.md" => "+++\ntitle = \"Off\"\ntoc = false\n+++\n## Alpha\n",
+      },
+      template_files: {
+        "page.html" => %({% if toc %}<nav class="docs-toc">{{ toc }}</nav>{% endif %}OUT={{ content }}),
+      },
+    ) do
+      on = File.read("public/on/index.html")
+      on.should contain(%(<nav class="docs-toc">))
+      on.should contain("<ul>")
+      on.should contain("#alpha")
+
+      off = File.read("public/off/index.html")
+      off.should_not contain("docs-toc")
+    end
+  end
 end

--- a/spec/unit/scaffolds_book_spec.cr
+++ b/spec/unit/scaffolds_book_spec.cr
@@ -83,6 +83,18 @@ describe Hwaro::Services::Scaffolds::Book do
       files.has_key?("partials/page-arrows.html").should be_true
     end
 
+    # The page template renders `{{ toc }}`, and the archetype enables it,
+    # so a chapter's in-page table of contents actually appears (previously
+    # `toc` was exposed by the engine but no scaffold template used it).
+    it "renders an in-page table of contents driven by the archetype" do
+      scaffold = Hwaro::Services::Scaffolds::Book.new
+      page = scaffold.template_files["page.html"]
+      page.should contain("{% if toc %}")
+      page.should contain("{{ toc }}")
+      page.should contain("book-toc")
+      scaffold.archetype_files["default.md"].should contain("toc = true")
+    end
+
     # Regression for gh#523: the book TOC sidebar used to bake the
     # original three chapters with hand-numbered "1.", "1.1" links
     # into the template. Adding a chapter via `hwaro new` left the

--- a/spec/unit/scaffolds_docs_spec.cr
+++ b/spec/unit/scaffolds_docs_spec.cr
@@ -72,6 +72,18 @@ describe Hwaro::Services::Scaffolds::Docs do
       footer.should contain("js/search.js")
     end
 
+    # The docs archetype sets `toc = true`, but the page template never
+    # rendered `{{ toc }}` — so the table of contents was silently dropped.
+    it "renders an in-page table of contents in the page template" do
+      scaffold = Hwaro::Services::Scaffolds::Docs.new
+      page = scaffold.template_files["page.html"]
+      page.should contain("{% if toc %}")
+      page.should contain("{{ toc }}")
+      page.should contain("docs-toc")
+      # And the docs archetypes that drive it still enable toc.
+      scaffold.archetype_files["guide.md"].should contain("toc = true")
+    end
+
     # Regression for gh#523: the docs sidebar used to be a hand-written
     # `<aside>` with the original three sections × three to four
     # pages baked in, so any page added via `hwaro new` never appeared

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -171,6 +171,7 @@ module Hwaro
             draft = {{ draft }}
             description = ""
             weight = 0
+            toc = true
             +++
 
             MD
@@ -425,6 +426,48 @@ module Hwaro
               margin: 0 auto;
               padding: 2.5rem 3rem;
               width: 100%;
+            }
+
+            .book-toc {
+              margin: 1.5rem 0 2rem 0;
+              padding: 1rem 1.25rem;
+              background: var(--bg-secondary);
+              border: 1px solid var(--border-light);
+              border-radius: var(--radius);
+            }
+
+            .book-toc-title {
+              margin: 0 0 0.5rem 0;
+              font-size: 0.8rem;
+              font-weight: 600;
+              text-transform: uppercase;
+              letter-spacing: 0.04em;
+              color: var(--text-muted);
+            }
+
+            .book-toc ul {
+              margin: 0;
+              padding-left: 1.1rem;
+              list-style: none;
+            }
+
+            .book-toc ul ul {
+              padding-left: 1rem;
+            }
+
+            .book-toc li {
+              margin: 0.25rem 0;
+              line-height: 1.5;
+            }
+
+            .book-toc a {
+              color: var(--text-secondary);
+              text-decoration: none;
+            }
+
+            .book-toc a:hover {
+              color: var(--primary);
+              text-decoration: underline;
             }
 
             /* ── Typography ── */
@@ -1329,6 +1372,7 @@ module Hwaro
               <main class="book-main">
                 <div class="book-content">
                   {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+                  {% if toc %}<nav class="book-toc" aria-label="On this page"><p class="book-toc-title">On this page</p>{{ toc }}</nav>{% endif %}
                   {{ content }}
                 </div>
             {% include "footer.html" %}

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -393,6 +393,48 @@ module Hwaro
               line-height: 1.2;
             }
 
+            .docs-toc {
+              margin: 1.5rem 0 2rem 0;
+              padding: 1rem 1.25rem;
+              background: var(--bg-secondary);
+              border: 1px solid var(--border-light);
+              border-radius: var(--radius);
+            }
+
+            .docs-toc-title {
+              margin: 0 0 0.5rem 0;
+              font-size: 0.8rem;
+              font-weight: 600;
+              text-transform: uppercase;
+              letter-spacing: 0.04em;
+              color: var(--text-muted);
+            }
+
+            .docs-toc ul {
+              margin: 0;
+              padding-left: 1.1rem;
+              list-style: none;
+            }
+
+            .docs-toc ul ul {
+              padding-left: 1rem;
+            }
+
+            .docs-toc li {
+              margin: 0.25rem 0;
+              line-height: 1.5;
+            }
+
+            .docs-toc a {
+              color: var(--text-secondary);
+              text-decoration: none;
+            }
+
+            .docs-toc a:hover {
+              color: var(--primary);
+              text-decoration: underline;
+            }
+
             .docs-main h2 {
               font-size: 1.4rem;
               font-weight: 600;
@@ -1056,6 +1098,7 @@ module Hwaro
             {% include "partials/sidebar.html" %}
               <main class="docs-main">
                 {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
+                {% if toc %}<nav class="docs-toc" aria-label="On this page"><p class="docs-toc-title">On this page</p>{{ toc }}</nav>{% endif %}
                 {{ content }}
             {% include "footer.html" %}
             HTML


### PR DESCRIPTION
## Problem

`toc = true` in front matter was silently ignored by every built-in scaffold. The engine *does* expose a `{{ toc }}` string (and `toc_obj`) when a page enables `toc`, but no shipped theme referenced it:

- The **docs** archetype already sets `toc = true`, yet docs pages rendered no table of contents at all.
- **book** chapters — the place an in-page TOC matters most — had none.

So a documented feature produced nothing out of the box, with no warning.

## Fix

Render a guarded TOC block in the docs and book page templates:

```jinja
{% if toc %}<nav class="docs-toc" aria-label="On this page"><p class="docs-toc-title">On this page</p>{{ toc }}</nav>{% endif %}
```

- Added matching `.docs-toc` / `.book-toc` CSS (theme variables, nested-list styling).
- Enabled `toc = true` in the **book** `default` archetype so chapters get a contents list out of the box (docs archetypes already set it).
- The `{% if toc %}` guard means pages with `toc = false` (or no headings) render nothing extra.

## Test

- Unit: docs & book `page.html` contain the guarded `{{ toc }}` wrapper + `*-toc` class; the docs (`guide.md`) and book (`default.md`) archetypes enable `toc`.
- Functional: a page with `toc = true` emits `<nav class="docs-toc">` + the `<ul>` with header anchors; a `toc = false` page omits it.
- 167 examples across the scaffold + TOC suites pass.