### PR TITLE
fix: eliminate latent bugs across subsystems (source audit)

### DIFF
--- a/spec/unit/bugfix_regression_spec.cr
+++ b/spec/unit/bugfix_regression_spec.cr
@@ -5,7 +5,6 @@ require "../../src/content/processors/template"
 require "../../src/utils/text_utils"
 require "../../src/utils/js_minifier"
 require "../../src/utils/html_minifier"
-require "../../src/utils/frontmatter_scanner"
 
 # Regression coverage for latent bugs fixed during the source-code audit.
 # Each block names the class of defect it guards against.
@@ -81,6 +80,11 @@ describe "bugfix regressions" do
       Hwaro::Utils::TextUtils.escape_xml("a\tb\nc\rd").should eq("a\tb\nc\rd")
     end
 
+    it "preserves DEL (0x7F, a legal XML char) on both fast and slow paths" do
+      Hwaro::Utils::TextUtils.escape_xml("ab").should eq("ab")      # fast path
+      Hwaro::Utils::TextUtils.escape_xml("a<b").should eq("a&lt;b") # slow path agrees
+    end
+
     it "still escapes the five XML special characters" do
       Hwaro::Utils::TextUtils.escape_xml("a & b < c > \"d\" 'e'").should eq("a &amp; b &lt; c &gt; &quot;d&quot; &apos;e&apos;")
     end
@@ -89,6 +93,10 @@ describe "bugfix regressions" do
   describe "JsMinifier template literals" do
     it "preserves blank lines inside a template literal" do
       Hwaro::Utils::JsMinifier.minify("const t = `line1\n\nline2`; var a=1;").should contain("line1\n\nline2")
+    end
+
+    it "preserves significant trailing whitespace inside a template literal" do
+      Hwaro::Utils::JsMinifier.minify("const css = `body {\n  color: red;   \n}`;").should contain("color: red;   ")
     end
 
     it "still collapses blank lines in plain code" do
@@ -122,6 +130,15 @@ describe "bugfix regressions" do
       vars = {"items" => Crinja::Value.new(arr)}
       result = render_filter("{% for item in items | sort_by(attribute='w') %}{{ item.w }},{% endfor %}", vars)
       result.should eq("1,2,10,20,100,")
+    end
+  end
+
+  describe "get_taxonomy_url (slug consistency)" do
+    it "uses safe_slugify so symbol-only terms don't yield dead // links" do
+      vars = {"base_url" => Crinja::Value.new("https://e.com")}
+      url = render_filter(%({{ get_taxonomy_url(kind="tags", term="🎉") }}), vars)
+      url.should_not contain("tags//")
+      url.should contain("/tags/term-")
     end
   end
 end

--- a/spec/unit/bugfix_regression_spec.cr
+++ b/spec/unit/bugfix_regression_spec.cr
@@ -1,0 +1,127 @@
+require "../spec_helper"
+require "../../src/content/processors/inline_markdown"
+require "../../src/content/processors/table_parser"
+require "../../src/content/processors/template"
+require "../../src/utils/text_utils"
+require "../../src/utils/js_minifier"
+require "../../src/utils/html_minifier"
+require "../../src/utils/frontmatter_scanner"
+
+# Regression coverage for latent bugs fixed during the source-code audit.
+# Each block names the class of defect it guards against.
+
+private def render_filter(template_str : String, vars : Hash(String, Crinja::Value) = {} of String => Crinja::Value) : String
+  Hwaro::Content::Processors::TemplateEngine.new.render(template_str, vars)
+end
+
+describe "bugfix regressions" do
+  describe "InlineMarkdown.safe_url? (XSS)" do
+    it "blocks control-character-obfuscated script schemes" do
+      Hwaro::Content::Processors::InlineMarkdown.safe_url?("java%09script:alert(1)").should be_false
+      Hwaro::Content::Processors::InlineMarkdown.safe_url?("java%0Ascript:alert(1)").should be_false
+      Hwaro::Content::Processors::InlineMarkdown.safe_url?("java%0Dscript:alert(1)").should be_false
+    end
+
+    it "still allows ordinary links" do
+      Hwaro::Content::Processors::InlineMarkdown.safe_url?("https://example.com/a%20b").should be_true
+      Hwaro::Content::Processors::InlineMarkdown.safe_url?("/relative/path").should be_true
+    end
+
+    it "still blocks plain javascript: links" do
+      Hwaro::Content::Processors::InlineMarkdown.safe_url?("javascript:alert(1)").should be_false
+    end
+  end
+
+  describe "InlineMarkdown.render (double escaping)" do
+    it "does not double-escape ampersands in link URLs" do
+      out = Hwaro::Content::Processors::InlineMarkdown.render("[x](https://e.com/?a=1&b=2)")
+      out.should contain("href=\"https://e.com/?a=1&amp;b=2\"")
+      out.should_not contain("&amp;amp;")
+    end
+  end
+
+  describe "TableParser fenced code blocks" do
+    it "does not convert a pipe table inside a fenced code block" do
+      md = "```\n| H1 | H2 |\n|----|----|\n| a  | b  |\n```"
+      out = Hwaro::Content::Processors::TableParser.process(md)
+      out.should_not contain("<table")
+      out.should contain("| H1 | H2 |")
+    end
+
+    it "still converts a real table outside a fence" do
+      md = "| H1 | H2 |\n|----|----|\n| a  | b  |"
+      Hwaro::Content::Processors::TableParser.process(md).should contain("<table")
+    end
+  end
+
+  describe "TextUtils.safe_slugify (collisions)" do
+    it "never returns an empty slug" do
+      Hwaro::Utils::TextUtils.safe_slugify("!!!").empty?.should be_false
+      Hwaro::Utils::TextUtils.safe_slugify("🎉").empty?.should be_false
+    end
+
+    it "keeps distinct all-symbol terms distinct and stable" do
+      a = Hwaro::Utils::TextUtils.safe_slugify("!!!")
+      b = Hwaro::Utils::TextUtils.safe_slugify("???")
+      a.should_not eq(b)
+      a.should eq(Hwaro::Utils::TextUtils.safe_slugify("!!!"))
+    end
+
+    it "matches slugify for normal input" do
+      Hwaro::Utils::TextUtils.safe_slugify("Hello World").should eq("hello-world")
+    end
+  end
+
+  describe "TextUtils.escape_xml (illegal control chars)" do
+    it "drops XML-1.0-illegal control characters" do
+      Hwaro::Utils::TextUtils.escape_xml("abc").should eq("abc")
+    end
+
+    it "preserves tab, LF and CR" do
+      Hwaro::Utils::TextUtils.escape_xml("a\tb\nc\rd").should eq("a\tb\nc\rd")
+    end
+
+    it "still escapes the five XML special characters" do
+      Hwaro::Utils::TextUtils.escape_xml("a & b < c > \"d\" 'e'").should eq("a &amp; b &lt; c &gt; &quot;d&quot; &apos;e&apos;")
+    end
+  end
+
+  describe "JsMinifier template literals" do
+    it "preserves blank lines inside a template literal" do
+      Hwaro::Utils::JsMinifier.minify("const t = `line1\n\nline2`; var a=1;").should contain("line1\n\nline2")
+    end
+
+    it "still collapses blank lines in plain code" do
+      Hwaro::Utils::JsMinifier.minify("var a=1;\n\n\nvar b=2;").includes?("\n\n").should be_false
+    end
+  end
+
+  describe "HtmlMinifier nested protected blocks" do
+    it "restores nested placeholders without leaking sentinels" do
+      out = Hwaro::Utils::HtmlMinifier.minify(%(<div> <script>var x = "<style>body{}</style>";</script> </div>))
+      out.includes?(String.new(Bytes[0])).should be_false
+      out.should_not contain("HW_HTML_")
+      out.should contain("<style>body{}</style>")
+    end
+  end
+
+  describe "jsonify filter" do
+    it "serializes arrays/numbers/hashes as real JSON" do
+      render_filter(%({{ [1, 2, 3] | jsonify }})).should eq("[1,2,3]")
+      render_filter(%({{ 42 | jsonify }})).should eq("42")
+    end
+  end
+
+  describe "sort_by filter (numeric)" do
+    it "sorts numeric attributes numerically, not lexicographically" do
+      arr = [2, 10, 1, 20, 100].map do |w|
+        h = {} of Crinja::Value => Crinja::Value
+        h[Crinja::Value.new("w")] = Crinja::Value.new(w)
+        Crinja::Value.new(h)
+      end
+      vars = {"items" => Crinja::Value.new(arr)}
+      result = render_filter("{% for item in items | sort_by(attribute='w') %}{{ item.w }},{% endfor %}", vars)
+      result.should eq("1,2,10,20,100,")
+    end
+  end
+end

--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -159,6 +159,37 @@ describe Hwaro::Core::Build::Builder do
       result.should contain("<p>after</p>")
     end
 
+    it "still skips fenced shortcodes after a Crinja control tag (block_depth regression)" do
+      # A `{% set %}` (and other Crinja control tags) must NOT count toward
+      # block-shortcode depth; otherwise the unbalanced tag pins depth > 0 and
+      # the following code fence is never recognized, expanding the fenced
+      # shortcode example instead of showing it verbatim.
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      templates = {"shortcodes/note" => "<div>{{ body }}</div>"}
+      context = {} of String => Crinja::Value
+
+      content = "{% set x = \"1\" %}\n\n```\n{{ shortcode(\"note\", text=\"skip\") }}\n```"
+      result = builder.test_process_shortcodes_jinja(content, templates, context, crinja_env_override: env)
+      result.should contain("{{ shortcode(\"note\", text=\"skip\") }}")
+      result.should_not contain("<div>skip</div>")
+    end
+
+    it "keeps a fenced code block inside a block shortcode body intact" do
+      # The original block-shortcode-wraps-a-fence fix must still hold: the
+      # whole block (including its fenced body) stays together and renders.
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      templates = {"shortcodes/note" => "<div class=\"note\">{{ body }}</div>"}
+      context = {} of String => Crinja::Value
+
+      content = "{% note %}\nintro\n\n```ruby\nputs 1\n```\n{% end %}"
+      result = builder.test_process_shortcodes_jinja(content, templates, context, crinja_env_override: env)
+      result.should contain("<div class=\"note\">")
+      result.should_not contain("{% note %}")
+      result.should_not contain("{% end %}")
+    end
+
     it "stores results in shortcode_results when provided" do
       builder = Hwaro::Core::Build::Builder.new
       env = Crinja.new

--- a/spec/unit/deployer_service_spec.cr
+++ b/spec/unit/deployer_service_spec.cr
@@ -449,10 +449,12 @@ describe "Deployer private helpers" do
       result.should eq("gsutil -m rsync -r -d {source}/ {url}")
     end
 
-    it "returns az command for az:// URL" do
+    it "returns az command for az:// URL with the container name inlined" do
       deployer = Hwaro::Services::Deployer.new
       result = deployer.test_auto_command_for_url("az://my-container", "/tmp")
-      result.should eq("az storage blob sync --source {source} --container {url}")
+      # The container name (uri.host) is inlined+shell-escaped; {url} would
+      # otherwise expand to the full az:// URL, which the az CLI rejects.
+      result.should eq("az storage blob sync --source {source} --container 'my-container'")
     end
 
     it "returns nil for unknown scheme" do
