### PR TITLE
fix(highlight): warn when use_cdn = false but self-hosted assets are missing

### DIFF
--- a/spec/functional/highlight_assets_spec.cr
+++ b/spec/functional/highlight_assets_spec.cr
@@ -1,0 +1,86 @@
+require "./support/build_helper"
+
+# =============================================================================
+# Highlight self-hosted asset validation
+#
+# `[highlight] use_cdn = false` makes the templates reference local highlight.js
+# assets (/assets/js/highlight.min.js + the theme CSS). Hwaro never ships those
+# files, so if the user hasn't placed them under static/ the references 404 and
+# syntax highlighting silently breaks. The build should warn instead.
+# =============================================================================
+
+private def capture_build_logs(&) : String
+  io = IO::Memory.new
+  prev = Hwaro::Logger.io
+  Hwaro::Logger.io = io
+  begin
+    yield
+  ensure
+    Hwaro::Logger.io = prev
+  end
+  io.to_s
+end
+
+private SELF_HOSTED_HIGHLIGHT_CONFIG = <<-TOML
+  title = "Test"
+  base_url = "http://localhost"
+
+  [highlight]
+  enabled = true
+  use_cdn = false
+  theme = "github"
+  TOML
+
+describe "Highlight: self-hosted asset validation" do
+  it "warns when use_cdn = false but the local highlight assets are missing" do
+    logs = capture_build_logs do
+      build_site(
+        SELF_HOSTED_HIGHLIGHT_CONFIG,
+        content_files: {"page.md" => "---\ntitle: P\n---\nBody"},
+        template_files: {"page.html" => "{{ highlight_js }}{{ content }}"},
+      ) { }
+    end
+
+    logs.should contain("use_cdn = false")
+    logs.should contain("/assets/js/highlight.min.js")
+    logs.should contain("/assets/css/highlight/github.min.css")
+  end
+
+  it "does not warn when the self-hosted highlight assets are present" do
+    logs = capture_build_logs do
+      build_site(
+        SELF_HOSTED_HIGHLIGHT_CONFIG,
+        content_files: {"page.md" => "---\ntitle: P\n---\nBody"},
+        template_files: {"page.html" => "{{ content }}"},
+        static_files: {
+          "assets/js/highlight.min.js"          => "// hljs",
+          "assets/css/highlight/github.min.css" => "/* theme */",
+        },
+      ) { }
+    end
+
+    logs.should_not contain("use_cdn = false")
+  end
+
+  it "does not warn when use_cdn = true, even with no local assets" do
+    config = <<-TOML
+      title = "Test"
+      base_url = "http://localhost"
+
+      [highlight]
+      enabled = true
+      use_cdn = true
+      theme = "github"
+      TOML
+
+    logs = capture_build_logs do
+      build_site(
+        config,
+        content_files: {"page.md" => "---\ntitle: P\n---\nBody"},
+        template_files: {"page.html" => "{{ content }}"},
+      ) { }
+    end
+
+    logs.should_not contain("use_cdn = false")
+  end
+end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1139,14 +1139,14 @@ module Hwaro::Core::Build::Phases::Render
     vars
   end
 
-  # Compute a content-based cache bust hash from local CSS/JS files.
   # Public URLs of self-hosted highlight.js assets that are referenced
   # (`[highlight] use_cdn = false`) but missing from `static/`. Empty when the
   # CDN is used, highlighting is disabled, or every asset is present. Hwaro
   # never copies these files itself, so the user is expected to drop them under
   # `static/assets/`; this surfaces the gap instead of shipping 404s.
   def missing_local_highlight_assets(config : Models::Config) : Array(String)
-    return [] of String unless config.highlight.enabled && !config.highlight.use_cdn
+    return [] of String unless config.highlight.enabled
+    return [] of String if config.highlight.use_cdn
 
     missing = [] of String
     css_rel = File.join("static", "assets", "css", "highlight", "#{config.highlight.theme}.min.css")
@@ -1166,6 +1166,7 @@ module Hwaro::Core::Build::Phases::Render
                 "static/assets/css/highlight/#{config.highlight.theme}.min.css), or set [highlight] use_cdn = true."
   end
 
+  # Compute a content-based cache bust hash from local CSS/JS files.
   # Returns an 8-character hex digest, or "" if no local files exist.
   private def compute_cache_bust(config : Models::Config) : String
     has_local_highlight = config.highlight.enabled && !config.highlight.use_cdn

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1092,6 +1092,12 @@ module Hwaro::Core::Build::Phases::Render
     vars["highlight_js"] = Crinja::Value.new(config.highlight.js_tag(cache_bust))
     vars["highlight_tags"] = Crinja::Value.new(config.highlight.tags(cache_bust))
 
