### PR TITLE
perf(build): faster builds with byte-identical output + deterministic server highlighting

### DIFF
--- a/scripts/benchmark_run.cr
+++ b/scripts/benchmark_run.cr
@@ -1,53 +1,156 @@
 require "file_utils"
 require "option_parser"
 
-# Generate dummy content
-def generate_content(count : Int32, force : Bool)
-  benchmark_dir = "benchmark"
-  content_dir = File.join(benchmark_dir, "content")
-  templates_dir = File.join(benchmark_dir, "templates")
+# Generates a deterministic benchmark site and times `hwaro build` against it.
+#
+# The corpus is designed to exercise the real render hot paths rather than a
+# trivial flat site: multiple sections with _index.md, fenced code blocks
+# (server-mode highlighting), a user shortcode, tags (taxonomies), TOC pages,
+# and internal @/ links. Generation is fully deterministic — same --count
+# always produces byte-identical input, so output trees can be diffed across
+# code changes.
+#
+# Usage:
+#   crystal run scripts/benchmark_run.cr -- --count 1000 --force --keep --runs 5
+#   crystal run scripts/benchmark_run.cr -- --generate-only --dir /tmp/bench-site
 
-  if Dir.exists?(content_dir)
-    if force
-      FileUtils.rm_rf(content_dir)
-    else
-      puts "Error: '#{content_dir}' directory already exists. Use --force to overwrite."
-      exit 1
+SECTIONS  = 8
+TAG_POOL  = ["crystal", "performance", "web", "ssg", "testing", "tooling"]
+LANGUAGES = ["crystal", "bash", "javascript"]
+
+def code_block(i : Int32) : String
+  lang = LANGUAGES[i % LANGUAGES.size]
+  case lang
+  when "crystal"
+    <<-CODE
+      ```crystal
+      # Shared example used across many pages
+      def greet(name : String) : String
+        "Hello, \#{name}!"
+      end
+
+      puts greet("page #{i}")
+      ```
+      CODE
+  when "bash"
+    <<-CODE
+      ```bash
+      # Shared example used across many pages
+      set -euo pipefail
+      echo "building page #{i}"
+      hwaro build --minify
+      ```
+      CODE
+  else
+    <<-CODE
+      ```javascript
+      // Shared example used across many pages
+      const pages = document.querySelectorAll("article");
+      console.log(`page #{i}: ${pages.length} articles`);
+      ```
+      CODE
+  end
+end
+
+def page_body(i : Int32, count : Int32) : String
+  target = (i + 37) % count
+  String.build do |io|
+    io << "## Overview\n\n"
+    io << "This is benchmark page #{i}. It contains enough prose to make "
+    io << "markdown rendering non-trivial, including *emphasis*, **strong** "
+    io << "text, `inline code`, and a [link](https://example.com/#{i}).\n\n"
+    io << "See also [page #{target}](@/section-#{target % SECTIONS}/page_#{target}.md).\n\n"
+    io << "## Details\n\n"
+    io << "- First point about topic #{i % 13}\n"
+    io << "- Second point referencing item #{i % 7}\n"
+    io << "- Third point with `code_span_#{i % 5}`\n\n"
+    if i % 10 < 3
+      io << code_block(i) << "\n\n"
+    end
+    if i % 10 == 3
+      io << "{{ note() }}\n\n"
+    end
+    io << "## Conclusion\n\n"
+    io << "Closing paragraph for page #{i} with a bit more text so the page "
+    io << "is not degenerate.\n"
+  end
+end
+
+def front_matter(i : Int32) : String
+  tags = [TAG_POOL[i % TAG_POOL.size], TAG_POOL[(i + 2) % TAG_POOL.size]]
+  toc = i % 5 == 0
+  String.build do |io|
+    io << "+++\n"
+    io << "title = \"Benchmark Page #{i}\"\n"
+    io << "date = \"2024-#{sprintf("%02d", (i % 12) + 1)}-#{sprintf("%02d", (i % 28) + 1)}\"\n"
+    io << "tags = [#{tags.map(&.inspect).join(", ")}]\n"
+    if toc
+      io << "toc = true\n"
+      io << "insert_anchor_links = true\n"
+    end
+    io << "+++\n"
+  end
+end
+
+def generate_content(site_dir : String, count : Int32, force : Bool)
+  content_dir = File.join(site_dir, "content")
+  templates_dir = File.join(site_dir, "templates")
+
+  [content_dir, templates_dir].each do |dir|
+    if Dir.exists?(dir)
+      if force
+        FileUtils.rm_rf(dir)
+      else
+        puts "Error: '#{dir}' directory already exists. Use --force to overwrite."
+        exit 1
+      end
     end
   end
-  FileUtils.mkdir_p(File.join(content_dir, "benchmark"))
 