@@ -497,6 +499,18 @@ describe "Deployer private helpers" do
       deployer = Hwaro::Services::Deployer.new
       result = deployer.test_local_directory_destination("file://")
       result.should be_nil
+    end
+
+    it "treats file://./out as project-relative, not filesystem root" do
+      deployer = Hwaro::Services::Deployer.new
+      result = deployer.test_local_directory_destination("file://./out")
+      result.should eq("./out")
+    end
+
+    it "preserves the leading segment of file://relative/path" do
+      deployer = Hwaro::Services::Deployer.new
+      result = deployer.test_local_directory_destination("file://relative/path")
+      result.should eq("relative/path")
     end
   end
 

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -139,7 +139,17 @@ module Hwaro
             parser.on("--dry-run", "Show planned changes without writing") { dry_run = true }
             parser.on("--confirm", "Ask for confirmation before deploying") { confirm = true }
             parser.on("--force", "Force upload/copy (ignore file comparisons)") { force = true }
-            parser.on("--max-deletes N", "Maximum number of deletes (default: deployment.maxDeletes or 256, -1 disables)") { |n| max_deletes = n.to_i }
+            parser.on("--max-deletes N", "Maximum number of deletes (default: deployment.maxDeletes or 256, -1 disables)") do |n|
+              parsed = n.to_i?
+              if parsed.nil?
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "Invalid --max-deletes value: #{n}",
+                  hint: "Pass an integer (use -1 to disable the delete cap).",
+                )
+              end
+              max_deletes = parsed
+            end
             parser.on("--list-targets", "List configured deployment targets and exit") { list_targets = true }
             CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
             CLI.register_flag(parser, ENV_FLAG) { |v| env_name = v }

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -134,11 +134,16 @@ module Hwaro
           if section = options.section
             begin
               sanitized_section = Services::Creator.sanitize_url_path(section)
+              # `sanitize_url_path` treats `.` as URL-safe, so it does NOT strip
+              # `..`. The section becomes an on-disk directory under content/, so
+              # run it through the same traversal guard as <path> — otherwise
+              # `--section ..` writes outside content/.
+              Services::Creator.validate_and_normalize_path!(File.join(sanitized_section, "x.md"))
             rescue ex : ArgumentError
               raise Hwaro::HwaroError.new(
                 code: Hwaro::Errors::HWARO_E_USAGE,
                 message: ex.message || "Invalid --section argument",
-                hint: "Sections become directory names; use ASCII letters/digits, CJK, or `- . _ ~`.",
+                hint: "Sections become directory names under content/; use ASCII letters/digits, CJK, or `- . _ ~`, and they cannot escape it with '..'.",
               )
             end
             if sanitized_section != section

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -204,7 +204,17 @@ module Hwaro
 
             # Server
             parser.on("-b HOST", "--bind HOST", "Bind address (default: 127.0.0.1)") { |h| host = h }
-            parser.on("-p PORT", "--port PORT", "Port to listen on (default: 3000)") { |p| port = p.to_i }
+            parser.on("-p PORT", "--port PORT", "Port to listen on (default: 3000)") do |p|
+              parsed = p.to_i?
+              if parsed.nil? || parsed < 1 || parsed > 65535
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "Invalid --port value: #{p}",
+                  hint: "Pass a port between 1 and 65535, e.g. -p 3000.",
+                )
+              end
+              port = parsed
+            end
             CLI.register_flag(parser, OPEN_BROWSER_FLAG) { |_| open_browser = true }
             CLI.register_flag(parser, NO_OPEN_BROWSER_FLAG) { |_| open_browser = false }
             parser.on("--access-log", "Show HTTP access log (e.g. GET requests)") { access_log = true }

--- a/src/cli/commands/tool/validate_command.cr
+++ b/src/cli/commands/tool/validate_command.cr
@@ -80,7 +80,10 @@ module Hwaro
                 }
               end
               puts({"findings" => findings}.to_json)
-              return
+              # Exit non-zero on hard errors so CI can gate on broken content
+              # (mirrors `tool doctor`'s exit-code behavior).
+              errors = issues.count { |i| i.level == :error }
+              exit(errors > 0 ? Hwaro::Errors::EXIT_CONTENT : Hwaro::Errors::EXIT_SUCCESS)
             end
 
             Logger.info "Validating content in '#{content_dir}'..."
@@ -106,6 +109,9 @@ module Hwaro
             infos = issues.count { |i| i.level == :info }
 
             Logger.info "Found #{errors} error(s), #{warnings} warning(s), #{infos} info(s)"
+
+            # Gate CI on hard errors (matches `tool doctor`).
+            exit(Hwaro::Errors::EXIT_CONTENT) if errors > 0
           end
 
           private def print_issue(issue : Services::Issue)

--- a/src/cli/runner.cr
+++ b/src/cli/runner.cr
@@ -113,9 +113,11 @@ module Hwaro
       rescue ex : Hwaro::HwaroError
         Runner.emit_hwaro_error(ex)
         exit(ex.exit_code)
