### PR TITLE
fix(amp): strip self-closing slash when converting <img> to <amp-img>

### DIFF
--- a/spec/unit/amp_spec.cr
+++ b/spec/unit/amp_spec.cr
@@ -100,6 +100,24 @@ describe Hwaro::Content::Seo::Amp do
       result.should_not contain(%(<div class="amp-img-container"><amp-img))
     end
 
+    # Markdown renders images as self-closing `<img … />`. The conversion regex
+    # greedily captured that trailing slash, producing the invalid
+    # `<amp-img … / layout="fill">`. The slash must be stripped.
+    it "does not leave a stray slash mid-tag for self-closing <img />" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      config = Hwaro::Models::Config.new
+
+      html = %(<p><img src="https://example.com/a.png" alt="A diagram" /></p>)
+      result = Hwaro::Content::Seo::Amp.convert_to_amp(html, page, config)
+      result.should contain("<amp-img")
+      result.should_not contain("<img")
+      result.should contain("</amp-img>")
+      # No orphaned self-closing slash before the appended layout attribute.
+      result.should_not match(/<amp-img[^>]*\/\s+layout=/)
+      result.should_not contain(%(alt="A diagram" /))
+    end
+
     it "removes inline style attributes" do
       page = Hwaro::Models::Page.new("test.md")
       page.url = "/test/"

--- a/src/content/seo/amp.cr
+++ b/src/content/seo/amp.cr
@@ -99,7 +99,10 @@ module Hwaro
 
           # Convert <img> to <amp-img>
           result = result.gsub(/<img([^>]*)\/?>/mi) do
-            attrs = $1
+            # `[^>]*` greedily swallows the self-closing slash from `<img … />`,
+            # which would otherwise be appended mid-tag as
+            # `<amp-img … / layout="…">` — invalid AMP. Strip a trailing slash.
+            attrs = $1.sub(/\s*\/\s*$/, "")
             has_width = attrs.includes?("width=")
             has_height = attrs.includes?("height=")
 


### PR DESCRIPTION
## Problem (final-cycle finding)

Markdown renders images as self-closing `<img … />`. The AMP conversion regex `/<img([^>]*)\/?>/` lets the greedy `[^>]*` capture the trailing slash, so it gets re-emitted **mid-tag**:

```html
<amp-img src="https://example.com/diagram.png" alt="A diagram" / layout="fill">
```

That `alt="…" / layout="fill"` is invalid AMP (the validator rejects the stray slash), so every AMP page with a content image fails validation.

## Fix

Strip a trailing slash (and surrounding whitespace) from the captured attributes before appending the layout attribute:

```crystal
attrs = .sub(/\s*\/\s*$/, "")
```

Result: `<amp-img src="…" alt="A diagram" layout="fill"></amp-img>`. Verified end-to-end on a built AMP page.

## Test

The existing img tests used non-self-closing `<img>` (so they missed this). Added a self-closing `<img />` case — the actual markdown output — asserting no stray slash survives before `layout=` and that `<amp-img>` is properly closed. Verified it fails without the fix. AMP suite (21 examples) green; format + ameba clean.