### PR TITLE
docs(landing): add install-method dropdown to Start building CTA

### DIFF
--- a/docs/static/assets/css/07-landing.css
+++ b/docs/static/assets/css/07-landing.css
@@ -650,16 +650,163 @@
     margin-bottom: 2.5rem;
 }
 
-.cta-install code {
+.install-picker {
+    position: relative;
+    display: inline-flex;
+    align-items: stretch;
+    background: #0a0a0c;
+    border: 1px solid #1a1a1e;
+    border-radius: 8px;
+    text-align: left;
+}
+
+.install-method {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: transparent;
+    border: none;
+    border-right: 1px solid #1a1a1e;
+    color: #ccc;
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+    font-weight: 500;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    border-radius: 8px 0 0 8px;
+    transition: background 0.15s ease, color 0.15s ease;
+    white-space: nowrap;
+}
+
+.install-method:hover {
+    background: #121216;
+    color: #fff;
+}
+
+.install-method-caret {
+    color: #666;
+    transition: transform 0.2s ease;
+}
+
+.install-method[aria-expanded="true"] .install-method-caret {
+    transform: rotate(180deg);
+}
+
+.install-command {
+    display: flex;
+    align-items: center;
     font-family: var(--font-mono);
     font-size: 0.9rem;
     color: #999;
-    background: #0a0a0c;
-    border: 1px solid #1a1a1e;
-    padding: 0.75rem 1.5rem;
-    border-radius: 8px;
-    display: inline-block;
+    padding: 0.75rem 1.25rem;
     letter-spacing: 0.01em;
+    white-space: nowrap;
+}
+
+.install-copy {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-left: 1px solid #1a1a1e;
+    color: #666;
+    padding: 0 1rem;
+    cursor: pointer;
+    border-radius: 0 8px 8px 0;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.install-copy:hover {
+    background: #121216;
+    color: #fff;
+}
+
+.install-copy.is-copied {
+    color: #4ade80;
+}
+
+.install-copy-check {
+    display: none;
+}
+
+.install-copy.is-copied .install-copy-icon {
+    display: none;
+}
+
+.install-copy.is-copied .install-copy-check {
+    display: block;
+}
+
+.install-menu {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    left: 0;
+    right: 0;
+    margin: 0;
+    padding: 0.35rem;
+    list-style: none;
+    background: #0c0c0f;
+    border: 1px solid #1f1f24;
+    border-radius: 10px;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+    z-index: 20;
+    opacity: 0;
+    transform: translateY(-6px);
+    pointer-events: none;
+    transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.install-picker.is-open .install-menu {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.install-option {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.6rem 0.85rem;
+    border-radius: 7px;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.install-option:hover,
+.install-option.is-selected {
+    background: #16161b;
+}
+
+.install-option-name {
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #eee;
+}
+
+.install-option-cmd {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: #777;
+}
+
+.install-more {
+    margin: 1.25rem 0 0 0;
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+}
+
+.install-more a {
+    color: #666;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.install-more a:hover {
+    color: #fff;
+    border-bottom-color: #444;
 }
 
 .cta-buttons {
@@ -748,5 +895,37 @@
 
     .landing-cta p {
         font-size: 1.2rem;
+    }
+
+    .install-more {
+        font-size: 0.85rem;
+    }
+
+    .install-picker {
+        flex-direction: column;
+        align-items: stretch;
+        width: 100%;
+        max-width: 360px;
+        margin: 0 auto;
+    }
+
+    .install-method {
+        justify-content: space-between;
+        border-right: none;
+        border-bottom: 1px solid #1a1a1e;
+        border-radius: 8px 8px 0 0;
+    }
+
+    .install-command {
+        justify-content: center;
+        font-size: 0.82rem;
+        overflow-x: auto;
+    }
+
+    .install-copy {
+        border-left: none;
+        border-top: 1px solid #1a1a1e;
+        border-radius: 0 0 8px 8px;
+        padding: 0.6rem;
     }
 }

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -409,7 +409,149 @@
                     One command to install. Three lines to deploy.
                 </p>
                 <div class="cta-install">
-                    <code>brew install hwaro/hwaro/hwaro</code>
+                    <div class="install-picker" id="install-picker">
+                        <button
+                            type="button"
+                            class="install-method"
+                            id="install-method-btn"
+                            aria-haspopup="listbox"
+                            aria-expanded="false"
+                        >
+                            <span
+                                class="install-method-name"
+                                id="install-method-name"
+                                >Homebrew</span
+                            >
+                            <svg
+                                class="install-method-caret"
+                                width="10"
+                                height="6"
+                                viewBox="0 0 10 6"
+                                fill="none"
+                                aria-hidden="true"
+                            >
+                                <path
+                                    d="M1 1l4 4 4-4"
+                                    stroke="currentColor"
+                                    stroke-width="1.5"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                />
+                            </svg>
+                        </button>
+                        <code class="install-command" id="install-command"
+                            >brew install hahwul/hwaro/hwaro</code
+                        >
+                        <button
+                            type="button"
+                            class="install-copy"
+                            id="install-copy"
+                            aria-label="Copy command"
+                        >
+                            <svg
+                                class="install-copy-icon"
+                                width="15"
+                                height="15"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                aria-hidden="true"
+                            >
+                                <rect
+                                    x="9"
+                                    y="9"
+                                    width="11"
+                                    height="11"
+                                    rx="2"
+                                    stroke="currentColor"
+                                    stroke-width="1.8"
+                                />
+                                <path
+                                    d="M5 15V5a2 2 0 0 1 2-2h10"
+                                    stroke="currentColor"
+                                    stroke-width="1.8"
+                                    stroke-linecap="round"
+                                />
+                            </svg>
+                            <svg
+                                class="install-copy-check"
+                                width="15"
+                                height="15"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                aria-hidden="true"
+                            >
+                                <path
+                                    d="M4 12.5l5 5 11-11"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                />
+                            </svg>
+                        </button>
+                        <ul
+                            class="install-menu"
+                            id="install-menu"
+                            role="listbox"
+                            aria-label="Installation method"
+                        >
+                            <li
+                                class="install-option is-selected"
+                                role="option"
+                                aria-selected="true"
+                                data-label="Homebrew"
+                                data-command="brew install hahwul/hwaro/hwaro"
+                            >
+                                <span class="install-option-name">Homebrew</span>
+                                <span class="install-option-cmd"
+                                    >brew install hahwul/hwaro/hwaro</span
+                                >
+                            </li>
+                            <li
+                                class="install-option"
+                                role="option"
+                                aria-selected="false"
+                                data-label="Snap"
+                                data-command="sudo snap install hwaro"
+                            >
+                                <span class="install-option-name">Snap</span>
+                                <span class="install-option-cmd"
+                                    >sudo snap install hwaro</span
+                                >
+                            </li>
+                            <li
+                                class="install-option"
+                                role="option"
+                                aria-selected="false"
+                                data-label="AUR"
+                                data-command="yay -S hwaro"
+                            >
+                                <span class="install-option-name"
+                                    >AUR (Arch)</span
+                                >
+                                <span class="install-option-cmd"
+                                    >yay -S hwaro</span
+                                >
+                            </li>
+                            <li
+                                class="install-option"
+                                role="option"
+                                aria-selected="false"
+                                data-label="Nix"
+                                data-command="nix profile install github:hahwul/hwaro"
+                            >
+                                <span class="install-option-name">Nix</span>
+                                <span class="install-option-cmd"
+                                    >nix profile install github:hahwul/hwaro</span
+                                >
+                            </li>
+                        </ul>
+                    </div>
+                    <p class="install-more">
+                        <a href="{{ base_url }}/start/installation/"
+                            >DEB · RPM · APK · build from source &amp; more →</a
+                        >
+                    </p>
                 </div>
                 <div class="cta-buttons">
                     <a href="{{ base_url }}/start/" class="btn btn-primary"
@@ -511,6 +653,74 @@
                 requestAnimationFrame(loop);
             }
             loop();
+        })();
+        </script>
+        <script>
+        (function() {
+            var picker = document.getElementById('install-picker');
+            if (!picker) return;
+            var btn = document.getElementById('install-method-btn');
+            var nameEl = document.getElementById('install-method-name');
+            var cmdEl = document.getElementById('install-command');
+            var copyBtn = document.getElementById('install-copy');
+            var options = picker.querySelectorAll('.install-option');
+            var copyTimer;
+
+            function close() {
+                picker.classList.remove('is-open');
+                btn.setAttribute('aria-expanded', 'false');
+            }
+
+            btn.addEventListener('click', function(e) {
+                e.stopPropagation();
+                var open = picker.classList.toggle('is-open');
+                btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+            });
+
+            for (var i = 0; i < options.length; i++) {
+                options[i].addEventListener('click', function() {
+                    for (var j = 0; j < options.length; j++) {
+                        options[j].classList.remove('is-selected');
+                        options[j].setAttribute('aria-selected', 'false');
+                    }
+                    this.classList.add('is-selected');
+                    this.setAttribute('aria-selected', 'true');
+                    nameEl.textContent = this.getAttribute('data-label');
+                    cmdEl.textContent = this.getAttribute('data-command');
+                    close();
+                });
+            }
+
+            copyBtn.addEventListener('click', function() {
+                var text = cmdEl.textContent.trim();
+                var done = function() {
+                    copyBtn.classList.add('is-copied');
+                    clearTimeout(copyTimer);
+                    copyTimer = setTimeout(function() {
+                        copyBtn.classList.remove('is-copied');
+                    }, 1600);
+                };
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(text).then(done, function() {});
+                } else {
+                    var ta = document.createElement('textarea');
+                    ta.value = text;
+                    ta.setAttribute('readonly', '');
+                    ta.style.position = 'absolute';
+                    ta.style.left = '-9999px';
+                    document.body.appendChild(ta);
+                    ta.select();
+                    try { document.execCommand('copy'); done(); } catch (e) {}
+                    document.body.removeChild(ta);
+                }
+            });
+
+            document.addEventListener('click', function(e) {
+                if (!picker.contains(e.target)) close();
+            });
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape') close();
+            });
         })();
         </script>
     </body>