-      rescue ex : OptionParser::InvalidOption
-        # Treat bad flags as classified usage errors so exit codes stay
-        # consistent with the documented taxonomy.
+      rescue ex : OptionParser::Exception
+        # Treat bad/missing flags as classified usage errors so exit codes stay
+        # consistent with the documented taxonomy. Catching the shared
+        # OptionParser::Exception superclass covers both InvalidOption and
+        # MissingOption (e.g. a value-taking flag passed with no value).
         err = Hwaro::HwaroError.new(
           code: Hwaro::Errors::HWARO_E_USAGE,
           message: ex.message || "invalid option",

--- a/src/content/pagination/paginator.cr
+++ b/src/content/pagination/paginator.cr
@@ -149,8 +149,10 @@ module Hwaro
 
         # Check if pagination is enabled for a section
         private def pagination_enabled_for_section?(section : Models::Section) : Bool
-          # Section-level override takes precedence
-          if enabled = section.pagination_enabled
+          # Section-level override takes precedence. Distinguish an explicit
+          # `false` (disable) from `nil` (no override) — `if enabled = false`
+          # would treat a deliberate disable like "not set" and fall through.
+          unless (enabled = section.pagination_enabled).nil?
             return enabled
           end
 

--- a/src/content/processors/filters/collection_filter.cr
+++ b/src/content/processors/filters/collection_filter.cr
@@ -36,12 +36,22 @@ module Hwaro
                 attr_key = Crinja::Value.new(arguments["attribute"].to_s)
                 reverse = arguments["reverse"].truthy?
 
-                sorted = arr.sort_by do |item|
+                # Compare values directly so numeric attributes (weight,
+                # word_count, numeric extra) sort numerically instead of
+                # lexicographically ("1","10","2"). Strings/dates fall back to
+                # string comparison; a missing attribute sorts as "".
+                sorted = arr.sort do |a, b|
                   begin
-                    item_hash = item.as_h
-                    item_hash[attr_key]?.try(&.to_s) || ""
+                    av = a.as_h[attr_key]? || Crinja::Value.new("")
+                    bv = b.as_h[attr_key]? || Crinja::Value.new("")
+                    cmp = if av.number? && bv.number?
+                            av.as_number <=> bv.as_number
+                          else
+                            av.to_s <=> bv.to_s
+                          end
+                    cmp || 0
                   rescue Exception
-                    ""
+                    0
                   end
                 end
 

--- a/src/content/processors/filters/date_filter.cr
+++ b/src/content/processors/filters/date_filter.cr
@@ -20,10 +20,13 @@ module Hwaro
                            if value.size > 19 && (value.includes?('+') || value.includes?('Z') || value.ends_with?("00"))
                              Time.parse_rfc3339(value) rescue Time.parse(value, "%Y-%m-%dT%H:%M:%S", Time::Location::UTC) rescue nil
                            else
-                             Time.parse(value, "%Y-%m-%dT%H:%M:%S", Time::Location::UTC) rescue nil
+                             # Fall back to minute precision (no seconds), e.g. "2024-01-15T10:30".
+                             Time.parse(value, "%Y-%m-%dT%H:%M:%S", Time::Location::UTC) rescue Time.parse(value, "%Y-%m-%dT%H:%M", Time::Location::UTC) rescue nil
                            end
                          elsif value.size > 10
-                           Time.parse(value, "%Y-%m-%d %H:%M:%S", Time::Location::UTC) rescue nil
+                           # Try seconds, then minute precision, then date-only so
+                           # space-separated datetimes without seconds still parse.
+                           Time.parse(value, "%Y-%m-%d %H:%M:%S", Time::Location::UTC) rescue Time.parse(value, "%Y-%m-%d %H:%M", Time::Location::UTC) rescue Time.parse(value, "%Y-%m-%d", Time::Location::UTC) rescue nil
                          else
                            Time.parse(value, "%Y-%m-%d", Time::Location::UTC) rescue nil
                          end

--- a/src/content/processors/filters/date_filter.cr
+++ b/src/content/processors/filters/date_filter.cr
@@ -24,9 +24,12 @@ module Hwaro
                              Time.parse(value, "%Y-%m-%dT%H:%M:%S", Time::Location::UTC) rescue Time.parse(value, "%Y-%m-%dT%H:%M", Time::Location::UTC) rescue nil
                            end
                          elsif value.size > 10
-                           # Try seconds, then minute precision, then date-only so
-                           # space-separated datetimes without seconds still parse.
-                           Time.parse(value, "%Y-%m-%d %H:%M:%S", Time::Location::UTC) rescue Time.parse(value, "%Y-%m-%d %H:%M", Time::Location::UTC) rescue Time.parse(value, "%Y-%m-%d", Time::Location::UTC) rescue nil
+                           # Try full datetime, then minute precision (no seconds).
+                           # No date-only fallback here: `%Y-%m-%d` consumes only
+                           # the first 10 chars, which would silently reformat
+                           # garbage like "2024-01-15xxx" instead of passing it
+                           # through unchanged.
+                           Time.parse(value, "%Y-%m-%d %H:%M:%S", Time::Location::UTC) rescue Time.parse(value, "%Y-%m-%d %H:%M", Time::Location::UTC) rescue nil
                          else
                            Time.parse(value, "%Y-%m-%d", Time::Location::UTC) rescue nil
                          end

--- a/src/content/processors/filters/misc_filter.cr
+++ b/src/content/processors/filters/misc_filter.cr
@@ -6,10 +6,33 @@ module Hwaro
     module Processors
       module Filters
         module MiscFilters
+          # Recursively serialize a Crinja value tree into a JSON::Builder.
+          # Direct `target.to_json(io)` cannot be used here — Crinja::Value#to_json
+          # opens its own document and raises inside an already-open builder.
+          def self.build_json(json : JSON::Builder, value : Crinja::Value)
+            build_json(json, value.raw)
+          end
+
+          def self.build_json(json : JSON::Builder, raw)
+            case raw
+            when Crinja::Value      then build_json(json, raw.raw)
+            when Crinja::SafeString then json.string(raw.to_s)
+            when Array              then json.array { raw.each { |v| build_json(json, v) } }
+            when Hash               then json.object { raw.each { |k, v| json.field(k.to_s) { build_json(json, v) } } }
+            when String, Int32, Int64, Float64, Bool, Nil
+              raw.to_json(json)
+            else
+              json.string(raw.to_s)
+            end
+          end
+
           def self.register(env : Crinja)
-            # JSON encode filter (escapes </ to prevent script-tag breakout in inline JS)
+            # JSON encode filter (escapes </ to prevent script-tag breakout in inline JS).
+            # Serialize the actual value tree — `target.to_s.to_json` would stringify
+            # the Crinja::Value first and emit broken JSON (e.g. "[Crinja::Value<...>]")
+            # for arrays/hashes/numbers.
             env.filters["jsonify"] = Crinja.filter do
-              target.to_s.to_json.gsub("</", "<\\/")
+              JSON.build { |b| MiscFilters.build_json(b, target) }.gsub("</", "<\\/")
             end
 
             # Default filter — returns fallback when target is nil/undefined or empty string

--- a/src/content/processors/filters/string_filter.cr
+++ b/src/content/processors/filters/string_filter.cr
@@ -8,7 +8,10 @@ module Hwaro
           def self.register(env : Crinja)
             # Truncate words filter
             env.filters["truncate_words"] = Crinja.filter({length: 50, end: "..."}) do
-              text = target.to_s
+              # Strip first: a leading-whitespace input would otherwise split into
+              # a leading "" token, consuming a word slot and emitting a stray
+              # leading space (off-by-one truncation).
+              text = target.to_s.strip
               length = (arguments["length"].as_number rescue 50).to_i
               ending = arguments["end"].to_s
 

--- a/src/content/processors/inline_markdown.cr
+++ b/src/content/processors/inline_markdown.cr
@@ -48,8 +48,12 @@ module Hwaro
           result = result.gsub(INLINE_IMAGE_RE) do
             alt = $1
             url = $2
+            # `result` was already HTML.escaped at the top, so `url`/`alt` are
+            # captured in their escaped form — emit them as-is (re-escaping here
+            # would double-encode `&` into `&amp;amp;`). Matches the link branch
+            # below, which already inserts `link_text` without re-escaping.
             if safe_url?(url)
-              %(<img src="#{HTML.escape(url)}" alt="#{HTML.escape(alt)}">)
+              %(<img src="#{url}" alt="#{alt}">)
             else
               "![#{alt}](#{url})"
             end
@@ -59,7 +63,7 @@ module Hwaro
             link_text = $1
             url = $2
             if safe_url?(url)
-              %(<a href="#{HTML.escape(url)}">#{link_text}</a>)
+              %(<a href="#{url}">#{link_text}</a>)
             else
               "[#{link_text}](#{url})"
             end
@@ -81,8 +85,13 @@ module Hwaro
         # Returns true for URLs we're willing to emit in a generated `href`/`src`.
         # Reject `javascript:`, `vbscript:`, `file:`, and non-image `data:` URIs.
         # Percent-decode first so encodings like `java%73cript:` don't slip past.
+        # Also strip ASCII control/whitespace bytes (NUL–space and DEL) anywhere
+        # in the decoded value: browsers ignore tabs/newlines/NULs inside a URL
+        # scheme, so `java%09script:` would otherwise execute as `javascript:`.
+        # The unsafe regexes are anchored at `^`, so stripping these from the
+        # whole string only affects scheme detection, never legitimate URLs.
         def safe_url?(url : String) : Bool
-          decoded = URI.decode(url.strip)
+          decoded = URI.decode(url.strip).gsub(/[\x00-\x20\x7f]/, "")
           return true if UNSAFE_DATA_PROTOCOL_RE.matches?(decoded)
           !UNSAFE_PROTOCOL_RE.matches?(decoded)
         end

--- a/src/content/processors/internal_link_resolver.cr
+++ b/src/content/processors/internal_link_resolver.cr
@@ -48,14 +48,21 @@ module Hwaro
             content_path = $1
             anchor = $2?
 
-            if content_path.empty?
+            # Split off a query string so `@/path.md?x=y` resolves on the path
+            # alone (pages_by_path keys never contain `?`), then re-append it.
+            # partition leaves path_part == content_path / query == "" when
+            # there's no `?`, preserving existing behavior.
+            path_part, _, query = content_path.partition('?')
+
+            if path_part.empty?
               Logger.warn "Empty internal link '@/' in '#{source_path}'"
               next match
             end
 
-            if page = pages_by_path[content_path]?
+            if page = pages_by_path[path_part]?
               page_url = page.url.starts_with?("/") ? page.url : "/#{page.url}"
               url = HTML.escape("#{base_path}#{page_url}")
+              url += "?#{HTML.escape(query)}" unless query.empty?
               if anchor && !anchor.empty?
                 "href=\"#{url}##{HTML.escape(anchor)}\""
               else

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -178,8 +178,10 @@ module Hwaro
             # certainly a truncated/mistyped JSON header — surface it as a
             # content error rather than silently treating it as body text.
             if end_idx = Utils::FrontmatterScanner.find_json_end(raw_content)
-              result = extract_from_json(raw_content[0, end_idx], file_path)
-              body = raw_content[end_idx..]
+              # find_json_end returns a BYTE offset; slice on bytes so multibyte
+              # (CJK/emoji/accented) JSON frontmatter isn't split mid-codepoint.
+              result = extract_from_json(raw_content.byte_slice(0, end_idx), file_path)
+              body = raw_content.byte_slice(end_idx)
               markdown_content = body.lchop("\r\n").lchop("\n")
             elsif !file_path.empty?
               raise Hwaro::HwaroError.new(

--- a/src/content/processors/table_parser.cr
+++ b/src/content/processors/table_parser.cr
@@ -111,8 +111,34 @@ module Hwaro
           lines = content.split("\n")
           result = [] of String
           i = 0
+          # Track fenced code blocks so verbatim pipe-table syntax shown inside
+          # ``` / ~~~ fences (common in docs) isn't converted to a real <table>.
+          # Mirrors MarkdownExtensions.process_lines_fence_aware.
+          in_fence = false
+          fence_marker = "```"
 
           while i < lines.size
+            stripped = lines[i].lstrip
+
+            if in_fence
+              in_fence = false if stripped.starts_with?(fence_marker)
+              result << lines[i]
+              i += 1
+              next
+            elsif stripped.starts_with?("```")
+              in_fence = true
+              fence_marker = "```"
+              result << lines[i]
+              i += 1
+              next
+            elsif stripped.starts_with?("~~~")
+              in_fence = true
+              fence_marker = "~~~"
+              result << lines[i]
+              i += 1
+              next
+            end
+
             # Check if this could be the start of a table
             if table_row?(lines[i]) && i + 1 < lines.size && separator_row?(lines[i + 1])
               # Try to parse the table

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -444,8 +444,10 @@ module Hwaro
             term = arguments["term"].to_s
             base_url = env.resolve("base_url").to_s
 
-            # Generate slug from term (use TextUtils for consistency with taxonomy pages)
-            slug = Utils::TextUtils.slugify(term)
+            # Generate slug from term. Must match the on-disk term page path,
+            # which uses safe_slugify — plain slugify("🎉") is "" → "/tags//"
+            # (a dead double-slash link) for all-symbol/emoji terms.
+            slug = Utils::TextUtils.safe_slugify(term)
 
             url = "/#{kind}/#{slug}/"
             Crinja::Value.new(base_url.rstrip("/") + url)

--- a/src/content/processors/xml.cr
+++ b/src/content/processors/xml.cr
@@ -42,8 +42,15 @@ module Hwaro
         # Only removes whitespace-only text nodes between tags (preserves mixed content)
         private def minify_xml(xml : String) : String
           xml
-            .gsub(/>\s*\n\s*</, "><")               # Remove whitespace-only text between tags (cross-line only)
-            .gsub(/<[^>]+>/, &.gsub(/\s{2,}/, " ")) # Collapse multiple spaces only within tags
+            .gsub(/>\s*\n\s*</, "><") # Remove whitespace-only text between tags (cross-line only)
+            .gsub(/<[^>]+>/) do |tag|
+              # Collapse whitespace runs only BETWEEN attributes; leave whitespace
+              # inside quoted attribute values intact (e.g. `title="a    b"`),
+              # otherwise the minifier silently corrupts attribute content.
+              tag.gsub(/("[^"]*"|'[^']*')|\s{2,}/) do |m|
+                (m.starts_with?('"') || m.starts_with?('\'')) ? m : " "
+              end
+            end
             .strip
         end
       end

--- a/src/content/seo/amp.cr
+++ b/src/content/seo/amp.cr
@@ -32,6 +32,13 @@ module Hwaro
 
           amp_config = config.amp
           prefix = amp_config.path_prefix.strip('/')
+          # A blank/slash-only prefix would make amp_output_path collapse to the
+          # canonical path (File.join drops empty components), overwriting every
+          # canonical page with its AMP variant. Refuse rather than destroy output.
+          if prefix.empty?
+            Logger.warn "AMP path_prefix resolves to empty; skipping AMP generation to avoid overwriting canonical pages."
+            return
+          end
           generated = 0
 
           pages.each do |page|
@@ -76,7 +83,12 @@ module Hwaro
 
           # Remove disallowed tags: <script> (except application/ld+json and amp scripts)
           # Use [\s\S]*? instead of .*? to match across newlines
-          result = result.gsub(/<script(?![^>]*type=["']application\/ld\+json["'])(?![^>]*(?:async|custom-element|src=["']https:\/\/cdn\.ampproject\.org))[^>]*>[\s\S]*?<\/script>/mi, "")
+          # The `async`/`custom-element` exceptions must be anchored to real
+          # attribute boundaries (preceded by whitespace, followed by a value /
+          # tag terminator); otherwise a substring match like `id="async"` would
+          # cause an author `<script>` to survive into the AMP page. The
+          # cdn.ampproject.org src allowlist stays in its own lookahead.
+          result = result.gsub(/<script(?![^>]*type=["']application\/ld\+json["'])(?![^>]*\s(?:async|custom-element)(?:\s|=|>|\/))(?![^>]*src=["']https:\/\/cdn\.ampproject\.org)[^>]*>[\s\S]*?<\/script>/mi, "")
 
           # Remove disallowed external stylesheets. AMP forbids
           # `<link rel="stylesheet">` except from allowlisted font providers;
@@ -140,13 +152,24 @@ module Hwaro
               <style amp-custom>.amp-img-container{position:relative;width:100%;min-height:200px}</style>
               <script async src="https://cdn.ampproject.org/v0.js"></script>
               HTML
-            result = result.sub(/<\/head>/i, "#{amp_boilerplate}\n</head>")
+            # The AMP runtime/boilerplate is mandatory. If the theme rendered no
+            # </head>, fall back to </body> (then end-of-doc) and warn rather than
+            # silently emitting an invalid AMP page.
+            if result.matches?(/<\/head>/i)
+              result = result.sub(/<\/head>/i, "#{amp_boilerplate}\n</head>")
+            elsif result.matches?(/<\/body>/i)
+              Logger.warn "AMP: no </head> in #{page.url}; injecting AMP boilerplate before </body>."
+              result = result.sub(/<\/body>/i, "#{amp_boilerplate}\n</body>")
+            else
+              Logger.warn "AMP: no </head> or </body> in #{page.url}; AMP page may be invalid."
+              result = "#{result}\n#{amp_boilerplate}"
+            end
           end
 
           # Add canonical link to the original page
           base_url = config.base_url.rstrip('/')
           canonical_url = Utils::TextUtils.escape_xml("#{base_url}#{page.url}")
-          unless result.includes?("rel=\"canonical\"")
+          if !result.includes?("rel=\"canonical\"") && result.matches?(/<\/head>/i)
             result = result.sub(/<\/head>/i, %(<link rel="canonical" href="#{canonical_url}">\n</head>))
           end
 
@@ -167,8 +190,12 @@ module Hwaro
           amp_url = Utils::TextUtils.escape_xml("#{base_url}/#{prefix}#{page.url}")
           link_tag = %(<link rel="amphtml" href="#{amp_url}">)
 
-          updated = html.sub(/<\/head>/i, "#{link_tag}\n</head>")
-          File.write(canonical_path, updated)
+          if html.matches?(/<\/head>/i)
+            updated = html.sub(/<\/head>/i, "#{link_tag}\n</head>")
+            File.write(canonical_path, updated)
+          else
+            Logger.warn "AMP: no </head> in #{canonical_path}; cannot inject rel=amphtml link."
+          end
         end
 
         private def self.output_path_for(page : Models::Page, output_dir : String) : String

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -434,8 +434,12 @@ module Hwaro
 
           # Truncate if needed
           if truncate > 0
-            # Strip HTML tags to get plain text for safe truncation
-            text_content = Utils::TextUtils.strip_html(html_content)
+            # Strip HTML tags to get plain text for safe truncation, then decode
+            # entities: this plain-text branch ends up in a `type="text"` Atom
+            # element (and an RSS description), which consumers decode exactly
+            # once — leaving `&amp;` here would double-escape to `&amp;amp;`.
+            # Mirrors summary_for_feed's HTML.unescape.
+            text_content = HTML.unescape(Utils::TextUtils.strip_html(html_content))
             if text_content.size > truncate
               text_content[0...truncate] + "..."
             else

--- a/src/content/seo/jsonld.cr
+++ b/src/content/seo/jsonld.cr
@@ -303,7 +303,11 @@ module Hwaro
         # `</script>` injection and the "script data double escape" trap a
         # bare `<!--<script` would otherwise spring (gh: dogfooding find).
         private def escape_for_script(json : String) : String
+          # U+2028/U+2029 are valid in JSON strings but are JS line terminators;
+          # escaping them (as Go's encoding/json does) keeps the JSON-LD payload
+          # parseable by stricter/older consumers embedding it in inline script.
           json.gsub('<', "\\u003c").gsub('>', "\\u003e").gsub('&', "\\u0026")
+            .gsub('\u2028', "\\u2028").gsub('\u2029', "\\u2029")
         end
 
         # Coerce a `page.extra[key]` value to `Array(String)` regardless of whether
@@ -316,6 +320,17 @@ module Hwaro
           when Array
             raw.compact_map { |v| v.as?(String) }
           end
+        end
+
+        # Read an array-of-tables `extra` value. A TOML `[[extra.faq]]` block (or
+        # equivalent JSON/YAML array of objects) parses to Array(ExtraValue) whose
+        # elements are Hash(String, ExtraValue); the flat-string helper above
+        # discards those. Returns nil when the value isn't a non-empty hash array.
+        private def extra_hash_array(page : Models::Page, key : String) : Array(Hash(String, Models::ExtraValue))?
+          raw = page.extra[key]?
+          return unless raw.is_a?(Array)
+          out = raw.compact_map { |v| v.as?(Hash(String, Models::ExtraValue)) }
+          out.empty? ? nil : out
         end
 
         private def extract_faq_items(page : Models::Page) : Array(NamedTuple(question: String, answer: String))
@@ -341,6 +356,15 @@ module Hwaro
             end
           end
 
+          # Table-array form documented above: [[extra.faq]] with question/answer.
+          if hash_items = extra_hash_array(page, "faq")
+            hash_items.each do |h|
+              q = h["question"]?.try(&.as?(String))
+              a = h["answer"]?.try(&.as?(String))
+              items << {question: q, answer: a} if q && a
+            end
+          end
+
           items
         end
 
@@ -362,6 +386,15 @@ module Hwaro
               names.zip(texts).each do |n, t|
                 steps << {name: n, text: t}
               end
+            end
+          end
+
+          # Table-array form documented above: [[extra.howto_steps]] name/text.
+          if hash_steps = extra_hash_array(page, "howto_steps")
+            hash_steps.each do |h|
+              n = h["name"]?.try(&.as?(String))
+              t = h["text"]?.try(&.as?(String))
+              steps << {name: n, text: t} if n && t
             end
           end
 

--- a/src/content/seo/llms.cr
+++ b/src/content/seo/llms.cr
@@ -110,7 +110,11 @@ module Hwaro
                 # The root index commonly has `title = ""` so its heading
                 # falls through to the site title; without this fallback
                 # the homepage rendered as `- [](url)` (no link label).
-                label = p.title.empty? ? config.title : p.title
+                raw_label = p.title.empty? ? config.title : p.title
+                # Escape link-label metacharacters so a title with a stray
+                # `[`/`]` doesn't break the `- [label](url)` Markdown link.
+                # (escape backslash first, then the brackets)
+                label = raw_label.gsub('\\', "\\\\").gsub('[', "\\[").gsub(']', "\\]")
                 str << "- [" << label << "](" << link << ")"
                 if d = p.description
                   str << ": " << d unless d.empty?

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -315,13 +315,15 @@ module Hwaro
                 skipped += 1
                 Logger.debug "  OG image: #{page.image} (cached)" if verbose
                 next
-              elsif File.exists?(expected_svg)
-                # A previous build fell back to SVG for this page (PNG render
-                # failed). Treat that emitted SVG as a valid cache hit so a
-                # stably-failing page doesn't re-render the SVG on every build.
+              elsif ext == "svg" && File.exists?(expected_svg)
+                # SVG-mode build (PNG unavailable or format=svg): a previously
+                # emitted SVG is a valid hit. Gated on ext=="svg" so that when
+                # PNG becomes available again (ext flips to "png") a page that
+                # only has a stale SVG falls through to re-render as PNG instead
+                # of being pinned to the old SVG.
                 page.image = "/#{ai.output_dir}/#{slug}.svg"
                 skipped += 1
-                Logger.debug "  OG image: #{page.image} (cached, svg fallback)" if verbose
+                Logger.debug "  OG image: #{page.image} (cached, svg)" if verbose
                 next
               end
             end

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -306,13 +306,24 @@ module Hwaro
             page_hash = compute_page_hash(page)
             new_entries[slug] = page_hash
 
-            expected_file = File.join(img_dir, "#{slug}.#{ext}")
+            expected_png = File.join(img_dir, "#{slug}.png")
+            expected_svg = File.join(img_dir, "#{slug}.svg")
 
-            if !config_changed && old_entries[slug]? == page_hash && File.exists?(expected_file)
-              page.image = "/#{ai.output_dir}/#{slug}.#{ext}"
-              skipped += 1
-              Logger.debug "  OG image: #{page.image} (cached)" if verbose
-              next
+            if !config_changed && old_entries[slug]? == page_hash
+              if ext == "png" && File.exists?(expected_png)
+                page.image = "/#{ai.output_dir}/#{slug}.png"
+                skipped += 1
+                Logger.debug "  OG image: #{page.image} (cached)" if verbose
+                next
+              elsif File.exists?(expected_svg)
+                # A previous build fell back to SVG for this page (PNG render
+                # failed). Treat that emitted SVG as a valid cache hit so a
+                # stably-failing page doesn't re-render the SVG on every build.
+                page.image = "/#{ai.output_dir}/#{slug}.svg"
+                skipped += 1
+                Logger.debug "  OG image: #{page.image} (cached, svg fallback)" if verbose
+                next
+              end
             end
 
             pending << {page, slug}
@@ -367,6 +378,15 @@ module Hwaro
                 Fiber.yield
               end
               true
+            end
+            # Surface render/I-O failures (e.g. File.write raising on disk full /
+            # permission). Without this, an exception is swallowed by the worker
+            # pool, page.image stays nil (no og:image tag), and the only signal
+            # is a silently lower "Generated N" count.
+            results.each do |result|
+              next if result.success
+              failed_slug = pending[result.index]?.try(&.[1])
+              Logger.warn "  OG image generation failed for #{failed_slug || "page ##{result.index}"}: #{result.error}"
             end
             generated = results.count(&.success)
           end
@@ -819,7 +839,8 @@ module Hwaro
             "#{config.title}|#{ai.background}|#{ai.text_color}|#{ai.accent_color}|" \
             "#{ai.secondary_color}|#{ai.font_size}|#{ai.logo}|#{ai.logo_position}|#{ai.show_title}|" \
             "#{ai.style}|#{ai.pattern_opacity}|#{ai.pattern_scale}|" \
-            "#{ai.background_image}|#{ai.overlay_opacity}|#{ai.format}|#{ai.font_path}"
+            "#{ai.background_image}|#{ai.overlay_opacity}|#{ai.format}|#{ai.font_path}|" \
+            "#{ai.accent_bars}|#{ai.text_panel}" # pixel-affecting; toggling them must invalidate the cache
           )
         end
 

--- a/src/content/seo/og_png_renderer.cr
+++ b/src/content/seo/og_png_renderer.cr
@@ -252,8 +252,10 @@ module Hwaro
           ai = config.og.auto_image
 
           # Build a cheap cache key from the things that affect the base pixels.
+          # accent_bars gates the baked-in top accent bar, so it must be part of
+          # the key — otherwise a serve-session toggle reuses a stale base layer.
           key = "#{ai.background}|#{ai.accent_color}|#{ai.secondary_color}|#{ai.style}|#{ai.pattern_opacity}|" \
-                "#{ai.pattern_scale}|#{ai.overlay_opacity}|#{bg_image_path}|#{ai.logo_position}"
+                "#{ai.pattern_scale}|#{ai.overlay_opacity}|#{bg_image_path}|#{ai.logo_position}|#{ai.accent_bars}"
 
           if @@last_base_key == key && (cached = @@last_base_layer)
             return cached

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -91,9 +91,16 @@ module Hwaro
           # terms, so site-internal links to it (e.g. the scaffold homepage's
           # `/tags/`, `/categories/`) don't 404 after a user removes the sample
           # terms. An empty index lists no terms rather than 404ing.
-          terms_map = lang_taxonomies.try(&.[taxonomy.name]?) ||
-                      site.taxonomies[taxonomy.name]? ||
-                      {} of String => Array(Models::Page)
+          # When a language-scoped map is in play (per-language call), a missing
+          # taxonomy key must mean an empty index for that language — never the
+          # global all-language map, which would leak foreign-language terms and
+          # 404 links into /<lang>/<taxonomy>/. The root call (lang_taxonomies
+          # == nil) keeps the global fallback.
+          terms_map = if lt = lang_taxonomies
+                        lt[taxonomy.name]? || {} of String => Array(Models::Page)
+                      else
+                        site.taxonomies[taxonomy.name]? || {} of String => Array(Models::Page)
+                      end
 
           base_path = "#{lang_prefix}/#{taxonomy.name}/"
           index_page = build_taxonomy_index_page(taxonomy, base_path)
@@ -101,7 +108,15 @@ module Hwaro
             index_page.language = language
           end
 
-          render_taxonomy_index(index_page, terms_map.keys.sort!, templates, site, output_dir, builder, verbose)
+          # Only list terms whose term pages are actually written for this
+          # language, so the index never links to a term page that the
+          # language-filtered loop below skips (dead /tags/<term>/ links).
+          index_terms = if language
+                          terms_map.select { |_term, pgs| pgs.any? { |p| (p.language || site.config.default_language) == language } }.keys
+                        else
+                          terms_map.keys
+                        end
+          render_taxonomy_index(index_page, index_terms.sort!, templates, site, output_dir, builder, verbose)
 
           terms_map.each do |term, pages|
             # Filter pages to the requested language when doing per-lang generation
@@ -225,7 +240,7 @@ module Hwaro
         lang_prefix : String = "",
         language : String? = nil,
       )
-        slug = Utils::TextUtils.slugify(term)
+        slug = Utils::TextUtils.safe_slugify(term)
         base_url = "#{lang_prefix}/#{taxonomy.name}/#{slug}/"
 
         index_page = Models::Section.new("taxonomies/#{taxonomy.name}/#{slug}/index.md")
@@ -425,7 +440,7 @@ module Hwaro
         String.build do |str|
           str << "<ul class=\"taxonomy-terms\">\n"
           terms.each do |term|
-            term_slug = Utils::TextUtils.slugify(term)
+            term_slug = Utils::TextUtils.safe_slugify(term)
             term_url = join_url(base_url, base_path, term_slug + "/")
             str << "  <li><a href=\"#{HTML.escape(term_url)}\">#{HTML.escape(term)}</a></li>\n"
           end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -341,10 +341,13 @@ module Hwaro
           # --- 3. Determine the full set of pages that need re-rendering ---
           pages_to_render = Set(Models::Page).new(changed_pages)
 
-          # Section index pages whose content lists include the changed pages
+          # Section index pages whose content lists include the changed pages.
+          # Include every language variant of the section (multilingual sites
+          # have one `_index.<lang>.md` per language under the same path).
           affected_sections.each do |section_name|
-            section = site.sections_by_name[section_name]?
-            pages_to_render << section if section
+            site.sections.each do |section|
+              pages_to_render << section if section.section == section_name
+            end
           end
 
           # Previous / next pages (both old and new neighbors after re-linking)

--- a/src/core/build/cache.cr
+++ b/src/core/build/cache.cr
@@ -7,6 +7,7 @@
 require "digest/md5"
 require "json"
 require "../../utils/logger"
+require "../../models/config"
 
 module Hwaro
   module Core
@@ -333,6 +334,24 @@ module Hwaro
           else
             ""
           end
+        end
+
+        # Compute a checksum for the *effective* (env-merged, env-substituted)
+        # config plus the active env name and resolved base_url. Hashing the
+        # parsed `config.raw` rather than the raw config.toml bytes means an
+        # env override file (config.<env>.toml), changed ${ENV_VAR}
+        # substitutions, or a --base-url override all invalidate the per-page
+        # cache — none of which the file-bytes hash above can detect — while a
+        # formatting-only edit to config.toml no longer forces a full rebuild.
+        def self.compute_config_hash(config : Models::Config, env : String? = nil) : String
+          digest = Digest::MD5.new
+          digest.update(env || "")
+          digest.update(config.base_url)
+          config.raw.keys.sort!.each do |key|
+            digest.update(key)
+            digest.update(config.raw[key].to_s)
+          end
+          digest.final.hexstring
         end
       end
     end

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -60,7 +60,10 @@ module Hwaro::Core::Build::Phases::Initialize
       # Compute global checksums for invalidation graph
       if cache_enabled
         template_hash = Cache.compute_templates_hash(ctx.templates)
-        config_hash = Cache.compute_config_hash
+        # Hash the effective merged config (+ env + base_url override), not the
+        # raw config.toml bytes, so env-override files and ${ENV_VAR} changes
+        # correctly invalidate the per-page cache.
+        config_hash = Cache.compute_config_hash(config, ctx.options.env)
         build_cache.set_global_checksums(template_hash, config_hash)
       end
     end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -672,7 +672,7 @@ module Hwaro::Core::Build::Phases::Render
     # child pages that did not set an explicit `template`. Sections render with
     # their own "section" template (handled above), so they are excluded here.
     unless page.is_a?(Models::Section)
-      if section = site.sections_by_name[page.section]?
+      if section = site.section_for(page.section, page.language)
         if pt = section.effective_page_template
           return pt if templates.has_key?(pt)
         end
@@ -987,7 +987,7 @@ module Hwaro::Core::Build::Phases::Render
         pages = site.pages_for_section(section_name, language)
 
         # Use section's sort_by setting if available, otherwise sort by title
-        section = site.sections_by_name[section_name]?
+        section = site.section_for(section_name, language)
         sort_by = section.try(&.sort_by) || "title"
         reverse = section.try(&.reverse) || false
         pages = Utils::SortUtils.sort_pages(pages, sort_by, reverse)
@@ -1114,7 +1114,7 @@ module Hwaro::Core::Build::Phases::Render
         end
         Crinja::Value.new({
           "name"  => Crinja::Value.new(term),
-          "slug"  => Crinja::Value.new(Utils::TextUtils.slugify(term)),
+          "slug"  => Crinja::Value.new(Utils::TextUtils.safe_slugify(term)),
           "pages" => Crinja::Value.new(term_pages_array),
           "count" => Crinja::Value.new(term_pages.size),
         })
@@ -1479,7 +1479,7 @@ module Hwaro::Core::Build::Phases::Render
       section_assets_val = assets_crinja
     elsif !page.section.empty?
       # For regular pages, find the parent section via O(1) lookup
-      section_page = site.sections_by_name[page.section]?
+      section_page = site.section_for(page.section, page.language)
       if section_page
         section_title = section_page.title
         section_description = section_page.description || ""
@@ -1644,7 +1644,7 @@ module Hwaro::Core::Build::Phases::Render
     seo_image = config.og.resolve_image_url(page.image, config.base_url) || ""
     seo_obj = {
       "canonical_url"   => Crinja::Value.new(canonical_url),
-      "og_type"         => Crinja::Value.new(config.og.og_type),
+      "og_type"         => Crinja::Value.new(og_type_override || config.og.og_type),
       "og_image"        => Crinja::Value.new(seo_image),
       "twitter_card"    => Crinja::Value.new(config.og.twitter_card),
       "twitter_site"    => Crinja::Value.new(config.og.twitter_site || ""),

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -141,18 +141,22 @@ module Hwaro::Core::Build::Phases::Transform
       path_parts = section.section.split("/")
       next if path_parts.size <= 1
 
-      # Find parent section
+      # Link to the immediate parent section when it exists.
       parent_path = path_parts[0..-2].join("/")
       if parent = sections_by_path[parent_path]?
         parent.add_subsection(section)
+      end
 
-        # Build ancestors chain
-        current_path = ""
-        path_parts[0..-2].each do |part|
-          current_path = current_path.empty? ? part : "#{current_path}/#{part}"
-          if ancestor = sections_by_path[current_path]?
-            section.ancestors << ancestor
-          end
+      # Build the ancestors chain from every EXISTING ancestor section, even
+      # when an intermediate `_index.md` is missing — otherwise a gap in the
+      # tree (e.g. `a/_index.md` + `a/b/c/_index.md`, no `a/b/_index.md`) drops
+      # all ancestors and the subsection link. Walk only path_parts[0..-2] so a
+      # section never becomes its own ancestor.
+      current_path = ""
+      path_parts[0..-2].each do |part|
+        current_path = current_path.empty? ? part : "#{current_path}/#{part}"
+        if ancestor = sections_by_path[current_path]?
+          section.ancestors << ancestor
         end
       end
     end

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -19,12 +19,25 @@ module Hwaro
     module Build
       module ShortcodeProcessor
         SHORTCODE_ARGS_REGEX = /(\w+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^,\s]+))/
+        # Detects a named argument (`key=`) at an argument boundary (string start
+        # or just after a comma). Used instead of a bare `includes?("=")` so an
+        # `=` inside a positional value (e.g. a query-string URL `?t=10`) doesn't
+        # get misparsed as named args. See issue: youtube()/figure() with URLs.
+        NAMED_ARG_RE = /(?:\A|,)\s*[A-Za-z_]\w*\s*=/
         # NOTE: POSITIONAL_ARG_REGEX is reserved for future use
         # POSITIONAL_ARG_REGEX  = /(?:^|,)\s*(?:"([^"]*)"|'([^']*)'|([^,\s=]+))/
         MAX_SHORTCODE_NESTING = 5
         BLOCK_OPEN_RE         = /\{\%\s*([a-zA-Z_][\w\-]*)\s*(?:\((.*?)\)|((?:\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^,%\s]+)\s*,?\s*)*))\s*\%\}/
         # Support both bare {% end %} and named {% endNAME %}.
         BLOCK_CLOSE_RE = /\{\%\s*end(?:\s+[a-zA-Z_][\w\-]*)?\s*\%\}/i
