### PR TITLE
fix(permalinks): map nested paths to root for empty target

### DIFF
--- a/spec/unit/calculate_page_url_spec.cr
+++ b/spec/unit/calculate_page_url_spec.cr
@@ -265,6 +265,43 @@ describe Hwaro::Core::Build::Builder do
 
         page.url.should eq("/archive/2023/wip/")
       end
+
+      it "maps a flat file under an empty-target source to root" do
+        builder = Hwaro::Core::Build::Builder.new
+        config = Hwaro::Models::Config.new
+        config.permalinks = {"pages" => ""}
+        builder.test_set_config(config)
+
+        page = Hwaro::Models::Page.new("pages/about.md")
+        builder.test_calculate_page_url(page)
+
+        page.url.should eq("/about/")
+      end
+
+      it "maps a nested subdirectory under an empty-target source to root without doubling slashes" do
+        builder = Hwaro::Core::Build::Builder.new
+        config = Hwaro::Models::Config.new
+        config.permalinks = {"pages" => ""}
+        builder.test_set_config(config)
+
+        page = Hwaro::Models::Page.new("pages/contact/info.md")
+        builder.test_calculate_page_url(page)
+
+        page.url.should eq("/contact/info/")
+      end
+
+      it "maps a nested section index under an empty-target source to root without doubling slashes" do
+        builder = Hwaro::Core::Build::Builder.new
+        config = Hwaro::Models::Config.new
+        config.permalinks = {"pages" => ""}
+        builder.test_set_config(config)
+
+        page = Hwaro::Models::Page.new("pages/contact/_index.md")
+        page.is_index = true
+        builder.test_calculate_page_url(page)
+
+        page.url.should eq("/contact/")
+      end
     end
 
     # -----------------------------------------------------------------------

--- a/spec/unit/markdown_hooks_spec.cr
+++ b/spec/unit/markdown_hooks_spec.cr
@@ -42,6 +42,33 @@ describe Hwaro::Content::Hooks::MarkdownHooks do
       end
     end
 
+    it "maps a nested path to root for an empty-target permalink without doubling slashes" do
+      Dir.mktmpdir do |tmpdir|
+        content_dir = File.join(tmpdir, "content", "pages", "contact")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "form.md"), "---\ntitle: Contact\n---\nReach me")
+
+        Dir.cd(tmpdir) do
+          manager = Hwaro::Core::Lifecycle::Manager.new
+          hooks = Hwaro::Content::Hooks::MarkdownHooks.new
+          hooks.register_hooks(manager)
+
+          options = Hwaro::Config::Options::BuildOptions.new
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+          site_config = Hwaro::Models::Config.new
+          site_config.permalinks["pages"] = ""
+          ctx.config = site_config
+
+          page = Hwaro::Models::Page.new("pages/contact/form.md")
+          ctx.pages << page
+
+          manager.trigger(Hwaro::Core::Lifecycle::HookPoint::AfterReadContent, ctx)
+
+          page.url.should eq("/contact/form/")
+        end
+      end
+    end
+
     it "filters drafts when drafts option is false" do
       Dir.mktmpdir do |tmpdir|
         content_dir = File.join(tmpdir, "content")

--- a/spec/unit/platform_config_spec.cr
+++ b/spec/unit/platform_config_spec.cr
@@ -208,6 +208,23 @@ describe Hwaro::Services::PlatformConfig do
           end
         end
       end
+
+      it "maps a nested alias to root for an empty-target permalink without doubling slashes" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/pages/contact")
+            File.write("content/pages/contact/form.md", "---\ntitle: Contact\naliases:\n  - /old-contact/\n---\nContent here\n")
+
+            config = Hwaro::Models::Config.new
+            config.permalinks["pages"] = ""
+            generator = Hwaro::Services::PlatformConfig.new(config)
+            result = generator.generate("netlify")
+
+            result.should contain("to = \"/contact/form/\"")
+            result.should_not contain("to = \"//contact/form/\"")
+          end
+        end
+      end
     end
 
     describe "codeberg-pages" do

--- a/src/content/hooks/markdown_hooks.cr
+++ b/src/content/hooks/markdown_hooks.cr
@@ -170,7 +170,8 @@ module Hwaro
               effective_dir = target
               break
             elsif directory_path.starts_with?("#{source}/")
-              effective_dir = directory_path.sub(/^#{Regex.escape(source)}\//, "#{target}/")
+              rest = directory_path[(source.size + 1)..]
+              effective_dir = target.empty? ? rest : "#{target}/#{rest}"
               break
             end
           end

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -273,7 +273,8 @@ module Hwaro::Core::Build::Phases::ParseContent
           effective_dir = target
           break
         elsif directory_path.starts_with?("#{source}/")
-          effective_dir = target + directory_path[source.size..]
+          rest = directory_path[(source.size + 1)..]
+          effective_dir = target.empty? ? rest : "#{target}/#{rest}"
           break
         end
       end

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -326,7 +326,8 @@ module Hwaro
             effective_dir = target
             break
           elsif directory_path.starts_with?("#{source}/")
-            effective_dir = directory_path.sub(/^#{Regex.escape(source)}\//, "#{target}/")
+            rest = directory_path[(source.size + 1)..]
+            effective_dir = target.empty? ? rest : "#{target}/#{rest}"
             break
           end
         end


### PR DESCRIPTION
## Summary

Permalinks already support **prefix matching** — a parent entry like `"pages"` remaps every path under `pages/`. But when the target is the site **root** (an empty string), nested paths produced doubled slashes:

```
pages/contact/_index.md  =>  //contact/   ❌  (expected /contact/)
pages/privacy/_index.md  =>  //privacy/   ❌
```

The prefix branch appended the matched directory's remainder — which keeps its leading boundary slash (`/contact`) — directly onto the (empty) target, so `"" + "/contact"` became `effective_dir = "/contact"` and the URL builder emitted `/` + `/contact` + `/`.

## Fix

Strip the boundary slash from the remainder and only re-join it with the target when the target is non-empty — mirroring the empty-target handling the exact-match branch already had:

```crystal
rest = directory_path[(source.size + 1)..]
effective_dir = target.empty? ? rest : "#{target}/#{rest}"
```

The same loop was copy-pasted in three places, all carrying the bug; fixed identically in each:
- `src/core/build/phases/parse_content.cr`
- `src/content/hooks/markdown_hooks.cr`
- `src/services/platform_config.cr`

Non-empty targets are unchanged (`old/posts` → `archive` still yields `/archive/2024/article/`).

## Result

A single entry now exposes a whole tree at the root:

```toml
[permalinks]
"pages" = ""     # pages/contact/_index.md -> /contact/, pages/about.md -> /about/
"archive" = ""   # archive/blog/... -> /blog/...
```

No need to list each subdirectory individually.

## Tests

Added 3 specs to `spec/unit/calculate_page_url_spec.cr` covering empty-target mapping for a flat file, a nested page, and a nested section index. Full suite green: **5075 examples, 0 failures**. `crystal tool format --check` and `ameba` both clean.