### PR TITLE
fix(scaffold): make the dynamic-nav example inert and multilingual-safe

### DIFF
--- a/spec/unit/scaffolds_spec.cr
+++ b/spec/unit/scaffolds_spec.cr
@@ -91,6 +91,23 @@ describe Hwaro::Services::Scaffolds::Simple do
       end
     end
 
+    it "keeps the dynamic-nav example inert ({% raw %}) and multilingual-safe" do
+      # Regression: the example `{% for s in site.sections %}` loop lived in a
+      # plain HTML comment, so Crinja executed it — emitting hidden, malformed
+      # `/ko/ko/posts/` links — and the example itself double-prefixed
+      # (`{{ lang_prefix }}{{ s.url }}`) and listed every language's section.
+      navs = {
+        Hwaro::Services::Scaffolds::Simple.new.template_files["header.html"],
+        Hwaro::Services::Scaffolds::Blog.new.template_files["partials/nav.html"],
+      }
+      navs.each do |nav|
+        nav.should contain("{% raw %}")                        # example is inert in the comment
+        nav.should contain("s.language == page_language")      # only current-language sections
+        nav.should contain("{{ base_url }}{{ s.url }}")        # s.url already carries the prefix
+        nav.should_not contain("{{ lang_prefix }}{{ s.url }}") # no double prefix
+      end
+    end
+
     it "wires pagination SEO links (rel=prev/next) into the header of SEO scaffolds" do
       # Regression: the engine builds `pagination_seo_links` (<link rel="prev"/
       # "next">) for paginated pages, but no scaffold rendered it, so paginated

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -514,12 +514,17 @@ module Hwaro
           <<-NAV
             <nav>
               <!-- Add links for new sections here (e.g. /notes/, /til/).
-                   Quick dynamic version (uncomment and remove the hardcoded links below):
-
+                   Dynamic version (copy out and remove the hardcoded links
+                   below). It lists only the current language's sections;
+                   s.url already includes the language prefix, so do NOT add
+                   lang_prefix. For custom ordering, set `weight` in each
+                   section's front matter and use sort(attribute="weight").
+                   (Wrapped in {% raw %} so the example isn't executed here.)
+                   {% raw %}
                    {% for s in site.sections | sort(attribute="title") %}
-                     {% if not s.transparent and s.name %}<a href="{{ base_url }}{{ lang_prefix }}{{ s.url }}">{{ s.title }}</a>{% endif %}
+                     {% if not s.transparent and s.name and s.language == page_language %}<a href="{{ base_url }}{{ s.url }}">{{ s.title }}</a>{% endif %}
                    {% endfor %}
-                   {# For custom ordering, set `weight` in each section's front matter and use sort(attribute="weight") #}
+                   {% endraw %}
               -->
               <a href="{{ base_url }}{{ lang_prefix }}/">Home</a>
               <a href="{{ base_url }}{{ lang_prefix }}/about/">About</a>

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -869,12 +869,17 @@ module Hwaro
                 <nav>
                   <!-- To add new top-level sections (e.g. /notes/, /projects/):
                        1. Create content/SECTION/_index.md
-                       2. Replace the links below with this compact dynamic loop:
-
+                       2. Replace the hardcoded links below with this dynamic
+                          loop. It shows only the current language's sections;
+                          s.url already carries the language prefix, so do NOT
+                          add lang_prefix. Sort by "weight" for explicit order.
+                       (Wrapped in {% raw %} so this example isn't executed
+                       while it lives in the comment.)
+                       {% raw %}
                        {% for s in site.sections | sort(attribute="title") %}
-                         {% if not s.transparent and s.name %}<a href="{{ base_url }}{{ lang_prefix }}{{ s.url }}">{{ s.title }}</a>{% endif %}
+                         {% if not s.transparent and s.name and s.language == page_language %}<a href="{{ base_url }}{{ s.url }}">{{ s.title }}</a>{% endif %}
                        {% endfor %}
-                       {# Use weight for explicit order: sort(attribute="weight") after setting weight in front matter #}
+                       {% endraw %}
                   -->
                   <a href="{{ base_url }}{{ lang_prefix }}/posts/">Posts</a>
                   <a href="{{ base_url }}{{ lang_prefix }}/archives/">Archives</a>


### PR DESCRIPTION
## Problem (deferred cycle-6 finding — H2)

The nav's "documentation" HTML comment contained a **live** `{% for s in site.sections %}` loop. Crinja processes `{% %}`/`{{ }}` even inside HTML comments, so it executed on every page — emitting hidden, **malformed** links into the comment. On Korean pages it produced `/ko/ko/posts/` because the example used `{{ lang_prefix }}{{ s.url }}` and `s.url` already carries the language prefix; it also listed every language's sections.

And the example was the *documented* pattern users are told to adopt — so copying it produced the same double-prefixed, cross-language nav.

## Fix

- Wrap the example in `{% raw %}…{% endraw %}` so Crinja keeps it as literal documentation instead of executing it (Crinja can't parse `{% %}` inside `{# #}` comments — it errors — so `{% raw %}` is the correct inert wrapper, not a Jinja comment).
- Correct the example pattern: filter to the current language (`{% if … and s.language == page_language %}`) and link via `{{ base_url }}{{ s.url }}` (no `lang_prefix`, since `s.url` is already prefixed).

Applied to the blog nav partial and the base nav (simple scaffold) — the two places with the live loop.

## Test

- Unit: both navs wrap the example in `{% raw %}`, use `s.language == page_language` + `{{ base_url }}{{ s.url }}`, and no longer contain `{{ lang_prefix }}{{ s.url }}`.
- Verified end-to-end: a multilingual `blog`/`simple` build emits **0** `/ko/ko/` anywhere; the example survives as literal text in the comment; and when copied into active use, the loop renders only the current language's sections with correct, non-doubled URLs (no en↔ko leak). format + ameba clean; full suite 5072 green.
