### PR TITLE
docs: refresh documentation theme with ember-lit dark design

### DIFF
--- a/docs/static/assets/css/01-variables.css
+++ b/docs/static/assets/css/01-variables.css
@@ -37,6 +37,29 @@
     --primary-light: #c87a7a;
     --success: #22c55e;
 
+    /* Ember — warm accent glow (the Hwaro "brazier" signature) */
+    --ember: rgba(179, 84, 84, 0.45);
+    --ember-soft: rgba(179, 84, 84, 0.16);
+    --ember-faint: rgba(179, 84, 84, 0.07);
+    --primary-gradient: linear-gradient(135deg, #c46262, #944545);
+    --rail-gradient: linear-gradient(180deg, #c46262, #944545);
+
+    /* Scrollbar — thin, ember-tinted (used by sidebar + TOC) */
+    --scrollbar-thumb: rgba(179, 84, 84, 0.3);
+    --scrollbar-thumb-hover: rgba(179, 84, 84, 0.55);
+
+    /* Surface elevation — white overlays stepped on the near-black canvas */
+    --surface-1: rgba(255, 255, 255, 0.022);
+    --surface-2: rgba(255, 255, 255, 0.04);
+    --surface-3: rgba(255, 255, 255, 0.06);
+    --hair: rgba(255, 255, 255, 0.06);
+    --hair-strong: rgba(255, 255, 255, 0.1);
+
+    /* Elevation shadows (ember-tinted, used sparingly on hover) */
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-card: 0 4px 16px -8px rgba(0, 0, 0, 0.6);
+    --glow-ember: 0 10px 30px -12px rgba(179, 84, 84, 0.45);
+
     /* Layout Dimensions */
     --header-h: 56px;
     --sidebar-w: 260px;
@@ -53,8 +76,11 @@
     --radius-sm: 4px;
     --radius-md: 6px;
     --radius-lg: 8px;
+    --radius-xl: 12px;
+    --radius-pill: 999px;
 
     /* Transitions */
     --transition-fast: 0.12s ease;
     --transition-normal: 0.2s ease;
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
 }

--- a/docs/static/assets/css/02-base.css
+++ b/docs/static/assets/css/02-base.css
@@ -21,12 +21,37 @@ body {
     font-size: 15px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+}
+
+/* Ambient ember — a faint warm bloom bleeding from the top of the canvas.
+   This is the signature that ties the dark theme to the "Hwaro / brazier" name. */
+.docs-container::before {
+    content: "";
+    position: fixed;
+    top: calc(var(--header-h) * -1);
+    left: 0;
+    right: 0;
+    height: 480px;
+    pointer-events: none;
+    z-index: -1;
+    background:
+        radial-gradient(
+            1000px 420px at 46% -10%,
+            rgba(196, 98, 98, 0.1),
+            transparent 68%
+        ),
+        radial-gradient(
+            760px 320px at 90% -14%,
+            rgba(196, 98, 98, 0.06),
+            transparent 72%
+        );
 }
 
 /* Selection */
 ::selection {
-    background: var(--primary);
-    color: #fff;
+    background: var(--ember-soft);
+    color: var(--text);
 }
 
 /* Links */
@@ -63,4 +88,16 @@ a:hover {
 img {
     max-width: 100%;
     height: auto;
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+        scroll-behavior: auto !important;
+    }
 }

--- a/docs/static/assets/css/03-layout.css
+++ b/docs/static/assets/css/03-layout.css
@@ -42,6 +42,7 @@
 }
 
 .docs-header nav a {
+    position: relative;
     font-family: var(--font-sans);
     color: #888;
     text-decoration: none;
@@ -134,12 +135,17 @@
     left: 0;
     width: var(--sidebar-w);
     height: calc(100vh - var(--header-h));
+    /* Distinct nav surface — a faint white-overlay step over the canvas so the
+       panel reads as its own depth layer, brighter near the header. */
     background: var(--bg);
-    border-right: 1px solid var(--border);
+    border-right: 1px solid var(--hair-strong);
+    box-shadow:
+        inset -1px 0 0 rgba(255, 255, 255, 0.02),
+        4px 0 24px -14px rgba(0, 0, 0, 0.9);
     padding: 1.25rem 0.75rem;
     overflow-y: auto;
     scrollbar-width: thin;
-    scrollbar-color: var(--border-light) transparent;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 
 .docs-sidebar::-webkit-scrollbar {
@@ -151,12 +157,12 @@
 }
 
 .docs-sidebar::-webkit-scrollbar-thumb {
-    background: var(--border);
-    border-radius: 4px;
+    background: var(--scrollbar-thumb);
+    border-radius: var(--radius-pill);
 }
 
 .docs-sidebar::-webkit-scrollbar-thumb:hover {
-    background: var(--border-light);
+    background: var(--scrollbar-thumb-hover);
 }
 
 .sidebar-section {
@@ -164,14 +170,27 @@
 }
 
 .sidebar-title {
-    font-family: var(--font-sans);
-    font-size: 0.7rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
     font-weight: 600;
     text-transform: uppercase;
     color: var(--text-dim);
     margin-bottom: 0.5rem;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.12em;
     padding-left: 0.75rem;
+}
+
+.sidebar-title::before {
+    content: "";
+    width: 5px;
+    height: 5px;
+    border-radius: 1px;
+    background: var(--primary);
+    box-shadow: 0 0 8px var(--ember);
+    flex-shrink: 0;
 }
 
 .sidebar-links {
@@ -185,6 +204,7 @@
 }
 
 .sidebar-links a {
+    position: relative;
     font-family: var(--font-sans);
     display: block;
     padding: 0.4rem 0.75rem;
@@ -192,22 +212,23 @@
     text-decoration: none;
     font-size: 0.835rem;
     font-weight: 400;
-    transition: all 0.12s ease;
+    transition:
+        color 0.15s var(--ease-out),
+        background 0.15s var(--ease-out);
     border-radius: 6px;
-    border-left: 2px solid transparent;
     border-bottom: none;
     margin-left: 0;
 }
 
 .sidebar-links a:hover {
-    background: var(--bg-hover);
+    background: var(--surface-2);
     color: var(--text);
     border-bottom: none;
 }
 
 .sidebar-links a.active {
-    background: var(--primary-dim);
-    color: var(--primary);
+    background: linear-gradient(90deg, var(--ember-soft), transparent 88%);
+    color: var(--primary-light);
     font-weight: 500;
     border-bottom: none;
 }
@@ -229,7 +250,9 @@
 .sidebar-sublinks {
     list-style: none;
     padding: 0;
-    margin: 0;
+    /* Depth guide — a faint rail that visualises the nesting level */
+    margin: 0.1rem 0 0.1rem 1rem;
+    border-left: 1px solid var(--border);
 }
 
 .sidebar-sublinks li {
@@ -237,29 +260,45 @@
 }
 
 .sidebar-sublinks a {
+    position: relative;
     font-family: var(--font-sans);
     display: block;
-    padding: 0.3rem 0.75rem 0.3rem 1.5rem;
+    padding: 0.3rem 0.75rem 0.3rem 0.6rem;
     color: var(--text-muted);
     text-decoration: none;
     font-size: 0.8rem;
     font-weight: 400;
-    transition: all 0.12s ease;
+    transition:
+        color 0.15s var(--ease-out),
+        background 0.15s var(--ease-out);
     border-radius: 6px;
     border-bottom: none;
 }
 
 .sidebar-sublinks a:hover {
-    background: var(--bg-hover);
+    background: var(--surface-2);
     color: var(--text);
     border-bottom: none;
 }
 
 .sidebar-sublinks a.active {
-    background: var(--primary-dim);
-    color: var(--primary);
+    background: linear-gradient(90deg, var(--ember-soft), transparent 88%);
+    color: var(--primary-light);
     font-weight: 500;
     border-bottom: none;
+}
+
+.sidebar-sublinks a.active::before {
+    content: "";
+    position: absolute;
+    left: -1px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 3px;
+    height: 56%;
+    border-radius: var(--radius-pill);
+    background: var(--rail-gradient);
+    box-shadow: 0 0 10px var(--ember);
 }
 
 /* =============================================================================
@@ -275,7 +314,7 @@
     padding: 1.5rem 1rem 4rem 1rem;
     overflow-y: auto;
     scrollbar-width: thin;
-    scrollbar-color: var(--border) transparent;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 
 .docs-toc::-webkit-scrollbar {
@@ -287,18 +326,22 @@
 }
 
 .docs-toc::-webkit-scrollbar-thumb {
-    background: var(--border);
-    border-radius: 4px;
+    background: var(--scrollbar-thumb);
+    border-radius: var(--radius-pill);
+}
+
+.docs-toc::-webkit-scrollbar-thumb:hover {
+    background: var(--scrollbar-thumb-hover);
 }
 
 .toc-title {
-    font-family: var(--font-sans);
-    font-size: 0.7rem;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
     font-weight: 600;
     text-transform: uppercase;
     color: var(--text-dim);
     margin-bottom: 0.75rem;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.12em;
 }
 
 .docs-toc > ul,
@@ -323,6 +366,7 @@
 
 .docs-toc a,
 .toc-list a {
+    position: relative;
     font-family: var(--font-sans);
     display: block;
     padding: 0.3rem 0.75rem;
@@ -346,8 +390,32 @@
 .docs-toc a.active,
 .toc-list a.active {
     color: var(--text);
-    border-left-color: var(--primary);
     border-bottom: none;
+}
+
+/* Active marker: a tapering ember streak that runs longer than the link and
+   thins out toward both ends, so it reads as flowing along the guide line.
+   drop-shadow follows the gradient's alpha, so the glow fades with the bar. */
+.docs-toc a.active::before,
+.toc-list a.active::before {
+    content: "";
+    position: absolute;
+    left: -1px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 2px;
+    height: 260%;
+    pointer-events: none;
+    border-radius: var(--radius-pill);
+    background: linear-gradient(
+        180deg,
+        transparent 0%,
+        var(--ember) 22%,
+        var(--primary) 50%,
+        var(--ember) 78%,
+        transparent 100%
+    );
+    filter: drop-shadow(0 0 3px var(--ember));
 }
 
 /* Nested TOC levels - indentation */

--- a/docs/static/assets/css/04-content.css
+++ b/docs/static/assets/css/04-content.css
@@ -4,12 +4,25 @@
 
 .docs-main > h1:first-child {
     font-family: var(--font-sans);
-    font-size: 1.85rem;
-    margin: 0 0 0.75rem 0;
-    font-weight: 700;
-    letter-spacing: -0.03em;
+    font-size: 2.05rem;
+    margin: 0 0 1.5rem 0;
+    font-weight: 800;
+    letter-spacing: -0.035em;
     color: var(--text);
-    line-height: 1.25;
+    line-height: 1.15;
+    text-wrap: balance;
+}
+
+/* Ember underline beneath the page title — the signature heat, restrained */
+.docs-main > h1:first-child::after {
+    content: "";
+    display: block;
+    width: 56px;
+    height: 3px;
+    margin-top: 1.1rem;
+    border-radius: var(--radius-pill);
+    background: var(--primary-gradient);
+    box-shadow: 0 0 14px var(--ember);
 }
 
 .docs-main h1 {
@@ -19,17 +32,26 @@
     font-weight: 700;
     letter-spacing: -0.02em;
     color: var(--text);
+    text-wrap: balance;
 }
 
 .docs-main h2 {
     font-family: var(--font-sans);
-    font-size: 1.25rem;
-    margin: 2.5rem 0 0.75rem 0;
+    font-size: 1.3rem;
+    margin: 3rem 0 0.9rem 0;
     padding-bottom: 0.6rem;
-    border-bottom: 1px solid var(--border);
-    font-weight: 600;
-    letter-spacing: -0.01em;
+    border-bottom: 1px solid transparent;
+    border-image: linear-gradient(
+            90deg,
+            var(--hair-strong),
+            var(--border) 45%,
+            transparent
+        )
+        1;
+    font-weight: 700;
+    letter-spacing: -0.015em;
     color: var(--text);
+    text-wrap: balance;
 }
 
 .docs-main h3 {
@@ -52,6 +74,31 @@
     margin: 0 0 1rem 0;
     color: var(--text-secondary);
     line-height: 1.75;
+    text-wrap: pretty;
+}
+
+/* Prose links — animated ember underline that grows on hover */
+.docs-main p a,
+.docs-main li a,
+.docs-main td a,
+.docs-main blockquote a {
+    color: var(--primary-light);
+    background-image: linear-gradient(var(--primary), var(--primary));
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 0% 1px;
+    transition:
+        background-size 0.25s var(--ease-out),
+        color 0.15s ease;
+    padding-bottom: 1px;
+}
+
+.docs-main p a:hover,
+.docs-main li a:hover,
+.docs-main td a:hover,
+.docs-main blockquote a:hover {
+    color: var(--primary-hover);
+    background-size: 100% 1px;
 }
 
 .docs-main ul,
@@ -189,26 +236,46 @@
     border-color: var(--success);
 }
 
