### PR TITLE
fix(scaffold): order blog series nav by series_weight, not flat date neighbours

### DIFF
--- a/spec/functional/series_nav_spec.cr
+++ b/spec/functional/series_nav_spec.cr
@@ -1,0 +1,77 @@
+require "./support/build_helper"
+
+# =============================================================================
+# Series navigation functional test.
+#
+# Verifies the scaffold's series-nav pattern — deriving prev/next from
+# `page.series_pages` (ordered by series_weight) via the 1-based
+# `page.series_index` — produces correct in-series ordering against the real
+# build engine (and is NOT ordered by the section's flat date neighbours).
+# =============================================================================
+
+SERIES_CONFIG = <<-TOML
+  title = "Test"
+  base_url = "http://localhost"
+
+  [series]
+  enabled = true
+  TOML
+
+# Minimal post template using the same series-nav logic the blog scaffold ships.
+SERIES_POST_TEMPLATE = <<-HTML
+  <article>
+  {% if page.series %}
+  <nav class="series-nav">
+    {% if page.series_index > 1 %}
+    <a class="series-prev" href="{{ page.series_pages[page.series_index - 2].url }}">{{ page.series_pages[page.series_index - 2].title }}</a>
+    {% endif %}
+    {% if page.series_index < (page.series_pages | length) %}
+    <a class="series-next" href="{{ page.series_pages[page.series_index].url }}">{{ page.series_pages[page.series_index].title }}</a>
+    {% endif %}
+  </nav>
+  {% endif %}
+  {{ content }}
+  </article>
+  HTML
+
+describe "Series navigation" do
+  it "orders prev/next by series_weight and omits prev on the first / next on the last" do
+    build_site(
+      SERIES_CONFIG,
+      content_files: {
+        "posts/_index.md" => "+++\ntitle = \"Posts\"\npage_template = \"post\"\n+++\n",
+        # Deliberately give later chapters EARLIER dates so date-ordering would
+        # disagree with series_weight — the nav must follow series_weight.
+        "posts/c1.md"    => "+++\ntitle = \"Chapter 1\"\ndate = \"2026-01-03\"\nseries = \"Guide\"\nseries_weight = 1\n+++\nC1",
+        "posts/c2.md"    => "+++\ntitle = \"Chapter 2\"\ndate = \"2026-01-02\"\nseries = \"Guide\"\nseries_weight = 2\n+++\nC2",
+        "posts/c3.md"    => "+++\ntitle = \"Chapter 3\"\ndate = \"2026-01-01\"\nseries = \"Guide\"\nseries_weight = 3\n+++\nC3",
+        "posts/loner.md" => "+++\ntitle = \"Loner\"\ndate = \"2026-01-09\"\n+++\nNot in a series",
+      },
+      template_files: {
+        "page.html"    => "{{ content }}",
+        "section.html" => "{{ content }}",
+        "post.html"    => SERIES_POST_TEMPLATE,
+      },
+    ) do
+      c1 = File.read("public/posts/c1/index.html")
+      c2 = File.read("public/posts/c2/index.html")
+      c3 = File.read("public/posts/c3/index.html")
+
+      # Chapter 1: no prev, next -> Chapter 2
+      c1.should_not contain("series-prev")
+      c1.should contain(%(series-next" href="/posts/c2/">Chapter 2))
+
+      # Chapter 2: prev -> Chapter 1, next -> Chapter 3
+      c2.should contain(%(series-prev" href="/posts/c1/">Chapter 1))
+      c2.should contain(%(series-next" href="/posts/c3/">Chapter 3))
+
+      # Chapter 3: prev -> Chapter 2, no next
+      c3.should contain(%(series-prev" href="/posts/c2/">Chapter 2))
+      c3.should_not contain("series-next")
+
+      # A non-series post never renders series nav (and must build fine despite
+      # an empty series_pages — no out-of-bounds indexing).
+      File.read("public/posts/loner/index.html").should_not contain("series-nav")
+    end
+  end
+end

--- a/spec/unit/scaffolds_blog_spec.cr
+++ b/spec/unit/scaffolds_blog_spec.cr
@@ -102,5 +102,18 @@ describe Hwaro::Services::Scaffolds::Blog do
       tpl.should contain("post-meta")
       tpl.should contain("page.date")
     end
+
+    # Series nav must walk `series_pages` (ordered by series_weight) via the
+    # 1-based `series_index`. It previously used page.lower/page.higher, which
+    # are the section's flat date-ordered neighbours — so chapters were ordered
+    # by date and could even link non-series posts.
+    it "builds series nav from series_pages/series_index, not page.lower/higher" do
+      tpl = Hwaro::Services::Scaffolds::Blog.new.template_files["post.html"].not_nil!
+      series_nav = tpl.partition("series-nav")[2]
+      series_nav.should contain("page.series_pages[page.series_index")
+      series_nav.should contain("page.series_index > 1")
+      series_nav.should_not contain("page.lower")
+      series_nav.should_not contain("page.higher")
+    end
   end
 end

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -937,14 +937,19 @@ module Hwaro
                     {{ content }}
                   </div>
 
+                  {# Series nav walks `series_pages` (ordered by series_weight)
+                     via the 1-based `series_index`, NOT page.lower/page.higher
+                     — those are the section's flat date-ordered neighbours, so
+                     they ordered chapters by date and even linked non-series
+                     posts. #}
                   {% if page.series %}
                   <nav class="series-nav" aria-label="Series navigation">
-                    {% if page.lower %}
-                    <a href="{{ base_url }}{{ page.lower.url }}" class="series-prev" rel="prev">← {{ page.lower.title | e }}</a>
+                    {% if page.series_index > 1 %}
+                    <a href="{{ base_url }}{{ page.series_pages[page.series_index - 2].url }}" class="series-prev" rel="prev">← {{ page.series_pages[page.series_index - 2].title | e }}</a>
                     {% endif %}
                     <span class="series-name">{{ page.series | e }}</span>
-                    {% if page.higher %}
-                    <a href="{{ base_url }}{{ page.higher.url }}" class="series-next" rel="next">{{ page.higher.title | e }} →</a>
+                    {% if page.series_index < (page.series_pages | length) %}
+                    <a href="{{ base_url }}{{ page.series_pages[page.series_index].url }}" class="series-next" rel="next">{{ page.series_pages[page.series_index].title | e }} →</a>
                     {% endif %}
                   </nav>
                   {% endif %}


### PR DESCRIPTION
## Problem (cycle-6 finding — series)

The blog `post.html` built its series prev/next from `page.lower` / `page.higher`, which are the **section's flat, date-ordered neighbours** — not the series order. For a 3-part series whose chapter dates don't line up with `series_weight`:

```
Chapter 2  ->  prev = Chapter 3,  next = Chapter 1   (inverted, ordered by date)
Chapter 1  ->  shows a prev (should be none)
Chapter 3  ->  shows a next (should be none)
```

The links could even point at **non-series** posts in the same section, since `page.lower/higher` span the whole section.

## Fix

Walk `page.series_pages` (ordered by `series_weight`) via the 1-based `page.series_index`: prev = `series_pages[index-2]`, next = `series_pages[index]`, guarded by `index > 1` and `index < length`. The `{% if page.series %}` wrapper keeps non-series pages from indexing the empty array.

After the fix: Ch1 → (none, Ch2), Ch2 → (Ch1, Ch3), Ch3 → (Ch2, none).

## Test

- Unit: the scaffold `post.html` series-nav references the `series_pages`/`series_index` pattern and no longer uses `page.lower`/`page.higher`.
- Functional: builds a 3-part series whose dates intentionally disagree with `series_weight`, asserting prev/next follow weight and that the first/last omit prev/next; a non-series post renders no series nav and builds fine (no out-of-bounds indexing). Verified end-to-end. format + ameba clean.
