### PR TITLE
fix: three multilingual/tooling bugs found by dogfooding

### DIFF
--- a/spec/functional/multilingual_spec.cr
+++ b/spec/functional/multilingual_spec.cr
@@ -367,4 +367,107 @@ describe "Multilingual: Taxonomy output" do
       ko.should_not contain("English Post")
     end
   end
+
+  it "honors the default language's per-language taxonomies list at the root" do
+    # The default language is served at the root and must respect its own
+    # `[languages.<default>].taxonomies` list, exactly like non-default
+    # languages do. Regression: the root previously used the global
+    # `[[taxonomies]]` set, so it emitted `/authors/` even though
+    # `languages.en.taxonomies` excluded it — while `/ko/authors/` was never
+    # emitted. That asymmetry produced dead links (the multilingual blog
+    # scaffold links to `/ko/authors/`).
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+      default_language = "en"
+
+      [[taxonomies]]
+      name = "tags"
+
+      [[taxonomies]]
+      name = "authors"
+
+      [languages.en]
+      language_name = "English"
+      weight = 1
+      taxonomies = ["tags"]
+
+      [languages.ko]
+      language_name = "한국어"
+      weight = 2
+      taxonomies = ["tags"]
+      TOML
+
+    build_site(
+      config,
+      content_files: {
+        "posts/_index.md"    => "---\ntitle: Posts\n---\n",
+        "posts/_index.ko.md" => "---\ntitle: 포스트\n---\n",
+        "posts/p.md"         => "---\ntitle: Post\ntags:\n  - x\nauthors:\n  - alice\n---\nEN",
+        "posts/p.ko.md"      => "---\ntitle: 글\ntags:\n  - x\nauthors:\n  - alice\n---\nKO",
+      },
+      template_files: {
+        "page.html"          => "{{ content }}",
+        "section.html"       => "{{ content }}",
+        "taxonomy.html"      => "<h1>{{ taxonomy_name }}</h1>",
+        "taxonomy_term.html" => "<h1>{{ taxonomy_term }}</h1>",
+      },
+    ) do
+      # Both languages enable `tags`, so tag pages exist for both spaces.
+      File.exists?("public/tags/x/index.html").should be_true
+      File.exists?("public/ko/tags/x/index.html").should be_true
+
+      # Neither language lists `authors`, so authors pages must NOT be emitted
+      # for either — including the default language at the root.
+      File.exists?("public/authors/index.html").should be_false
+      Dir.exists?("public/authors").should be_false
+      Dir.exists?("public/ko/authors").should be_false
+    end
+  end
+
+  it "emits a taxonomy for every language when each per-language list enables it" do
+    # Mirror of the scaffold's fixed config: the per-language `taxonomies`
+    # lists include `authors`, so both the root and the language-prefixed
+    # space generate it (no dead `/ko/authors/` link).
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+      default_language = "en"
+
+      [[taxonomies]]
+      name = "tags"
+
+      [[taxonomies]]
+      name = "authors"
+
+      [languages.en]
+      language_name = "English"
+      weight = 1
+      taxonomies = ["tags", "authors"]
+
+      [languages.ko]
+      language_name = "한국어"
+      weight = 2
+      taxonomies = ["tags", "authors"]
+      TOML
+
+    build_site(
+      config,
+      content_files: {
+        "posts/_index.md"    => "---\ntitle: Posts\n---\n",
+        "posts/_index.ko.md" => "---\ntitle: 포스트\n---\n",
+        "posts/p.md"         => "---\ntitle: Post\nauthors:\n  - alice\n---\nEN",
+        "posts/p.ko.md"      => "---\ntitle: 글\nauthors:\n  - alice\n---\nKO",
+      },
+      template_files: {
+        "page.html"          => "{{ content }}",
+        "section.html"       => "{{ content }}",
+        "taxonomy.html"      => "<h1>{{ taxonomy_name }}</h1>",
+        "taxonomy_term.html" => "<h1>{{ taxonomy_term }}</h1>",
+      },
+    ) do
+      File.exists?("public/authors/alice/index.html").should be_true
+      File.exists?("public/ko/authors/alice/index.html").should be_true
+    end
+  end
 end

