### PR TITLE
fix: closest-match front-matter typo hint and dangling slug hyphen

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -1059,6 +1059,13 @@ describe Hwaro::Services::Creator do
       Hwaro::Services::Creator.sanitize_url_path("!foo!/!bar!").should eq("foo/bar")
     end
 
+    it "does not leave a hyphen dangling against an extension dot" do
+      # Punctuation right before the extension used to leave `foo-.md`
+      # because strip('-') can't reach a hyphen that sits before `.md`.
+      Hwaro::Services::Creator.sanitize_url_path("posts/my post!.md").should eq("posts/my-post.md")
+      Hwaro::Services::Creator.sanitize_url_path("a!.b").should eq("a.b")
+    end
+
     it "preserves path separators and the RFC 3986 unreserved set" do
       Hwaro::Services::Creator.sanitize_url_path("posts/my_post.v2.md").should eq("posts/my_post.v2.md")
       Hwaro::Services::Creator.sanitize_url_path("a/b/c~d.md").should eq("a/b/c~d.md")

--- a/spec/unit/processors_gaps_spec.cr
+++ b/spec/unit/processors_gaps_spec.cr
@@ -169,6 +169,25 @@ describe Hwaro::Content::Processors::Markdown do
       end
     end
 
+    it "suggests the closest known key, not merely the first within threshold" do
+      # `tag` is distance 1 from `tags` but distance 2 from `toc`. Because
+      # `toc` precedes `tags` in KNOWN_FRONT_MATTER_KEYS, a first-match scan
+      # would wrongly suggest `toc`; the suggester must pick the closest key.
+      previous_io = Hwaro::Logger.io
+      sink = IO::Memory.new
+      Hwaro::Logger.io = sink
+
+      begin
+        md = Hwaro::Content::Processors::Markdown.new
+        md.parse("---\ntag: x\n---\nbody", "test.md")
+        out = sink.to_s
+        out.should contain("did you mean 'tags'")
+        out.should_not contain("'toc'")
+      ensure
+        Hwaro::Logger.io = previous_io
+      end
+    end
+
     it "does not warn for keys far from any known key (likely intentional)" do
       previous_io = Hwaro::Logger.io
       sink = IO::Memory.new

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -63,15 +63,23 @@ module Hwaro
         # Warn about unknown front-matter keys that look like typos of known keys.
         # Uses Levenshtein distance ≤ 2 to detect likely misspellings while ignoring
         # intentional custom fields (which tend to differ significantly from known keys).
+        # Suggests the *closest* known key, not merely the first within the threshold —
+        # otherwise `tag` (a typo of `tags`, distance 1) would resolve to whichever
+        # distance-2 key happens to appear earlier in the set (e.g. `toc`).
         private def warn_typo_keys(unknown_keys : Array(String), file_path : String)
           return if file_path.empty?
           unknown_keys.each do |key|
+            best : String? = nil
+            best_distance = Int32::MAX
             KNOWN_FRONT_MATTER_KEYS.each do |known|
               dist = levenshtein(key, known)
-              if dist > 0 && dist <= 2
-                Logger.warn "#{file_path}: unknown front-matter key '#{key}' — did you mean '#{known}'?"
-                break
+              if dist < best_distance
+                best_distance = dist
+                best = known
               end
+            end
+            if (suggestion = best) && best_distance > 0 && best_distance <= 2
+              Logger.warn "#{file_path}: unknown front-matter key '#{key}' — did you mean '#{suggestion}'?"
             end
           end
         end

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -127,6 +127,11 @@ module Hwaro
             end
           end
         end.strip('-')
+          # Drop hyphens that landed next to a dot — e.g. punctuation right
+          # before an extension (`foo!.md` → `foo-.md`) leaves a dangling
+          # hyphen that `strip('-')` cannot reach because the trailing char
+          # is the extension, not the hyphen. Collapse both `-.` and `.-`.
+          .gsub("-.", ".").gsub(".-", ".")
       end
 
       private def self.url_safe_char?(char : Char) : Bool


### PR DESCRIPTION
## Summary

Two small correctness bugs surfaced while dogfooding `hwaro init` → `build` → `serve`/`new` across the bundled scaffolds.

### 1. Front-matter typo hint suggested the wrong key
`warn_typo_keys` warned with the **first** known key within Levenshtein distance ≤ 2 (in set-insertion order) instead of the **closest** one:

| input | before | after |
|-------|--------|-------|
| `tag` | `did you mean 'toc'?` (dist 2) | `did you mean 'tags'?` (dist 1) ✅ |
| `math` | `did you mean 'date'?` (dist 2) | `did you mean 'path'?` (dist 1) ✅ |

`tag` → `tags` is an extremely common typo, so the misleading hint was easy to hit. Now picks the minimum-distance key, matching the existing `Utils::CommandSuggester` behavior.

### 2. `hwaro new` left a dangling hyphen before the extension
`sanitize_url_segment` runs `.strip('-')`, which can't reach a hyphen that sits *before* `.md`:

```
hwaro new "posts/my post!.md"
  before → content/posts/my-post-.md
  after  → content/posts/my-post.md   ✅
```

Punctuation adjacent to a dot (`-.` / `.-`) is now collapsed to `.`.

## Testing
- Added regression specs for both (`tag → tags`, `foo!.md → foo.md`).
- `crystal tool format --check` ✅
- `ameba` (360 files) → 0 failures ✅
- Full suite → **5120 examples, 0 failures** ✅

Both are user-visible polish fixes with no behavior change for already-clean input.