### PR TITLE
style(spec): fix Ameba ChainedCallWithNoBang lint failures

### DIFF
--- a/spec/unit/text_utils_spec.cr
+++ b/spec/unit/text_utils_spec.cr
@@ -109,7 +109,7 @@ describe Hwaro::Utils::TextUtils do
     it "gives distinct terms that slugify identically unique slugs" do
       map = Hwaro::Utils::TextUtils.disambiguated_slugs(["C++", "C#"])
       # Both base-slugify to "c"; the sorted-first term keeps the base slug.
-      map.values.sort.should eq(["c", "c-2"])
+      map.values.sort!.should eq(["c", "c-2"])
       map["C++"].should_not eq(map["C#"])
     end
 
@@ -122,8 +122,9 @@ describe Hwaro::Utils::TextUtils do
     it "does not collide a generated suffix with a real term that already uses it" do
       # "A"/"A " both slugify to "a"; a real "a-2" must not be overwritten.
       map = Hwaro::Utils::TextUtils.disambiguated_slugs(["A", "A ", "a-2"])
-      map.values.sort.should eq(map.values.uniq.sort)
-      map.values.size.should eq(3)
+      values = map.values
+      values.size.should eq(values.uniq.size)
+      values.size.should eq(3)
     end
   end
 


### PR DESCRIPTION
## Summary

The `lint` job on `main` ([run 27094475464](https://github.com/hahwul/hwaro/actions/runs/27094475464/job/79963982225)) failed with four Ameba `Performance/ChainedCallWithNoBang` warnings, all in `spec/unit/text_utils_spec.cr`:

- `Use bang method variant sort! after chained values call` (×2)
- `Use bang method variant uniq! after chained values call`
- `Use bang method variant sort! after chained uniq call`

## Changes

- **Line 112** — `map.values.sort` → `map.values.sort!`. `values` returns a fresh array, so mutating in place is safe and `sort!` always returns the array.
- **Lines 124–126** — restructured the uniqueness assertion to bind `values = map.values` first, then assert `values.size.should eq(values.uniq.size)`. The `uniq` call no longer chains off a transformer (its receiver is a local), and `.size` has no bang variant, so the rule is satisfied.

### Why not `uniq!`?

`uniq!` returns `nil` when there are no duplicates to remove — which is exactly the case this test exercises (all slug values are distinct). Blindly applying the bang would have broken the assertion, so the chain was restructured instead.

The assertions are semantically equivalent to before (all values unique, three of them).

https://claude.ai/code/session_01GUJNpURs915K6BtfFVhzfV

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUJNpURs915K6BtfFVhzfV)_