--- a/spec/functional/multilingual_spec.cr
+++ b/spec/functional/multilingual_spec.cr
@@ -425,6 +425,53 @@ describe "Multilingual: Taxonomy output" do
     end
   end
 
+  it "emits all global taxonomies at the root when the default language omits the taxonomies key" do
+    # A `[languages.<default>]` block without a `taxonomies` key inherits the
+    # global set, so a third taxonomy (`authors`) is still emitted at the root
+    # rather than silently dropped — guards the upgrade path for hand-written
+    # configs that predate per-language taxonomy filtering.
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+      default_language = "en"
+
+      [[taxonomies]]
+      name = "tags"
+
+      [[taxonomies]]
+      name = "authors"
+
+      [languages.en]
+      language_name = "English"
+      weight = 1
+
+      [languages.ko]
+      language_name = "한국어"
+      weight = 2
+      TOML
+
+    build_site(
+      config,
+      content_files: {
+        "posts/_index.md"    => "---\ntitle: Posts\n---\n",
+        "posts/_index.ko.md" => "---\ntitle: 포스트\n---\n",
+        "posts/p.md"         => "---\ntitle: Post\ntags:\n  - x\nauthors:\n  - alice\n---\nEN",
+        "posts/p.ko.md"      => "---\ntitle: 글\ntags:\n  - x\nauthors:\n  - alice\n---\nKO",
+      },
+      template_files: {
+        "page.html"          => "{{ content }}",
+        "section.html"       => "{{ content }}",
+        "taxonomy.html"      => "<h1>{{ taxonomy_name }}</h1>",
+        "taxonomy_term.html" => "<h1>{{ taxonomy_term }}</h1>",
+      },
+    ) do
+      File.exists?("public/tags/x/index.html").should be_true
+      File.exists?("public/authors/alice/index.html").should be_true
+      # Non-default language inherits the global set too.
+      File.exists?("public/ko/authors/alice/index.html").should be_true
+    end
+  end
+
   it "emits a taxonomy for every language when each per-language list enables it" do
     # Mirror of the scaffold's fixed config: the per-language `taxonomies`
     # lists include `authors`, so both the root and the language-prefixed

--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -745,6 +745,12 @@ describe Hwaro::Core::Build::Builder do
       output.scan("alert").size.should eq(1)
       output.should contain("youtube")
       output.should contain("Crinja syntax")
+      # The message must show BOTH conversion forms: self-closing shortcodes
+      # (youtube/figure/gist) map to `{{ name(...) }}`, paired ones to the
+      # block `{% name(...) %}…{% end %}`. Advising the block form for a
+      # self-closing shortcode yields an unclosed tag that renders literally.
+      output.should contain("{{ name(arg=\"v\") }}")
+      output.should contain("{% name(arg=\"v\") %}")
     end
 
     it "stays silent when content has no Hugo-style shortcodes" do

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -1477,6 +1477,53 @@ describe Hwaro::Models::Config do
       ja.build_search_index.should be_false
     end
 
+    it "inherits the global taxonomy set when a language omits the taxonomies key" do
+      # A `[languages.<code>]` block without a `taxonomies` key must inherit the
+      # full global `[[taxonomies]]` set, not the hardcoded `["tags",
+      # "categories"]` default — otherwise a third taxonomy (e.g. `authors`)
+      # silently vanishes from that language's output (a regression for the
+      # default language served at the root).
+      config = load_config(<<-TOML)
+        title = "Test"
+        default_language = "en"
+
+        [[taxonomies]]
+        name = "tags"
+        [[taxonomies]]
+        name = "categories"
+        [[taxonomies]]
+        name = "authors"
+
+        [languages.en]
+        language_name = "English"
+
+        [languages.ko]
+        language_name = "한국어"
+        taxonomies = ["tags"]
+        TOML
+
+      # Omitted key → inherit every global taxonomy.
+      config.languages["en"].taxonomies.should eq(["tags", "categories", "authors"])
+      # Explicit key → honored verbatim (narrowing is still possible).
+      config.languages["ko"].taxonomies.should eq(["tags"])
+    end
+
+    it "honors an explicit empty taxonomies list (no inheritance)" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [[taxonomies]]
+        name = "tags"
+
+        [languages.ko]
+        language_name = "한국어"
+        taxonomies = []
+        TOML
+
+      # Explicit `[]` means "no taxonomies", distinct from an omitted key.
+      config.languages["ko"].taxonomies.should eq([] of String)
+    end
+
     it "loads language generate_feed = false from TOML (overrides default true)" do
       config = load_config(<<-TOML)
         title = "Test"

