### PR TITLE
ci(homebrew): ship a fully prebuilt-binary formula (relink macOS to openssl@3)

### DIFF
--- a/.github/homebrew/hwaro.rb.tmpl
+++ b/.github/homebrew/hwaro.rb.tmpl
@@ -1,0 +1,46 @@
+# typed: strict
+# frozen_string_literal: true
+
+# This file is rendered by hwaro's release pipeline (.github/workflows/publish-homebrew.yml).
+# DO NOT EDIT by hand.
+class Hwaro < Formula
+  desc "Lightweight and fast static site generator (SSG) written in Crystal"
+  homepage "https://github.com/hahwul/hwaro"
+  version "__VERSION__"
+  license "MIT"
+
+  on_macos do
+    # macOS binaries are dynamically linked; openssl@3 is the only non-system
+    # dependency (enforced by an otool guard in release-binary.yml).
+    depends_on "openssl@3"
+
+    on_arm do
+      url "https://github.com/hahwul/hwaro/releases/download/v__VERSION__/hwaro-v__VERSION__-osx-arm64"
+      sha256 "__SHA_OSX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/hwaro/releases/download/v__VERSION__/hwaro-v__VERSION__-osx-x86_64"
+      sha256 "__SHA_OSX_X86_64__"
+    end
+  end
+
+  on_linux do
+    # Linux release binaries are statically linked (musl), so they are self-contained.
+    on_arm do
+      url "https://github.com/hahwul/hwaro/releases/download/v__VERSION__/hwaro-v__VERSION__-linux-arm64"
+      sha256 "__SHA_LINUX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/hwaro/releases/download/v__VERSION__/hwaro-v__VERSION__-linux-x86_64"
+      sha256 "__SHA_LINUX_X86_64__"
+    end
+  end
+
+  def install
+    bin.install Dir["hwaro-v__VERSION__-*"].first => "hwaro"
+  end
+
+  test do
+    system "#{bin}/hwaro", "version"
+  end
+end

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,32 +1,105 @@
 ---
 name: Homebrew tap Publish
 on:
-  release:
-    types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.15.2)"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
+permissions:
+  contents: read
 jobs:
-  homebrew-releaser:
+  publish-formula:
+    name: Publish prebuilt formula to tap
+    # Only run after a release-triggered binary build succeeds (mirrors release-deb.yml),
+    # or on manual dispatch. The prebuilt formula needs the release binaries to exist first.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
     runs-on: ubuntu-latest
-    name: homebrew-releaser
     steps:
-      - name: Release Hwaro to Homebrew tap
-        uses: Justintime50/homebrew-releaser@v3
+      - name: Checkout source (formula template)
+        uses: actions/checkout@v6
         with:
-          homebrew_owner: hahwul
-          homebrew_tap: homebrew-hwaro
-          formula_folder: Formula
-          github_token: ${{ secrets.HWARO_PUBLISH_TOKEN }}
-          commit_owner: hahwul
-          commit_email: hahwul@gmail.com
-          depends_on: |
-            "crystal"
-          install: |
-            system "shards install"
-            system "shards build --release --no-debug --production -Dpreview_mt"
-            bin.install "bin/hwaro"
-          test: 'system "#{bin}/hwaro", "version"'
-          update_readme_table: false
-          ignore_warnings: true
-          skip_commit: false
-          skip_checksum: true
-          debug: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
+
+      - name: Resolve version
+        id: ver
+        # Pass event data via env (never interpolate ${{ }} straight into the
+        # script body) so a crafted tag/branch name can't inject shell.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RAW="$DISPATCH_VERSION"
+          else
+            RAW="$RUN_BRANCH"
+          fi
+          # Strip leading 'v' if present
+          VERSION="${RAW#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Download release binaries and compute checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          # All release binaries are prebuilt: Linux is static musl; macOS is
+          # dynamically linked against openssl@3 (declared in the formula).
+          for asset in osx-arm64 osx-x86_64 linux-arm64 linux-x86_64; do
+            gh release download "v$V" --repo hahwul/hwaro \
+              --pattern "hwaro-v$V-$asset" --output "hwaro-v$V-$asset"
+          done
+          {
+            echo "SHA_OSX_ARM64=$(sha256sum "hwaro-v$V-osx-arm64" | awk '{print $1}')"
+            echo "SHA_OSX_X86_64=$(sha256sum "hwaro-v$V-osx-x86_64" | awk '{print $1}')"
+            echo "SHA_LINUX_ARM64=$(sha256sum "hwaro-v$V-linux-arm64" | awk '{print $1}')"
+            echo "SHA_LINUX_X86_64=$(sha256sum "hwaro-v$V-linux-x86_64" | awk '{print $1}')"
+          } >> "$GITHUB_ENV"
+
+      - name: Render formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p out
+          sed \
+            -e "s|__VERSION__|$V|g" \
+            -e "s|__SHA_OSX_ARM64__|$SHA_OSX_ARM64|g" \
+            -e "s|__SHA_OSX_X86_64__|$SHA_OSX_X86_64|g" \
+            -e "s|__SHA_LINUX_ARM64__|$SHA_LINUX_ARM64|g" \
+            -e "s|__SHA_LINUX_X86_64__|$SHA_LINUX_X86_64|g" \
+            .github/homebrew/hwaro.rb.tmpl > out/hwaro.rb
+          echo "----- rendered formula -----"
+          cat out/hwaro.rb
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v6
+        with:
+          repository: hahwul/homebrew-hwaro
+          token: ${{ secrets.HWARO_PUBLISH_TOKEN }}
+          path: tap
+
+      - name: Commit and push formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p tap/Formula
+          cp out/hwaro.rb tap/Formula/hwaro.rb
+          cd tap
+          git config user.name "hahwul"
+          git config user.email "hahwul@gmail.com"
+          git add Formula/hwaro.rb
+          if git diff --cached --quiet; then
+            echo "Formula unchanged; nothing to publish."
+            exit 0
+          fi
+          git commit -m "hwaro $V"
+          git push

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -19,6 +19,8 @@ jobs:
             platform: linux
           - os: macos-latest
             platform: macos
