### PR TITLE
fix(build): publish static dotfiles in cached builds; filter cruft (#610, #611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `[static]` config: control which files under `static/` get published. A built-in denylist drops OS/editor/VCS cruft (`.DS_Store`, `Thumbs.db`, `desktop.ini`, `.git/`, vim swap/backup files); `exclude = [...]` adds project-specific globs and `use_default_excludes = false` opts out (#611)
+
+### Fixed
+- Static files: hidden dot-paths under `static/` (e.g. `.well-known/`) are now published in cached (`--cache`) builds. The incremental copy path used Crystal's `Dir.glob`, which skips hidden entries by default, so the GitHub Action (which always builds with `--cache`) dropped `security.txt`/`humans.txt`/ACME challenges from deployed sites. Both cold and cached builds now share one copy path and publish identical files (#610)
+
 ## v0.15.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- `[static]` config: control which files under `static/` get published. A built-in denylist drops OS/editor/VCS cruft (`.DS_Store`, `Thumbs.db`, `desktop.ini`, `.git/`, vim swap/backup files); `exclude = [...]` adds project-specific globs and `use_default_excludes = false` opts out (#611)
+- `[static]` config: control which files under `static/` get published. A built-in denylist drops OS/editor/VCS cruft (`.DS_Store`, `Thumbs.db`, `desktop.ini`, `.git/`, vim swap files); `exclude = [...]` adds patterns — a glob like `*.bak` matches at any depth, `drafts/**` scopes a subtree, a literal name is anchored to an exact file/directory — and `use_default_excludes = false` opts out (#611)
 
 ### Fixed
 - Static files: hidden dot-paths under `static/` (e.g. `.well-known/`) are now published in cached (`--cache`) builds. The incremental copy path used Crystal's `Dir.glob`, which skips hidden entries by default, so the GitHub Action (which always builds with `--cache`) dropped `security.txt`/`humans.txt`/ACME challenges from deployed sites. Both cold and cached builds now share one copy path and publish identical files (#610)

--- a/docs/content/deploy/_index.md
+++ b/docs/content/deploy/_index.md
@@ -19,6 +19,8 @@ hwaro build --minify
 
 This performs conservative optimization — HTML comments and trailing whitespace are removed, JSON/XML whitespace is compacted. All code blocks and content structure are preserved.
 
+Everything in `static/` is copied into `public/` and deployed — including hidden dot-paths such as `.well-known/security.txt` and `.domains` — identically for cold and `--cache`/incremental builds. Common OS/editor/VCS cruft (`.DS_Store`, `.git/`, …) is filtered out automatically; see [Static Files](/start/config/#static-files) to tune it.
+
 ## General Steps
 
 1. Build the site: `hwaro build`

--- a/docs/content/deploy/codeberg-pages/index.md
+++ b/docs/content/deploy/codeberg-pages/index.md
@@ -195,6 +195,8 @@ static/
 └── .domains
 ```
 
+Hwaro copies hidden dot-paths from `static/` verbatim into `public/` on every build — cold or `--cache`/incremental — so `static/.domains` always reaches the served branch. See [Static Files](/start/config/#static-files) for details.
+
 ### 2. Configure DNS
 
 Pick **one** of the three options below.

--- a/docs/content/features/content-files.md
+++ b/docs/content/features/content-files.md
@@ -120,12 +120,12 @@ For page bundles, colocated assets are also available via `page.assets`:
 | Feature | Content Files (`content/`) | Static Files (`static/`) |
 |---------|---------------------------|--------------------------|
 | Colocated with content | ✅ Yes | ❌ No |
-| Requires configuration | ✅ Yes | ❌ No (always copied) |
+| Requires configuration | ✅ Yes | ❌ No (copied by default, cruft filtered) |
 | Extension filtering | ✅ Yes | ❌ No |
-| Path filtering | ✅ Yes | ❌ No |
+| Path filtering | ✅ Yes (`disallow_paths`) | ✅ Yes (`[static]` `exclude`) |
 | Best for | Per-page assets | Site-wide assets |
 
-Use **content files** for assets that belong to specific pages (screenshots, diagrams, attachments). Use **static files** for site-wide assets (CSS, JS, logos, favicons).
+Use **content files** for assets that belong to specific pages (screenshots, diagrams, attachments). Use **static files** for site-wide assets (CSS, JS, logos, favicons) — see [`[static]`](/start/config/#static-files) to exclude cruft or specific paths.
 
 ## Tips
 

--- a/docs/content/start/config.md
+++ b/docs/content/start/config.md
@@ -125,6 +125,23 @@ feed = true
 | sitemap | bool | true | Include taxonomy pages in sitemap |
 | paginate | int | — | Pages per pagination page |
 
+## Static Files
+
+Everything under `static/` is copied verbatim into the site root, preserving its directory structure — `static/css/app.css` is served at `/css/app.css`. Hidden entries are included too, so `static/.well-known/security.txt` is published at `/.well-known/security.txt`. By default Hwaro filters out common OS, editor, and VCS cruft so it never ships to production.
+
+```toml
+[static]
+use_default_excludes = true              # filter built-in cruft (default)
+exclude = ["*.bak", "drafts/**"]         # extra patterns to skip
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| use_default_excludes | bool | true | Filter the built-in cruft denylist (`.DS_Store`, `Thumbs.db`, `desktop.ini`, `.git`, vim swap files, …) |
+| exclude | array | [] | Extra patterns to skip. A glob like `*.bak` matches at any depth, `drafts/**` scopes a subtree, and a literal name is anchored to an exact file or directory (`drafts` drops `drafts/…`) |
+
+The built-in denylist only removes cruft — legitimate dot-paths such as `.well-known/` and `.domains` are **never** filtered and are always published, identically for cold and `--cache`/incremental builds. Set `use_default_excludes = false` to disable the built-in filtering entirely.
+
 ## Feature Configuration Reference
 
 Each feature has its own documentation with full configuration details. Below is a quick reference of all `config.toml` sections.
@@ -144,6 +161,7 @@ Each feature has its own documentation with full configuration details. Below is
 | `[image_processing]` | [Image Processing](/features/image-processing/) | Image resizing & LQIP |
 | `[image_processing.lqip]` | [Image Processing](/features/image-processing/#lqip-low-quality-image-placeholders) | Base64 blur-up placeholders |
 | `[content.files]` | [Content Files](/features/content-files/) | Publish non-Markdown files |
+| `[static]` | [Static Files](#static-files) | Filter cruft / exclude paths from the `static/` copy |
 | `[series]` | [Series](/features/series/) | Group posts into ordered series |
 | `[related]` | [Related Posts](/features/related-posts/) | Related content recommendations |
 | `[llms]` | [LLMs.txt](/features/llms-txt/) | AI/LLM crawler instructions |

--- a/spec/functional/static_files_spec.cr
+++ b/spec/functional/static_files_spec.cr
@@ -1,0 +1,63 @@
+require "./support/build_helper"
+
+# End-to-end coverage for static-file publishing. These run a full build via
+# Builder#run so they exercise the same path the GitHub Action takes — most
+# importantly the cached path (`cache: true`), where `.well-known/` used to be
+# dropped (issue #610) and where OS/VCS cruft should be filtered (#611).
+describe "Build: static file publishing" do
+  {true, false}.each do |cache|
+    mode = cache ? "cached" : "cold"
+
+    it "publishes .well-known and filters cruft in a #{mode} build" do
+      build_site(
+        BASIC_CONFIG,
+        content_files: {"index.md" => "---\ntitle: Home\n---\nHi"},
+        template_files: {"page.html" => "{{ content }}"},
+        static_files: {
+          ".well-known/security.txt" => "Contact: mailto:x@y.z",
+          ".well-known/humans.txt"   => "HAHWUL",
+          "robots.txt"               => "User-agent: *",
+          ".DS_Store"                => "junk",
+          "css/.DS_Store"            => "junk",
+          ".git/config"              => "[core]",
+        },
+        cache: cache,
+      ) do
+        # Legitimate dot-paths are published.
+        File.exists?("public/.well-known/security.txt").should be_true
+        File.read("public/.well-known/security.txt").should eq("Contact: mailto:x@y.z")
+        File.exists?("public/.well-known/humans.txt").should be_true
+        File.exists?("public/robots.txt").should be_true
+
+        # Cruft is filtered out.
+        File.exists?("public/.DS_Store").should be_false
+        File.exists?("public/css/.DS_Store").should be_false
+        File.exists?("public/.git/config").should be_false
+      end
+    end
+  end
+
+  it "respects a custom [static] exclude in a cached build" do
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+
+      [static]
+      exclude = ["*.bak"]
+      TOML
+
+    build_site(
+      config,
+      content_files: {"index.md" => "---\ntitle: Home\n---\nHi"},
+      template_files: {"page.html" => "{{ content }}"},
+      static_files: {
+        "keep.txt"   => "keep",
+        "secret.bak" => "drop",
+      },
+      cache: true,
+    ) do
+      File.exists?("public/keep.txt").should be_true
+      File.exists?("public/secret.bak").should be_false
+    end
+  end
+end

--- a/spec/unit/phases_initialize_spec.cr
+++ b/spec/unit/phases_initialize_spec.cr
@@ -188,7 +188,7 @@ describe Hwaro::Core::Build::Phases::Initialize do
             File.write("static/.DS_Store", "junk")
             File.write("static/css/.DS_Store", "junk")
             File.write("static/.git/config", "[core]")
-            File.write("static/notes.txt~", "backup")
+            File.write("static/.main.css.swp", "swap")
             FileUtils.mkdir_p("public")
 
             builder = Hwaro::Core::Build::Builder.new
@@ -198,7 +198,7 @@ describe Hwaro::Core::Build::Phases::Initialize do
             File.exists?("public/.DS_Store").should be_false
             File.exists?("public/css/.DS_Store").should be_false
             File.exists?("public/.git/config").should be_false
-            File.exists?("public/notes.txt~").should be_false
+            File.exists?("public/.main.css.swp").should be_false
           end
         end
       end

--- a/spec/unit/phases_initialize_spec.cr
+++ b/spec/unit/phases_initialize_spec.cr
@@ -154,6 +154,95 @@ describe Hwaro::Core::Build::Phases::Initialize do
         end
       end
     end
+
+    # Regression: hidden dot-directories such as `.well-known/` must be
+    # published. Crystal's `Dir.glob` skips hidden entries by default, which
+    # previously dropped them from cached builds (issue #610).
+    {true, false}.each do |incremental|
+      mode = incremental ? "incremental" : "non-incremental"
+
+      it "copies hidden dot-directories like .well-known in #{mode} mode" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("static/.well-known")
+            File.write("static/.well-known/security.txt", "Contact: mailto:x@y.z")
+            File.write("static/robots.txt", "User-agent: *")
+            FileUtils.mkdir_p("public")
+
+            builder = Hwaro::Core::Build::Builder.new
+            builder.test_copy_static_files("public", incremental: incremental)
+
+            File.exists?("public/.well-known/security.txt").should be_true
+            File.read("public/.well-known/security.txt").should eq("Contact: mailto:x@y.z")
+            File.exists?("public/robots.txt").should be_true
+          end
+        end
+      end
+
+      it "excludes OS/VCS cruft like .DS_Store and .git in #{mode} mode" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("static/css")
+            FileUtils.mkdir_p("static/.git")
+            File.write("static/css/main.css", "body{}")
+            File.write("static/.DS_Store", "junk")
+            File.write("static/css/.DS_Store", "junk")
+            File.write("static/.git/config", "[core]")
+            File.write("static/notes.txt~", "backup")
+            FileUtils.mkdir_p("public")
+
+            builder = Hwaro::Core::Build::Builder.new
+            builder.test_copy_static_files("public", incremental: incremental)
+
+            File.exists?("public/css/main.css").should be_true
+            File.exists?("public/.DS_Store").should be_false
+            File.exists?("public/css/.DS_Store").should be_false
+            File.exists?("public/.git/config").should be_false
+            File.exists?("public/notes.txt~").should be_false
+          end
+        end
+      end
+    end
+
+    it "honors a custom [static] exclude list from config" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("static")
+          File.write("static/keep.txt", "keep")
+          File.write("static/secret.bak", "drop")
+          FileUtils.mkdir_p("public")
+
+          config = Hwaro::Models::Config.new
+          config.static.exclude = ["*.bak"]
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_set_config_for_init(config)
+          builder.test_copy_static_files("public")
+
+          File.exists?("public/keep.txt").should be_true
+          File.exists?("public/secret.bak").should be_false
+        end
+      end
+    end
+
+    it "publishes cruft when use_default_excludes is disabled" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("static")
+          File.write("static/.DS_Store", "junk")
+          FileUtils.mkdir_p("public")
+
+          config = Hwaro::Models::Config.new
+          config.static.use_default_excludes = false
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_set_config_for_init(config)
+          builder.test_copy_static_files("public")
+
+          File.exists?("public/.DS_Store").should be_true
+        end
+      end
+    end
   end
 
   describe "#load_templates" do

--- a/spec/unit/static_config_spec.cr
+++ b/spec/unit/static_config_spec.cr
@@ -42,11 +42,23 @@ describe Hwaro::Models::StaticConfig do
       config.excluded?("nested/.git/HEAD").should be_true
     end
 
-    it "excludes transient editor files by suffix, including hidden variants" do
+    it "excludes vim swap files by leaf-name suffix, including hidden variants" do
       config = Hwaro::Models::StaticConfig.new
-      config.excluded?("notes.txt~").should be_true
       config.excluded?(".index.html.swp").should be_true
       config.excluded?("dir/file.swo").should be_true
+    end
+
+    it "does not treat a trailing tilde as default cruft" do
+      # `foo~` is a legal file name, so the default denylist must not drop it.
+      config = Hwaro::Models::StaticConfig.new
+      config.excluded?("changelog~").should be_false
+      config.excluded?("downloads/snapshot~").should be_false
+    end
+
+    it "applies the swap-file suffix to the leaf name only, not directories" do
+      # A directory whose name ends in a swap suffix must not drop its subtree.
+      config = Hwaro::Models::StaticConfig.new
+      config.excluded?("assets.swp/logo.png").should be_false
     end
 
     it "honors use_default_excludes = false" do
@@ -76,6 +88,21 @@ describe Hwaro::Models::StaticConfig do
       config.exclude = ["drafts/**"]
       config.excluded?("drafts/a/b.txt").should be_true
       config.excluded?("published/note.txt").should be_false
+    end
+
+    it "anchors a literal name so it does not over-exclude same-named files" do
+      config = Hwaro::Models::StaticConfig.new
+      config.exclude = ["config"]
+      config.excluded?("config").should be_true      # exact top-level file
+      config.excluded?("sub/config").should be_false # same name elsewhere is kept
+    end
+
+    it "treats a literal directory name as a subtree" do
+      config = Hwaro::Models::StaticConfig.new
+      config.exclude = ["drafts"]
+      config.excluded?("drafts/wip.txt").should be_true # whole folder dropped
+      config.excluded?("drafts").should be_true
+      config.excluded?("draftsman.txt").should be_false # prefix, not a subtree
     end
 
     it "keeps default excludes active alongside custom excludes" do

--- a/spec/unit/static_config_spec.cr
+++ b/spec/unit/static_config_spec.cr
@@ -1,0 +1,123 @@
+require "../spec_helper"
+
+# Helper to load a Config from a TOML string via a temp file.
+private def load_config(toml : String) : Hwaro::Models::Config
+  File.tempfile("hwaro-static-config", ".toml") do |file|
+    file.print(toml)
+    file.flush
+    return Hwaro::Models::Config.load(file.path)
+  end
+  raise "unreachable"
+end
+
+describe Hwaro::Models::StaticConfig do
+  describe "#initialize" do
+    it "defaults to an empty exclude list with default excludes enabled" do
+      config = Hwaro::Models::StaticConfig.new
+      config.exclude.should eq([] of String)
+      config.use_default_excludes.should be_true
+    end
+  end
+
+  describe "#excluded?" do
+    it "does not exclude ordinary files" do
+      config = Hwaro::Models::StaticConfig.new
+      config.excluded?("robots.txt").should be_false
+      config.excluded?("css/main.css").should be_false
+    end
+
+    it "never excludes legitimate dot-paths like .well-known" do
+      config = Hwaro::Models::StaticConfig.new
+      config.excluded?(".well-known/security.txt").should be_false
+      config.excluded?(".well-known/humans.txt").should be_false
+    end
+
+    it "excludes OS/VCS cruft by default at any depth" do
+      config = Hwaro::Models::StaticConfig.new
+      config.excluded?(".DS_Store").should be_true
+      config.excluded?("css/.DS_Store").should be_true
+      config.excluded?("Thumbs.db").should be_true
+      config.excluded?("assets/desktop.ini").should be_true
+      config.excluded?(".git/config").should be_true
+      config.excluded?("nested/.git/HEAD").should be_true
+    end
+
+    it "excludes transient editor files by suffix, including hidden variants" do
+      config = Hwaro::Models::StaticConfig.new
+      config.excluded?("notes.txt~").should be_true
+      config.excluded?(".index.html.swp").should be_true
+      config.excluded?("dir/file.swo").should be_true
+    end
+
+    it "honors use_default_excludes = false" do
+      config = Hwaro::Models::StaticConfig.new
+      config.use_default_excludes = false
+      config.excluded?(".DS_Store").should be_false
+      config.excluded?(".git/config").should be_false
+    end
+
+    it "applies custom glob excludes against the relative path" do
+      config = Hwaro::Models::StaticConfig.new
+      config.exclude = ["*.bak", "drafts/**"]
+      config.excluded?("keep-me.bak").should be_true
+      config.excluded?("drafts/wip.txt").should be_true
+      config.excluded?("robots.txt").should be_false
+    end
+
+    it "matches a bare-name glob like *.bak at any depth" do
+      config = Hwaro::Models::StaticConfig.new
+      config.exclude = ["*.bak"]
+      config.excluded?("nested/deep/secret.bak").should be_true
+      config.excluded?("nested/keep.txt").should be_false
+    end
+
+    it "scopes a path glob like drafts/** to its subtree" do
+      config = Hwaro::Models::StaticConfig.new
+      config.exclude = ["drafts/**"]
+      config.excluded?("drafts/a/b.txt").should be_true
+      config.excluded?("published/note.txt").should be_false
+    end
+
+    it "keeps default excludes active alongside custom excludes" do
+      config = Hwaro::Models::StaticConfig.new
+      config.exclude = ["*.bak"]
+      config.excluded?(".DS_Store").should be_true
+      config.excluded?("note.bak").should be_true
+    end
+  end
+end
+
+describe "Config: [static] parsing" do
+  it "defaults to an enabled denylist with no custom excludes" do
+    config = load_config(<<-TOML)
+      title = "T"
+      base_url = "http://localhost"
+      TOML
+    config.static.use_default_excludes.should be_true
+    config.static.exclude.should eq([] of String)
+  end
+
+  it "parses exclude as an array and use_default_excludes as a bool" do
+    config = load_config(<<-TOML)
+      title = "T"
+      base_url = "http://localhost"
+
+      [static]
+      use_default_excludes = false
+      exclude = ["*.bak", "drafts/**"]
+      TOML
+    config.static.use_default_excludes.should be_false
+    config.static.exclude.should eq(["*.bak", "drafts/**"])
+  end
+
+  it "accepts a single string for exclude" do
+    config = load_config(<<-TOML)
+      title = "T"
+      base_url = "http://localhost"
+
+      [static]
+      exclude = "*.tmp"
+      TOML
+    config.static.exclude.should eq(["*.tmp"])
+  end
+end

--- a/src/content/hooks/image_hooks.cr
+++ b/src/content/hooks/image_hooks.cr
@@ -344,7 +344,11 @@ module Hwaro
         )
           return unless Dir.exists?("static")
 
-          Dir.glob(File.join("static", "**", "*")).each do |file|
+          # Match the static copy path: include hidden entries so images under
+          # published dot-dirs (e.g. `static/.well-known/`) get resize variants
+          # too. Excluded cruft is filtered out just below.
+          glob_match = File::MatchOptions.glob_default | File::MatchOptions::DotFiles
+          Dir.glob(File.join("static", "**", "*"), match: glob_match).each do |file|
             next unless File.file?(file)
             next unless Processors::ImageProcessor.image?(file)
             next unless safe_path?(file, "static")

--- a/src/content/hooks/image_hooks.cr
+++ b/src/content/hooks/image_hooks.cr
@@ -130,7 +130,7 @@ module Hwaro
           collect_page_asset_jobs(ctx, output_dir, resolved_output, jobs, seen, fast_start_priority)
           if fast_start_priority.nil?
             collect_content_file_jobs(config, output_dir, resolved_output, jobs, seen) if config.content_files.enabled?
-            collect_static_jobs(output_dir, resolved_output, jobs, seen)
+            collect_static_jobs(config, output_dir, resolved_output, jobs, seen)
           end
 
           return if jobs.empty?
@@ -336,6 +336,7 @@ module Hwaro
         end
 
         private def collect_static_jobs(
+          config : Models::Config,
           output_dir : String,
           resolved_output : String,
           jobs : Array(ImageJob),
@@ -349,6 +350,11 @@ module Hwaro
             next unless safe_path?(file, "static")
 
             relative = Path[file].relative_to("static").to_s
+            # Don't emit resized variants for files the static copy filters out
+            # (`[static] exclude`), otherwise excluded images would leak into
+            # the output even though their originals are never published.
+            next if config.static.excluded?(relative)
+
             original_url = "/" + relative
             next if seen.includes?(original_url)
             dest_dir = File.join(output_dir, File.dirname(relative))

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -631,6 +631,7 @@ module Hwaro
         # Copy only the specified static files to the output directory.
         # Used by serve mode when only static files have changed.
         def copy_changed_static(changed_files : Array(String), output_dir : String, verbose : Bool = false)
+          static_config = static_publish_config
           copied = 0
           changed_files.each do |src_path|
             next unless File.exists?(src_path)
@@ -641,6 +642,7 @@ module Hwaro
             rescue ArgumentError
               src_path.lchop("static/")
             end
+            next if static_config.excluded?(relative)
             dest_path = File.join(output_dir, relative)
 
             Hwaro::Utils::FileSafe.mkdir_p(File.dirname(dest_path))

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -82,40 +82,71 @@ module Hwaro::Core::Build::Phases::Initialize
   private def copy_static_files(output_dir : String, verbose : Bool, incremental : Bool = false)
     return unless Dir.exists?("static")
 
-    if incremental
-      # Incremental mode: only copy files that are newer than their destination
-      copy_static_files_incremental("static", output_dir, verbose)
-    else
-      FileUtils.cp_r("static/.", "#{output_dir}/")
-      Logger.action :copy, "static files", :blue if verbose
-    end
-  end
-
-  # Copy only changed static files by comparing mtime, using parallel I/O
-  private def copy_static_files_incremental(src_dir : String, output_dir : String, verbose : Bool)
-    # First pass: collect files that need copying (sequential, fast stat calls)
-    files_to_copy = [] of {String, String} # {src, dest}
-    Dir.glob(File.join(src_dir, "**", "*")) do |src_path|
-      next if File.directory?(src_path)
-
-      relative = Path[src_path].relative_to(src_dir).to_s
-      dest_path = File.join(output_dir, relative)
-
-      needs_copy = if File.exists?(dest_path)
-                     File.info(src_path).modification_time > File.info(dest_path).modification_time
-                   else
-                     true
-                   end
-
-      files_to_copy << {src_path, dest_path} if needs_copy
-    end
-
+    # Single source of truth for both cold and incremental builds: walk
+    # `static/` once (including hidden entries like `.well-known/`), drop
+    # excluded cruft, then copy the survivors in parallel. Keeping both modes
+    # on the same path guarantees `--cache` and cold builds publish exactly
+    # the same files (see issues #610/#611).
+    files_to_copy = collect_static_files("static", output_dir, static_publish_config, incremental)
     return if files_to_copy.empty?
 
-    # Ensure destination directories exist (must be sequential to avoid races)
+    copy_static_pairs(files_to_copy)
+
+    label = incremental ? "static files (#{files_to_copy.size} updated)" : "static files"
+    Logger.action :copy, label, :blue if verbose
+  end
+
+  # The effective `[static]` publishing config, falling back to defaults (which
+  # keep the built-in cruft denylist on) when config hasn't loaded yet — e.g.
+  # in unit tests that exercise the copy directly. Shared by both the full
+  # build and the serve-watch copy so they filter identically.
+  private def static_publish_config : Models::StaticConfig
+    @config.try(&.static) || Models::StaticConfig.new
+  end
+
+  # Walk `static/` and return the `{src, dest}` pairs that need copying.
+  #
+  # Hidden files/dirs are matched explicitly via `DotFiles` — Crystal's glob
+  # skips them by default, which previously dropped `.well-known/` from cached
+  # builds (#610). Excluded paths (`StaticConfig#excluded?`) are filtered out
+  # for both modes (#611). In incremental mode, files whose destination is
+  # newer-or-equal are skipped.
+  private def collect_static_files(
+    src_dir : String,
+    output_dir : String,
+    static_config : Models::StaticConfig,
+    incremental : Bool,
+  ) : Array({String, String})
+    files_to_copy = [] of {String, String}
+    glob_match = File::MatchOptions.glob_default | File::MatchOptions::DotFiles
+
+    Dir.glob(File.join(src_dir, "**", "*"), match: glob_match) do |src_path|
+      next if File.directory?(src_path)
+      # Skip dangling symlinks so the copy worker doesn't log a spurious
+      # failure (parity with the serve-watch path's existence guard).
+      next unless File.exists?(src_path)
+
+      relative = Path[src_path].relative_to(src_dir).to_s
+      next if static_config.excluded?(relative)
+
+      dest_path = File.join(output_dir, relative)
+      if incremental && File.exists?(dest_path) &&
+         File.info(src_path).modification_time <= File.info(dest_path).modification_time
+        next
+      end
+
+      files_to_copy << {src_path, dest_path}
+    end
+
+    files_to_copy
+  end
+
+  # Copy the given `{src, dest}` pairs using a parallel worker pool. Directory
+  # creation stays sequential to avoid the check-then-create race that fires
+  # under the multi-threaded runtime.
+  private def copy_static_pairs(files_to_copy : Array({String, String}))
     files_to_copy.each { |_, dest| Hwaro::Utils::FileSafe.mkdir_p(File.dirname(dest)) }
 
-    # Second pass: copy files in parallel using worker pool
     config = ParallelConfig.new(enabled: true)
     worker_count = config.calculate_workers(files_to_copy.size)
 
@@ -142,8 +173,6 @@ module Hwaro::Core::Build::Phases::Initialize
       end
     end
     worker_count.times { done.receive }
-
-    Logger.action :copy, "static files (#{files_to_copy.size} updated)", :blue if verbose
   end
 
   private def load_templates : Hash(String, String)

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -121,10 +121,11 @@ module Hwaro::Core::Build::Phases::Initialize
     glob_match = File::MatchOptions.glob_default | File::MatchOptions::DotFiles
 
     Dir.glob(File.join(src_dir, "**", "*"), match: glob_match) do |src_path|
-      next if File.directory?(src_path)
-      # Skip dangling symlinks so the copy worker doesn't log a spurious
-      # failure (parity with the serve-watch path's existence guard).
-      next unless File.exists?(src_path)
+      # One stat for both checks: skip directories, and skip dangling symlinks
+      # (`info?` is nil when the target is missing) so the copy worker doesn't
+      # log a spurious failure.
+      info = File.info?(src_path, follow_symlinks: true)
+      next if info.nil? || info.directory?
 
       relative = Path[src_path].relative_to(src_dir).to_s
       next if static_config.excluded?(relative)

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -788,6 +788,71 @@ module Hwaro
       end
     end
 
+    # `[static]` — controls which files under `static/` get published.
+    #
+    # `static/` is copied verbatim into the site root, so OS/editor/VCS cruft
+    # placed there (`.DS_Store`, `Thumbs.db`, `.git/`, vim swap files, …) would
+    # otherwise be deployed. A built-in denylist filters the common offenders;
+    # `exclude` adds project-specific shell-glob patterns (matched against both
+    # the path relative to `static/` and the bare file name, so `*.bak` filters
+    # at any depth while `drafts/**` scopes to a subtree), and
+    # `use_default_excludes = false` opts out of the built-in list entirely.
+    #
+    # Note: this only filters *cruft*. Legitimate dot-paths such as
+    # `.well-known/` are NOT in the denylist and are always published.
+    class StaticConfig
+      # Exact file/dir names that should essentially never be published.
+      # Matched per path segment, so an entry like `.git` filters that
+      # directory (and everything under it) at any depth.
+      DEFAULT_EXCLUDE_NAMES = Set{
+        ".DS_Store", ".AppleDouble", ".LSOverride", ".Spotlight-V100",
+        ".Trashes", ".fseventsd", ".DocumentRevisions-V100", ".TemporaryItems",
+        ".VolumeIcon.icns", "__MACOSX",
+        "Thumbs.db", "ehthumbs.db", "ehthumbs_vista.db", "desktop.ini", ".directory",
+        ".git", ".gitignore", ".gitattributes", ".gitmodules", ".gitkeep",
+        ".svn", ".hg", ".bzr",
+      }
+
+      # Suffixes for transient editor files (vim swap, emacs/backup). Matched
+      # against each path segment so hidden variants (e.g. `.foo.txt.swp`) are
+      # caught too — a plain `*.swp` glob would miss the leading dot.
+      DEFAULT_EXCLUDE_SUFFIXES = [".swp", ".swo", "~"]
+
+      property exclude : Array(String)
+      property use_default_excludes : Bool
+
+      def initialize
+        @exclude = [] of String
+        @use_default_excludes = true
+      end
+
+      # Whether `relative_path` (relative to `static/`) should be filtered out
+      # of the published output. `exclude` entries are shell globs matched
+      # against the POSIX-normalized relative path and the bare file name, so a
+      # pattern like `*.bak` filters at any depth (Crystal's `*` does not cross
+      # `/`) while a path pattern like `drafts/**` scopes to a subtree.
+      def excluded?(relative_path : String) : Bool
+        normalized = Path[relative_path].to_posix.to_s
+        return false if normalized.empty? || normalized == "."
+
+        if @use_default_excludes
+          segments = normalized.split('/')
+          return true if segments.any? { |segment| default_excluded_segment?(segment) }
+        end
+
+        return false if @exclude.empty?
+        basename = File.basename(normalized)
+        @exclude.any? do |pattern|
+          File.match?(pattern, normalized) || File.match?(pattern, basename)
+        end
+      end
+
+      private def default_excluded_segment?(segment : String) : Bool
+        return true if DEFAULT_EXCLUDE_NAMES.includes?(segment)
+        DEFAULT_EXCLUDE_SUFFIXES.any? { |suffix| segment.ends_with?(suffix) }
+      end
+    end
+
     class Config
       property title : String
       property description : String
@@ -818,6 +883,7 @@ module Hwaro
       property amp : AmpConfig
       property image_processing : ImageProcessingConfig
       property doctor : DoctorConfig
+      property static : StaticConfig
       property permalinks : Hash(String, String)
       property raw : Hash(String, TOML::Any)
       @base_url_stripped : String? = nil
@@ -853,6 +919,7 @@ module Hwaro
         @amp = AmpConfig.new
         @image_processing = ImageProcessingConfig.new
         @doctor = DoctorConfig.new
+        @static = StaticConfig.new
         @permalinks = {} of String => String
         @raw = Hash(String, TOML::Any).new
       end
@@ -1049,6 +1116,7 @@ module Hwaro
         load_amp(config)
         load_image_processing(config)
         load_doctor(config)
+        load_static(config)
         load_deployment(config)
 
         config
@@ -1538,6 +1606,15 @@ module Hwaro
 
         if ignore = s["ignore"]?.try(&.as_a?)
           config.doctor.ignore = ignore.compact_map(&.as_s?)
+        end
+      end
+
+      private def self.load_static(config : Config)
+        return unless s = config.raw["static"]?.try(&.as_h?)
+
+        config.static.use_default_excludes = bool_value(s["use_default_excludes"]?, config.static.use_default_excludes)
+        if exclude_any = s["exclude"]?
+          config.static.exclude = string_or_array(exclude_any)
         end
       end
 

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -793,9 +793,9 @@ module Hwaro
     # `static/` is copied verbatim into the site root, so OS/editor/VCS cruft
     # placed there (`.DS_Store`, `Thumbs.db`, `.git/`, vim swap files, …) would
     # otherwise be deployed. A built-in denylist filters the common offenders;
-    # `exclude` adds project-specific shell-glob patterns (matched against both
-    # the path relative to `static/` and the bare file name, so `*.bak` filters
-    # at any depth while `drafts/**` scopes to a subtree), and
+    # `exclude` adds project-specific patterns — a glob like `*.bak` filters at
+    # any depth, `drafts/**` scopes a subtree, and a literal name is anchored to
+    # an exact file or directory (`drafts` drops `drafts/…`) — and
     # `use_default_excludes = false` opts out of the built-in list entirely.
     #
     # Note: this only filters *cruft*. Legitimate dot-paths such as
@@ -813,10 +813,17 @@ module Hwaro
         ".svn", ".hg", ".bzr",
       }
 
-      # Suffixes for transient editor files (vim swap, emacs/backup). Matched
-      # against each path segment so hidden variants (e.g. `.foo.txt.swp`) are
-      # caught too — a plain `*.swp` glob would miss the leading dot.
-      DEFAULT_EXCLUDE_SUFFIXES = [".swp", ".swo", "~"]
+      # Suffixes for vim swap files, matched against the leaf file name only.
+      # Kept deliberately narrow: a name ending in `.swp`/`.swo` is never a
+      # legitimate published asset, so the always-on default denylist can't
+      # silently drop real content. Emacs-style `~` backups are intentionally
+      # NOT here — a trailing tilde is a legal file name, so filtering it is
+      # left to an explicit `exclude` pattern.
+      DEFAULT_EXCLUDE_SUFFIXES = [".swp", ".swo"]
+
+      # Glob metacharacters that distinguish an `exclude` glob from a literal
+      # path/name.
+      GLOB_METACHARS = /[*?\[{]/
 
       property exclude : Array(String)
       property use_default_excludes : Bool
@@ -827,29 +834,44 @@ module Hwaro
       end
 
       # Whether `relative_path` (relative to `static/`) should be filtered out
-      # of the published output. `exclude` entries are shell globs matched
-      # against the POSIX-normalized relative path and the bare file name, so a
-      # pattern like `*.bak` filters at any depth (Crystal's `*` does not cross
-      # `/`) while a path pattern like `drafts/**` scopes to a subtree.
+      # of the published output.
+      #
+      # `exclude` entries match two ways depending on their shape:
+      # - a glob (contains `* ? [ {`) matches the relative path, and — when it
+      #   has no `/` — the bare file name too, so `*.bak` filters at any depth
+      #   while `drafts/**` scopes to a subtree;
+      # - a literal is anchored: it matches that exact path or, when it names a
+      #   directory, the whole subtree under it. So `drafts` drops `drafts/...`
+      #   but `config` only drops a top-level `config`, never a same-named file
+      #   nested elsewhere.
       def excluded?(relative_path : String) : Bool
         normalized = Path[relative_path].to_posix.to_s
         return false if normalized.empty? || normalized == "."
 
         if @use_default_excludes
           segments = normalized.split('/')
-          return true if segments.any? { |segment| default_excluded_segment?(segment) }
+          # Exact-name cruft (`.git`, `.DS_Store`, …) filters at any depth; the
+          # swap-file suffix check applies to the leaf name only, so a directory
+          # whose name happens to end in `.swp` doesn't take its subtree with it.
+          return true if segments.any? { |segment| DEFAULT_EXCLUDE_NAMES.includes?(segment) }
+          return true if DEFAULT_EXCLUDE_SUFFIXES.any? { |suffix| segments.last.ends_with?(suffix) }
         end
 
         return false if @exclude.empty?
         basename = File.basename(normalized)
-        @exclude.any? do |pattern|
-          File.match?(pattern, normalized) || File.match?(pattern, basename)
-        end
+        @exclude.any? { |pattern| pattern_matches?(pattern, normalized, basename) }
       end
 
-      private def default_excluded_segment?(segment : String) : Bool
-        return true if DEFAULT_EXCLUDE_NAMES.includes?(segment)
-        DEFAULT_EXCLUDE_SUFFIXES.any? { |suffix| segment.ends_with?(suffix) }
+      private def pattern_matches?(pattern : String, normalized : String, basename : String) : Bool
+        if GLOB_METACHARS.matches?(pattern)
+          # Glob: match the full relative path, plus the bare name for a
+          # path-less glob so it applies at any depth.
+          File.match?(pattern, normalized) ||
+            (!pattern.includes?('/') && File.match?(pattern, basename))
+        else
+          # Literal: an exact file, or a directory subtree rooted at it.
+          normalized == pattern || normalized.starts_with?("#{pattern}/")
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #610. Fixes #611.

## Problem

`static/.well-known/` (and any dot-path under `static/`) was **missing from deployed sites**. Root cause: the two static-copy paths disagreed.

- Cold build (`hwaro build`): `FileUtils.cp_r("static/.", …)` → copies hidden files ✅
- Cached build (`hwaro build --cache`): an incremental path using `Dir.glob("static/**/*")`, which in Crystal skips hidden entries by default (`match: glob_default`) ❌

The GitHub Action's entrypoint **always** appends `--cache` (to preserve restored OG images), so every deployed build took the incremental path and silently dropped `.well-known/` — breaking `security.txt` (RFC 9116), `humans.txt`, and ACME challenges.

```
hwaro build         --output /tmp/cold     # .well-known/ present
hwaro build --cache --output /tmp/cached   # .well-known/ MISSING  ← what the Action runs
```

## Fix

**#610 — unify the copy paths.** Both cold and incremental builds now go through one `collect_static_files` → `copy_static_pairs` walk that matches hidden entries explicitly (`File::MatchOptions.glob_default | DotFiles`). `--cache` and cold builds now publish identical files. The mtime-skip is the only mode-specific behavior.

**#611 — `[static]` denylist.** A new `Hwaro::Models::StaticConfig` filters OS/editor/VCS cruft that should never ship:

```toml
[static]
# extends the built-in denylist (.DS_Store, Thumbs.db, desktop.ini, .git/,
# vim swap/backup files, …) with project-specific globs:
exclude = ["*.bak", "drafts/**"]   # *.bak matches at any depth; drafts/** scopes a subtree
# use_default_excludes = false     # opt out of the built-in list entirely
```

The filter is applied through a single shared helper (`static_publish_config` + `StaticConfig#excluded?`) across **all** static consumers — cold build, incremental build, the serve-watch copy (`copy_changed_static`), and the image-processing static collector (`collect_static_jobs`) — so an excluded file can't slip in via one path while being filtered by another. Legitimate dot-paths like `.well-known/` are **not** in the denylist and are always published.

## Behavior notes (intentional)

- The unified walk copies files, not empty directories or symlinked dirs. This is **not a regression for deployed sites**: the production `--cache` path already used `Dir.glob` and never preserved those. Cold builds are the only ones that change, and empty dirs/symlinks aren't web content.
- `hwaro tool unused-assets` still globs `static/` without the exclusion — it's a link/usage diagnostic, not a publish path, so its notion of "asset" is deliberately broader. Left as-is.

## Testing

- New `spec/unit/static_config_spec.cr` — `StaticConfig#excluded?` matrix + `[static]` TOML parsing.
- Extended `spec/unit/phases_initialize_spec.cr` — `.well-known/` kept and cruft dropped in **both** incremental and non-incremental modes; custom `exclude`; `use_default_excludes = false`.
- New `spec/functional/static_files_spec.cr` — full `Builder#run` with `cache: true` (the production path) asserting `.well-known/` ships and cruft is filtered.
- Full suite: **5147 examples, 0 failures**. Ameba: **0 failures**. Manual repro against a real site confirmed `.well-known/` now ships under `--cache`, cruft is filtered, custom globs match at any depth, and a build with a dangling symlink exits 0 with no error log.