-  count.times do |i|
-    File.write(File.join(content_dir, "benchmark", "page_#{i}.md"), <<-MD
+  SECTIONS.times do |s|
+    section_dir = File.join(content_dir, "section-#{s}")
+    FileUtils.mkdir_p(section_dir)
+    File.write(File.join(section_dir, "_index.md"), <<-MD
       +++
-      title = "Benchmark Page #{i}"
-      date = "2024-01-01"
+      title = "Section #{s}"
+      description = "Benchmark section #{s}"
       +++
 
-      # Page #{i}
-
-      This is a benchmark page.
+      Index of benchmark section #{s}.
       MD
     )
   end
 
-  # Create a template that iterates over all pages to stress-test the variable construction
-  if Dir.exists?(templates_dir)
-    if force
-      FileUtils.rm_rf(templates_dir)
-    else
-      puts "Error: '#{templates_dir}' directory already exists. Use --force to overwrite."
-      exit 1
-    end
+  count.times do |i|
+    path = File.join(content_dir, "section-#{i % SECTIONS}", "page_#{i}.md")
+    File.write(path, front_matter(i) + "\n" + page_body(i, count))
   end
-  FileUtils.mkdir_p(templates_dir)
-  File.write(File.join(templates_dir, "default.html"), <<-HTML
+
+  FileUtils.mkdir_p(File.join(templates_dir, "shortcodes"))
+  File.write(File.join(templates_dir, "base.html"), <<-HTML
     <!DOCTYPE html>
     <html>
-    <head><title>{{ page.title }}</title></head>
+    <head><title>{% block title %}Benchmark{% endblock %}</title></head>
     <body>
+      {% block body %}{% endblock %}
+    </body>
+    </html>
+    HTML
+  )
+  # Iterating over all pages stress-tests template variable construction.
+  File.write(File.join(templates_dir, "default.html"), <<-HTML
+    {% extends "base.html" %}
+    {% block title %}{{ page.title }}{% endblock %}
+    {% block body %}
       <h1>{{ page.title }}</h1>
       {{ content }}
+
+      <h2>Section Pages</h2>
+      <ul>
+      {% for p in section.pages %}
+        <li><a href="{{ p.url }}">{{ p.title }}</a></li>
+      {% endfor %}
+      </ul>
 
       <h2>All Pages</h2>
       <ul>
@@ -55,61 +158,99 @@ def generate_content(count : Int32, force : Bool)
         <li><a href="{{ p.url }}">{{ p.title }}</a></li>
       {% endfor %}
       </ul>
-    </body>
-    </html>
+    {% endblock %}
+    HTML
+  )
+  File.write(File.join(templates_dir, "shortcodes", "note.html"), <<-HTML
+    <div class="note"><strong>Note:</strong> benchmark shortcode body.</div>
     HTML
   )
 
-  # Copy config.toml to benchmark directory
-  if File.exists?("config.toml")
-    FileUtils.cp("config.toml", File.join(benchmark_dir, "config.toml"))
-  else
-    # Create a minimal config.toml if not exists
-    File.write(File.join(benchmark_dir, "config.toml"), <<-TOML
-      title = "Benchmark Site"
-      description = "Benchmark site for testing"
-      base_url = "http://localhost:3000"
-      TOML
-    )
-  end
+  File.write(File.join(site_dir, "config.toml"), <<-TOML
+    title = "Benchmark Site"
+    description = "Benchmark site for hwaro performance testing"
+    base_url = "http://localhost:3000"
+
+    [[taxonomies]]
+    name = "tags"
+
+    [search]
+    enabled = true
+
+    [highlight]
+    mode = "server"
+    TOML
+  )
 end
 
-# Run build
-def run_build
-  puts "Building hwaro..."
-  status = Process.run("shards", ["build", "--release"], output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+def compile_hwaro
+  puts "Building hwaro (release, parity with shipped binaries)..."
+  # Same flags as .github/workflows/release-binary.yml so measurements
+  # reflect what users actually run.
+  status = Process.run("shards", ["build", "--release", "--no-debug", "-Dpreview_mt"],
+    output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
   unless status.success?
     puts "Build failed"
     exit 1
   end
+end
 
-  Dir.cd("benchmark") do
-    puts "Running hwaro build..."
-    start_time = Time.instant
-    status = Process.run("../bin/hwaro", ["build"], output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
-    end_time = Time.instant
+def run_builds(site_dir : String, runs : Int32, build_args : Array(String), verbose : Bool)
+  hwaro_bin = File.expand_path("bin/hwaro")
+  times = [] of Float64
 
-    if status.success?
-      puts "Build time: #{(end_time - start_time).total_seconds}s"
-    else
-      puts "Hwaro build failed"
-      exit 1
+  Dir.cd(site_dir) do
+    runs.times do |run|
+      output = verbose ? Process::Redirect::Inherit : Process::Redirect::Close
+      start_time = Time.instant
+      status = Process.run(hwaro_bin, ["build"] + build_args, output: output, error: Process::Redirect::Inherit)
+      elapsed = (Time.instant - start_time).total_seconds
+
+      unless status.success?
+        puts "Hwaro build failed (run #{run + 1})"
+        exit 1
+      end
+      times << elapsed
+      puts "Run #{run + 1}: #{elapsed.round(3)}s"
     end
+  end
+
+  if times.size >= 3
+    # Discard the first run (FS warm-up), report the median of the rest.
+    steady = times[1..].sort
+    median = steady[steady.size // 2]
+    puts "Median of runs 2..#{times.size}: #{median.round(3)}s"
   end
 end
 
 count = 5000
 force = false
+keep = false
+runs = 1
+skip_compile = false
+generate_only = false
+verbose = false
+site_dir = "benchmark"
+build_args = [] of String
+
 OptionParser.parse do |parser|
-  parser.on("-c COUNT", "--count=COUNT", "Number of pages") { |c| count = c.to_i }
-  parser.on("-f", "--force", "Overwrite content and templates directories") { force = true }
+  parser.on("-c COUNT", "--count=COUNT", "Number of pages (default 5000)") { |c| count = c.to_i }
+  parser.on("-f", "--force", "Overwrite existing content/templates") { force = true }
+  parser.on("-k", "--keep", "Keep the site directory after the run") { keep = true }
+  parser.on("-d DIR", "--dir=DIR", "Site directory (default ./benchmark)") { |d| site_dir = d }
+  parser.on("-r RUNS", "--runs=RUNS", "Timed build runs (default 1)") { |r| runs = r.to_i }
+  parser.on("-s", "--skip-compile", "Reuse existing bin/hwaro") { skip_compile = true }
+  parser.on("-g", "--generate-only", "Generate the corpus and exit") { generate_only = true }
+  parser.on("-v", "--verbose", "Show hwaro build output") { verbose = true }
+  parser.on("--build-args=ARGS", "Extra args for `hwaro build` (space-separated)") { |a| build_args = a.split(' ', remove_empty: true) }
 end
 
-# Create benchmark directory
-FileUtils.mkdir_p("benchmark")
+FileUtils.mkdir_p(site_dir)
+generate_content(site_dir, count, force)
+puts "Generated #{count} pages in #{site_dir}/"
+exit 0 if generate_only
 
-generate_content(count, force)
-run_build
+compile_hwaro unless skip_compile
+run_builds(site_dir, runs, build_args, verbose)
 
-# Clean up benchmark directory
-FileUtils.rm_rf("benchmark")
+FileUtils.rm_rf(site_dir) unless keep

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -11,6 +11,7 @@ require "yaml"
 require "toml"
 require "json"
 require "xml"
+require "digest/md5"
 require "./base"
 require "./syntax_highlighter"
 require "./markdown_extensions"
@@ -943,6 +944,41 @@ module Hwaro
       # @param emoji - if true, converts emoji shortcodes to emoji characters
       def render(content : String, highlight : Bool = true, safe : Bool = false, lazy_loading : Bool = false, emoji : Bool = false, markdown_config : Models::MarkdownConfig? = nil) : Tuple(String, Array(Models::TocHeader))
         @@instance.render(content, highlight, safe, lazy_loading, emoji, markdown_config)
+      end
+
+      # Memoized default-options body render for the Generate-phase
+      # fallbacks: on warm --cache builds (and in streaming mode) feeds and
+      # search hit pages whose `page.content` is empty because the Render
+      # phase skipped them, and the same page can be re-rendered up to four
+      # times in one build (feed summary + full body + section feed +
+      # search index). Output is a pure function of the raw content for the
+      # default arguments, so it is shared by content digest.
+      #
+      # Mutex-guarded — feeds and search run as parallel fibers. The byte
+      # cap keeps streaming mode's memory bound: once full, renders still
+      # happen, they just stop being remembered.
+      @@body_cache = {} of String => String
+      @@body_cache_bytes = 0_i64
+      @@body_cache_mutex = Mutex.new
+      BODY_CACHE_MAX_BYTES = 32_i64 * 1024 * 1024
+
+      def render_body_cached(content : String) : String
+        key = Digest::MD5.hexdigest(content)
+        @@body_cache_mutex.synchronize do
+          if cached = @@body_cache[key]?
+            return cached
+          end
+        end
+
+        html, _ = render(content)
+
+        @@body_cache_mutex.synchronize do
+          unless @@body_cache.has_key?(key) || @@body_cache_bytes + html.bytesize > BODY_CACHE_MAX_BYTES
+            @@body_cache[key] = html
+            @@body_cache_bytes += html.bytesize
+          end
+        end
+        html
       end
 
       # Returns parsed metadata and content

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -31,7 +31,16 @@ module Hwaro
           do_strikethrough = true
           do_heading_ids = config.heading_ids
 
-          if do_task_lists || do_strikethrough || do_heading_ids
+          # Whole-content marker pre-check (memchr-fast): with none of the
+          # enabled extensions' markers present, the line pass is the
+          # identity transform and only rebuilds the string — skip it. The
+          # per-line includes? guards below are unchanged, so any page that
+          # passes this check transforms exactly as before.
+          markers_present = (do_task_lists && (result.includes?("[ ]") || result.includes?("[x]") || result.includes?("[X]"))) ||
+                            (do_strikethrough && result.includes?("~~")) ||
+                            (do_heading_ids && result.includes?("{#"))
+
+          if markers_present
             result = process_lines_fence_aware(result) do |line, _in_fence|
               transformed = line
 

--- a/src/content/processors/syntax_highlighter.cr
+++ b/src/content/processors/syntax_highlighter.cr
@@ -16,6 +16,7 @@
 
 require "markd"
 require "tartrazine"
+require "digest/md5"
 require "./table_parser"
 require "./markdown_extensions"
 require "set"
@@ -88,6 +89,31 @@ module Hwaro
         @@unknown_languages = Set(String).new
         @@unknown_mutex = Mutex.new
 
+        # Serializes ALL Tartrazine work (lexer acquisition + tokenization).
+        # The shard's compiled rules each hold a single PCRE2 match_data
+        # buffer reused by every match() call (bytes_regex.cr), and those
+        # rules are shared across lexer instances via the template cache —
+        # so two -Dpreview_mt workers tokenizing the same language corrupt
+        # each other's matches. That raised intermittently, and the rescue
+        # below silently degraded random code blocks to plain output,
+        # making build output nondeterministic.
+        @@tartrazine_mutex = Mutex.new
+
+        # Highlighted-output memo keyed by (language, code digest). Output
+        # is a pure function of the input pair, so identical code blocks —
+        # repeated install snippets, shortcode bodies, serve-mode rebuilds —
+        # skip tokenization entirely. Also keeps the serialized section
+        # above from becoming a bottleneck on code-heavy sites. `nil`
+        # (tokenization failed, deterministic now) is cached too.
+        @@result_cache = {} of String => String?
+        @@result_mutex = Mutex.new
+        # Blocks larger than this are highlighted but not cached, keeping
+        # memory bounded; the entry cap guards pathological unique-block
+        # counts (clear-on-full is deterministic for output, only a speed
+        # hit).
+        MAX_CACHED_BLOCK_BYTES = 65_536
+        MAX_CACHE_ENTRIES      =  2_048
+
         # Highlight `code` as `lang`, returning HTML-escaped markup with
         # hljs-class spans — or nil when no lexer exists for the language
         # (callers fall back to plain client-style output).
@@ -95,28 +121,48 @@ module Hwaro
           normalized = lang.downcase
           return if @@unknown_mutex.synchronize { @@unknown_languages.includes?(normalized) }
 
-          lexer = begin
-            Tartrazine.lexer(normalized)
-          rescue
-            @@unknown_mutex.synchronize { @@unknown_languages << normalized }
-            Logger.debug "Server highlight: no lexer for '#{normalized}', falling back to plain output"
-            return
-          end
-
-          String.build do |io|
-            lexer.tokenizer(code).each do |token|
-              value = HTML.escape(token[:value])
-              if css_class = class_for(token[:type])
-                io << %(<span class=") << css_class << %(">) << value << "</span>"
-              else
-                io << value
-              end
+          cacheable = code.bytesize <= MAX_CACHED_BLOCK_BYTES
+          cache_key = "#{normalized}\0#{Digest::MD5.hexdigest(code)}" if cacheable
+          if cache_key
+            @@result_mutex.synchronize do
+              return @@result_cache[cache_key] if @@result_cache.has_key?(cache_key)
             end
           end
-        rescue ex
-          # A lexer bug must never take down the build — degrade to plain.
-          Logger.debug "Server highlight failed for '#{lang}': #{ex.message}"
-          nil
+
+          result = @@tartrazine_mutex.synchronize do
+            lexer = begin
+              Tartrazine.lexer(normalized)
+            rescue
+              @@unknown_mutex.synchronize { @@unknown_languages << normalized }
+              Logger.debug "Server highlight: no lexer for '#{normalized}', falling back to plain output"
+              return
+            end
+
+            begin
+              String.build do |io|
+                lexer.tokenizer(code).each do |token|
+                  value = HTML.escape(token[:value])
+                  if css_class = class_for(token[:type])
+                    io << %(<span class=") << css_class << %(">) << value << "</span>"
+                  else
+                    io << value
+                  end
+                end
+              end
+            rescue ex
+              # A lexer bug must never take down the build — degrade to plain.
+              Logger.debug "Server highlight failed for '#{lang}': #{ex.message}"
+              nil
+            end
+          end
+
+          if cache_key
+            @@result_mutex.synchronize do
+              @@result_cache.clear if @@result_cache.size >= MAX_CACHE_ENTRIES
+              @@result_cache[cache_key] = result
+            end
+          end
+          result
         end
 
         private def class_for(token_type : String) : String?

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -116,7 +116,7 @@ module Hwaro
               if !page.content.empty?
                 html_content = page.content
               else
-                html_content, _ = Processor::Markdown.render(page.raw_content)
+                html_content = Processor::Markdown.render_body_cached(page.raw_content)
               end
 
               # Strip HTML tags AND decode entities so the index stores

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -367,7 +367,7 @@ module Hwaro
           # Fall back to a stripped + truncated body. Prefer the
           # already-rendered HTML; degrade to the raw markdown only if
           # render hasn't run.
-          html = page.content.empty? ? Processor::Markdown.render(page.raw_content)[0] : page.content
+          html = page.content.empty? ? Processor::Markdown.render_body_cached(page.raw_content) : page.content
           text = HTML.unescape(Utils::TextUtils.strip_html(html)).strip
           truncate_for_feed(text, limit)
         end
@@ -383,8 +383,7 @@ module Hwaro
         # (gh#526).
         private def self.full_content_for_feed(page : Models::Page) : String
           return page.content unless page.content.empty?
-          rendered, _ = Processor::Markdown.render(page.raw_content)
-          rendered
+          Processor::Markdown.render_body_cached(page.raw_content)
         end
 
         # Collect taxonomy terms that should appear as `<category>`
@@ -433,8 +432,7 @@ module Hwaro
           html_content = if !page.content.empty?
                            page.content
                          else
-                           rendered, _ = Processor::Markdown.render(page.raw_content)
-                           rendered
+                           Processor::Markdown.render_body_cached(page.raw_content)
                          end
 
           # Truncate if needed

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -159,6 +159,15 @@ module Hwaro
           @cache_manager
         end
 
+        # Profiler to thread into per-page render loops, or nil when
+        # profiling is off. The record_* methods already no-op when
+        # disabled, but callers test the reference before taking
+        # timestamps — passing nil skips two Time.instant calls and a
+        # redundant determine_template per rendered page.
+        private def active_profiler : Profiler?
+          @profiler.try { |p| p.enabled? ? p : nil }
+        end
+
         # Access build context for external inspection (e.g. emitting JSON
         # output after a build). Returns nil before `run` has been invoked.
         def context : Lifecycle::BuildContext?
@@ -487,7 +496,7 @@ module Hwaro
           error_overlay = options.error_overlay
           render_list.each do |page|
             next unless page.render
-            render_page(page, site, templates, output_dir, minify, highlight, safe, verbose, global_vars, error_overlay: error_overlay, profiler: @profiler)
+            render_page(page, site, templates, output_dir, minify, highlight, safe, verbose, global_vars, error_overlay: error_overlay, profiler: active_profiler)
             if cache.enabled?
               source_path = File.join("content", page.path)
               output_path = get_output_path(page, output_dir)
@@ -685,9 +694,9 @@ module Hwaro
           count = if pages_to_render.empty?
                     0
                   elsif options.parallel && pages_to_render.size > 1
-                    process_files_parallel(pages_to_render, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: error_overlay, profiler: @profiler)
+                    process_files_parallel(pages_to_render, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: error_overlay, profiler: active_profiler)
                   else
-                    process_files_sequential(pages_to_render, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: error_overlay, profiler: @profiler)
+                    process_files_sequential(pages_to_render, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: error_overlay, profiler: active_profiler)
                   end
 
           # Re-generate 404 page with new template
@@ -790,9 +799,9 @@ module Hwaro
           renderable = pages.select(&.render)
 
           count = if options.parallel && renderable.size > 1
-                    process_files_parallel(renderable, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: options.error_overlay, profiler: @profiler)
+                    process_files_parallel(renderable, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: options.error_overlay, profiler: active_profiler)
                   else
-                    process_files_sequential(renderable, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: options.error_overlay, profiler: @profiler)
+                    process_files_sequential(renderable, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: options.error_overlay, profiler: active_profiler)
                   end
 
           # Refresh feeds / sitemap / search now that every page has rendered

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -118,6 +118,12 @@ module Hwaro
         @i18n_translations : Content::I18n::TranslationData = Content::I18n::TranslationData.new
         # Per-section cache of Crinja::Value arrays, keyed by "section_name:language"
         @section_pages_crinja_cache : Hash(String, Array(Crinja::Value)) = {} of String => Array(Crinja::Value)
+        # Companion url→index map per section list, populated together with
+        # (and invalidated exactly like) @section_pages_crinja_cache. Used
+        # for O(1) current-page exclusion in build_template_variables —
+        # the previous per-page linear Array#index scan made rendering a
+        # flat N-page section O(N²).
+        @section_pages_url_index_cache : Hash(String, Hash(String, Int32)) = {} of String => Hash(String, Int32)
         # Per-section cache of Crinja::Value arrays for section assets, keyed by section name
         @section_assets_crinja_cache : Hash(String, Array(Crinja::Value)) = {} of String => Array(Crinja::Value)
         # Track created directories to avoid redundant mkdir_p syscalls
@@ -169,6 +175,7 @@ module Hwaro
           end
           @cache_manager.register("section_pages_crinja", "Section page lists as Crinja values", runtime: true) do
             @section_pages_crinja_cache.clear
+            @section_pages_url_index_cache.clear
           end
           @cache_manager.register("section_assets_crinja", "Section asset lists as Crinja values", runtime: true) do
             @section_assets_crinja_cache.clear
@@ -1087,6 +1094,7 @@ module Hwaro
               # drop every language's entry for the section, like section_pages.
               @ancestors_crinja_cache.reject! { |k, _| k.starts_with?("#{section_name}:") }
               @section_pages_crinja_cache.reject! { |k, _| k.starts_with?("#{section_name}:") }
+              @section_pages_url_index_cache.reject! { |k, _| k.starts_with?("#{section_name}:") }
               @section_assets_crinja_cache.delete(section_name)
             end
           end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -481,9 +481,11 @@ module Hwaro
           render_list.each do |page|
             next unless page.render
             render_page(page, site, templates, output_dir, minify, highlight, safe, verbose, global_vars, error_overlay: error_overlay, profiler: @profiler)
-            source_path = File.join("content", page.path)
-            output_path = get_output_path(page, output_dir)
-            cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
+            if cache.enabled?
+              source_path = File.join("content", page.path)
+              output_path = get_output_path(page, output_dir)
+              cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
+            end
           end
 
           cache.save if options.cache

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -136,6 +136,14 @@ module Hwaro
         @ancestors_crinja_cache : Hash(String, Array(Crinja::Value)) = {} of String => Array(Crinja::Value)
         # Per-page related_posts Crinja::Value cache (avoids rebuilding the array on each build_template_variables call)
         @related_posts_crinja_cache : Hash(String, Crinja::Value) = {} of String => Crinja::Value
+        # Per-page template closure hash memo (page.path → hash). On cached
+        # builds the hash is needed twice per page (filter_changed_pages and
+        # cache.update) and costs shortcode regex scans over the raw content.
+        # Cleared with the runtime caches; incremental builds drop entries
+        # for re-parsed pages (their content — hence shortcode usage — may
+        # have changed).
+        @page_template_hash_memo : Hash(String, String) = {} of String => String
+        @page_template_hash_mutex : Mutex = Mutex.new
         # Mutex to protect shared Crinja value caches during parallel rendering.
         # Crystal fibers are single-threaded by default, but this guards against
         # future multi-threaded mode (-Dpreview_mt) and ensures correctness.
@@ -197,6 +205,9 @@ module Hwaro
           end
           @cache_manager.register("related_posts_crinja", "Related posts as Crinja values", runtime: true) do
             @related_posts_crinja_cache.clear
+          end
+          @cache_manager.register("page_template_hash", "Per-page template closure hashes", runtime: true) do
+            @page_template_hash_mutex.synchronize { @page_template_hash_memo.clear }
           end
           @cache_manager.register("build_cache", "Persistent file-change tracking (.hwaro_cache.json)", runtime: false) do
             @cache.try(&.clear)
@@ -317,6 +328,8 @@ module Hwaro
             # Re-read, re-parse front-matter and recalculate URL
             parse_single_page(page)
             page.generate_permalink(config.base_url)
+            # Content (shortcode usage) or front-matter template may have changed
+            @page_template_hash_mutex.synchronize { @page_template_hash_memo.delete(page.path) }
 
             # A changed [cascade] affects descendant pages that are NOT in the
             # changed set — incremental bookkeeping can't reach them, so
@@ -575,6 +588,7 @@ module Hwaro
 
             parse_single_page(page)
             page.generate_permalink(config.base_url)
+            @page_template_hash_mutex.synchronize { @page_template_hash_memo.delete(page.path) }
 
             # A changed [cascade] affects descendants outside the changed set
             # — escalate to a full rebuild, mirroring run_incremental.

--- a/src/core/build/cache.cr
+++ b/src/core/build/cache.cr
@@ -110,6 +110,11 @@ module Hwaro
         @current_template_hash : String = ""
         @current_config_hash : String = ""
 
+        # True when in-memory state diverges from what's on disk, so #save
+        # can skip rewriting the whole JSON on no-op warm builds. Set under
+        # @mutex wherever entries or metadata actually change.
+        @dirty : Bool = false
+
         def initialize(@enabled : Bool = true, @cache_path : String = CACHE_FILE)
           @entries = {} of String => CacheEntry
           @metadata = CacheMetadata.new
@@ -145,6 +150,9 @@ module Hwaro
             @mutex.synchronize { @entries.clear }
           end
 
+          if invalidated || @metadata.template_hash != template_hash || @metadata.config_hash != config_hash
+            @dirty = true
+          end
           @metadata = CacheMetadata.new(template_hash: template_hash, config_hash: config_hash)
         end
 
@@ -235,6 +243,7 @@ module Hwaro
               current = @entries[file_path]?
               if current.nil? || current.mtime <= mtime
                 @entries[file_path] = entry
+                @dirty = true
               end
             end
           rescue ex
@@ -245,7 +254,7 @@ module Hwaro
         # Remove entry from cache
         def invalidate(file_path : String)
           @mutex.synchronize do
-            @entries.delete(file_path)
+            @dirty = true if @entries.delete(file_path)
           end
         end
 
@@ -254,14 +263,18 @@ module Hwaro
           @mutex.synchronize do
             @entries.clear
             @metadata = CacheMetadata.new
+            @dirty = true
           end
           File.delete(@cache_path) if File.exists?(@cache_path)
         end
 
         # Save cache to disk using atomic write (temp file + rename)
         # to prevent corruption from partial writes (e.g. disk full, crash).
+        # No-op when nothing changed since load — a warm all-hits build
+        # otherwise re-serializes every entry just to write identical bytes.
         def save
           return unless @enabled
+          return unless @dirty
           tmp_path = "#{@cache_path}.tmp"
           begin
             # Snapshot shared state under the mutex: parallel fibers may still
@@ -272,6 +285,7 @@ module Hwaro
             end
             File.write(tmp_path, data.to_json)
             File.rename(tmp_path, @cache_path)
+            @dirty = false
           rescue ex
             Logger.warn "Cache: failed to save cache file: #{ex.message}"
             # Clean up temp file if rename failed
@@ -300,11 +314,14 @@ module Hwaro
             @metadata = data.metadata
             data.entries.each { |e| @entries[e.path] = e }
           rescue JSON::ParseException | JSON::SerializableError
-            # Fall back to legacy format (plain array of entries)
+            # Fall back to legacy format (plain array of entries); mark dirty
+            # so the next save upgrades the file to the metadata format even
+            # on an otherwise no-op build.
             begin
               entries = Array(CacheEntry).from_json(content)
               entries.each { |e| @entries[e.path] = e }
               @metadata = CacheMetadata.new
+              @dirty = true
             rescue ex : JSON::ParseException | JSON::SerializableError
               Logger.warn "Cache: corrupt cache file, rebuilding from scratch: #{ex.message}"
               @entries.clear

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1080,9 +1080,45 @@ module Hwaro::Core::Build::Phases::Render
         default_lang = site.config.default_language
         arr = pages.map { |p| page_to_crinja_list_value(p, default_lang) }
         @section_pages_crinja_cache[cache_key] = arr
+        @section_pages_url_index_cache[cache_key] = build_section_pages_url_index(arr)
         arr
       end
     end
+  end
+
+  # The cached section list plus its url→index map, for O(1) current-page
+  # exclusion. Both caches are filled and invalidated together under
+  # @crinja_cache_mutex (reentrant), so the index is rebuilt here only as
+  # a defensive fallback.
+  private def cached_section_pages_with_index(
+    section_name : String,
+    language : String?,
+    site : Models::Site,
+  ) : {Array(Crinja::Value), Hash(String, Int32)}
+    cache_key = "#{section_name}:#{language}"
+    @crinja_cache_mutex.synchronize do
+      arr = cached_section_pages_crinja(section_name, language, site)
+      index = @section_pages_url_index_cache[cache_key]?
+      unless index
+        index = build_section_pages_url_index(arr)
+        @section_pages_url_index_cache[cache_key] = index
+      end
+      {arr, index}
+    end
+  end
+
+  # First occurrence wins, mirroring the Array#index scan this replaces.
+  private def build_section_pages_url_index(pages : Array(Crinja::Value)) : Hash(String, Int32)
+    index = Hash(String, Int32).new(initial_capacity: pages.size)
+    pages.each_with_index do |value, i|
+      raw = value.raw
+      next unless raw.is_a?(Hash)
+      if url = raw["url"]?
+        key = url.to_s
+        index[key] = i unless index.has_key?(key)
+      end
+    end
+    index
   end
 
   # Build a lookup map from content path → Page for internal link resolution.
@@ -1639,13 +1675,10 @@ module Hwaro::Core::Build::Phases::Render
         section_pages_array = paginator.pages.map { |p| page_to_crinja_list_value(p, default_lang) }
       else
         # Non-paginated: use per-section cache, then exclude current page.
-        # Find index once, then build result skipping that slot (pre-sized array avoids realloc).
-        all_section = cached_section_pages_crinja(current_section, page.language, site)
-        page_url_str = page.url
-        skip_idx = all_section.index do |v|
-          raw = v.raw
-          raw.is_a?(Hash) && raw["url"]?.try(&.to_s) == page_url_str
-        end
+        # O(1) lookup via the cached url→index map, then build result
+        # skipping that slot (pre-sized array avoids realloc).
+        all_section, url_index = cached_section_pages_with_index(current_section, page.language, site)
+        skip_idx = url_index[page.url]?
         section_pages_array = if skip_idx
                                 arr = Array(Crinja::Value).new(all_section.size - 1)
                                 all_section.each_with_index { |v, i| arr << v unless i == skip_idx }

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -238,12 +238,26 @@ module Hwaro::Core::Build::Phases::Render
   # dependency tracking off (config, or a dynamic include in the graph),
   # returns the whole-site templates checksum — matching the previous
   # invalidate-everything behavior.
+  #
+  # Memoized per page for the duration of a build: cached builds need this
+  # twice per page (filter_changed_pages, then cache.update after render)
+  # and the shortcode scan walks the full raw content per shortcode
+  # template. A racy duplicate computation is harmless — both fibers store
+  # the same deterministic value.
   protected def page_template_hash(page : Models::Page, templates : Hash(String, String), site : Models::Site) : String
     deps = @template_deps
     return @global_templates_hash unless @per_page_template_hash && deps
 
+    @page_template_hash_mutex.synchronize do
+      if cached = @page_template_hash_memo[page.path]?
+        return cached
+      end
+    end
+
     entry_template = determine_template(page, templates, site)
-    deps.closure_hash(entry_template, deps.shortcodes_used_in(page.raw_content))
+    hash = deps.closure_hash(entry_template, deps.shortcodes_used_in(page.raw_content))
+    @page_template_hash_mutex.synchronize { @page_template_hash_memo[page.path] = hash }
+    hash
   end
 
   private def get_output_path(page : Models::Page, output_dir : String) : String

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -97,9 +97,9 @@ module Hwaro::Core::Build::Phases::Render
       count = if ctx.options.streaming?
                 render_streaming(pages_to_build, site, templates, output_dir, minify, build_cache, use_highlight, verbose, global_vars, error_overlay, parallel, ctx.options.batch_size)
               elsif parallel && pages_to_build.size > 1
-                process_files_parallel(pages_to_build, site, templates, output_dir, minify, build_cache, use_highlight, verbose, global_vars, error_overlay: error_overlay, profiler: @profiler)
+                process_files_parallel(pages_to_build, site, templates, output_dir, minify, build_cache, use_highlight, verbose, global_vars, error_overlay: error_overlay, profiler: active_profiler)
               else
-                process_files_sequential(pages_to_build, site, templates, output_dir, minify, build_cache, use_highlight, verbose, global_vars, error_overlay: error_overlay, profiler: @profiler)
+                process_files_sequential(pages_to_build, site, templates, output_dir, minify, build_cache, use_highlight, verbose, global_vars, error_overlay: error_overlay, profiler: active_profiler)
               end
       ctx.stats.pages_rendered = count
     end
@@ -195,9 +195,9 @@ module Hwaro::Core::Build::Phases::Render
       Logger.debug "  Streaming batch #{batch_num} (#{batch.size} pages)"
 
       count = if parallel && batch.size > 1
-                process_files_parallel(batch, site, templates, output_dir, minify, build_cache, use_highlight, verbose, global_vars, error_overlay: error_overlay, profiler: @profiler)
+                process_files_parallel(batch, site, templates, output_dir, minify, build_cache, use_highlight, verbose, global_vars, error_overlay: error_overlay, profiler: active_profiler)
               else
-                process_files_sequential(batch, site, templates, output_dir, minify, build_cache, use_highlight, verbose, global_vars, error_overlay: error_overlay, profiler: @profiler)
+                process_files_sequential(batch, site, templates, output_dir, minify, build_cache, use_highlight, verbose, global_vars, error_overlay: error_overlay, profiler: active_profiler)
               end
       total_count += count
 

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -318,9 +318,15 @@ module Hwaro::Core::Build::Phases::Render
               template_name = determine_template(page, templates, site)
               profiler.record_template(template_name, page.content.bytesize.to_i64, elapsed_ms)
             end
-            source_path = File.join("content", page.path)
-            output_path = get_output_path(page, output_dir)
-            cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
+            # Guard argument evaluation, not just the call: update is a no-op
+            # when the cache is disabled (the default build), but its
+            # arguments cost a template-hash computation — shortcode regex
+            # scans over the raw content plus an MD5 — per page.
+            if cache.enabled?
+              source_path = File.join("content", page.path)
+              output_path = get_output_path(page, output_dir)
+              cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
+            end
             results.send(true)
           rescue ex : Hwaro::HwaroError
             error_mutex.synchronize do
@@ -436,9 +442,13 @@ module Hwaro::Core::Build::Phases::Render
         template_name = determine_template(page, templates, site)
         profiler.record_template(template_name, page.content.bytesize.to_i64, elapsed_ms)
       end
-      source_path = File.join("content", page.path)
-      output_path = get_output_path(page, output_dir)
-      cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
+      # See the parallel worker: skip argument evaluation entirely when the
+      # cache is disabled — the template-hash computation is per-page work.
+      if cache.enabled?
+        source_path = File.join("content", page.path)
+        output_path = get_output_path(page, output_dir)
+        cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
+      end
       count += 1
     end
     count

--- a/src/core/build/template_deps.cr
+++ b/src/core/build/template_deps.cr
@@ -45,12 +45,19 @@ module Hwaro
         @direct : Hash(String, Set(String))
         @content_hashes : Hash(String, String)
         @closures : Hash(String, Set(String))
+        @closure_hashes : Hash(String, String)
         @shortcode_usage_patterns : Hash(String, Regex)
+        # @closures and @closure_hashes fill lazily, and parallel render
+        # workers reach them through cache.update → closure_hash — an
+        # unsynchronized Hash insert under -Dpreview_mt.
+        @lazy_mutex : Mutex
 
         def initialize(templates : Hash(String, String))
           @direct = {} of String => Set(String)
           @content_hashes = {} of String => String
           @closures = {} of String => Set(String)
+          @closure_hashes = {} of String => String
+          @lazy_mutex = Mutex.new
           @dynamic = false
 
           @shortcode_names = templates.keys
@@ -105,6 +112,10 @@ module Hwaro
         # Unknown references stay in the set: they hash as "absent", so a
         # template appearing later changes the closure hash and re-renders.
         def closure(name : String) : Set(String)
+          @lazy_mutex.synchronize { closure_unlocked(name) }
+        end
+
+        private def closure_unlocked(name : String) : Set(String)
           if cached = @closures[name]?
             return cached
           end
@@ -122,18 +133,35 @@ module Hwaro
         # Stable fingerprint of everything that influences a page's rendered
         # template output: the entry template's closure plus the closures of
         # every shortcode template the page content invokes.
+        #
+        # Memoized: sites have a handful of distinct (entry template,
+        # shortcode set) combinations but compute this once or twice per
+        # page on cached builds. The memo lives for this instance's
+        # lifetime, which is exactly one template (re)load — invalidation
+        # is automatic.
         def closure_hash(entry_template : String, shortcode_templates : Set(String) = Set(String).new) : String
-          names = closure(entry_template).dup
-          shortcode_templates.each { |sc| names.concat(closure(sc)) }
-
-          digest = Digest::MD5.new
-          names.to_a.sort!.each do |name|
-            digest.update(name)
-            digest.update("=")
-            digest.update(@content_hashes[name]? || "<missing>")
-            digest.update(";")
+          memo_key = String.build do |io|
+            io << entry_template
+            shortcode_templates.to_a.sort!.each { |sc| io << '|' << sc }
           end
-          digest.final.hexstring
+
+          @lazy_mutex.synchronize do
+            if cached = @closure_hashes[memo_key]?
+              return cached
+            end
+
+            names = closure_unlocked(entry_template).dup
+            shortcode_templates.each { |sc| names.concat(closure_unlocked(sc)) }
+
+            digest = Digest::MD5.new
+            names.to_a.sort!.each do |name|
+              digest.update(name)
+              digest.update("=")
+              digest.update(@content_hashes[name]? || "<missing>")
+              digest.update(";")
+            end
+            @closure_hashes[memo_key] = digest.final.hexstring
+          end
         end
 
         # All templates whose closure intersects `changed` — i.e. every


### PR DESCRIPTION
## Summary

Performance pass over the build pipeline with a hard constraint: **output stays byte-identical** (every change verified by `diff -r` of `public/` trees built before/after). Along the way it fixes a real correctness bug — nondeterministic server-mode highlighting under `-Dpreview_mt`.

### Correctness fix (the headline)

- **fix(highlight): nondeterministic server-mode output under parallel rendering** (61c2183)
  The vendored tartrazine shard is not thread-safe: each compiled rule holds a single PCRE2 `match_data` buffer shared across lexer instances. Concurrent tokenization corrupted match state; the degrade-to-plain rescue swallowed the error, so **random code blocks lost highlighting on any given build** (and `search.json` text drifted with them). All Tartrazine work is now serialized behind a mutex, with a bounded `(lang, code-digest)` result memo so repeated blocks skip tokenization entirely. Before: 2–3 files flipped per 1k-page build. After: 5 consecutive builds byte-identical.

### Perf changes (each commit independently verified byte-identical)

- **Skip cache bookkeeping when cache is off** (002b308): `Cache#update` is a no-op when disabled, but its arguments cost shortcode regex scans + MD5 per page on every default build. Guarded all three call sites with `cache.enabled?`.
- **O(1) current-page exclusion in section lists** (2f1c158): per-page `Array#index` scan over the section's full Crinja list made flat sections O(N²); replaced with a url→index map cached alongside the list and invalidated with it.
- **Per-page no-op work** (83e0a96): nil profiler threading when `--profile` is off (2× `Time.instant` + redundant `determine_template` per page); `Cache#save` dirty flag (no-op warm builds stop rewriting `.hwaro_cache.json`); markdown extensions skip the identity line pass when no `~~`/task-list/`{#id}` markers exist.
- **Template hash computed once + race fix** (e78e3b4): cached builds computed the per-page closure hash twice (filter + update); now memoized per build. Also fixes an unsynchronized lazy `Hash` insert in `TemplateDeps#closure` reachable from parallel workers.
- **Generate-phase fallback markdown memo** (cc71e5f): feeds/search re-rendered cache-skipped pages' markdown up to 4× per build (and per serve-mode rebuild); now memoized by content digest. The fragile `page.content.empty?` / streaming decision logic is untouched.
- **Benchmark harness** (4dc6b89): deterministic realistic corpus (sections, code fences, shortcode, tags, toc, search+server-highlight config), release-parity compile flags, `--keep/--runs/--dir/--generate-only` flags.

## Verification

- Byte-identical output: 1k-page benchmark corpus + testapp, baseline binary vs final binary (`diff -r` empty)
- Warm `--cache` 5k output byte-identical pre/post the Generate-phase memo (separate worktree binary)
- `--cache` semantics intact: warm second run skips all 1008 pages; editing a shortcode template invalidates exactly its 100 user pages; content change rewrites the cache file while a no-op build doesn't
- Targeted specs green throughout (cache, template-deps, server-highlight, feeds/search/seo, integration, multilingual: 129+103+128+38 examples); full suite + lint gate on CI
- `crystal tool format --check` + `ameba` clean (370 files)

## Notes for reviewers

- Warm-cache `search.json`/feeds legitimately differ from cold builds for pages with anchors/shortcodes (fallback render skips the full Render pipeline) — **pre-existing behavior, deliberately preserved**; verified unchanged old-vs-new.
- 5k cold-build baseline on this corpus is dominated by Crinja template evaluation (an all-pages nav loop), so wall-clock deltas from these commits are modest there; the wins concentrate on default cache-off bookkeeping, flat large sections, warm/no-op cached builds, serve-mode rebuilds, and code-heavy sites.