+    # `use_cdn = false` emits <script src="/assets/js/highlight.min.js"> (+ css),
+    # but Hwaro doesn't ship those files — if the user hasn't placed them under
+    # static/assets/ the references 404 and highlighting silently breaks. Warn
+    # once per build (build_global_vars runs once) so it isn't a silent footgun.
+    warn_missing_local_highlight_assets(config)
+
     # Math (KaTeX/MathJax) and Mermaid renderer scripts. When `math = true`
     # or `mermaid = true` is set in config, the markdown processor emits the
     # right wrapper markup but without these script tags the browser sees
@@ -1134,6 +1140,32 @@ module Hwaro::Core::Build::Phases::Render
   end
 
   # Compute a content-based cache bust hash from local CSS/JS files.
+  # Public URLs of self-hosted highlight.js assets that are referenced
+  # (`[highlight] use_cdn = false`) but missing from `static/`. Empty when the
+  # CDN is used, highlighting is disabled, or every asset is present. Hwaro
+  # never copies these files itself, so the user is expected to drop them under
+  # `static/assets/`; this surfaces the gap instead of shipping 404s.
+  def missing_local_highlight_assets(config : Models::Config) : Array(String)
+    return [] of String unless config.highlight.enabled && !config.highlight.use_cdn
+
+    missing = [] of String
+    css_rel = File.join("static", "assets", "css", "highlight", "#{config.highlight.theme}.min.css")
+    js_rel = File.join("static", "assets", "js", "highlight.min.js")
+    missing << "/assets/css/highlight/#{config.highlight.theme}.min.css" unless File.exists?(css_rel)
+    missing << "/assets/js/highlight.min.js" unless File.exists?(js_rel)
+    missing
+  end
+
+  private def warn_missing_local_highlight_assets(config : Models::Config)
+    missing = missing_local_highlight_assets(config)
+    return if missing.empty?
+
+    Logger.warn "[highlight] use_cdn = false but self-hosted asset(s) are missing: " \
+                "#{missing.join(", ")}. Syntax highlighting will not load (the references 404). " \
+                "Add the highlight.js build under static/ (static/assets/js/highlight.min.js and " \
+                "static/assets/css/highlight/#{config.highlight.theme}.min.css), or set [highlight] use_cdn = true."
+  end
+
   # Returns an 8-character hex digest, or "" if no local files exist.
   private def compute_cache_bust(config : Models::Config) : String
     has_local_highlight = config.highlight.enabled && !config.highlight.use_cdn


### PR DESCRIPTION
## Problem

Setting `[highlight] use_cdn = false` makes the rendered `<head>` reference local assets:

```html
<link rel="stylesheet" href="/assets/css/highlight/github.min.css?v=d41d8cd9">
<script src="/assets/js/highlight.min.js?v=d41d8cd9"></script>
```

But Hwaro **never ships or copies those files** — `use_cdn = false` assumes the user has self-hosted the highlight.js build under `static/assets/`. If they haven't (nothing tells them to), both references **404** and syntax highlighting silently breaks. Tells:

- `?v=d41d8cd9` is the first 8 chars of the **empty-string MD5** — the cache-bust step hashed a non-existent file.
- Neither `doctor` nor `tool check-links` catches it (one checks config-referenced paths, the other only content-markdown links).

## Fix

Emit a build warning (once per build, in `build_global_vars`) when `use_cdn = false` and the expected files are missing from `static/`:

```
[highlight] use_cdn = false but self-hosted asset(s) are missing:
/assets/css/highlight/github.min.css, /assets/js/highlight.min.js.
Syntax highlighting will not load (the references 404). Add the highlight.js
build under static/ (static/assets/js/highlight.min.js and
static/assets/css/highlight/github.min.css), or set [highlight] use_cdn = true.
```

The check lives in a small reusable `missing_local_highlight_assets(config)` helper.

## Test

New functional spec captures build logs and asserts: warns when `use_cdn = false` + assets missing; silent when the assets are present; silent when `use_cdn = true`. 122 examples across highlight/asset/build-integration suites pass.

## Note

This is the minimal, non-breaking fix (surface the gap). A larger follow-up could have `init`/scaffold fetch and ship the highlight.js assets so `use_cdn = false` works with zero manual steps.