### PR TITLE
feat(images): auto-add srcset/sizes to content images with generated variants

### DIFF
--- a/spec/unit/responsive_images_spec.cr
+++ b/spec/unit/responsive_images_spec.cr
@@ -1,0 +1,99 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+require "../../src/content/hooks/image_hooks"
+
+# =============================================================================
+# Unit specs for responsive content-image rewriting (srcset/sizes injection).
+#
+# When image_processing generated width variants for an <img>, the render
+# phase rewrites the tag to add `srcset`/`sizes` so browsers can pick an
+# appropriately-sized variant instead of always loading the full-size source.
+# =============================================================================
+
+# Expose the private render-phase helper for direct testing.
+module Hwaro::Core::Build
+  class Builder
+    def test_apply_responsive_images(html : String, page : Hwaro::Models::Page, config : Hwaro::Models::Config) : String
+      apply_responsive_images(html, page, config)
+    end
+  end
+end
+
+private def with_resize_map(map, &)
+  prior = Hwaro::Content::Hooks::ImageHooks.resize_map
+  Hwaro::Content::Hooks::ImageHooks.set_resize_map(map)
+  begin
+    yield
+  ensure
+    Hwaro::Content::Hooks::ImageHooks.set_resize_map(prior)
+  end
+end
+
+private def enabled_config : Hwaro::Models::Config
+  c = Hwaro::Models::Config.new
+  c.image_processing.enabled = true
+  c
+end
+
+private def bundle_page : Hwaro::Models::Page
+  p = Hwaro::Models::Page.new("posts/foo/index.md")
+  p.url = "/posts/foo/"
+  p
+end
+
+SAMPLE_MAP = {
+  "/posts/foo/photo.png" => {400 => "/posts/foo/photo_400w.png", 800 => "/posts/foo/photo_800w.png"},
+}
+
+describe "Responsive content images" do
+  it "adds srcset + sizes to a relative content image with variants" do
+    with_resize_map(SAMPLE_MAP) do
+      out = Hwaro::Core::Build::Builder.new.test_apply_responsive_images(
+        %(<p><img src="photo.png" alt="A"></p>), bundle_page, enabled_config)
+      out.should contain(%(srcset="/posts/foo/photo_400w.png 400w, /posts/foo/photo_800w.png 800w"))
+      out.should contain(%(sizes="100vw"))
+      out.should contain(%(src="photo.png")) # original src preserved
+    end
+  end
+
+  it "resolves an absolute src against the resize map" do
+    with_resize_map(SAMPLE_MAP) do
+      out = Hwaro::Core::Build::Builder.new.test_apply_responsive_images(
+        %(<img src="/posts/foo/photo.png">), bundle_page, enabled_config)
+      out.should contain(%(srcset="/posts/foo/photo_400w.png 400w, /posts/foo/photo_800w.png 800w"))
+    end
+  end
+
+  it "leaves images without generated variants untouched" do
+    with_resize_map(SAMPLE_MAP) do
+      out = Hwaro::Core::Build::Builder.new.test_apply_responsive_images(
+        %(<img src="other.png" alt="x">), bundle_page, enabled_config)
+      out.should eq(%(<img src="other.png" alt="x">))
+    end
+  end
+
+  it "skips external images" do
+    with_resize_map(SAMPLE_MAP) do
+      out = Hwaro::Core::Build::Builder.new.test_apply_responsive_images(
+        %(<img src="https://cdn.example.com/posto.png">), bundle_page, enabled_config)
+      out.should_not contain("srcset")
+    end
+  end
+
+  it "does not double-process an <img> that already has a srcset" do
+    with_resize_map(SAMPLE_MAP) do
+      html = %(<img src="photo.png" srcset="preset.png 100w">)
+      out = Hwaro::Core::Build::Builder.new.test_apply_responsive_images(html, bundle_page, enabled_config)
+      out.should eq(html)
+    end
+  end
+
+  it "is a no-op when image_processing is disabled" do
+    with_resize_map(SAMPLE_MAP) do
+      disabled = Hwaro::Models::Config.new # enabled defaults to false
+      out = Hwaro::Core::Build::Builder.new.test_apply_responsive_images(
+        %(<img src="photo.png">), bundle_page, disabled)
+      out.should_not contain("srcset")
+    end
+  end
+end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -499,6 +499,11 @@ module Hwaro::Core::Build::Phases::Render
       html_content = Content::Processors::InternalLinkResolver.resolve(html_content, pages_by_path, page.path, site.config.base_url)
     end
 
+    # Make content images responsive: when image_processing generated width
+    # variants for an <img>, add srcset/sizes so browsers pick an appropriate
+    # size instead of always loading the full-resolution source.
+    html_content = apply_responsive_images(html_content, page, site.config)
+
     # Store rendered HTML in page.content for reuse by Feed/Search generators
     # (avoids expensive re-rendering of Markdown in Generate phase)
     page.content = html_content
