### PR TITLE
fix(new): escape title/date in archetype front matter

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -127,6 +127,32 @@ describe Hwaro::Services::Creator do
       end
     end
 
+    # Regression: archetype substitution injected the raw title/date, so a
+    # title containing a double quote (`My "Quoted" Post`) produced invalid
+    # TOML (`title = "My "Quoted" Post"`) and the generated file failed to
+    # build. The values must be escaped like `tags` already is.
+    it "escapes a quoted title/tags in archetype front matter (valid TOML)" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          FileUtils.mkdir_p("archetypes")
+          File.write("archetypes/custom.md", "+++\ntitle = \"{{ title }}\"\ndate = \"{{ date }}\"\ntags = {{ tags }}\n+++\n")
+
+          options = Hwaro::Config::Options::NewOptions.new(
+            path: "post.md", title: %(My "Quoted" Post), archetype: "custom", tags: [%(a "b"), "c"])
+          Hwaro::Services::Creator.new.run(options)
+
+          content = File.read("content/post.md")
+          content.should contain(%(title = "My \\"Quoted\\" Post"))
+          # Front matter must parse as valid TOML.
+          fm = content.lines.reject { |l| l.strip == "+++" }.join("\n")
+          parsed = TOML.parse(fm)
+          parsed["title"].as_s.should eq(%(My "Quoted" Post))
+          parsed["tags"].as_a.map(&.as_s).should eq([%(a "b"), "c"])
+        end
+      end
+    end
+
     it "uses an implicit archetype based on directory" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -452,12 +452,19 @@ module Hwaro
       end
 
       private def process_archetype(archetype_content : String, title : String, date : String, is_draft : Bool, tags : Array(String)) : String
-        tags_str = tags.empty? ? "[]" : "[#{tags.map { |t| "\"#{t.gsub("\"", "\\\"")}\"" }.join(", ")}]"
+        # Archetypes wrap these placeholders in quoted TOML fields
+        # (`title = "{{ title }}"`), so the substituted values must be escaped
+        # the same way `tags` already is — otherwise a title/date containing a
+        # double quote (e.g. `My "Quoted" Post`) yields invalid TOML and the
+        # generated file fails to build.
+        safe_title = escape_string(title)
+        safe_date = escape_string(date)
+        tags_str = tags.empty? ? "[]" : "[#{tags.map { |t| "\"#{escape_string(t)}\"" }.join(", ")}]"
         content = archetype_content
-          .gsub("{{ title }}", title)
-          .gsub("{{title}}", title)
-          .gsub("{{ date }}", date)
-          .gsub("{{date}}", date)
+          .gsub("{{ title }}", safe_title)
+          .gsub("{{title}}", safe_title)
+          .gsub("{{ date }}", safe_date)
+          .gsub("{{date}}", safe_date)
           .gsub("{{ draft }}", is_draft.to_s)
           .gsub("{{draft}}", is_draft.to_s)
           .gsub("{{ tags }}", tags_str)


### PR DESCRIPTION
## Problem (cycle-5 finding — `new`)

`hwaro new` substitutes values into archetype placeholders, but injected the **raw** title/date into quoted TOML fields (`title = "{{ title }}"`). A title with a double quote produced invalid TOML:

```
hwaro new posts/x.md -t 'My "Quoted" Post'
→ title = "My "Quoted" Post"     # invalid TOML
→ hwaro tool validate: ✘ TOML frontmatter parse error: unexpected token 'Quoted' at 1:14
```

So the generated file silently failed the next build. `tags` were already escaped (`"a \"b\""`); only `title`/`date` were not — an inconsistency. (Scaffolds with a matching archetype, e.g. blog's `posts.md`, hit this path; the no-archetype fallback already escaped correctly.)

## Fix

Escape `title` and `date` with the same `escape_string` helper used for `tags` (and by the fallback path) before substituting. Output: `title = "My \"Quoted\" Post"` — valid TOML.

## Test

Added a regression spec: an archetype with `title`/`date`/`tags` placeholders + a quoted title and quoted tag → asserts the escaped literal **and** that the front matter parses as valid TOML with the original values round-tripping. Verified it fails without the fix. Creator suite (67 examples) green; format + ameba clean.

## Cycle-5 `new` context (otherwise healthy)

- Overwriting an existing file is correctly refused (`HWARO_E_IO`, original preserved).
- `--json` output valid (`path`, `status`).