### PR TITLE
fix: base_url subpath support for alias redirects and PWA URLs

### DIFF
--- a/docs/content/features/pwa.md
+++ b/docs/content/features/pwa.md
@@ -45,6 +45,8 @@ cache_strategy = "cache-first"
 | precache_urls | array | [] | URLs to cache during service worker install |
 | cache_strategy | string | `"cache-first"` | Asset fetch strategy: `cache-first`, `network-first`, or `stale-while-revalidate` |
 
+> Write `start_url`, `icons`, `offline_page`, and `precache_urls` as plain root-relative paths **without** your `base_url` prefix (e.g. `start_url = "/"`, not `"/repo/"`). When `base_url` includes a subpath (GitHub Pages project sites), Hwaro prepends it automatically in the generated `manifest.json` and `sw.js`.
+
 ## Icon Sizing
 
 Icon sizes are automatically extracted from filenames:

--- a/spec/functional/build_integration_spec.cr
+++ b/spec/functional/build_integration_spec.cr
@@ -421,6 +421,22 @@ describe "Build Integration: Redirects" do
       File.exists?("public/promo.html/index.html").should be_false
     end
   end
+
+  it "prefixes alias redirects with base_url's path for subpath deployments" do
+    # GitHub/GitLab project pages serve the site under a subpath. The alias
+    # redirect must include that prefix or it 404s (it previously emitted a
+    # bare `/posts/.../` that resolved against the domain root).
+    build_site(
+      "title = \"T\"\nbase_url = \"https://example.com/myblog\"\n",
+      content_files: {
+        "posts/new.md" => "---\ntitle: New\naliases:\n  - /old/\n  - /legacy.html\n---\nNew",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+    ) do
+      File.read("public/old/index.html").should contain("url=/myblog/posts/new/")
+      File.read("public/legacy.html").should contain("url=/myblog/posts/new/")
+    end
+  end
 end
 
 # ---------------------------------------------------------------------------

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -149,6 +149,40 @@ describe Hwaro::Models::Config do
     end
   end
 
+  describe "#base_path" do
+    it "returns the path component for a subpath deployment" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com/myblog/"
+      config.base_path.should eq("/myblog")
+    end
+
+    it "returns a nested path component" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com/a/b"
+      config.base_path.should eq("/a/b")
+    end
+
+    it "returns an empty string for a domain-root base_url" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+      config.base_path.should eq("")
+    end
+
+    it "returns an empty string for an empty base_url" do
+      config = Hwaro::Models::Config.new
+      config.base_url = ""
+      config.base_path.should eq("")
+    end
+
+    it "recomputes after base_url is reassigned" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com/one"
+      config.base_path.should eq("/one")
+      config.base_url = "https://example.com/two"
+      config.base_path.should eq("/two")
+    end
+  end
+
   describe "#initialize" do
     it "has default values" do
       config = Hwaro::Models::Config.new

--- a/spec/unit/pwa_spec.cr
+++ b/spec/unit/pwa_spec.cr
@@ -1,11 +1,11 @@
 require "../spec_helper"
 require "json"
 
-private def make_site(pwa_toml : String = "") : Hwaro::Models::Site
+private def make_site(pwa_toml : String = "", base_url : String = "https://example.com") : Hwaro::Models::Site
   config_str = <<-TOML
     title = "Test Site"
     description = "A test site"
-    base_url = "https://example.com"
+    base_url = "#{base_url}"
     #{pwa_toml}
     TOML
 
@@ -230,6 +230,70 @@ describe Hwaro::Content::Seo::Pwa do
 
         content = File.read(File.join(dir, "sw.js"))
         content.should contain("/offline.html")
+      end
+    end
+
+    # GitHub/GitLab project pages serve the site under a subpath. Every
+    # site-internal root-relative PWA URL must carry that prefix or the
+    # installed app launches the wrong origin and the precache keys never
+    # match the requests the page actually makes.
+    context "with a subpath base_url" do
+      it "prefixes start_url and icon srcs in the manifest" do
+        Dir.mktmpdir do |dir|
+          site = make_site(<<-TOML, base_url: "https://user.github.io/myrepo/")
+            [pwa]
+            enabled = true
+            icons = ["static/icon-192.png", "https://cdn.example.com/icon.png"]
+            TOML
+
+          Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+          manifest = JSON.parse(File.read(File.join(dir, "manifest.json")))
+          manifest["start_url"].as_s.should eq("/myrepo/")
+          icons = manifest["icons"].as_a
+          icons[0]["src"].as_s.should eq("/myrepo/icon-192.png")
+          # Absolute icon URLs are left untouched.
+          icons[1]["src"].as_s.should eq("https://cdn.example.com/icon.png")
+        end
+      end
+
+      it "prefixes precache URLs, offline page, and the navigation fallback in sw.js" do
+        Dir.mktmpdir do |dir|
+          site = make_site(<<-TOML, base_url: "https://user.github.io/myrepo/")
+            [pwa]
+            enabled = true
+            offline_page = "/offline.html"
+            precache_urls = ["/", "/css/main.css"]
+            cache_strategy = "network-first"
+            TOML
+
+          Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+          content = File.read(File.join(dir, "sw.js"))
+          content.should contain(%("/myrepo/"))
+          content.should contain(%("/myrepo/css/main.css"))
+          content.should contain(%("/myrepo/offline.html"))
+          # The hardcoded root fallback must follow the subpath too.
+          content.should contain(%(caches.match("/myrepo/offline.html") || caches.match("/myrepo/")))
+          # No bare-root key should leak through.
+          content.should_not contain(%(caches.match("/")))
+        end
+      end
+
+      it "leaves URLs untouched for a domain-root base_url" do
+        Dir.mktmpdir do |dir|
+          site = make_site(<<-TOML, base_url: "https://example.com")
+            [pwa]
+            enabled = true
+            precache_urls = ["/css/main.css"]
+            TOML
+
+          Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+          manifest = JSON.parse(File.read(File.join(dir, "manifest.json")))
+          manifest["start_url"].as_s.should eq("/")
+          File.read(File.join(dir, "sw.js")).should contain(%("/css/main.css"))
+        end
       end
     end
   end

--- a/src/content/seo/pwa.cr
+++ b/src/content/seo/pwa.cr
@@ -17,10 +17,11 @@ module Hwaro
         private def self.generate_manifest(site : Models::Site, output_dir : String, verbose : Bool)
           config = site.config
           pwa = config.pwa
+          base_path = config.base_path
 
           icons = pwa.icons.map do |icon_path|
             size = extract_icon_size(icon_path)
-            url_path = normalize_icon_path(icon_path)
+            url_path = with_base_path(normalize_icon_path(icon_path), base_path)
             {
               "src"   => url_path,
               "sizes" => size,
@@ -33,7 +34,7 @@ module Hwaro
               json.field "name", pwa.name || config.title
               json.field "short_name", pwa.short_name || pwa.name || config.title
               json.field "description", config.description unless config.description.empty?
-              json.field "start_url", pwa.start_url
+              json.field "start_url", with_base_path(pwa.start_url, base_path)
               json.field "display", pwa.display
               json.field "theme_color", pwa.theme_color
               json.field "background_color", pwa.background_color
@@ -63,29 +64,38 @@ module Hwaro
         private def self.generate_service_worker(site : Models::Site, output_dir : String, verbose : Bool)
           config = site.config
           pwa = config.pwa
+          base_path = config.base_path
 
-          # Build precache URL list
-          precache_urls = pwa.precache_urls.dup
-          precache_urls << pwa.start_url unless precache_urls.includes?(pwa.start_url)
+          # Resolve the launch URL against base_url's path so the precache key
+          # and the navigation fallback match what the page actually loads from
+          # on a subpath deployment (e.g. `/myrepo/` rather than `/`).
+          resolved_start = with_base_path(pwa.start_url, base_path)
+
+          # Build precache URL list (each entry is a site-internal root-relative
+          # path that must carry the subpath prefix, same as start_url).
+          precache_urls = pwa.precache_urls.map { |u| with_base_path(u, base_path) }
+          precache_urls << resolved_start unless precache_urls.includes?(resolved_start)
           if offline = pwa.offline_page
-            precache_urls << offline unless precache_urls.includes?(offline)
+            resolved_offline = with_base_path(offline, base_path)
+            precache_urls << resolved_offline unless precache_urls.includes?(resolved_offline)
           end
 
           precache_json = precache_urls.map(&.inspect).join(",\n  ")
           offline_url = if op = pwa.offline_page
-                          op.inspect
+                          with_base_path(op, base_path).inspect
                         else
-                          pwa.start_url.inspect
+                          resolved_start.inspect
                         end
+          root_url = resolved_start.inspect
           cache_version = Time.utc.to_unix
 
           fetch_handler = case pwa.cache_strategy
                           when "network-first"
-                            network_first_handler(offline_url)
+                            network_first_handler(offline_url, root_url)
                           when "stale-while-revalidate"
-                            stale_while_revalidate_handler(offline_url)
+                            stale_while_revalidate_handler(offline_url, root_url)
                           else
-                            cache_first_handler(offline_url)
+                            cache_first_handler(offline_url, root_url)
                           end
 
           sw_content = <<-JS
@@ -121,13 +131,13 @@ module Hwaro
 
         # --- Fetch handler strategies ---
 
-        private def self.cache_first_handler(offline_url : String) : String
+        private def self.cache_first_handler(offline_url : String, root_url : String) : String
           <<-JS
             self.addEventListener('fetch', event => {
               if (event.request.mode === 'navigate') {
                 event.respondWith(
                   fetch(event.request).catch(() =>
-                    caches.match(#{offline_url}) || caches.match('/')
+                    caches.match(#{offline_url}) || caches.match(#{root_url})
                   )
                 );
                 return;
@@ -147,7 +157,7 @@ module Hwaro
             JS
         end
 
-        private def self.network_first_handler(offline_url : String) : String
+        private def self.network_first_handler(offline_url : String, root_url : String) : String
           <<-JS
             self.addEventListener('fetch', event => {
               event.respondWith(
@@ -160,7 +170,7 @@ module Hwaro
                 }).catch(() =>
                   caches.match(event.request).then(cached =>
                     cached || (event.request.mode === 'navigate'
-                      ? caches.match(#{offline_url}) || caches.match('/')
+                      ? caches.match(#{offline_url}) || caches.match(#{root_url})
                       : undefined)
                   )
                 )
@@ -169,7 +179,7 @@ module Hwaro
             JS
         end
 
-        private def self.stale_while_revalidate_handler(offline_url : String) : String
+        private def self.stale_while_revalidate_handler(offline_url : String, root_url : String) : String
           <<-JS
             self.addEventListener('fetch', event => {
               event.respondWith(
@@ -182,7 +192,7 @@ module Hwaro
                     return response;
                   }).catch(() => {
                     if (event.request.mode === 'navigate') {
-                      return caches.match(#{offline_url}) || caches.match('/');
+                      return caches.match(#{offline_url}) || caches.match(#{root_url});
                     }
                     return undefined;
                   });
@@ -191,6 +201,18 @@ module Hwaro
               );
             });
             JS
+        end
+
+        # Prefix a site-internal root-relative path with `base_url`'s path
+        # component so manifest/service-worker URLs resolve on subpath
+        # deployments (e.g. GitHub Pages project sites under `/repo/`). Absolute
+        # URLs and non-root-relative values are returned unchanged; `base_path`
+        # is "" for a domain-root deployment, so this is a no-op there.
+        private def self.with_base_path(path : String, base_path : String) : String
+          return path if base_path.empty?
+          return path if path.starts_with?("http://") || path.starts_with?("https://")
+          return path unless path.starts_with?("/")
+          "#{base_path}#{path}"
         end
 
         # Normalize icon path to a URL path.

--- a/src/content/seo/pwa.cr
+++ b/src/content/seo/pwa.cr
@@ -17,11 +17,10 @@ module Hwaro
         private def self.generate_manifest(site : Models::Site, output_dir : String, verbose : Bool)
           config = site.config
           pwa = config.pwa
-          base_path = config.base_path
 
           icons = pwa.icons.map do |icon_path|
             size = extract_icon_size(icon_path)
-            url_path = with_base_path(normalize_icon_path(icon_path), base_path)
+            url_path = config.with_base_path(normalize_icon_path(icon_path))
             {
               "src"   => url_path,
               "sizes" => size,
@@ -34,7 +33,7 @@ module Hwaro
               json.field "name", pwa.name || config.title
               json.field "short_name", pwa.short_name || pwa.name || config.title
               json.field "description", config.description unless config.description.empty?
-              json.field "start_url", with_base_path(pwa.start_url, base_path)
+              json.field "start_url", config.with_base_path(pwa.start_url)
               json.field "display", pwa.display
               json.field "theme_color", pwa.theme_color
               json.field "background_color", pwa.background_color
@@ -64,25 +63,24 @@ module Hwaro
         private def self.generate_service_worker(site : Models::Site, output_dir : String, verbose : Bool)
           config = site.config
           pwa = config.pwa
-          base_path = config.base_path
 
           # Resolve the launch URL against base_url's path so the precache key
           # and the navigation fallback match what the page actually loads from
           # on a subpath deployment (e.g. `/myrepo/` rather than `/`).
-          resolved_start = with_base_path(pwa.start_url, base_path)
+          resolved_start = config.with_base_path(pwa.start_url)
 
           # Build precache URL list (each entry is a site-internal root-relative
           # path that must carry the subpath prefix, same as start_url).
-          precache_urls = pwa.precache_urls.map { |u| with_base_path(u, base_path) }
+          precache_urls = pwa.precache_urls.map { |u| config.with_base_path(u) }
           precache_urls << resolved_start unless precache_urls.includes?(resolved_start)
           if offline = pwa.offline_page
-            resolved_offline = with_base_path(offline, base_path)
+            resolved_offline = config.with_base_path(offline)
             precache_urls << resolved_offline unless precache_urls.includes?(resolved_offline)
           end
 
           precache_json = precache_urls.map(&.inspect).join(",\n  ")
           offline_url = if op = pwa.offline_page
-                          with_base_path(op, base_path).inspect
+                          config.with_base_path(op).inspect
                         else
                           resolved_start.inspect
                         end
@@ -201,18 +199,6 @@ module Hwaro
               );
             });
             JS
-        end
-
-        # Prefix a site-internal root-relative path with `base_url`'s path
-        # component so manifest/service-worker URLs resolve on subpath
-        # deployments (e.g. GitHub Pages project sites under `/repo/`). Absolute
-        # URLs and non-root-relative values are returned unchanged; `base_path`
-        # is "" for a domain-root deployment, so this is a no-op there.
-        private def self.with_base_path(path : String, base_path : String) : String
-          return path if base_path.empty?
-          return path if path.starts_with?("http://") || path.starts_with?("https://")
-          return path unless path.starts_with?("/")
-          "#{base_path}#{path}"
         end
 
         # Normalize icon path to a URL path.

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -448,7 +448,7 @@ module Hwaro::Core::Build::Phases::Render
     # Handle redirect_to for pages AND sections
     if page.has_redirect?
       generate_redirect_page(page, output_dir, verbose)
-      generate_aliases(page, output_dir, verbose)
+      generate_aliases(page, site, output_dir, verbose)
       return
     end
 
@@ -547,7 +547,7 @@ module Hwaro::Core::Build::Phases::Render
       write_output(page, output_dir, final_html, verbose)
     end
 
-    generate_aliases(page, output_dir, verbose)
+    generate_aliases(page, site, output_dir, verbose)
   end
 
   private def generate_redirect_page(
@@ -676,7 +676,7 @@ module Hwaro::Core::Build::Phases::Render
     "page"
   end
 
-  private def generate_aliases(page : Models::Page, output_dir : String, verbose : Bool)
+  private def generate_aliases(page : Models::Page, site : Models::Site, output_dir : String, verbose : Bool)
     page.aliases.each do |alias_path|
       alias_clean = Utils::PathUtils.sanitize_path(alias_path.lchop("/"))
       # An alias that already names an HTML file (`/legacy.html`,
@@ -693,7 +693,13 @@ module Hwaro::Core::Build::Phases::Render
 
       ensure_dir(File.dirname(dest_path))
 
-      redirect_url = page.url
+      # Prefix the page's root-relative URL with `base_url`'s path component so
+      # the redirect still resolves when the site is deployed under a subpath
+      # (e.g. GitHub Pages project sites at `/repo/`). `base_path` is "" for a
+      # domain-root deployment, leaving `/posts/x/` unchanged.
+      target = page.url
+      target = "/#{target}" unless target.starts_with?('/')
+      redirect_url = "#{site.config.base_path}#{target}"
       File.write(dest_path, Utils::RedirectHtml.simple_redirect(redirect_url))
       Logger.action :create, dest_path, :yellow if verbose
     end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -695,11 +695,11 @@ module Hwaro::Core::Build::Phases::Render
 
       # Prefix the page's root-relative URL with `base_url`'s path component so
       # the redirect still resolves when the site is deployed under a subpath
-      # (e.g. GitHub Pages project sites at `/repo/`). `base_path` is "" for a
-      # domain-root deployment, leaving `/posts/x/` unchanged.
-      target = page.url
-      target = "/#{target}" unless target.starts_with?('/')
-      redirect_url = "#{site.config.base_path}#{target}"
+      # (e.g. GitHub Pages project sites at `/repo/`). `page.url` may arrive
+      # without a leading slash (see sitemap), so normalize before prefixing;
+      # `with_base_path` is a no-op for a domain-root deployment.
+      target = page.url.starts_with?('/') ? page.url : "/#{page.url}"
+      redirect_url = site.config.with_base_path(target)
       File.write(dest_path, Utils::RedirectHtml.simple_redirect(redirect_url))
       Logger.action :create, dest_path, :yellow if verbose
     end

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -892,6 +892,20 @@ module Hwaro
         end
       end
 
+      # Prefix a site-internal root-relative path (e.g. `/posts/x/`) with
+      # `base_path` so generated URLs resolve under a subpath deployment.
+      # Absolute `http(s)://` URLs and paths that are not root-relative are
+      # returned unchanged; a no-op when `base_path` is "" (domain-root deploy).
+      # Callers that may hold a path without a leading slash (e.g. some
+      # `page.url` values) should normalize it first — this helper only
+      # prefixes values that already start with "/".
+      def with_base_path(path : String) : String
+        return path if base_path.empty?
+        return path if path.starts_with?("http://") || path.starts_with?("https://")
+        return path unless path.starts_with?("/")
+        "#{base_path}#{path}"
+      end
+
       # Check if site is multilingual
       def multilingual? : Bool
         codes = @languages.keys

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -821,6 +821,7 @@ module Hwaro
       property permalinks : Hash(String, String)
       property raw : Hash(String, TOML::Any)
       @base_url_stripped : String? = nil
+      @base_path : String? = nil
 
       def initialize
         @title = "Hwaro Site"
@@ -863,11 +864,32 @@ module Hwaro
       def base_url=(value : String)
         @base_url = value.rstrip("/")
         @base_url_stripped = nil
+        @base_path = nil
       end
 
       # Cached base_url with trailing slash stripped (avoids repeated rstrip per page)
       def base_url_stripped : String
         @base_url_stripped ||= @base_url.rstrip("/")
+      end
+
+      # Path component of `base_url`, used to make root-relative links work when
+      # the site is deployed under a subpath (e.g. GitHub/GitLab project pages
+      # served at `https://user.github.io/repo/`). For `https://x.com/repo` this
+      # returns `/repo`; for a domain-root deployment (`https://x.com`) or an
+      # empty `base_url` it returns `""`. Trailing slashes are stripped so callers
+      # can build `base_path + page.url` without producing `//`.
+      def base_path : String
+        @base_path ||= begin
+          stripped = base_url_stripped
+          if stripped.empty?
+            ""
+          else
+            path = URI.parse(stripped).path.rstrip("/")
+            path == "/" ? "" : path
+          end
+        rescue URI::Error
+          ""
+        end
       end
 
       # Check if site is multilingual


### PR DESCRIPTION
## Summary

Found while dogfooding hwaro across the scaffolds with a GitHub-Pages-style subpath `base_url`. Two generators emit **bare-root, site-internal URLs** that 404 when the site is deployed under a subpath (e.g. project pages at `https://user.github.io/repo/`). Every other generator already prefixes correctly — sitemap, RSS `<link>`/`atom:link`, and `search.json` all include `/repo/…`; aliases and the PWA module were the outliers.

Both fixes are **no-ops for domain-root deploys**, so existing behaviour is unchanged.

## Bugs fixed

**1. Alias redirects dropped the subpath** — `src/core/build/phases/render.cr`
`generate_aliases` wrote `page.url` verbatim, so a `/old/` alias redirected to `/posts/x/` instead of `/repo/posts/x/`.

**2. PWA manifest + service worker assumed a domain-root deploy** — `src/content/seo/pwa.cr`
`start_url`, icon `src`, `precache_urls`, `offline_page`, and the hardcoded `caches.match('/')` navigation fallback all ignored the subpath. The installed PWA launched the wrong origin and precache keys never matched the page's actual requests.

## Approach

- Add `Config#base_path` (`src/models/config.cr`) — returns `base_url`'s path component (`/repo`, or `""` for a domain-root/empty `base_url`); memoized and reset in `base_url=`.
- Route every auto-generated site-internal root-relative URL in aliases and PWA through `base_path`. Absolute `http(s)://` URLs pass through untouched; it's a no-op when `base_path` is `""`.

## Tests

Regression tests added: 5 for `base_path`, 1 for subpath aliases, 3 for subpath PWA (manifest + sw.js + domain-root no-op).

Verified end-to-end with `--base-url https://user.github.io/myrepo/`: aliases, `manifest.json`, and `sw.js` all carry the `/myrepo/` prefix exactly once (no double-prefix), and a domain-root build is byte-for-byte unchanged.

- `crystal spec` → 5109 examples, 0 failures
- `crystal tool format --check` → clean
- `ameba` → 0 failures