### PR TITLE
docs(sidebar): thin scrollbar with global color and hover-reveal

### DIFF
--- a/docs/static/assets/css/03-layout.css
+++ b/docs/static/assets/css/03-layout.css
@@ -145,11 +145,16 @@
     padding: 1.25rem 0.75rem;
     overflow-y: auto;
     scrollbar-width: thin;
-    scrollbar-color: var(--scrollbar-thumb) transparent;
+    /* Hidden until you interact with the panel; color matches the global scrollbar. */
+    scrollbar-color: transparent transparent;
+}
+
+.docs-sidebar:hover {
+    scrollbar-color: var(--border) transparent;
 }
 
 .docs-sidebar::-webkit-scrollbar {
-    width: 5px;
+    width: 3px;
 }
 
 .docs-sidebar::-webkit-scrollbar-track {
@@ -157,12 +162,17 @@
 }
 
 .docs-sidebar::-webkit-scrollbar-thumb {
-    background: var(--scrollbar-thumb);
+    background: transparent;
     border-radius: var(--radius-pill);
+    transition: background 0.2s ease;
 }
 
-.docs-sidebar::-webkit-scrollbar-thumb:hover {
-    background: var(--scrollbar-thumb-hover);
+.docs-sidebar:hover::-webkit-scrollbar-thumb {
+    background: var(--border);
+}
+
+.docs-sidebar:hover::-webkit-scrollbar-thumb:hover {
+    background: var(--border-light);
 }
 
 .sidebar-section {


### PR DESCRIPTION
## Summary
- Slim the docs sidebar scrollbar (WebKit track `5px` → `3px`)
- Match its color to the global scrollbar (`--border` / `--border-light`) instead of the ember-tinted `--scrollbar-thumb`
- Keep the thumb transparent until the sidebar is hovered, so it stays out of the way before you interact with the panel

## Notes
- CSS-only change in `docs/static/assets/css/03-layout.css`
- Pure-CSS hover-reveal is used as the standard approximation of "show only while scrolling" (true scroll-event detection would need JS)
- The TOC scrollbar still uses the ember-tinted `--scrollbar-thumb` variables; only the sidebar was changed