### PR TITLE
fix: three SEO/tooling bugs found by dogfooding

### DIFF
--- a/spec/unit/deadlink_command_spec.cr
+++ b/spec/unit/deadlink_command_spec.cr
@@ -317,6 +317,44 @@ describe Hwaro::CLI::Commands::Tool::DeadlinkCommand do
       end
     end
 
+    # Regression (dogfooding find): the checker treated Zola-style `@/`
+    # content-root links as paths relative to the source file, so a valid
+    # `@/index.md` resolved to `content/@/index.md` and was reported dead
+    # even though the build resolves it fine.
+    it "resolves Zola-style @/ content-root links" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "index.md"), "home")
+        FileUtils.mkdir_p(File.join(dir, "posts"))
+        File.write(File.join(dir, "posts", "hello.md"), "post")
+
+        links = [
+          Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+            file: File.join(dir, "posts", "other.md"), url: "@/index.md", kind: :internal
+          ),
+          Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+            file: File.join(dir, "posts", "other.md"), url: "@/posts/hello.md", kind: :internal
+          ),
+        ]
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        cmd.check_internal_links_for_test(links, dir).should be_empty
+      end
+    end
+
+    it "still flags missing @/ content-root links" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "index.md"), "home")
+        link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+          file: File.join(dir, "index.md"), url: "@/does-not-exist.md", kind: :internal
+        )
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        results = cmd.check_internal_links_for_test([link], dir)
+        results.size.should eq(1)
+        results[0].error.not_nil!.should contain("not found")
+      end
+    end
+
     it "detects broken image paths" do
       Dir.mktmpdir do |dir|
         File.write(File.join(dir, "test.md"), "content")

--- a/spec/unit/feeds_spec.cr
+++ b/spec/unit/feeds_spec.cr
@@ -1527,6 +1527,26 @@ describe Hwaro::Content::Seo::Feeds do
       rss.should_not contain("<description>&lt;h1&gt;Hello")
     end
 
+    it "strips markup from a <!-- more --> summary instead of dumping raw markdown (gh#491)" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("post.md")
+      page.title = "Post"
+      page.url = "/post/"
+      # No frontmatter description: the feed should use the summary, but as
+      # plain text — not the raw markdown chunk with `##` and code fences.
+      page.summary = "## Intro\n\nHello world"
+      page.summary_html = "<h2>Intro</h2>\n<p>Hello world</p>"
+
+      rss = Hwaro::Content::Seo::Feeds.generate_rss(
+        [page], config, "rss.xml", false, "Test", ""
+      )
+
+      rss.should contain("<description>Intro Hello world</description>")
+      rss.should_not contain("##")
+    end
+
     it "emits <content:encoded> with the full body when full_content is on (gh#526)" do
       config = Hwaro::Models::Config.new
       config.base_url = "https://example.com"

--- a/spec/unit/jsonld_extended_spec.cr
+++ b/spec/unit/jsonld_extended_spec.cr
@@ -211,4 +211,30 @@ describe Hwaro::Content::Seo::JsonLd do
       result.should contain("FAQPage")
     end
   end
+
+  describe "script-context escaping" do
+    it "escapes <, >, & as \\uXXXX so JSON-LD can't break out of <script> (dogfooding find)" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/post/"
+      # The `<!--<script>` prefix triggers the HTML "script data double
+      # escape" trap; a later real </script> would not close the element.
+      page.title = "Break <!--<script>out</script> attempt & more"
+
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+      result = Hwaro::Content::Seo::JsonLd.article(page, config)
+
+      # No raw HTML-significant characters survive inside the <script> body.
+      body = result.sub(%(<script type="application/ld+json">), "").sub("</script>", "")
+      body.should_not contain("<")
+      body.should_not contain(">")
+      body.should contain("\\u003c")
+      body.should contain("\\u003e")
+      body.should contain("\\u0026")
+
+      # …and it still decodes back to the original title.
+      json = JSON.parse(body)
+      json["headline"].as_s.should eq("Break <!--<script>out</script> attempt & more")
+    end
+  end
 end

--- a/spec/unit/page_methods_spec.cr
+++ b/spec/unit/page_methods_spec.cr
@@ -188,6 +188,43 @@ describe Hwaro::Models::Page do
     end
   end
 
