### PR TITLE
fix(scaffold): stop nav-hint comment from leaking {% raw %} into pages

### DIFF
--- a/spec/functional/scaffold_nav_comment_spec.cr
+++ b/spec/functional/scaffold_nav_comment_spec.cr
@@ -1,0 +1,52 @@
+require "./support/build_helper"
+require "../../src/services/scaffolds/blog"
+require "../../src/services/scaffolds/simple"
+
+# Regression: the blog and base nav templates ship an HTML comment that
+# documents the dynamic `site.sections` loop. The example is wrapped in a
+# single `{% raw %}…{% endraw %}` block so Crinja renders it literally
+# instead of executing it.
+#
+# The explanatory prose used to *name* the tag with a bare `{% raw %}`
+# ("Wrapped in {% raw %} so this example isn't executed"). Crinja has no
+# concept of HTML comments, so it treated that bare tag as a real raw-block
+# open: the prose after it was swallowed (rendered as "Wrapped in  so …")
+# and the inner `{% raw %}` delimiter leaked verbatim into every generated
+# page. These tests build the real scaffolds and assert the hint comment
+# renders cleanly.
+describe "Scaffold nav hint comment (regression)" do
+  it "blog scaffold renders the section-loop hint without leaking raw tags" do
+    scaffold = Hwaro::Services::Scaffolds::Blog.new
+    build_site(
+      scaffold.config_content,
+      content_files: scaffold.content_files,
+      template_files: scaffold.template_files,
+      static_files: scaffold.static_files,
+    ) do
+      html = File.read("public/index.html")
+      # The example loop is shown literally inside the comment…
+      html.should contain("{% for s in site.sections")
+      # …but the raw-block delimiters themselves are consumed, never leaked.
+      html.should_not contain("{% raw %}")
+      html.should_not contain("{% endraw %}")
+      # …and the explanatory prose survives intact.
+      html.should contain("wrapped in a raw block")
+    end
+  end
+
+  it "simple scaffold (base nav) renders the section-loop hint without leaking raw tags" do
+    scaffold = Hwaro::Services::Scaffolds::Simple.new
+    build_site(
+      scaffold.config_content,
+      content_files: scaffold.content_files,
+      template_files: scaffold.template_files,
+      static_files: scaffold.static_files,
+    ) do
+      html = File.read("public/index.html")
+      html.should contain("{% for s in site.sections")
+      html.should_not contain("{% raw %}")
+      html.should_not contain("{% endraw %}")
+      html.should contain("wrapped in a raw block")
+    end
+  end
+end

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -519,7 +519,8 @@ module Hwaro
                    s.url already includes the language prefix, so do NOT add
                    lang_prefix. For custom ordering, set `weight` in each
                    section's front matter and use sort(attribute="weight").
-                   (Wrapped in {% raw %} so the example isn't executed here.)
+                   (The example below is wrapped in a raw block so it
+                   isn't executed here.)
                    {% raw %}
                    {% for s in site.sections | sort(attribute="title") %}
                      {% if not s.transparent and s.name and s.language == page_language %}<a href="{{ base_url }}{{ s.url }}">{{ s.title }}</a>{% endif %}

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -873,8 +873,8 @@ module Hwaro
                           loop. It shows only the current language's sections;
                           s.url already carries the language prefix, so do NOT
                           add lang_prefix. Sort by "weight" for explicit order.
-                       (Wrapped in {% raw %} so this example isn't executed
-                       while it lives in the comment.)
+                       (The example below is wrapped in a raw block so it
+                       isn't executed while it lives in the comment.)
                        {% raw %}
                        {% for s in site.sections | sort(attribute="title") %}
                          {% if not s.transparent and s.name and s.language == page_language %}<a href="{{ base_url }}{{ s.url }}">{{ s.title }}</a>{% endif %}


### PR DESCRIPTION
## Summary

Found while dogfooding the scaffolds (`hwaro init blog`/`simple` → `build`): the nav-hint HTML comment leaks Crinja `{% raw %}` delimiters into the source of **every generated page**, and its explanatory sentence renders mangled.

### Root cause

The blog (`partials/nav.html`) and base (`header.html`) nav templates document the dynamic `site.sections` loop inside an HTML comment, wrapping the example in a single `{% raw %}...{% endraw %}` block so Crinja shows it literally.

The explanatory prose, though, *named* the tag with a bare `{% raw %}`:

```
(Wrapped in {% raw %} so this example isn't executed ...)
```

Crinja has no notion of HTML comments, so it treated that bare tag as a **real** raw-block open. The result, baked into every page:

- the prose was swallowed → rendered as `(Wrapped in  so this example...)` (note the empty gap)
- the inner `{% raw %}` delimiter leaked verbatim into the output

### Fix

Reword the prose to "wrapped in a raw block" so it no longer contains a bare tag. The real `{% raw %}...{% endraw %}` pair around the example is untouched. The comment now renders cleanly in `blog`/`simple` and every scaffold inheriting the base nav.

Before / after (rendered into `public/index.html`):

```diff
- (Wrapped in  so this example isn't executed
- while it lives in the comment.)
- {% raw %}
- {% for s in site.sections | sort(attribute="title") %}
+ (The example below is wrapped in a raw block so it
+ isn't executed while it lives in the comment.)
+ {% for s in site.sections | sort(attribute="title") %}
```

## Tests

- Adds `spec/functional/scaffold_nav_comment_spec.cr` — builds the **blog** and **simple** scaffolds and asserts the hint comment renders without leaking `{% raw %}`/`{% endraw %}` and with the prose intact. Verified red-green (fails if the bare tag is reintroduced).
- `crystal tool format` clean, `ameba` 0 failures.
- Full suite: **5125 examples, 0 failures**.