+        # Broader close matcher for the outer fence loop's depth tracking: it
+        # must recognize every closer the normalization step collapses to
+        # `{% end %}` — bare `{% end %}` and named `{% endNAME %}` / `{% end NAME %}`
+        # with OR without a space — so it stays balanced against BLOCK_OPEN_RE
+        # (which also matches `{% endalert %}` as an opener). Without the no-space
+        # form, block_depth would never return to zero and fence protection would
+        # silently break for the rest of the document.
+        BLOCK_ANY_CLOSE_RE = /\{\%\s*end[\s\w\-]*\%\}/i
 
         # Placeholder left in the content stream for each rendered shortcode
         # before Markdown runs. HTML-comment form so CommonMark treats it as
@@ -110,6 +123,11 @@ module Hwaro
             fence_marker = ""
             fence_close_regex : Regex? = nil
             buffer = String::Builder.new
+            # Nesting depth of open block shortcodes. While > 0 we must NOT treat
+            # a fence line as a buffer boundary, otherwise a block shortcode whose
+            # body contains a fenced code block gets split across chunks and its
+            # `{% name %}` / `{% end %}` tags leak as literal text.
+            block_depth = 0
 
             content.each_line(chomp: false) do |line|
               if in_fence
@@ -122,7 +140,17 @@ module Hwaro
                 next
               end
 
