### PR TITLE
fix(scaffold): render pagination SEO links (rel=prev/next) in theme headers

### DIFF
--- a/spec/functional/pagination_seo_links_spec.cr
+++ b/spec/functional/pagination_seo_links_spec.cr
@@ -1,0 +1,68 @@
+require "./support/build_helper"
+
+# =============================================================================
+# Pagination SEO links functional test.
+#
+# Verifies that a header rendering `{{ pagination_seo_links }}` emits
+# rel=prev/next on paginated pages, and that the links carry the correct
+# per-language prefix on a multilingual site (no leak to the default language,
+# no doubled prefix).
+# =============================================================================
+
+PAGINATION_SEO_CONFIG = <<-TOML
+  title = "Test"
+  base_url = "http://localhost"
+  default_language = "en"
+
+  [pagination]
+  enabled = true
+  per_page = 2
+
+  [languages.en]
+  language_name = "English"
+
+  [languages.ko]
+  language_name = "한국어"
+  TOML
+
+# Section template that surfaces the SEO links (a real header would put these
+# in <head>; the test only needs them in the output).
+PAGINATION_SEO_TEMPLATES = {
+  "page.html"    => "{{ content }}",
+  "section.html" => "{{ pagination_seo_links }}{{ section_list }}",
+}
+
+private def paginated_content : Hash(String, String)
+  files = {
+    "posts/_index.md"    => "---\ntitle: Posts\n---\n",
+    "posts/_index.ko.md" => "---\ntitle: 포스트\n---\n",
+  }
+  (1..5).each do |i|
+    files["posts/p#{i}.md"] = "---\ntitle: EN #{i}\ndate: 2026-01-0#{i}\n---\nEN"
+    files["posts/p#{i}.ko.md"] = "---\ntitle: KO #{i}\ndate: 2026-01-0#{i}\n---\nKO"
+  end
+  files
+end
+
+describe "Pagination SEO links" do
+  it "emits rel=prev/next with the correct per-language prefix" do
+    build_site(PAGINATION_SEO_CONFIG, content_files: paginated_content, template_files: PAGINATION_SEO_TEMPLATES) do
+      # 5 posts / per_page 2 => pages 1,2,3 for each language.
+      # EN page 2: prev -> /posts/, next -> /posts/page/3/
+      en2 = File.read("public/posts/page/2/index.html")
+      en2.should contain(%(<link rel="prev" href="http://localhost/posts/">))
+      en2.should contain(%(<link rel="next" href="http://localhost/posts/page/3/">))
+
+      # KO page 2: prefixed with /ko/, no leak to the en root, no /ko/ko/.
+      ko2 = File.read("public/ko/posts/page/2/index.html")
+      ko2.should contain(%(<link rel="prev" href="http://localhost/ko/posts/">))
+      ko2.should contain(%(<link rel="next" href="http://localhost/ko/posts/page/3/">))
+      ko2.should_not contain("/ko/ko/")
+
+      # Page 1 has next only (no prev).
+      en1 = File.read("public/posts/index.html")
+      en1.should contain(%(<link rel="next" href="http://localhost/posts/page/2/">))
+      en1.should_not contain(%(rel="prev"))
+    end
+  end
+end

--- a/spec/unit/scaffolds_spec.cr
+++ b/spec/unit/scaffolds_spec.cr
@@ -91,6 +91,20 @@ describe Hwaro::Services::Scaffolds::Simple do
       end
     end
 
+    it "wires pagination SEO links (rel=prev/next) into the header of SEO scaffolds" do
+      # Regression: the engine builds `pagination_seo_links` (<link rel="prev"/
+      # "next">) for paginated pages, but no scaffold rendered it, so paginated
+      # pages shipped without rel=prev/next.
+      {
+        Hwaro::Services::Scaffolds::Simple.new,
+        Hwaro::Services::Scaffolds::Blog.new,
+        Hwaro::Services::Scaffolds::Docs.new,
+        Hwaro::Services::Scaffolds::Book.new,
+      }.each do |scaffold|
+        scaffold.template_files["header.html"].should contain("{{ pagination_seo_links }}")
+      end
+    end
+
     it "markdownifies the alert shortcode body so markdown inside alerts renders" do
       # Regression: the alert shortcode emitted `{{ body }}` verbatim, so
       # `{% alert %}**bold**{% end %}` rendered the literal `**bold**` instead

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -342,6 +342,7 @@ module Hwaro
               {{ og_all_tags }}
               {{ jsonld }}
               {{ hreflang_tags }}
+              {{ pagination_seo_links }}
               #{styles}
               {{ highlight_css }}
               {{ math_tags }}

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -142,6 +142,7 @@ module Hwaro
               {{ og_all_tags }}
               {{ jsonld }}
               {{ hreflang_tags }}
+              {{ pagination_seo_links }}
               #{styles}
               {{ highlight_css }}
               {{ math_tags }}

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -136,6 +136,7 @@ module Hwaro
               {{ og_all_tags }}
               {{ jsonld }}
               {{ hreflang_tags }}
+              {{ pagination_seo_links }}
               #{styles}
               {{ highlight_css }}
               {{ math_tags }}

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -172,6 +172,7 @@ module Hwaro
               {{ og_all_tags }}
               {{ jsonld }}
               {{ hreflang_tags }}
+              {{ pagination_seo_links }}
               #{styles}
               {{ highlight_css }}
               {{ math_tags }}


### PR DESCRIPTION
## Problem (cycle-7 finding — pagination × multilingual)

The engine builds `pagination_seo_links` — `<link rel="prev">` / `<link rel="next">` — for paginated section/taxonomy pages (`render_seo_links`), but **no scaffold header rendered the `{{ pagination_seo_links }}` var**. So every paginated page (`/posts/page/2/`, taxonomy term pages, …) shipped without rel=prev/next — a missing SEO signal for paginated series. Same gap class as the JSON-LD / TOC / related ones.

Found while probing pagination × multilingual: the engine's links are already correctly language-prefixed (`/posts/page/3/` vs `/ko/posts/page/3/`, page 1 next-only), so the only thing missing was the theme rendering them.

## Fix

Add `{{ pagination_seo_links }}` to the `base`/`blog`/`docs`/`book` headers, next to `{{ hreflang_tags }}`.

## Test

- Unit: all four SEO scaffolds' headers contain `{{ pagination_seo_links }}`.
- Functional (multilingual): a paginated build emits `rel="prev"`/`rel="next"` on page 2, with the correct per-language prefix — en page 2 → `/posts/` + `/posts/page/3/`, ko page 2 → `/ko/posts/` + `/ko/posts/page/3/` (no leak to the default language, no `/ko/ko/` doubling); page 1 has next only. Verified end-to-end. format + ameba clean.

## Cycle-7 context (pagination × multilingual — otherwise healthy)

- Per-language section + taxonomy pagination generate correct `/ko/posts/page/N/` and `/ko/tags/T/page/N/` paths with correctly-prefixed page links and language-scoped contents.
- After #592, root taxonomy pagination correctly counts the **filtered** default-language posts (e.g. 5 en posts, `paginate_by=2` → pages 2,3 — not 4,5), with proper per-page distribution and no cross-language leak.