--- a/spec/unit/deadlink_command_spec.cr
+++ b/spec/unit/deadlink_command_spec.cr
@@ -112,6 +112,26 @@ describe Hwaro::CLI::Commands::Tool::DeadlinkCommand do
         links[0].url.should eq("https://nested.example.com")
       end
     end
+
+    it "ignores links inside fenced code blocks and inline code" do
+      Dir.mktmpdir do |dir|
+        content = <<-MD
+          Real link: [Real](https://real.example.com)
+
+          ```markdown
+          [Example](https://example.com/in-fence)
+          ```
+
+          Inline `[Inline](https://example.com/inline)` should be ignored too.
+          MD
+        File.write(File.join(dir, "test.md"), content)
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        links = cmd.find_links_for_test(dir)
+
+        links.map(&.url).should eq(["https://real.example.com"])
+      end
+    end
   end
 
   describe "#find_internal_links" do
@@ -149,6 +169,30 @@ describe Hwaro::CLI::Commands::Tool::DeadlinkCommand do
 
         links.size.should eq(1)
         links[0].url.should eq("/page/")
+      end
+    end
+
+    it "ignores internal links and images inside fenced code blocks" do
+      # Regression: the docs scaffold ships an image-syntax example
+      # `![Diagram](/images/diagram.png)` inside a ```markdown fence. It is a
+      # snippet, not a real image, so it must not be reported as a dead link.
+      Dir.mktmpdir do |dir|
+        content = <<-MD
+          Reference images like this:
+
+          ```markdown
+          ![Diagram](/images/diagram.png)
+          [Guide](/guide/missing/)
+          ```
+
+          But [this real link](/page/) should still be found.
+          MD
+        File.write(File.join(dir, "test.md"), content)
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        links = cmd.find_internal_links_for_test(dir)
+
+        links.map(&.url).should eq(["/page/"])
       end
     end
   end

--- a/spec/unit/scaffold_link_integrity_spec.cr
+++ b/spec/unit/scaffold_link_integrity_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../src/models/config"
 require "../../src/services/scaffolds/blog"
 require "../../src/services/scaffolds/blog_dark"
 require "../../src/services/scaffolds/docs"
@@ -36,8 +37,8 @@ private def extract_internal_links(body : String) : Array(String)
   links
 end
 
-describe "scaffold internal link integrity" do
-  scaffolds = {
+private def scaffold_fixtures
+  {
     "blog"      => Hwaro::Services::Scaffolds::Blog.new,
     "blog_dark" => Hwaro::Services::Scaffolds::BlogDark.new,
     "docs"      => Hwaro::Services::Scaffolds::Docs.new,
@@ -47,6 +48,19 @@ describe "scaffold internal link integrity" do
     "simple"    => Hwaro::Services::Scaffolds::Simple.new,
     "bare"      => Hwaro::Services::Scaffolds::Bare.new,
   }
+end
+
+private def load_config_from_string(toml : String) : Hwaro::Models::Config
+  File.tempfile("hwaro-scaffold-config", ".toml") do |file|
+    file.print(toml)
+    file.flush
+    return Hwaro::Models::Config.load(file.path)
+  end
+  raise "unreachable"
+end
+
+describe "scaffold internal link integrity" do
+  scaffolds = scaffold_fixtures
 
   scaffolds.each do |name, scaffold|
     it "#{name}: every internal link resolves to a generated page or auto-route" do
@@ -65,6 +79,32 @@ describe "scaffold internal link integrity" do
       end
 
       broken.should eq([] of String)
+    end
+  end
+end
+
+# Multilingual regression: the language-prefixed content the scaffold emits
+# rewrites taxonomy links to `/ko/tags/`, `/ko/authors/`, etc. Those resolve
+# only if the generated per-language `taxonomies` config enables that taxonomy
+# for the language. The per-language lists previously omitted `authors` while
+# the global `[[taxonomies]]` set (and the content links) included it, so a
+# multilingual blog emitted a dead `/ko/authors/` link.
+describe "scaffold multilingual taxonomy config integrity" do
+  scaffold_fixtures.each do |name, scaffold|
+    it "#{name}: every per-language taxonomies list covers the global taxonomy set" do
+      config = load_config_from_string(scaffold.minimal_config_content(false, ["en", "ko"]))
+
+      global_taxonomies = config.taxonomies.map(&.name).to_set
+      next if global_taxonomies.empty? # scaffolds without taxonomies (e.g. bare)
+
+      config.languages.each do |lang_code, lang_cfg|
+        missing = global_taxonomies - lang_cfg.taxonomies.to_set
+        missing.should(
+          eq(Set(String).new),
+          "language '#{lang_code}' omits taxonomies #{missing.to_a} that the global [[taxonomies]] " \
+          "defines; the root would emit them but '#{lang_code}' would not, leaving dead links"
+        )
+      end
     end
   end
 end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -166,12 +166,24 @@ module Hwaro
             Logger.info "----------------------------------------"
           end
 
+          # Markdown links inside fenced code blocks or inline code spans are
+          # documentation examples (e.g. a `![Diagram](/images/diagram.png)`
+          # snippet demonstrating image syntax), not real links. Strip them
+          # before scanning so `check-links` doesn't report false-positive dead
+          # links — mirrors the code-stripping the scaffold link-integrity spec
+          # already performs.
+          private def strip_code(content : String) : String
+            content
+              .gsub(/```[\s\S]*?```/, "")
+              .gsub(/`[^`\n]*`/, "")
+          end
+
           private def find_external_links(dir : String) : Array(Link)
             links = [] of Link
             link_regex = /(?:!\[[^\]]*?\]|\[[^\]]*?\])\((https?:\/\/[^\s\)]+)\)/
 
             Dir.glob("#{dir}/**/*.md").each do |file|
-              content = File.read(file)
+              content = strip_code(File.read(file))
               content.scan(link_regex) do |match|
                 links << Link.new(file: file, url: match[1], kind: :external)
               end
@@ -183,7 +195,7 @@ module Hwaro
             links = [] of Link
 
             Dir.glob("#{dir}/**/*.md").each do |file|
-              content = File.read(file)
+              content = strip_code(File.read(file))
 
               # Regular links (exclude images by using negative lookbehind)
               content.scan(/(?<!!)\[([^\]]*)\]\(([^\)]+)\)/) do |match|

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -34,7 +34,20 @@ module Hwaro
         # links and translated titles), a cross-language leak. Non-multilingual
         # sites pass `nil` (no filtering needed — every page is the one space).
         root_language = config.multilingual? ? config.default_language : nil
-        generate_taxonomies_for_language(config.taxonomies, site, output_dir, templates, builder, verbose, language: root_language, lang_prefix: "")
+
+        # On a multilingual site the default language is served at the root and,
+        # like every other language, should honor its own per-language
+        # `taxonomies` list. Previously the root always used the global
+        # `config.taxonomies`, so the default language silently ignored
+        # `[languages.<default>].taxonomies` while non-default languages
+        # respected theirs — an asymmetry that emitted e.g. `/authors/` but never
+        # `/ko/authors/` for identical per-language config. Fall back to the
+        # global list when the default language has no `[languages.<code>]` block.
+        root_taxonomies = config.taxonomies
+        if root_language && (default_cfg = config.languages[root_language]?)
+          root_taxonomies = config.taxonomies.select { |t| default_cfg.taxonomies.includes?(t.name) }
+        end
+        generate_taxonomies_for_language(root_taxonomies, site, output_dir, templates, builder, verbose, language: root_language, lang_prefix: "")
 
         # For multilingual sites, also generate language-prefixed taxonomy pages
         # (e.g. /en/tags/, /en/categories/) using only pages of that language.

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1697,11 +1697,15 @@ module Hwaro::Core::Build::Phases::Render
 
   # Hugo-style `{{< name >}}` shortcodes aren't a Hwaro syntax — they'd
   # otherwise reach Markdown unchanged and ship as HTML-escaped literals
-  # (`{{&lt; alert &gt;}}`) in the rendered page. The conversion is
-  # mechanical (`{{< name args >}}` → `{% name(args) %}`), but doing it
-  # silently would hide the migration step from the author. Warn once
-  # per page and list the distinct shortcode names so the message is
-  # actionable in a `hwaro build` log even with hundreds of pages.
+  # (`{{&lt; alert &gt;}}`) in the rendered page. The conversion depends on
+  # whether the shortcode wraps a body: self-closing Hugo shortcodes
+  # (`{{< youtube id="v" >}}`) map to the direct-call form `{{ youtube(id="v") }}`,
+  # while paired ones (`{{< alert >}}…{{< /alert >}}`) map to the block form
+  # `{% alert(…) %}…{% end %}`. Emitting `{% youtube(…) %}` for a self-closing
+  # shortcode produces an unclosed block tag that still ships as literal text,
+  # so the warning must show both forms. Warn once per page and list the
+  # distinct shortcode names so the message is actionable in a `hwaro build`
+  # log even with hundreds of pages.
   HUGO_SHORTCODE_RE = /\{\{<\s*\/?\s*([a-zA-Z_][\w\-]*)/
 
   private def warn_hugo_shortcode_syntax(raw : String, path : String) : Nil
@@ -1710,8 +1714,9 @@ module Hwaro::Core::Build::Phases::Render
     return if names.empty?
     sorted = names.to_a.sort
     Logger.warn "Hugo-style shortcode syntax `{{< … >}}` is not supported and will render as literal text in #{path}. " \
-                "Found: #{sorted.join(", ")}. Convert to Hwaro's Crinja syntax: " \
-                "`{{< name arg=\"v\" >}}body{{< /name >}}` → `{% name(arg=\"v\") %}body{% end %}` (or better: `{% endname %}`). Named closers are recommended."
+                "Found: #{sorted.join(", ")}. Convert to Hwaro's Crinja syntax — self-closing: " \
+                "`{{< name arg=\"v\" >}}` → `{{ name(arg=\"v\") }}`; with a body: " \
+                "`{{< name arg=\"v\" >}}body{{< /name >}}` → `{% name(arg=\"v\") %}body{% end %}` (named closer `{% endname %}` recommended)."
   end
 
   # Resolve the page kind into an `og:type` override. Returns "website"

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1325,6 +1325,16 @@ module Hwaro
 
           if taxonomies = lang_hash["taxonomies"]?.try(&.as_a?)
             lang_config.taxonomies = taxonomies.compact_map(&.as_s?)
+          else
+            # No per-language `taxonomies` key → inherit the global
+            # `[[taxonomies]]` set rather than the hardcoded `["tags",
+            # "categories"]` default. Otherwise a `[languages.<code>]` block
+            # that omits the key silently restricts that language to two
+            # taxonomies, dropping any third (e.g. `authors`) from its output —
+            # for the default language that means a taxonomy generated before
+            # this block existed would disappear at the root. `load_taxonomies`
+            # runs before `load_languages`, so `config.taxonomies` is populated.
+            lang_config.taxonomies = config.taxonomies.map(&.name)
           end
 
           config.languages[lang_code] = lang_config

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -279,7 +279,7 @@ module Hwaro
 
         lang_configs = languages.map_with_index do |lang, index|
           lang_name = language_display_name(lang)
-          taxonomies_line = skip_taxonomies ? "" : "\n  taxonomies = [\"tags\", \"categories\"]"
+          taxonomies_line = skip_taxonomies ? "" : "\n  taxonomies = [\"tags\", \"categories\", \"authors\"]"
           "  [languages.#{lang}]\n" \
           "  language_name = \"#{lang_name}\"\n" \
           "  weight = #{index + 1}\n" \

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -262,7 +262,7 @@ module Hwaro
               str << "[languages]\n"
               lang_blocks = multilingual_languages.map_with_index do |lang, index|
                 lang_name = language_display_name(lang)
-                tax_line = skip_taxonomies ? "" : "\n  taxonomies = [\"tags\", \"categories\"]"
+                tax_line = skip_taxonomies ? "" : "\n  taxonomies = [\"tags\", \"categories\", \"authors\"]"
                 "  [languages.#{lang}]\n" \
                 "  language_name = \"#{lang_name}\"\n" \
                 "  weight = #{index + 1}\n" \


### PR DESCRIPTION
## Summary

도구를 직접 빌드해서 여러 scaffold(blog/docs/book/simple)로 멀티링궐 사이트를 만들고, 내장 진단 명령(`check-links`/`doctor`/`validate`)과 출력물 점검을 통해 발견한 **실제 버그들**을 수정합니다. 각 수정에는 회귀 테스트가 포함되며, 전체 스펙(5100 examples)과 lint(`crystal tool format` + `ameba`)를 통과합니다.

## 1. 멀티링궐 taxonomy 비대칭 → `/ko/authors/` 죽은 링크 (`fix(taxonomies)`)

멀티링궐에서 **기본 언어(root)** 는 전역 `[[taxonomies]]` 로 생성하고, **비기본 언어**만 언어별 `taxonomies` 목록으로 필터링했습니다. 즉 `[languages.<default>].taxonomies` 가 무시되어 `/authors/` 는 생기는데 `/ko/authors/` 는 안 생겼습니다.

- **엔진**(`taxonomies.cr`): root도 기본 언어의 언어별 목록을 따르도록 수정(해당 블록이 없으면 전역 집합으로 fallback).
- **Scaffold**(`base.cr`, `initializer.cr`): 언어별 목록이 `["tags","categories"]` 로 하드코딩돼 `authors` 가 빠져 있었으나, 전역 설정·콘텐츠 링크와 맞게 `authors` 추가.

결과: 멀티링궐 blog scaffold의 `check-links` 가 *죽은 링크 1개 → 12개 모두 정상*.

## 2. 언어별 `taxonomies` 키 생략 시 전역 집합 상속 (`fix(config)`) — 리뷰 반영

`[languages.<code>]` 블록이 `taxonomies` 키를 생략하면 `LanguageConfig` 기본값 `["tags","categories"]` 가 유지되어, 1번 수정 후 세 번째 전역 taxonomy(예: `authors`)가 root에서 조용히 사라지는 **업그레이드 회귀**가 생겼습니다(직접 재현 확인). 키 생략 시 전역 `[[taxonomies]]` 집합을 상속하도록 수정 — 명시적 목록(빈 목록 포함)은 그대로 존중합니다.

## 3. `check-links` 가 코드 펜스 내부 링크를 오탐 (`fix(check-links)`)

원본 Markdown을 그대로 스캔해 ` ```markdown ` 펜스/인라인 코드 안의 예시 링크·이미지를 실제 링크로 취급했습니다(docs scaffold의 `![Diagram](/images/diagram.png)`). 스캔 전 코드 영역 제거로 수정.

결과: docs scaffold *죽은 링크 2개 → 18개 모두 정상*, 실제 링크는 계속 검사.

## 4. Hugo 마이그레이션 경고가 self-closing shortcode에 잘못된 안내 (`fix(shortcodes)`)

경고가 `{{< name args >}}` → `{% name(args) %}` 만 안내했는데, `{% %}` 는 `{% end %}` 닫힘이 필요한 블록(쌍) 형식이라 self-closing shortcode(youtube 등)는 그대로 literal로 깨집니다. 두 형식을 모두 안내하도록 수정: self-closing → `{{ name(args) }}`, 쌍 → `{% name(args) %}body{% end %}`.

## 이상 없이 확인된 항목 (버그 아님)

sitemap/RSS/feeds XML 이스케이프(`& < > " '`), TOML↔YAML↔JSON front matter 라운드트립, task list/footnote/definition list, `{{ }}` shortcode.

## Test plan

- [x] `crystal spec` — 5100 examples, 0 failures
- [x] `crystal tool format --check` / `./bin/ameba` — 통과
- [x] CI(lint, tests 1.19/1.20, docker amd64/arm64) 전부 pass
- [x] 각 수정 전 회귀 테스트 실패 → 수정 후 통과 확인