### PR TITLE
fix(multilingual): scope root taxonomy term listings to the default language

### DIFF
--- a/spec/functional/multilingual_spec.cr
+++ b/spec/functional/multilingual_spec.cr
@@ -320,4 +320,51 @@ describe "Multilingual: Taxonomy output" do
       Dir.exists?("public/en").should be_false
     end
   end
+
+  it "scopes the root taxonomy term listing to the default language (no cross-language leak)" do
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+      default_language = "en"
+
+      [[taxonomies]]
+      name = "tags"
+
+      [languages.en]
+      language_name = "English"
+      taxonomies = ["tags"]
+
+      [languages.ko]
+      language_name = "한국어"
+      taxonomies = ["tags"]
+      TOML
+
+    build_site(
+      config,
+      content_files: {
+        "posts/_index.md"    => "---\ntitle: Posts\n---\n",
+        "posts/_index.ko.md" => "---\ntitle: 포스트\n---\n",
+        "posts/p.md"         => "---\ntitle: English Post\ntags:\n  - crystal\n---\nEN",
+        "posts/p.ko.md"      => "---\ntitle: 한국어 포스트\ntags:\n  - crystal\n---\nKO",
+      },
+      template_files: {
+        "page.html"     => "{{ content }}",
+        "section.html"  => "{{ content }}",
+        "taxonomy.html" => "{{ content }}",
+        # The engine renders the term's page list into `content`.
+        "taxonomy_term.html" => "{{ content }}",
+      },
+    ) do
+      # Root (default-language) term lists the English post only.
+      root = File.read("public/tags/crystal/index.html")
+      root.should contain("English Post")
+      root.should_not contain("한국어 포스트")
+      root.should_not contain("/ko/posts/")
+
+      # Korean term lists the Korean post only.
+      ko = File.read("public/ko/tags/crystal/index.html")
+      ko.should contain("한국어 포스트")
+      ko.should_not contain("English Post")
+    end
+  end
 end

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -27,8 +27,14 @@ module Hwaro
         # Reuse a single Builder instance across all taxonomy renders
         builder = Core::Build::Builder.new
 
-        # Generate root taxonomies (for default language / non-multilingual sites)
-        generate_taxonomies_for_language(config.taxonomies, site, output_dir, templates, builder, verbose, language: nil, lang_prefix: "")
+        # Generate root taxonomies. On a multilingual site the root is the
+        # default language's space (its content pages live at the root), so
+        # scope the term listings to default-language pages — otherwise the
+        # English `/tags/foo/` page also lists the Korean posts (with `/ko/`
+        # links and translated titles), a cross-language leak. Non-multilingual
+        # sites pass `nil` (no filtering needed — every page is the one space).
+        root_language = config.multilingual? ? config.default_language : nil
+        generate_taxonomies_for_language(config.taxonomies, site, output_dir, templates, builder, verbose, language: root_language, lang_prefix: "")
 
         # For multilingual sites, also generate language-prefixed taxonomy pages
         # (e.g. /en/tags/, /en/categories/) using only pages of that language.


### PR DESCRIPTION
## Problem (cycle-6 finding — multilingual deep)

On a multilingual site, the root taxonomy term pages listed posts from **all** languages. The English `/tags/crystal/` page (`<html lang="en">`) listed the Korean posts too — with Korean titles and `/ko/posts/...` links:

```
/tags/crystal/  ->  EN Rel 1-3  AND  KO Rel 1-3   (cross-language leak)
/ko/tags/crystal/  ->  KO Rel 1-3                  (correctly scoped)
```

So the default-language taxonomy was inconsistent with everything else: default-language *content* lives at the root and is single-language, and the per-language `/ko/` taxonomy was already filtered — only the root mixed languages.

## Cause

`Taxonomies` runs the root pass with `language: nil`, which uses the unfiltered `site.taxonomies` (every language's pages). The per-language passes filter by language; the root did not.

## Fix

Pass `language: config.default_language` for the root pass on multilingual sites (`nil` for single-language sites, where no filtering is needed). The existing per-term filter then scopes root term pages to default-language posts; terms with no default-language posts are skipped.

## Test

Added a functional spec: a shared tag across an en + ko post → the root `/tags/crystal/` lists the English post and **not** the Korean one (no `/ko/posts/` links), while `/ko/tags/crystal/` lists the Korean post only. Verified end-to-end; the existing `/en/`-duplication (B4) and single-language taxonomy tests still pass. Full suite 5064 examples green; format + ameba clean.