+  describe "#plain_summary" do
+    it "returns nil when the page has no summary" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.plain_summary.should be_nil
+    end
+
+    it "strips markup and collapses whitespace from the rendered summary (gh#491)" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.summary = "## Heading\n\nbody"
+      page.summary_html = "<h2>Heading</h2>\n<p>body</p>"
+      # No literal newlines, headings, or tags — safe for a meta attribute.
+      page.plain_summary.should eq("Heading body")
+    end
+
+    it "decodes HTML entities so escaped chars aren't double-escaped (gh#491)" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.summary = "code"
+      page.summary_html = "<pre><code>A--&gt;B</code></pre>"
+      page.plain_summary.should eq("A-->B")
+    end
+
+    it "soft-truncates on a word boundary with an ellipsis" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.summary_html = "<p>#{"word " * 60}</p>"
+      result = page.plain_summary(20).not_nil!
+      result.size.should be <= 21 # 20 chars + ellipsis, trimmed at a space
+      result.ends_with?("…").should be_true
+      result.should_not contain("  ")
+    end
+
+    it "falls back to the raw summary when summary_html is unset" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.summary = "Just plain text."
+      page.plain_summary.should eq("Just plain text.")
+    end
+  end
+
   describe "#generate_permalink" do
     it "generates permalink from base_url and page url" do
       page = Hwaro::Models::Page.new("test.md")

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -220,7 +220,13 @@ module Hwaro
 
             links.each do |link|
               base_dir = File.dirname(link.file)
-              target = if link.url.starts_with?("/")
+              target = if link.url.starts_with?("@/")
+                         # Zola-style content-root link (`@/posts/hello.md`).
+                         # The build resolves these against the content dir,
+                         # so the checker must too — otherwise valid links
+                         # like `@/index.md` were reported dead (dogfooding find).
+                         File.join(content_dir, link.url[2..])
+                       elsif link.url.starts_with?("/")
                          File.join(content_dir, link.url.lstrip("/"))
                        else
                          File.join(base_dir, link.url)

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -1,4 +1,5 @@
 require "file_utils"
+require "html"
 require "../../models/config"
 require "../../models/page"
 require "../../models/section"
@@ -337,29 +338,34 @@ module Hwaro
         end
 
         # Summary text for `<description>` / atom `<summary>`. Prefers
-        # frontmatter `description`, falls back to a rendered `summary`
-        # (if the markdown processor produced one), and finally to a
-        # plain-text excerpt of the body (gh#526).
+        # frontmatter `description`, falls back to a plain-text rendering of
+        # the `<!-- more -->` summary, and finally to a plain-text excerpt
+        # of the body (gh#526). The summary is stripped of markup so raw
+        # markdown (`##` headings, code fences, math) never leaks into the
+        # feed `<description>` (gh#491).
         private def self.summary_for_feed(page : Models::Page, config : Models::Config) : String
           if desc = page.description
             return desc unless desc.empty?
           end
 
-          if summary = page.summary
-            return summary unless summary.empty?
+          limit = config.feeds.truncate > 0 ? config.feeds.truncate : 300
+
+          if summary_html = page.summary_html
+            text = HTML.unescape(Utils::TextUtils.strip_html(summary_html)).strip
+            return truncate_for_feed(text, limit) unless text.empty?
           end
 
           # Fall back to a stripped + truncated body. Prefer the
           # already-rendered HTML; degrade to the raw markdown only if
           # render hasn't run.
           html = page.content.empty? ? Processor::Markdown.render(page.raw_content)[0] : page.content
-          text = Utils::TextUtils.strip_html(html).strip
-          limit = config.feeds.truncate > 0 ? config.feeds.truncate : 300
-          if text.size > limit
-            "#{text[0...limit]}..."
-          else
-            text
-          end
+          text = HTML.unescape(Utils::TextUtils.strip_html(html)).strip
+          truncate_for_feed(text, limit)
+        end
+
+        # Hard-truncate plain text to `limit` characters with an ellipsis.
+        private def self.truncate_for_feed(text : String, limit : Int32) : String
+          text.size > limit ? "#{text[0...limit]}..." : text
         end
 
         # Full HTML body suitable for `<content:encoded>` / atom

--- a/src/content/seo/jsonld.cr
+++ b/src/content/seo/jsonld.cr
@@ -292,7 +292,18 @@ module Hwaro
         end
 
         private def wrap_script(json : String) : String