-              if match = line.match(/^\s*(`{3,}|~{3,})/)
+              # Track block-shortcode open/close tags on this line. An open is a
+              # BLOCK_OPEN_RE match that is not itself a close tag (BLOCK_OPEN_RE
+              # also matches `{% end %}` / `{% endname %}`).
+              line.scan(BLOCK_OPEN_RE) do |m|
+                block_depth += 1 unless BLOCK_ANY_CLOSE_RE.matches?(m[0])
+              end
+              line.scan(BLOCK_ANY_CLOSE_RE) do
+                block_depth -= 1 if block_depth > 0
+              end
+
+              if block_depth == 0 && (match = line.match(/^\s*(`{3,}|~{3,})/))
                 io << process_shortcodes_in_text(buffer.to_s, templates, context, shortcode_results, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
                 buffer = String::Builder.new
                 in_fence = true
@@ -373,8 +401,10 @@ module Hwaro
           return args unless args_str
           return args if args_str.strip.empty?
 
-          # First try named arguments
-          has_named = args_str.includes?("=")
+          # First try named arguments. Require an identifier-equals at an arg
+          # boundary so an `=` embedded in a positional/quoted value (a URL
+          # query string like `?v=2`) doesn't trip the named-arg branch.
+          has_named = args_str.matches?(NAMED_ARG_RE)
           if has_named
             args_str.scan(SHORTCODE_ARGS_REGEX) do |match|
               key = match[1]

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -38,6 +38,14 @@ module Hwaro
         # form, block_depth would never return to zero and fence protection would
         # silently break for the rest of the document.
         BLOCK_ANY_CLOSE_RE = /\{\%\s*end[\s\w\-]*\%\}/i
+        # Crinja/Jinja control-statement tags (and their `end*` forms). These
+        # legitimately appear in markdown content (e.g. `{% set x = 1 %}`,
+        # `{% if c %}…{% endif %}`) and must NOT count toward block-shortcode
+        # depth — otherwise an unbalanced `{% set %}` would pin block_depth > 0
+        # and permanently disable fenced-code-block protection in the outer loop.
+        # `\b` keeps shortcodes that merely start with a keyword (e.g. `setup`,
+        # `endorsement`) from matching.
+        CRINJA_CONTROL_TAG_RE = /\A\{\%-?\s*(?:if|elif|else|endif|for|endfor|set|endset|with|endwith|raw|endraw|filter|endfilter|block|endblock|macro|endmacro|call|endcall|autoescape|endautoescape|trans|endtrans|pluralize|comment|endcomment|include|import|from|extends|do)\b/i
 
         # Placeholder left in the content stream for each rendered shortcode
         # before Markdown runs. HTML-comment form so CommonMark treats it as
@@ -140,13 +148,18 @@ module Hwaro
                 next
               end
 
-              # Track block-shortcode open/close tags on this line. An open is a
-              # BLOCK_OPEN_RE match that is not itself a close tag (BLOCK_OPEN_RE
-              # also matches `{% end %}` / `{% endname %}`).
+              # Track block-shortcode open/close tags on this line so a fence
+              # inside a block-shortcode body doesn't split the block. Crinja
+              # control tags (`{% set %}`, `{% if %}`/`{% endif %}`, …) are
+              # ignored — counting them would desync the depth (an unbalanced
+              # `{% set %}` would pin depth > 0 and break fence protection).
               line.scan(BLOCK_OPEN_RE) do |m|
-                block_depth += 1 unless BLOCK_ANY_CLOSE_RE.matches?(m[0])
+                tag = m[0]
+                next if CRINJA_CONTROL_TAG_RE.matches?(tag) || BLOCK_ANY_CLOSE_RE.matches?(tag)
+                block_depth += 1
               end
-              line.scan(BLOCK_ANY_CLOSE_RE) do
+              line.scan(BLOCK_ANY_CLOSE_RE) do |m|
+                next if CRINJA_CONTROL_TAG_RE.matches?(m[0])
                 block_depth -= 1 if block_depth > 0
               end
 

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1203,7 +1203,9 @@ module Hwaro
       # would abort the build with an unclassified crash instead of running.
       private def self.int_value(raw : TOML::Any?, default : Int32) : Int32
         return default unless raw
-        val = raw.as_i64? || raw.as_f?.try { |f| f.clamp(Int32::MIN.to_f64, Int32::MAX.to_f64).to_i64 }
+        # `finite?` guard: NaN.clamp is NaN and NaN.to_i64 raises OverflowError,
+        # so a `nan`/`-nan` float in config would otherwise crash the build.
+        val = raw.as_i64? || raw.as_f?.try { |f| f.finite? ? f.clamp(Int32::MIN.to_f64, Int32::MAX.to_f64).to_i64 : nil }
         return default unless val
         val.clamp(Int32::MIN.to_i64, Int32::MAX.to_i64).to_i32
       end
@@ -1220,7 +1222,7 @@ module Hwaro
       # non-numeric). Clamps to Int32 range like int_value so an oversized value
       # never raises OverflowError out of as_i?/to_i at the inline call sites.
       private def self.int_or_nil(raw : TOML::Any) : Int32?
-        val = raw.as_i64? || raw.as_f?.try { |f| f.clamp(Int32::MIN.to_f64, Int32::MAX.to_f64).to_i64 }
+        val = raw.as_i64? || raw.as_f?.try { |f| f.finite? ? f.clamp(Int32::MIN.to_f64, Int32::MAX.to_f64).to_i64 : nil }
         val.try(&.clamp(Int32::MIN.to_i64, Int32::MAX.to_i64).to_i32)
       end
 

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -991,6 +991,10 @@ module Hwaro
       def with_base_path(path : String) : String
         return path if base_path.empty?
         return path if path.starts_with?("http://") || path.starts_with?("https://")
+        # Protocol-relative URLs (`//cdn.example.com/x`) are external — leave
+        # them untouched, matching how render.cr / internal_link_resolver treat
+        # `//host`. Without this they'd become `/base//cdn.example.com/x`.
+        return path if path.starts_with?("//")
         return path unless path.starts_with?("/")
         "#{base_path}#{path}"
       end
@@ -1193,15 +1197,31 @@ module Hwaro
       end
 
       # Safe integer loader: handles both integer and float TOML values.
+      # Uses the 64-bit accessor and clamps to Int32 range so an oversized
+      # config value (e.g. `per_page = 9999999999` or `1e30`) yields a clamped
+      # Int32 instead of raising OverflowError out of `as_i?`/`to_i` — which
+      # would abort the build with an unclassified crash instead of running.
       private def self.int_value(raw : TOML::Any?, default : Int32) : Int32
         return default unless raw
-        raw.as_i? || raw.as_f?.try(&.to_i) || default
+        val = raw.as_i64? || raw.as_f?.try { |f| f.clamp(Int32::MIN.to_f64, Int32::MAX.to_f64).to_i64 }
+        return default unless val
+        val.clamp(Int32::MIN.to_i64, Int32::MAX.to_i64).to_i32
       end
 
       # Safe float loader: handles both float and integer TOML values.
+      # Uses as_i64? (Int64#to_f never overflows) to avoid the OverflowError
+      # that as_i? raises for integers above Int32::MAX.
       private def self.float_value(raw : TOML::Any?, default : Float64) : Float64
         return default unless raw
-        raw.as_f? || raw.as_i?.try(&.to_f) || default
+        raw.as_f? || raw.as_i64?.try(&.to_f) || default
+      end
+
+      # Non-raising Int32 extraction from a single TOML value (nil if absent or
+      # non-numeric). Clamps to Int32 range like int_value so an oversized value
+      # never raises OverflowError out of as_i?/to_i at the inline call sites.
+      private def self.int_or_nil(raw : TOML::Any) : Int32?
+        val = raw.as_i64? || raw.as_f?.try { |f| f.clamp(Int32::MIN.to_f64, Int32::MAX.to_f64).to_i64 }
+        val.try(&.clamp(Int32::MIN.to_i64, Int32::MAX.to_i64).to_i32)
       end
 
       # Extracts a string-or-array TOML value into an Array(String).
@@ -1432,7 +1452,7 @@ module Hwaro
           taxonomy = TaxonomyConfig.new(name)
           taxonomy.feed = bool_value(taxonomy_hash["feed"]?, taxonomy.feed)
           taxonomy.sitemap = bool_value(taxonomy_hash["sitemap"]?, taxonomy.sitemap)
-          taxonomy.paginate_by = taxonomy_hash["paginate_by"]?.try { |v| v.as_i? || v.as_f?.try(&.to_i) }
+          taxonomy.paginate_by = taxonomy_hash["paginate_by"]?.try { |v| int_or_nil(v) }
           taxonomy
         end
       end
@@ -1610,7 +1630,7 @@ module Hwaro
         config.image_processing.quality = int_value(s["quality"]?, config.image_processing.quality).clamp(1, 100)
         if widths = s["widths"]?.try(&.as_a?)
           config.image_processing.widths = widths.compact_map { |w|
-            val = w.as_i? || w.as_f?.try(&.to_i)
+            val = int_or_nil(w)
             val && val > 0 ? val : nil
           }
         end
@@ -1656,11 +1676,11 @@ module Hwaro
         end
 
         max_deletes_any = s["maxDeletes"]? || s["max_deletes"]?
-        if max_deletes_val = max_deletes_any.try { |v| v.as_i? || v.as_f?.try(&.to_i) }
+        if max_deletes_val = max_deletes_any.try { |v| int_or_nil(v) }
           config.deployment.max_deletes = max_deletes_val
         end
 
-        if workers_val = s["workers"]?.try { |v| v.as_i? || v.as_f?.try(&.to_i) }
+        if workers_val = s["workers"]?.try { |v| int_or_nil(v) }
           config.deployment.workers = workers_val
         end
 

--- a/src/models/site.cr
+++ b/src/models/site.cr
@@ -18,7 +18,12 @@ module Hwaro
       # Lookup indices for performance
       property pages_by_section : Hash(String, Array(Page))
       property sections_by_parent : Hash(String, Array(Section))
-      property sections_by_name : Hash(String, Section)
+      # Keyed by (section path, language) so a multilingual site's per-language
+      # `_index.<lang>.md` files don't collide — previously a single
+      # `Hash(String, Section)` kept only the first-globbed language, making
+      # section title/description/sort_by/page_template resolve to the wrong
+      # language. Use `section_for(name, language)` to look up with fallback.
+      property sections_by_name : Hash(Tuple(String, String?), Section)
       property pages_for_section_cache : Hash(Tuple(String, String?), Array(Page))
       @lookup_index_built : Bool = false
       @all_content_cache : Array(Page)?
@@ -33,8 +38,17 @@ module Hwaro
 
         @pages_by_section = {} of String => Array(Page)
         @sections_by_parent = {} of String => Array(Section)
-        @sections_by_name = {} of String => Section
+        @sections_by_name = {} of Tuple(String, String?) => Section
         @pages_for_section_cache = {} of Tuple(String, String?) => Array(Page)
+      end
+
+      # Resolve a section by path for a given language, falling back to the
+      # language-neutral (default-language) index when no language-specific
+      # `_index.<lang>.md` exists, then to the configured default language.
+      def section_for(name : String, language : String?) : Section?
+        @sections_by_name[{name, language}]? ||
+          @sections_by_name[{name, nil}]? ||
+          @sections_by_name[{name, @config.default_language}]?
       end
 
       def taxonomy_terms(name : String) : Array(String)
@@ -68,8 +82,8 @@ module Hwaro
         end
 
         @sections.each do |s|
-          # Index by section name for O(1) lookup
-          @sections_by_name[s.section] ||= s
+          # Index by (section name, language) for O(1) language-aware lookup
+          @sections_by_name[{s.section, s.language}] ||= s
 
           # s.section is the section this object represents (e.g. "blog").
           # We want to index it by its PARENT section (e.g. "").

--- a/src/services/content_lister.cr
+++ b/src/services/content_lister.cr
@@ -238,7 +238,9 @@ module Hwaro
           # Try JSON Front Matter (balanced {...} at file start)
         elsif content.starts_with?('{') && (end_idx = Utils::FrontmatterScanner.find_json_end(content))
           begin
-            json_fm = JSON.parse(content[0, end_idx])
+            # find_json_end returns a BYTE offset; byte_slice keeps multibyte
+            # JSON frontmatter intact so title/date aren't silently lost.
+            json_fm = JSON.parse(content.byte_slice(0, end_idx))
             if json_fm.as_h?
               title = json_fm["title"]?.try(&.as_s?) || title
               draft = json_fm["draft"]?.try(&.as_bool?) || false

--- a/src/services/content_stats.cr
+++ b/src/services/content_stats.cr
@@ -90,7 +90,11 @@ module Hwaro
         end
 
         words_total = word_counts.sum
-        words_avg = published_items.empty? ? 0 : words_total // published_items.size
+        # Divide by the number of files actually read (word_counts), not the
+        # published count — a file unreadable between listing and read is skipped
+        # from word_counts but would otherwise dilute the average. Matches the
+        # population used by words_min/words_max below.
+        words_avg = word_counts.empty? ? 0 : words_total // word_counts.size
         words_min = word_counts.min? || 0
         words_max = word_counts.max? || 0
 

--- a/src/services/content_validator.cr
+++ b/src/services/content_validator.cr
@@ -173,7 +173,9 @@ module Hwaro
             return
           end
           begin
-            json_data = JSON.parse(content[0, end_idx])
+            # find_json_end returns a BYTE offset; byte_slice avoids flagging
+            # valid multibyte JSON frontmatter as a parse error.
+            json_data = JSON.parse(content.byte_slice(0, end_idx))
             if h = json_data.as_h?
               result = {} of String => FrontmatterValue
               h.each do |k, value|

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -266,7 +266,15 @@ module Hwaro
               hint: "Pass a non-empty --title.",
             )
           end
-          filename = title.downcase.gsub(/[^\p{L}\p{N}]+/, "-").strip("-") + ".md"
+          slug = title.downcase.gsub(/[^\p{L}\p{N}]+/, "-").strip("-")
+          if slug.empty?
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "Title '#{title}' contains no filename-safe characters.",
+              hint: "Use a --title with ASCII letters/digits or CJK characters, or pass an explicit <path>.md.",
+            )
+          end
+          filename = slug + ".md"
           full_path = File.join(base_dir, filename)
         end
 
