### PR TITLE
fix(build): don't print "No content found" on a cached no-op rebuild

### DIFF
--- a/spec/functional/cache_spec.cr
+++ b/spec/functional/cache_spec.cr
@@ -323,3 +323,64 @@ describe "Cache: Cache with section content" do
     end
   end
 end
+
+describe "Cache: empty-site hint" do
+  # The "No content found" hint must not fire on a cached no-op rebuild.
+  # `--cache` skips unchanged pages (counted as cache_hits) rather than
+  # re-rendering them, so pages_rendered is 0 even though the site is full.
+  it "does not print 'No content found' on a cached no-op rebuild" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", BASIC_CONFIG)
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates")
+        File.write("content/page.md", "---\ntitle: Page\n---\nContent")
+        File.write("templates/page.html", "{{ content }}")
+
+        builder1 = Hwaro::Core::Build::Builder.new
+        Hwaro::Content::Hooks.all.each { |h| builder1.register(h) }
+        builder1.run(output_dir: "public", parallel: false, cache: true, highlight: false, verbose: false, profile: false)
+
+        # Capture the second (no-op) build's log.
+        io = IO::Memory.new
+        prev = Hwaro::Logger.io
+        Hwaro::Logger.io = io
+        begin
+          builder2 = Hwaro::Core::Build::Builder.new
+          Hwaro::Content::Hooks.all.each { |h| builder2.register(h) }
+          builder2.run(output_dir: "public", parallel: false, cache: true, highlight: false, verbose: false, profile: false)
+        ensure
+          Hwaro::Logger.io = prev
+        end
+
+        io.to_s.should_not contain("No content found")
+      end
+    end
+  end
+
+  # Positive control: a genuinely empty site still warns (and confirms the
+  # hint is reachable through Logger.io capture, so the assertion above is real).
+  it "still prints 'No content found' when there is no content at all" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", BASIC_CONFIG)
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates")
+        File.write("templates/page.html", "{{ content }}")
+
+        io = IO::Memory.new
+        prev = Hwaro::Logger.io
+        Hwaro::Logger.io = io
+        begin
+          builder = Hwaro::Core::Build::Builder.new
+          Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+          builder.run(output_dir: "public", parallel: false, cache: true, highlight: false, verbose: false, profile: false)
+        ensure
+          Hwaro::Logger.io = prev
+        end
+
+        io.to_s.should contain("No content found")
+      end
+    end
+  end
+end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -804,7 +804,12 @@ module Hwaro
           # index files are also written to disk, so a bare "N pages" count
           # misleads users who diff this number against `find public -name '*.html'`.
           Logger.success "Build complete! Generated #{ctx.stats.pages_rendered} content pages#{raw_msg} in #{elapsed.total_milliseconds.round(2)}ms."
-          if ctx.stats.pages_rendered == 0 && ctx.stats.raw_files_processed == 0
+          # Only warn about an empty site when nothing was built at all. Under
+          # `--cache`, unchanged pages are skipped (counted as `cache_hits`)
+          # rather than re-rendered, so `pages_rendered` is 0 on a no-op rebuild
+          # even though the site is full — guarding on `cache_hits == 0` keeps
+          # the hint from misfiring on every cached rebuild.
+          if ctx.stats.pages_rendered == 0 && ctx.stats.cache_hits == 0 && ctx.stats.raw_files_processed == 0
             Logger.info "No content found. Add Markdown files under content/ before deploying, or run `hwaro new <path>.md` to scaffold one."
           end
 


### PR DESCRIPTION
## Problem

The empty-site hint added in v0.14.0 fires on the wrong condition. With `--cache`, unchanged pages are *skipped* (counted as `cache_hits`) rather than re-rendered, so `pages_rendered` is 0 even when the site is full. A no-op cached rebuild therefore prints a false, alarming warning:

```
hwaro build --cache   # then again with no changes:
  Cache enabled (6 valid entries)
  Found 6 pages.
  Skipping 6 unchanged pages.
  …
Build complete! Generated 0 content pages in 11ms.
No content found. Add Markdown files under content/ before deploying, or run `hwaro new <path>.md` to scaffold one.
```

The same false warning appears after deleting any single file when the rest stay cached. (Found while dogfooding incremental builds.)

## Cause

`builder.cr`: `if ctx.stats.pages_rendered == 0 && ctx.stats.raw_files_processed == 0`. `pages_rendered` counts pages *rendered this build*, which is 0 on a fully-cached rebuild.

## Fix

Also require `ctx.stats.cache_hits == 0`, so the hint only fires when nothing was built **or** cached — i.e. a genuinely empty site. The field already exists (set in the render phase).

## Test

Added two functional specs in `cache_spec.cr`: a cached no-op rebuild of a non-empty site must **not** print "No content found"; a genuinely empty site **still** does (positive control, which also proves the hint is reachable via `Logger.io` capture). Verified the first fails without the fix. Cache + build-integration suites (100 examples) stay green.