-/* Inline code */
+/* Inline code — warm ember tint so it reads as a distinct token */
 code {
     font-family: var(--font-mono);
-    background: var(--bg-subtle);
+    background: var(--ember-faint);
     padding: 0.15rem 0.4rem;
     font-size: 0.85em;
     color: var(--primary-light);
-    border: 1px solid var(--border);
+    border: 1px solid var(--hair);
     border-radius: 5px;
 }
 
 pre {
     font-family: var(--font-mono);
     background: var(--code-bg);
-    padding: 0.8rem 1.25rem;
+    padding: 1rem 1.25rem;
     overflow-x: auto;
-    border: 1px solid var(--border);
-    border-radius: 8px;
+    border: 1px solid var(--hair-strong);
+    border-radius: var(--radius-xl);
     margin: 0.75rem 0 1rem 0;
     position: relative;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.035),
+        var(--shadow-card);
+}
+
+/* Ember hairline along the top edge of the code block */
+pre::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 1.25rem;
+    right: 1.25rem;
+    height: 1px;
+    background: linear-gradient(
+        90deg,
+        transparent,
+        var(--ember-soft) 20%,
+        var(--ember-soft) 80%,
+        transparent
+    );
 }
 
 pre code {
@@ -236,9 +303,9 @@ table {
     border-collapse: collapse;
     margin: 1rem 0 1.5rem 0;
     font-size: 0.85rem;
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     overflow: hidden;
-    border: 1px solid var(--border);
+    border: 1px solid var(--hair-strong);
 }
 
 th,
@@ -249,11 +316,14 @@ td {
 }
 
 th {
-    background: var(--bg-elevated);
+    background: linear-gradient(180deg, var(--surface-3), var(--surface-1));
+    font-family: var(--font-mono);
     font-weight: 600;
     color: var(--text);
-    font-size: 0.8rem;
-    letter-spacing: 0.02em;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-bottom: 1px solid var(--hair-strong);
 }
 
 td {
@@ -268,8 +338,12 @@ tr:last-child td {
     border-bottom: none;
 }
 
+tbody tr {
+    transition: background 0.12s var(--ease-out);
+}
+
 tr:hover td {
-    background: var(--bg-hover);
+    background: var(--ember-faint);
 }
 
 /* =============================================================================
@@ -277,12 +351,14 @@ tr:hover td {
    ============================================================================= */
 
 blockquote {
-    margin: 1rem 0 1.5rem 0;
-    padding: 0.75rem 1.25rem;
-    border-left: 3px solid var(--primary);
+    position: relative;
+    margin: 1.5rem 0;
+    padding: 0.9rem 1.25rem 0.9rem 1.5rem;
+    border-left: 3px solid transparent;
+    border-image: var(--rail-gradient) 1;
     color: var(--text-secondary);
-    background: var(--bg-subtle);
-    border-radius: 0 8px 8px 0;
+    background: linear-gradient(90deg, var(--ember-faint), transparent 90%);
+    border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
     font-style: normal;
 }
 
@@ -295,11 +371,33 @@ blockquote p + p {
 }
 
 /* =============================================================================
-   Horizontal Rule
+   Horizontal Rule — gradient fade with a glowing ember node
    ============================================================================= */
 
 hr {
     border: none;
-    border-top: 1px solid var(--border);
-    margin: 2.5rem 0;
+    height: 1px;
+    margin: 2.75rem 0;
+    position: relative;
+    background: linear-gradient(
+        90deg,
+        transparent,
+        var(--border-light) 28%,
+        var(--hair-strong) 50%,
+        var(--border-light) 72%,
+        transparent
+    );
+}
+
+hr::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--primary);
+    box-shadow: 0 0 12px var(--ember);
 }