+          - os: macos-15-intel
+            platform: macos
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Crystal
@@ -56,10 +58,30 @@ jobs:
         name: Build binary (macOS)
         run: |
           mkdir -p build
+          # Link against current OpenSSL (openssl@3). Without pinning PKG_CONFIG_PATH
+          # the build can pick up an EOL openssl@1.1, producing a binary that won't
+          # launch on a clean machine (dyld: libssl.1.1.dylib not found).
+          brew install openssl@3
+          export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          BIN="build/hwaro-${GITHUB_REF_SLUG}-osx-${ARCH}"
           crystal build src/main.cr \
-            -o build/hwaro-${GITHUB_REF_SLUG}-osx-${ARCH} \
+            -o "$BIN" \
             --no-debug --release \
             -Dpreview_mt
+          echo "== otool -L $BIN ==" && otool -L "$BIN"
+          # Guard 1: never ship a macOS binary linked against EOL openssl@1.1.
+          if otool -L "$BIN" | grep -q 'openssl@1.1'; then
+            echo "::error::macOS binary still links EOL openssl@1.1"; exit 1
+          fi
+          # Guard 2: openssl@3 must be the ONLY Homebrew dynamic dep. Anything else
+          # means the Homebrew formula's depends_on list is out of date.
+          EXTRA="$(otool -L "$BIN" \
+            | grep -oE '/(opt/homebrew|usr/local)/(opt|Cellar)/[^/]+' \
+            | grep -v 'openssl@3' | sort -u || true)"
+          if [ -n "$EXTRA" ]; then
+            echo "::error::unexpected non-openssl@3 Homebrew deps (update formula depends_on):"
+            echo "$EXTRA"; exit 1
+          fi
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
## What

Replace the `homebrew-releaser` **source-build** formula with a **templated, fully prebuilt-binary** formula — every platform (macOS arm64/Intel, Linux arm64/x86_64) now installs a prebuilt binary, so `brew install hwaro` is a fast download with no Crystal toolchain.

Closes #613

## Changes

- **`.github/workflows/release-binary.yml`**
  - Adds a `macos-15-intel` matrix entry → produces the previously-missing `hwaro-vX-osx-x86_64` binary. (`macos-13` is retired as of Dec 2025; `macos-15-intel` is the current Intel runner, valid until ~Aug 2027.)
  - Pins the macOS build to **openssl@3** via `PKG_CONFIG_PATH`. The v0.15.2 macOS binary linked EOL **`openssl@1.1`** (removed from homebrew-core) and would not launch on a clean machine.
  - Adds an **`otool` guard**: the build fails if the binary links `openssl@1.1` *or any Homebrew lib other than `openssl@3`* — so the formula's `depends_on` can never silently drift out of sync with the binary.
- **`.github/homebrew/hwaro.rb.tmpl`** (new) — templated formula. macOS blocks point at the prebuilt binaries with `depends_on "openssl@3"`; Linux blocks point at the static-musl binaries; single `bin.install Dir["hwaro-v#{version}-*"]` install.
- **`.github/workflows/publish-homebrew.yml`** (rewritten) — drops `homebrew-releaser`. Triggers on `workflow_run` after **Build and Release Binaries** completes (same gating as `release-deb.yml`), downloads all 4 binaries, computes `sha256`, renders the formula via `sed`, and pushes to `hahwul/homebrew-hwaro` with `HWARO_PUBLISH_TOKEN`. `workflow_dispatch` kept for manual re-publishing.

## Platform coverage

| Platform | Install |
|---|---|
| macOS arm64 | prebuilt `osx-arm64` (`depends_on "openssl@3"`) |
| macOS Intel | prebuilt `osx-x86_64` (`depends_on "openssl@3"`) |
| Linux arm64 | prebuilt `linux-arm64` (static musl) |
| Linux x86_64 | prebuilt `linux-x86_64` (static musl) |

## Validation

- Built hwaro **locally** with `PKG_CONFIG_PATH` pinned to openssl@3 → `otool -L` confirms it links `libssl.3.dylib`/`libcrypto.3.dylib` (openssl@3), and the binary runs.
- **End-to-end Homebrew install** of the relinked binary via a throwaway tap → installs with `depends_on "openssl@3"`, the glob install resolves, and `hwaro version` runs.
- `ruby -c` on the rendered formula → **Syntax OK**; `brew style` → **no offenses**.
- Both workflows validate as YAML.

## Notes

- The relink + formula change ship together and take effect on the **next release** (the existing v0.15.2 asset still links openssl@1.1; the publish workflow only runs on new releases).
- User-facing commands unchanged: `brew tap hahwul/hwaro && brew install hwaro`.
- Also fixes the previously mangled formula `desc` (was `"() is a lightweight..."`).
- No Crystal sources touched, so the `crystal format` / `ameba` CI gates are unaffected.