@@ -466,6 +474,18 @@ module Hwaro
       private def find_archetype(explicit_archetype : String?, path : String) : String?
         # 1. If explicit archetype is given, use it
         if explicit_archetype
+          # Keep the archetype name inside archetypes/. `<path>` and `--section`
+          # are already traversal-guarded; --archetype must be too, or it can
+          # read arbitrary on-disk `.md` files (e.g. ../../etc/passwd.md).
+          # Nested archetypes (tools/develop) stay allowed — only block `..`
+          # and absolute paths.
+          if explicit_archetype.includes?("..") || Path[explicit_archetype].absolute?
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "Invalid archetype name: #{explicit_archetype}",
+              hint: "Archetype names are relative to archetypes/; '..' and absolute paths are not allowed.",
+            )
+          end
           archetype_path = File.join(ARCHETYPES_DIR, "#{explicit_archetype}.md")
           if File.exists?(archetype_path)
             Logger.debug "Using archetype: #{archetype_path}"
@@ -587,7 +607,10 @@ module Hwaro
         String.build do |str|
           str << "---\n"
           str << "title: \"#{safe_title}\"\n"
-          str << "date: #{date}\n"
+          # Quote+escape the date so an unusual --date (e.g. "2024: weird") is
+          # valid YAML, and a normal date parses back as a String scalar (an
+          # unquoted YYYY-MM-DD parses as a Time node and is silently dropped).
+          str << "date: \"#{escape_string(date)}\"\n"
           extra_fields.each { |f| str << "#{f}: \"\"\n" }
           str << "draft: true\n" if is_draft
           unless tags.empty?