@@ -691,6 +696,49 @@ module Hwaro::Core::Build::Phases::Render
       redirect_url = page.url
       File.write(dest_path, Utils::RedirectHtml.simple_redirect(redirect_url))
       Logger.action :create, dest_path, :yellow if verbose
+    end
+  end
+
+  # Rewrite content <img> tags to add `srcset`/`sizes` when the image has
+  # generated width variants (see ImageHooks). Only runs when image_processing
+  # is enabled and at least one variant exists. A relative `src` is resolved
+  # against the page URL to match the resize map keys (which are site-absolute,
+  # e.g. `/posts/foo/photo.png`); absolute `src` is used as-is. External
+  # (http/protocol-relative/data:) sources and tags that already carry a
+  # `srcset` (e.g. emitted by the `resize_image()` helper) are left untouched.
+  IMG_TAG_RE = /<img\b[^>]*>/
+  IMG_SRC_RE = /\ssrc\s*=\s*("([^"]*)"|'([^']*)')/
+
+  private def apply_responsive_images(html : String, page : Models::Page, config : Models::Config) : String
+    return html unless config.image_processing.enabled
+    return html unless html.includes?("<img")
+
+    resize_map = Content::Hooks::ImageHooks.resize_map
+    return html if resize_map.empty?
+
+    html.gsub(IMG_TAG_RE) do |tag|
+      next tag if tag.includes?("srcset")
+      m = tag.match(IMG_SRC_RE)
+      next tag unless m
+      src = m[2]? || m[3]? || ""
+      next tag if src.empty?
+      next tag if src.starts_with?("http://") || src.starts_with?("https://") ||
+                  src.starts_with?("//") || src.starts_with?("data:")
+
+      key = if src.starts_with?("/")
+              src
+            else
+              base = page.url.ends_with?("/") ? page.url : "#{page.url}/"
+              "#{base}#{src}".gsub("//", "/")
+            end
+
+      widths = resize_map[key]?
+      next tag unless widths && !widths.empty?
+
+      srcset = widths.to_a.sort_by { |(w, _)| w }.map { |(w, url)| "#{url} #{w}w" }.join(", ")
+      additions = %( srcset="#{srcset}")
+      additions += %( sizes="100vw") unless tag =~ /\ssizes\s*=/
+      tag.sub("<img", "<img#{additions}")
     end
   end
 

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -733,7 +733,8 @@ module Hwaro::Core::Build::Phases::Render
             end
 
       widths = resize_map[key]?
-      next tag unless widths && !widths.empty?
+      next tag unless widths
+      next tag if widths.empty?
 
       srcset = widths.to_a.sort_by { |(w, _)| w }.map { |(w, url)| "#{url} #{w}w" }.join(", ")
       additions = %( srcset="#{srcset}")


### PR DESCRIPTION
## Problem (cycle-2 finding C3)

With `[image_processing]` enabled, Hwaro generates width variants (`photo_400w.png`, `photo_800w.png`, …) and an LQIP for content images — but a markdown `![](photo.png)` rendered as a plain `<img src="photo.png">`:

```
public/posts/with-image/photo_400w.png   ← generated
public/posts/with-image/photo_800w.png   ← generated
<img src="photo.png" alt="A photo" />     ← no srcset → full-size always loaded
```

So the variants were **orphaned** for normal post images, and "responsive images" only worked if you hand-wrote the `resize_image()` template helper. (Direction confirmed with the maintainer: auto-apply `srcset`.)

## Change

The render phase rewrites content `<img>` tags that have generated variants to add `srcset` + `sizes="100vw"`:

```html
<img srcset="/posts/with-image/photo_400w.png 400w, /posts/with-image/photo_800w.png 800w"
     sizes="100vw" src="photo.png" alt="A photo" />
```

- A relative `src` is resolved against the page URL to match the (site-absolute) resize-map keys; an absolute `src` is used as-is.
- **Left untouched:** external (`http`/`https`/`//`/`data:`) sources, images with no generated variants, and tags that already carry a `srcset` (e.g. emitted by `resize_image()`).
- **Gated on `image_processing.enabled`**, so behavior only changes for sites that opted into image processing — no impact otherwise. Cheap guard (`html.includes?("<img")`) skips the work entirely on image-free pages.

LQIP blur-up wiring needs theme CSS/JS, so it's intentionally left as a follow-up.

## Test

- Unit spec exercising the rewrite: relative + absolute src get srcset/sizes; images without variants, external sources, already-`srcset` tags, and disabled config are all no-ops.
- Verified end-to-end on a real build: a page-bundle markdown image now emits the srcset above; the previously-orphaned `_400w`/`_800w` files are now referenced.
- image-hooks / image-processor / build-integration / toc suites stay green (190 examples).