--- a/docs/static/assets/css/05-components.css
+++ b/docs/static/assets/css/05-components.css
@@ -45,43 +45,7 @@
    Section List — Card Style
    ============================================================================= */
 
-ul.section-list {
-    list-style: none;
-    padding: 0;
-    display: grid;
-    gap: 0.5rem;
-    margin: 1.5rem 0;
-}
-
-ul.section-list li {
-    padding: 0.875rem 1.125rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    transition: all 0.15s ease;
-    position: relative;
-}
-
-ul.section-list li:hover {
-    border-color: var(--border-light);
-    background: var(--bg-hover);
-}
-
-ul.section-list li a {
-    font-weight: 500;
-    color: var(--text);
-    font-size: 0.9rem;
-    border-bottom: none;
-}
-
-ul.section-list li a:hover {
-    color: var(--primary);
-}
-
-/* =============================================================================
-   Page List — Section index pages
-   ============================================================================= */
-
+ul.section-list,
 ul.page-list {
     list-style: none;
     padding: 0;
@@ -90,19 +54,51 @@ ul.page-list {
     margin: 1.5rem 0;
 }
 
+ul.section-list li,
 ul.page-list li {
-    padding: 0.875rem 1.125rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    transition: all 0.15s ease;
+    position: relative;
+    padding: 0.95rem 2.5rem 0.95rem 1.125rem;
+    background: var(--surface-1);
+    border: 1px solid var(--hair);
+    border-radius: var(--radius-lg);
+    transition:
+        transform 0.2s var(--ease-out),
+        border-color 0.2s var(--ease-out),
+        background 0.2s var(--ease-out),
+        box-shadow 0.2s var(--ease-out);
 }
 
+ul.section-list li:hover,
 ul.page-list li:hover {
-    border-color: var(--border-light);
-    background: var(--bg-hover);
+    transform: translateY(-2px);
+    border-color: var(--ember);
+    background: var(--surface-2);
+    box-shadow: var(--glow-ember);
 }
 
+/* Sliding arrow affordance */
+ul.section-list li::after,
+ul.page-list li::after {
+    content: "→";
+    position: absolute;
+    right: 1.125rem;
+    top: 50%;
+    transform: translateY(-50%) translateX(-6px);
+    color: var(--primary);
+    font-size: 0.95rem;
+    opacity: 0;
+    transition:
+        opacity 0.2s var(--ease-out),
+        transform 0.2s var(--ease-out);
+}
+
+ul.section-list li:hover::after,
+ul.page-list li:hover::after {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+}
+
+ul.section-list li a,
 ul.page-list li a {
     font-weight: 500;
     color: var(--text);
@@ -110,8 +106,17 @@ ul.page-list li a {
     border-bottom: none;
 }
 
-ul.page-list li a:hover {
-    color: var(--primary);
+/* Let the whole card be the click target */
+ul.section-list li a::after,
+ul.page-list li a::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+}
+
+ul.section-list li:hover a,
+ul.page-list li:hover a {
+    color: var(--primary-light);
 }
 
 /* =============================================================================
@@ -121,7 +126,14 @@ ul.page-list li a:hover {
 .docs-footer {
     margin-top: 4rem;
     padding-top: 1.5rem;
-    border-top: 1px solid var(--border);
+    border-top: 1px solid transparent;
+    border-image: linear-gradient(
+            90deg,
+            var(--hair-strong),
+            var(--border) 40%,
+            transparent
+        )
+        1;
     color: var(--text-dim);
     font-size: 0.8rem;
     display: flex;
@@ -165,20 +177,29 @@ ul.page-list li a:hover {
 }
 
 .feature-card {
-    background: var(--bg-card);
+    background: var(--surface-1);
+    border: 1px solid var(--hair);
+    border-radius: var(--radius-lg);
     padding: 1.25rem;
-    transition: all 0.15s ease;
+    transition:
+        transform 0.2s var(--ease-out),
+        border-color 0.2s var(--ease-out),
+        background 0.2s var(--ease-out),
+        box-shadow 0.2s var(--ease-out);
 }
 
 .feature-card:hover {
-    border-color: var(--border-light);
-    background: var(--bg-hover);
+    transform: translateY(-2px);
+    border-color: var(--ember);
+    background: var(--surface-2);
+    box-shadow: var(--glow-ember);
 }
 
 .feature-icon {
     font-size: 1.35rem;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.6rem;
     line-height: 1;
+    filter: drop-shadow(0 0 10px var(--ember-soft));
 }
 
 .feature-card h3 {
@@ -209,18 +230,24 @@ ul.page-list li a:hover {
 
 .doc-card {
     display: block;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: 10px;
+    background: var(--surface-1);
+    border: 1px solid var(--hair);
+    border-radius: var(--radius-xl);
     padding: 1.25rem;
     text-decoration: none;
-    transition: all 0.15s ease;
+    transition:
+        transform 0.2s var(--ease-out),
+        border-color 0.2s var(--ease-out),
+        background 0.2s var(--ease-out),
+        box-shadow 0.2s var(--ease-out);
     border-bottom: none;
 }
 
 .doc-card:hover {
-    border-color: var(--primary-dark);
-    background: var(--bg-hover);
+    transform: translateY(-2px);
+    border-color: var(--ember);
+    background: var(--surface-2);
+    box-shadow: var(--glow-ember);
     border-bottom: none;
 }
 


### PR DESCRIPTION
## Summary

Refines the documentation site design. Keeps the existing **near-black + muted-red** palette and calm tone, but adds depth, warmth, and motion so the docs feel intentional and on-brand (Hwaro = brazier / 화로). **CSS-only — landing page unaffected.**

## Changes

- **Ambient ember** glow bleeding from the top of each page
- **Surface depth**: luminance-stepped overlays; ember-tinted inline code, code blocks, tables, blockquotes
- **Typography**: mono "technical" labels (sidebar/TOC titles, table headers), ember underline under page titles, gradient-fade `h2` rules, ember-node `hr`
- **Cards** (index/feature/doc): hover lift + ember glow + sliding `→`
- **Sidebar**: clearer panel separation, nested guide lines, glowing active ember rail
- **TOC active marker**: a tapering streak that thins/fades along the guide line
- **Scrollbars**: thin, ember-tinted thumbs for sidebar + TOC
- **Motion**: animated prose-link underlines; `transform`/`opacity`/`filter` only; honors `prefers-reduced-motion`

## Verification

- `hwaro build` clean (64 pages)
- Checked desktop + mobile (390px); landing page unchanged
- No `.cr` changes (Crystal lint gates N/A)