@@ -611,7 +634,10 @@ module Hwaro
       end
 
       private def escape_string(value : String) : String
-        value.gsub("\"", "\\\"").gsub("\n", " ")
+        # Escape backslash FIRST, then quotes — otherwise a value like `C:\path`
+        # or a trailing `\` produces invalid TOML/YAML basic strings (e.g. a
+        # trailing `\"` escapes the closing quote).
+        value.gsub("\\", "\\\\").gsub("\"", "\\\"").gsub("\n", " ")
       end
     end
   end

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -893,6 +893,10 @@ module Hwaro
         a = a.rstrip('/')
         b = b.rstrip('/')
         return false if a.empty? || b.empty?
+        # Identical directories also count as overlap — otherwise a
+        # source == destination config slips past the overlap refusal and a
+        # strip_index_html target can mutate/delete the source tree.
+        return true if a == b
         b.starts_with?(a + "/")
       end
 
@@ -989,8 +993,12 @@ module Hwaro
         when "gs"
           "gsutil -m rsync -r -d {source}/ {url}"
         when "az"
-          # az://container → Azure Blob Storage
-          "az storage blob sync --source {source} --container {url}"
+          # az://container → Azure Blob Storage. Inline the container name
+          # (uri.host), shell-escaped — `{url}` would expand to the full
+          # `az://container` URL, which the az CLI rejects as a container name.
+          container = uri.host
+          return if container.nil? || container.empty?
+          "az storage blob sync --source {source} --container #{shell_escape(container)}"
         end
       end
 
@@ -999,11 +1007,12 @@ module Hwaro
           uri = URI.parse(url)
           return unless uri.scheme == "file"
           # Allow both file:///abs/path and file://relative/path forms.
+          # For a relative form (file://./out, file://relative/path) URI puts the
+          # first segment in `host`; prepend it so the path isn't silently
+          # rooted at the filesystem root (file://./out must be ./out, not /out).
           path = uri.path
-          if path.empty?
-            if host = uri.host
-              path = host unless host.empty?
-            end
+          if host = uri.host
+            path = host + path unless host.empty?
           end
           return if path.empty?
           return path

--- a/src/services/frontmatter_converter.cr
+++ b/src/services/frontmatter_converter.cr
@@ -220,8 +220,10 @@ module Hwaro
         end_idx = Utils::FrontmatterScanner.find_json_end(content)
         return unless end_idx
 
-        json_str = content[0, end_idx]
-        body = content[end_idx..].lchop("\r\n").lchop("\n")
+        # find_json_end returns a BYTE offset; slice on bytes so multibyte
+        # JSON frontmatter isn't corrupted/truncated mid-codepoint.
+        json_str = content.byte_slice(0, end_idx)
+        body = content.byte_slice(end_idx).lchop("\r\n").lchop("\n")
         {json_str, body}
       end
 

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -54,6 +54,13 @@ module Hwaro
         "public"
       end
 
+      # Escape a value for a TOML basic string. Front-matter aliases are
+      # arbitrary user input; an unescaped quote/backslash would produce an
+      # unparseable netlify.toml.
+      private def toml_escape(s : String) : String
+        s.gsub('\\', "\\\\").gsub('"', "\\\"")
+      end
+
       private def generate_netlify : String
         lines = [] of String
         lines << "[build]"
@@ -70,8 +77,8 @@ module Hwaro
           lines << ""
           redirects.each do |from, to|
             lines << "[[redirects]]"
-            lines << "  from = \"#{from}\""
-            lines << "  to = \"#{to}\""
+            lines << "  from = \"#{toml_escape(from)}\""
+            lines << "  to = \"#{toml_escape(to)}\""
             lines << "  status = 301"
             lines << ""
           end
@@ -147,6 +154,9 @@ module Hwaro
           lines << ""
           lines << "# Redirects: Create a `#{output_dir}/_redirects` file with:"
           redirects.each do |from, to|
+            # _redirects is space-delimited; an alias with whitespace or a quote
+            # would silently corrupt the rule, so skip malformed entries.
+            next if from.matches?(/\s|"/) || to.matches?(/\s|"/)
             lines << "# #{from} #{to} 301"
           end
         end

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -78,16 +78,19 @@ module Hwaro
         # untouched.
         protected def localize_internal_links(body : String, lang : String) : String
           prefix = "/#{lang}/"
-          body.gsub(/(!?)\[([^\]]*)\]\((\/[^)\s]+)\)/) do |match|
+          # Allow an optional Markdown link title (`(/posts/ "All posts")`) and
+          # preserve it — otherwise titled links keep the default-language URL.
+          body.gsub(/(!?)\[([^\]]*)\]\((\/[^)\s]+)(\s+"[^"]*")?\)/) do |match|
             bang = $~[1]
             label = $~[2]
             target = $~[3]
+            title = $~[4]? || ""
             if !bang.empty?
               match
             elsif target.starts_with?(prefix) || target == "/#{lang}"
               match
             else
-              "[#{label}](#{prefix}#{target.lchop("/")})"
+              "[#{label}](#{prefix}#{target.lchop("/")}#{title})"
             end
           end
         end

--- a/src/services/scaffolds/remote.cr
+++ b/src/services/scaffolds/remote.cr
@@ -93,7 +93,9 @@ module Hwaro
 
         # Parse a remote source string into {owner, repo, subpath}
         def self.parse_source(source : String) : {String, String, String}
-          if source.starts_with?("github:") || source.starts_with?("git:")
+          # `git://github.com/owner/repo` is a protocol URL, not the `git:owner/repo`
+          # shorthand — route it to the URL parser below, which handles it correctly.
+          if source.starts_with?("github:") || (source.starts_with?("git:") && !source.starts_with?("git://"))
             raw = source.sub(/^(?:github|git):/, "")
             parts = raw.split("/")
             if parts.size < 2 || parts[0].empty? || parts[1].empty?
@@ -304,6 +306,12 @@ module Hwaro
           end
 
           data = JSON.parse(response.body)
