### PR TITLE
fix(config): normalize base_url trailing slash at build time

### DIFF
--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -126,6 +126,29 @@ describe Hwaro::Models::Config do
     end
   end
 
+  describe "#base_url= normalization" do
+    # A trailing slash makes `{{ base_url }}/path` templates and canonical/og
+    # URLs emit `//`; the setter strips it so config.toml and --base-url agree.
+    it "strips a trailing slash on assignment" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com/"
+      config.base_url.should eq("https://example.com")
+      config.base_url_stripped.should eq("https://example.com")
+    end
+
+    it "strips a trailing slash from a subpath base_url" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com/sub/"
+      config.base_url.should eq("https://example.com/sub")
+    end
+
+    it "leaves a slash-free base_url unchanged" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com/sub"
+      config.base_url.should eq("https://example.com/sub")
+    end
+  end
+
   describe "#initialize" do
     it "has default values" do
       config = Hwaro::Models::Config.new

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -791,7 +791,7 @@ module Hwaro
     class Config
       property title : String
       property description : String
-      property base_url : String
+      getter base_url : String
       property sitemap : SitemapConfig
       property robots : RobotsConfig
       property llms : LlmsConfig
@@ -854,6 +854,15 @@ module Hwaro
         @doctor = DoctorConfig.new
         @permalinks = {} of String => String
         @raw = Hash(String, TOML::Any).new
+      end
+
+      # Normalize on assignment: a trailing slash makes `{{ base_url }}/path`
+      # templates (and canonical/og URLs) emit `//`. Strip it so the build is
+      # correct whether the trailing slash came from config.toml or `--base-url`
+      # (previously only `doctor --fix` normalized this).
+      def base_url=(value : String)
+        @base_url = value.rstrip("/")
+        @base_url_stripped = nil
       end
 
       # Cached base_url with trailing slash stripped (avoids repeated rstrip per page)

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -463,9 +463,13 @@ module Hwaro
         # `validate_base_url!`, so any base_url reaching this point is either
         # empty or a well-formed http(s) URL. We only cover the remaining
         # style advisories here.
+        # `config.base_url` is normalized (trailing slash stripped) on load, so
+        # inspect the RAW config value for the trailing-slash advisory — the
+        # build is already correct, but `--fix` still tidies the file.
+        raw_base_url = config.raw["base_url"]?.try(&.as_s?)
         if config.base_url.empty?
           issues << Issue.new(id: "base-url-missing", level: :warning, category: "config", file: @config_path, message: "base_url is not set")
-        elsif config.base_url.ends_with?("/")
+        elsif raw_base_url && raw_base_url.ends_with?("/")
           issues << Issue.new(id: "base-url-trailing-slash", level: :warning, category: "config", file: @config_path,
             message: "base_url should not end with a trailing slash")
         end


### PR DESCRIPTION
## Problem (cycle-4 finding, init/build focus)

A `base_url` with a trailing slash — from `config.toml` **or** `--base-url` — produced `//` throughout the build:

```
hwaro build --base-url "https://ex.com/sub/"
→ <a href="https://ex.com/sub//about/">      (template {{ base_url }}/about/)
→ <meta property="og:url" content="https://ex.com/sub//posts/hello-world/">
```

Meanwhile `sitemap.xml` (which used `base_url_stripped`) stayed correct — so the same build emitted **inconsistent** URLs. Only `doctor --fix` normalized the trailing slash; a plain `build` did not, so a config-file trailing slash (a very common mistake) shipped broken `//` links and canonical/OG URLs.

## Fix

Normalize in the `Config#base_url=` setter (strip trailing slash). Both real assignment sites — config load and the `--base-url` override — go through the setter, so config-file and CLI paths now agree, and `{{ base_url }}/path` always yields a single slash. `validate_base_url!` still *accepts* a trailing slash (user input is permissive; the setter normalizes).

## Test

- Unit: `base_url=` strips a trailing slash (root + subpath), leaves slash-free values unchanged, and keeps `base_url_stripped` consistent.
- Verified end-to-end: `--base-url https://ex.com/sub/` now emits **0** double-slashes across hrefs, og:url, canonical, and sitemap.
- Full config/models/seo/build-integration suites (324 examples) green; the existing `doctor --fix` base_url-normalization test still passes; format + ameba clean.

## Cycle-4 context (init/build sweep — otherwise healthy)

- All 8 scaffolds × {default, minimal, full, skip-taxonomies} init → build → doctor: clean.
- init error/refusal exit codes correct (non-empty refuse=1, --clean w/ .git=2, unknown scaffold=1, missing input=6).
- build determinism: parallel == --no-parallel, and build-twice byte-identical.
- `--json`, `--minify`, `--skip-og-image`, `--skip-cache-busting` all behave correctly.