### PR DESCRIPTION
## Summary

Improves the **"Start building."** CTA on the docs landing page. Instead of a single static `brew` command, visitors now get an interactive install-method picker.

- Dropdown to switch between four one-line installers: **Homebrew**, **Snap**, **AUR (Arch)**, **Nix** — selecting one swaps the displayed command live.
- Copy-to-clipboard button with checkmark feedback (`navigator.clipboard` + `execCommand` fallback).
- Secondary link to the full installation guide for the multi-step methods (DEB / RPM / APK / build from source).
- Closes the dropdown on outside-click and `Escape`; styled to match the existing dark landing aesthetic; stacks vertically on mobile.

## Drive-by fix

The landing showed `brew install hwaro/hwaro/hwaro`, but the Homebrew tap is `hahwul/hwaro`. Corrected the shorthand to `brew install hahwul/hwaro/hwaro`, now consistent with `docs/content/start/installation.md`.

## Testing

- `crystal tool format --check` — clean (no `.cr` files touched).
- `hwaro build` — succeeds (64 pages); rendered `public/index.html` contains the dropdown markup, all four commands, the corrected brew command, and the installation-guide link.

## Files

- `docs/templates/index.html` — picker markup + vanilla-JS interaction.
- `docs/static/assets/css/07-landing.css` — picker/menu/copy styles + mobile responsive rules.