+          # GitHub sets `truncated` when the recursive tree exceeds its size
+          # limit and returns a PARTIAL listing — warn so silently-dropped
+          # scaffold files don't read as a clean checkout.
+          if data["truncated"]?.try(&.as_bool?)
+            Logger.warn "GitHub truncated the recursive tree for #{owner}/#{repo}@#{branch}; the scaffold may be incomplete (large repository)."
+          end
           data["tree"]?.try(&.as_a?) || raise Hwaro::HwaroError.new(
             code: Hwaro::Errors::HWARO_E_NETWORK,
             message: "GitHub tree response for #{owner}/#{repo}@#{branch} is missing 'tree'",

--- a/src/utils/html_minifier.cr
+++ b/src/utils/html_minifier.cr
@@ -151,11 +151,22 @@ module Hwaro
         result
       end
 
+      # Restore in a fixed-point loop: a protected block (e.g. a `<style>`
+      # extracted before `<script>`) can be captured *inside* a later block, so
+      # the first restore leaves an inner placeholder behind. Re-scan until no
+      # token remains. Terminates because restored content is original author
+      # HTML, which cannot contain a valid \x00-delimited token (NUL is illegal
+      # in author input), and a dangling index returns $0 unchanged.
       private def restore_sensitive_blocks(html : String, preserves : Array(String)) : String
-        html.gsub(REGEX_PRESERVE_TOKEN) do
-          idx = $1.to_i
-          idx < preserves.size ? preserves[idx] : $0
+        loop do
+          replaced = html.gsub(REGEX_PRESERVE_TOKEN) do
+            idx = $1.to_i
+            idx < preserves.size ? preserves[idx] : $0
+          end
+          break if replaced == html
+          html = replaced
         end
+        html
       end
 
       # Collapse whitespace between two structural tokens. The token

--- a/src/utils/js_minifier.cr
+++ b/src/utils/js_minifier.cr
@@ -17,6 +17,13 @@ module Hwaro
 
       # Perform conservative JS minification
       def minify(js : String) : String
+        # Multi-line template literals are stashed as NUL-delimited placeholders
+        # so the final per-line rstrip / blank-line pass can't mutate bytes that
+        # are part of a string value (a blank line or significant trailing
+        # whitespace inside a `...` literal). Restored verbatim at the end.
+        # (Plain "" / '' strings and /regex/ literals can't contain raw newlines,
+        # so the line pass never touches them.)
+        protected_spans = [] of String
         result = String.build do |io|
           i = 0
           len = js.size
@@ -45,31 +52,37 @@ module Hwaro
               next
             end
 
-            # Template literals — track ${...} nesting depth
+            # Template literals — track ${...} nesting depth. Captured into a
+            # placeholder so the trailing line-cleanup pass can't alter newlines
+            # or whitespace that are part of the literal's value.
             if c == '`'
-              io << c
-              i += 1
-              depth = 0
-              while i < len
-                sc = chars[i]
-                io << sc
-                if sc == '\\' && i + 1 < len
+              lit = String.build do |lb|
+                lb << c
+                i += 1
+                depth = 0
+                while i < len
+                  sc = chars[i]
+                  lb << sc
+                  if sc == '\\' && i + 1 < len
+                    i += 1
+                    lb << chars[i]
+                  elsif sc == '$' && i + 1 < len && chars[i + 1] == '{'
+                    lb << chars[i + 1]
+                    i += 1
+                    depth += 1
+                  elsif sc == '{' && depth > 0
+                    # Nested brace inside ${...}
+                  elsif sc == '}' && depth > 0
+                    depth -= 1
+                  elsif sc == '`' && depth == 0
+                    break
+                  end
                   i += 1
-                  io << chars[i]
-                elsif sc == '$' && i + 1 < len && chars[i + 1] == '{'
-                  io << chars[i + 1]
-                  i += 1
-                  depth += 1
-                elsif sc == '{' && depth > 0
-                  # Nested brace inside ${...}
-                elsif sc == '}' && depth > 0
-                  depth -= 1
-                elsif sc == '`' && depth == 0
-                  break
                 end
                 i += 1
               end
-              i += 1
+              protected_spans << lit
+              io << "\x00JSPL#{protected_spans.size - 1}\x00"
               next
             end
 
@@ -132,10 +145,15 @@ module Hwaro
           end
         end
 
-        # Collapse multiple blank lines
+        # Collapse multiple blank lines (placeholders survive: they contain no
+        # trailing whitespace and are never empty).
         lines = result.lines.map(&.rstrip)
         lines.reject!(&.empty?)
-        lines.join("\n").strip
+        cleaned = lines.join("\n").strip
+
+        # Restore protected template literals verbatim.
+        return cleaned if protected_spans.empty?
+        cleaned.gsub(/\x00JSPL(\d+)\x00/) { protected_spans[$1.to_i] }
       end
 
       # Determine whether a `/` at position `pos` in `chars` is likely a regex

--- a/src/utils/js_minifier.cr
+++ b/src/utils/js_minifier.cr
@@ -151,9 +151,14 @@ module Hwaro
         lines.reject!(&.empty?)
         cleaned = lines.join("\n").strip
 
-        # Restore protected template literals verbatim.
+        # Restore protected template literals verbatim. Bounds-guard the index
+        # so an adversarial literal `\x00JSPLn\x00` sequence in the source (NUL
+        # is not valid JS) can't raise IndexError — emit it unchanged instead.
         return cleaned if protected_spans.empty?
-        cleaned.gsub(/\x00JSPL(\d+)\x00/) { protected_spans[$1.to_i] }
+        cleaned.gsub(/\x00JSPL(\d+)\x00/) do
+          idx = $1.to_i
+          idx < protected_spans.size ? protected_spans[idx] : $0
+        end
       end
 
       # Determine whether a `/` at position `pos` in `chars` is likely a regex

--- a/src/utils/redirect_html.cr
+++ b/src/utils/redirect_html.cr
@@ -25,6 +25,8 @@ module Hwaro
           .gsub("\"", "\\\"")
           .gsub("\n", "\\n")
           .gsub("\r", "\\r")
+          .gsub("\u2028", "\\u2028") # JS line terminators: would otherwise
+          .gsub("\u2029", "\\u2029") # break the string literal on pre-ES2019 engines
           .gsub("</", "<\\/")
 
         <<-HTML

--- a/src/utils/text_utils.cr
+++ b/src/utils/text_utils.cr
@@ -42,6 +42,17 @@ module Hwaro
         end.rstrip('-')
       end
 
+      # Like `slugify` but never returns "". An all-symbol/emoji input (e.g. a
+      # tag of "!!!" or "🎉") slugifies to "", which would make distinct terms
+      # collide onto the same URL/output path and create a `//` path segment.
+      # Falls back to a deterministic, stable token derived from the input's
+      # UTF-8 bytes so distinct inputs stay distinct and the slug is identical
+      # across builds (unlike `String#hash`, which is per-process seeded).
+      def safe_slugify(text : String) : String
+        s = slugify(text)
+        s.empty? ? "term-#{text.to_slice.hexstring}" : s
+      end
+
       # Check if a character is a Unicode letter (non-ASCII)
       private def unicode_letter?(char : Char) : Bool
         !char.ascii? && char.letter?
@@ -70,19 +81,28 @@ module Hwaro
             when '>'  then io << "&gt;"
             when '"'  then io << "&quot;"
             when '\'' then io << "&apos;"
-            else           io << char
+            when .ascii_control?
+              # XML 1.0 forbids C0 control chars except tab/LF/CR. A stray
+              # control byte (e.g. \f or \v sneaked in via JSON/quoted-YAML
+              # frontmatter) would otherwise make the whole feed/sitemap
+              # unparseable — drop the illegal ones, keep the allowed three.
+              io << char if char == '\t' || char == '\n' || char == '\r'
+            else io << char
             end
           end
         end
       end
 
-      # Byte-level scan for the five XML special chars. Avoids the regex
-      # engine and Unicode decoding — all targets are 7-bit ASCII so the
-      # byte view is exact even for UTF-8 input.
+      # Byte-level scan for the five XML special chars plus XML-illegal C0
+      # control bytes (so the fast path doesn't skip the control-char cleanup).
+      # Avoids the regex engine and Unicode decoding — all targets are 7-bit
+      # ASCII so the byte view is exact even for UTF-8 input.
       private def contains_xml_special?(text : String) : Bool
         text.each_byte do |b|
           case b
           when 0x26, 0x3C, 0x3E, 0x22, 0x27 # & < > " '
+            return true
+          when 0x00..0x08, 0x0B, 0x0C, 0x0E..0x1F # XML-illegal C0 controls
             return true
           end
         end

--- a/src/utils/text_utils.cr
+++ b/src/utils/text_utils.cr
@@ -85,8 +85,10 @@ module Hwaro
               # XML 1.0 forbids C0 control chars except tab/LF/CR. A stray
               # control byte (e.g. \f or \v sneaked in via JSON/quoted-YAML
               # frontmatter) would otherwise make the whole feed/sitemap
-              # unparseable — drop the illegal ones, keep the allowed three.
-              io << char if char == '\t' || char == '\n' || char == '\r'
+              # unparseable — drop those. DEL (0x7F) is a legal XML char, so
+              # keep it; this also matches contains_xml_special?'s gate exactly.
+              o = char.ord
+              io << char unless o < 0x20 && o != 0x09 && o != 0x0A && o != 0x0D
             else io << char
             end
           end


### PR DESCRIPTION
## Summary

A source-wide audit surfaced and verified **59 latent bugs**; this PR fixes **57** of them. Two are intentionally deferred (documented in code comments) because the obvious fix would regress worse than the bug.

Only `.cr` files are touched: **45 files, +712 / −130**.

## Highlights by category

**Security / escaping**
- `inline_markdown`: block control-char-obfuscated script schemes (`java%09script:`) in `safe_url?`; stop double-escaping link/image URLs
- `jsonld`: escape U+2028/U+2029 inside inline `<script>` JSON-LD
- `feeds`/`sitemap`: drop XML-1.0-illegal C0 control chars in `escape_xml`
- `amp`: anchor `<script>` `async`/`custom-element` exceptions to real attribute boundaries so author scripts are stripped; refuse empty `path_prefix` (would overwrite canonical pages)
- `redirect_html`: escape U+2028/U+2029 JS line terminators
- `new --section` / `--archetype`: reject path traversal out of `content/`
- `platform_config`: TOML-escape netlify aliases; skip malformed `_redirects`
- `creator`: escape backslashes in TOML/YAML front matter

**Encoding (multibyte)**
- `find_json_end` returns a **byte** offset but callers sliced it as a char index → corrupted multibyte JSON frontmatter (`markdown`, `frontmatter_converter`, `content_validator`, `content_lister`)
- XML minifier preserved attribute-value whitespace; date filter parses no-seconds datetimes

**Caching**
- build cache hashes the effective merged config (env override + `${VAR}` + base_url), not raw `config.toml` bytes
- OG cache keys include `accent_bars`/`text_panel`; SVG fallback counts as a cache hit

**Logic / correctness**
- multilingual taxonomy: scope index terms per language, never fall back to the global all-language map (fixes 404 links + cross-language leak)
- `sections_by_name` is now language-aware (`section_for`)
- tables / block-shortcodes inside fenced code blocks left verbatim
- `sort_by` numeric; `jsonify` real value tree; `pagination_enabled = false` honored; int-overflow clamp; empty-slug collision guard; JS/HTML minifier protected-block fixes; section ancestors with missing intermediate `_index`; protocol-relative `//host`; `@/path?query` resolution

**Error handling / CLI**
- `tool validate` exits non-zero on errors (CI gate); `MissingOption` / `--port` / `--max-deletes` classified as usage errors; OG parallel render/IO failures surfaced; `az://` passes container name; `file://./out` is project-relative; `source == dest` counts as overlap; `content_stats` averages over files actually read; scaffold truncated-tree warning, titled-link localization, `git://` URL routing

## Deferred (with rationale in comments)
1. **Streaming feeds/search degradation** — fixing it naively defeats `--memory-limit`'s peak-memory bound; correct fix needs incremental per-batch generation.
2. **Extensioned custom `path` frontmatter** — the `get_output_path` guard would regress dotted slugs; raw files are the supported mechanism.

## Verification
- `crystal spec`: **5207 examples, 0 failures, 0 errors, 0 pending** (adds `spec/unit/bugfix_regression_spec.cr`, +19)
- `ameba`: 0 failures · `crystal tool format --check`: clean
- Full codegen build + end-to-end smoke (scaffold → build → CLI checks) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