-          %(<script type="application/ld+json">#{json.gsub("</", "<\\/")}</script>)
+          %(<script type="application/ld+json">#{escape_for_script(json)}</script>)
+        end
+
+        # Escape HTML-significant characters as `\uXXXX` so JSON can never
+        # break out of the surrounding `<script>` element. `<` etc. are
+        # valid JSON escapes that decode back to the original characters in
+        # any JSON parser, so the structured data stays intact. This mirrors
+        # Go's `encoding/json` HTML escaping and defends against both
+        # `</script>` injection and the "script data double escape" trap a
+        # bare `<!--<script` would otherwise spring (gh: dogfooding find).
+        private def escape_for_script(json : String) : String
+          json.gsub('<', "\\u003c").gsub('>', "\\u003e").gsub('&', "\\u0026")
         end
 
         # Coerce a `page.extra[key]` value to `Array(String)` regardless of whether

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1603,11 +1603,14 @@ module Hwaro::Core::Build::Phases::Render
     # which breaks link previews (gh issue list, fix #1).
     effective_og_title = page.title.empty? ? config.title : page.title
 
-    # Use page.description if present, otherwise the auto-generated summary
-    # (first paragraph-ish), finally fall back to site description. This
-    # gives social cards much better per-post text without requiring every
-    # author to write a description in frontmatter.
-    effective_og_desc = page.description.presence || page.summary.presence || config.description
+    # Use page.description if present, otherwise a plain-text rendering of
+    # the `<!-- more -->` summary, finally fall back to site description.
+    # `plain_summary` strips markup so raw markdown (headings, code fences,
+    # literal newlines) never breaks the single-line meta attribute — using
+    # `page.summary` directly here dumped the raw chunk into og/twitter
+    # tags (gh#491). This gives social cards good per-post text without
+    # requiring every author to write a description in frontmatter.
+    effective_og_desc = page.description.presence || page.plain_summary || config.description
 
     og_tags = config.og.og_tags(effective_og_title, effective_og_desc, effective_url, page.image, config.base_url, og_type_override)
     twitter_tags = config.og.twitter_tags(effective_og_title, effective_og_desc, page.image, config.base_url)

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -1,3 +1,6 @@
+require "html"
+require "../utils/text_utils"
+
 module Hwaro
   module Models
     # Recursive value type for `page.extra`. Keeps `Array(String)` in the union
@@ -274,6 +277,34 @@ module Hwaro
       # Get effective summary (summary or description fallback)
       def effective_summary : String?
         @summary || @description
+      end
+
+      # Plain-text rendering of the `<!-- more -->` summary, safe to embed
+      # in single-line contexts like `og:description`,
+      # `twitter:description`, or a feed `<description>`. Uses the
+      # already-rendered `summary_html` and strips markup so raw markdown
+      # (`##` headings, code fences, math, literal newlines) never leaks
+      # into meta tags — see https://github.com/hahwul/hwaro/issues/491.
+      # Returns nil when the page has no summary. Soft-truncates to `limit`
+      # characters on a word boundary.
+      def plain_summary(limit : Int32 = 200) : String?
+        # Prefer the rendered summary HTML (populated during parsing); fall
+        # back to the raw markdown chunk only if render hasn't run yet —
+        # strip_html still removes any inline HTML there.
+        source = @summary_html || @summary
+        return unless source
+        # Strip tags, then decode entities so escaped chars from rendered
+        # HTML (e.g. `&gt;` inside code blocks) become real characters —
+        # the meta-tag layer re-escapes them, avoiding `&amp;gt;` artifacts.
+        text = HTML.unescape(Hwaro::Utils::TextUtils.strip_html(source)).strip
+        return if text.empty?
+        return text if text.size <= limit
+
+        truncated = text[0, limit]
+        if (idx = truncated.rindex(' ')) && idx > limit // 2
+          truncated = truncated[0, idx]
+        end
+        "#{truncated.rstrip}…"
       end
     end
   end


### PR DESCRIPTION
## Summary

While dogfooding `hwaro` — building sites across every scaffold (`simple`/`bare`/`blog`/`docs`/`book` + dark variants), a multilingual site, and feature-heavy sites (math, Mermaid, footnotes, shortcodes, drafts/scheduled/expired posts, aliases, pagination, OG images, AMP, PWA, TOC, internal links, import, dev server) — three latent bugs surfaced. Each is fixed here with regression tests.

### 1. Raw markdown leaked into `og:description` / `twitter:description` / RSS `<description>`
When a post had a `<!-- more -->` summary but **no explicit `description`**, the raw markdown chunk (literal newlines, `##` headings, code fences, math) was emitted straight into the single-line meta attributes and the RSS `<description>`, breaking the HTML `<head>` and feed XML.

- Added `Page#plain_summary` — strips tags from the already-rendered `summary_html`, decodes HTML entities (so code-block `&gt;` doesn't become `&amp;gt;`), and soft-truncates on a word boundary.
- `render.cr` og/twitter tags and `feeds.cr` `summary_for_feed` now route through plain text. Related to #491.

### 2. JSON-LD could break out of its `<script>` block (XSS vector)
`wrap_script` only escaped `</` → `<\/`. A title/tag containing `<!--<script` trips the HTML *script-data-double-escape* state, after which the wrapper's real `</script>` no longer closes the element. Now escapes `<`, `>`, `&` as `\uXXXX` (Go `encoding/json` style) — still valid JSON that decodes back to the original text, but cannot break out of the script context.

### 3. `check-links` false-positived on Zola-style `@/` links
The checker treated `@/index.md` as relative to the source file (`content/@/index.md`) and reported valid links as **dead**, even though the build resolves them fine. Now resolves `@/` against the content root, matching the build's resolver.

## Test plan
- Added regression tests: `Page#plain_summary` (5), feeds summary stripping (1), JSON-LD script escaping (1), deadlink `@/` resolution (2).
- **5118 examples, 0 failures.**
- `crystal tool format --check` and `./bin/ameba` (360 files) both clean.
- Each fix re-verified against freshly generated sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)