### PR TITLE
fix(security): close symlink-exfil, WS-origin, and rm_rf footgun gaps

### DIFF
--- a/spec/unit/live_reload_spec.cr
+++ b/spec/unit/live_reload_spec.cr
@@ -114,5 +114,17 @@ describe Hwaro::Services::LiveReloadHandler do
     it "rejects a cross-site Origin with 403" do
       livereload_status_for_origin("http://evil.example.com").should eq(403)
     end
+
+    it "rejects a request with no Origin header with 403 (fail closed)" do
+      # A browser always sends Origin on a WebSocket handshake; an absent
+      # Origin means a non-browser or crafted request. The handler must
+      # reject it rather than skip validation entirely.
+      headers = HTTP::Headers{"Host" => "localhost:1313"}
+      request = HTTP::Request.new("GET", Hwaro::Services::LiveReloadHandler::LIVE_RELOAD_PATH, headers)
+      response = HTTP::Server::Response.new(IO::Memory.new)
+      context = HTTP::Server::Context.new(request, response)
+      Hwaro::Services::LiveReloadHandler.new.call(context)
+      context.response.status_code.should eq(403)
+    end
   end
 end

--- a/spec/unit/path_utils_spec.cr
+++ b/spec/unit/path_utils_spec.cr
@@ -101,4 +101,41 @@ describe Hwaro::Utils::PathUtils do
       Hwaro::Utils::PathUtils.sanitize_path("/a/b/c/../../d").should eq("a/b/c/d")
     end
   end
+
+  describe ".resolves_within?" do
+    it "accepts a plain file inside the root" do
+      Dir.mktmpdir do |root|
+        File.write(File.join(root, "asset.txt"), "x")
+        Hwaro::Utils::PathUtils.resolves_within?(File.join(root, "asset.txt"), root).should be_true
+      end
+    end
+
+    it "accepts a symlink pointing inside the root" do
+      Dir.mktmpdir do |root|
+        target = File.join(root, "real.txt")
+        File.write(target, "x")
+        link = File.join(root, "link.txt")
+        File.symlink(target, link)
+        Hwaro::Utils::PathUtils.resolves_within?(link, root).should be_true
+      end
+    end
+
+    it "rejects a symlink whose target escapes the root" do
+      Dir.mktmpdir do |outside|
+        secret = File.join(outside, "secret.txt")
+        File.write(secret, "leak")
+        Dir.mktmpdir do |root|
+          link = File.join(root, "leak.txt")
+          File.symlink(secret, link)
+          Hwaro::Utils::PathUtils.resolves_within?(link, root).should be_false
+        end
+      end
+    end
+
+    it "returns false for a dangling/unreadable path" do
+      Dir.mktmpdir do |root|
+        Hwaro::Utils::PathUtils.resolves_within?(File.join(root, "nope.txt"), root).should be_false
+      end
+    end
+  end
 end

--- a/spec/unit/phases_initialize_spec.cr
+++ b/spec/unit/phases_initialize_spec.cr
@@ -86,6 +86,34 @@ describe Hwaro::Core::Build::Phases::Initialize do
         end
       end
     end
+
+    it "refuses to wipe the project directory itself (output_dir resolves to cwd)" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("source.md", "important")
+
+          builder = Hwaro::Core::Build::Builder.new
+          ex = expect_raises(Hwaro::HwaroError) do
+            builder.test_setup_output_dir(".", incremental: false)
+          end
+          ex.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+          # The guard fires before rm_rf, so project files survive.
+          File.exists?("source.md").should be_true
+        end
+      end
+    end
+
+    it "refuses to wipe a parent of the project directory" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "sub"))
+        Dir.cd(File.join(dir, "sub")) do
+          builder = Hwaro::Core::Build::Builder.new
+          expect_raises(Hwaro::HwaroError) do
+            builder.test_setup_output_dir("..", incremental: false)
+          end
+        end
+      end
+    end
   end
 
   describe "#copy_static_files" do
@@ -199,6 +227,32 @@ describe Hwaro::Core::Build::Phases::Initialize do
             File.exists?("public/css/.DS_Store").should be_false
             File.exists?("public/.git/config").should be_false
             File.exists?("public/.main.css.swp").should be_false
+          end
+        end
+      end
+    end
+
+    it "copies an in-project symlink but skips one escaping the project" do
+      # A symlink whose target lives outside the project must not leak that
+      # file into the published output; an in-repo symlink is still copied.
+      Dir.mktmpdir do |outside|
+        secret = File.join(outside, "secret.txt")
+        File.write(secret, "leak")
+
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("static")
+            File.write("static/real.txt", "in-repo")
+            File.symlink(File.expand_path("static/real.txt"), "static/inside.txt")
+            File.symlink(secret, "static/outside.txt")
+            FileUtils.mkdir_p("public")
+
+            builder = Hwaro::Core::Build::Builder.new
+            builder.test_copy_static_files("public")
+
+            File.exists?("public/inside.txt").should be_true
+            File.read("public/inside.txt").should eq("in-repo")
+            File.exists?("public/outside.txt").should be_false
           end
         end
       end

--- a/spec/unit/phases_write_spec.cr
+++ b/spec/unit/phases_write_spec.cr
@@ -125,6 +125,31 @@ describe Hwaro::Core::Build::Phases::Write do
       end
     end
 
+    it "skips a bundle asset symlink whose target escapes the project" do
+      Dir.mktmpdir do |outside|
+        secret = File.join(outside, "secret.txt")
+        File.write(secret, "leak")
+
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/blog/post")
+            File.write("content/blog/post/index.md", "---\ntitle: Post\n---\n")
+            File.symlink(secret, "content/blog/post/leak.txt")
+            FileUtils.mkdir_p("public")
+
+            page = Hwaro::Models::Page.new("blog/post/index.md")
+            page.url = "/blog/post/"
+            page.assets = ["blog/post/leak.txt"]
+
+            builder = Hwaro::Core::Build::Builder.new
+            builder.test_process_assets([page], "public", false)
+
+            File.exists?("public/blog/post/leak.txt").should be_false
+          end
+        end
+      end
+    end
+
     it "skips pages with no assets" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -90,10 +90,38 @@ module Hwaro::Core::Build::Phases::Initialize
       # In incremental mode (--cache), keep existing output to avoid
       # re-generating unchanged pages and re-copying unchanged static files.
       unless incremental
+        guard_destructive_clean!(output_dir)
         FileUtils.rm_rf(output_dir)
       end
     end
     Hwaro::Utils::FileSafe.mkdir_p(output_dir)
+  end
+
+  # Refuse to recursively delete a directory that isn't safely *inside* a
+  # sane workspace. A cold `hwaro build` clears `output_dir` before writing;
+  # a mistyped or hostile config value (""/"."/"/"/an absolute path/an
+  # ancestor of the project) would turn that `rm_rf` into a wipe of the
+  # filesystem root, the home directory, or the project source itself.
+  private def guard_destructive_clean!(output_dir : String)
+    expanded = File.expand_path(output_dir)
+    cwd = File.expand_path(Dir.current)
+
+    reason =
+      if expanded == "/" || Path[expanded].parent.to_s == expanded
+        "the filesystem root"
+      elsif expanded == Path.home.to_s
+        "the home directory"
+      elsif cwd == expanded || cwd.starts_with?(expanded + File::SEPARATOR)
+        "the project directory (or a parent of it)"
+      end
+
+    if reason
+      raise Hwaro::HwaroError.new(
+        code: Hwaro::Errors::HWARO_E_CONFIG,
+        message: "Refusing to delete #{reason}: output_dir resolves to #{expanded.inspect}.",
+        hint: "Point output_dir at a dedicated subdirectory such as \"public\"."
+      )
+    end
   end
 
   private def copy_static_files(output_dir : String, verbose : Bool, incremental : Bool = false)
@@ -143,6 +171,15 @@ module Hwaro::Core::Build::Phases::Initialize
       # log a spurious failure.
       info = File.info?(src_path, follow_symlinks: true)
       next if info.nil? || info.directory?
+
+      # A symlinked file whose target escapes the project would publish
+      # content from outside the site (e.g. `static/leak -> ~/.ssh/id_rsa`).
+      # Skip those; in-repo symlinks resolve back within the project root
+      # and are still copied. Only symlinks pay the realpath cost.
+      if File.symlink?(src_path) && !Hwaro::Utils::PathUtils.resolves_within?(src_path, Dir.current)
+        Logger.warn "Skipping static symlink pointing outside the project: #{src_path}"
+        next
+      end
 
       relative = Path[src_path].relative_to(src_dir).to_s
       next if static_config.excluded?(relative)

--- a/src/core/build/phases/write.cr
+++ b/src/core/build/phases/write.cr
@@ -121,6 +121,18 @@ module Hwaro::Core::Build::Phases::Write
 
         next unless File.exists?(source_path)
 
+        # A symlinked bundle asset whose target escapes the project would
+        # publish a file from outside the site; skip it (mirrors the static
+        # copy guard). In-repo symlinks resolve within the project and pass.
+        if File.symlink?(source_path) && !Hwaro::Utils::PathUtils.resolves_within?(source_path, Dir.current)
+          Logger.warn "Skipping bundle asset symlink pointing outside the project: #{source_path}"
+          next
+        end
+
+        # Defense in depth: never write outside the output directory even if
+        # an asset's relative path somehow climbs out of the bundle.
+        next unless Hwaro::Utils::OutputGuard.within_output_dir?(dest_path, output_dir)
+
         Hwaro::Utils::FileSafe.mkdir_p(File.dirname(dest_path))
         FileUtils.cp(source_path, dest_path)
         Logger.action :copy, dest_path, :blue if verbose

--- a/src/services/server/live_reload_handler.cr
+++ b/src/services/server/live_reload_handler.cr
@@ -28,35 +28,43 @@ module Hwaro
           # Only allow connections from the same host the dev server is bound to.
           origin = context.request.headers["Origin"]?
           host = context.request.headers["Host"]?
-          if origin && host
-            # Fail closed on unparseable Origins: URI.parse raises on inputs
-            # like an oversized port ("http://h:99999999999" -> OverflowError),
-            # and an attacker-controlled header must never crash the handler
-            # or slip past the check.
-            origin_uri = begin
-              URI.parse(origin)
-            rescue
-              context.response.status_code = 403
-              context.response.print "Forbidden: invalid origin"
-              return
-            end
-            origin_host = origin_uri.host
-            # Strip brackets from IPv6 literals (e.g. "[::1]" -> "::1")
-            if origin_host && origin_host.starts_with?('[') && origin_host.ends_with?(']')
-              origin_host = origin_host[1..-2]
-            end
-            # Host may be a bracketed IPv6 literal ("[::1]:1313") whose colons
-            # would confuse a plain split-on-":" port strip.
-            server_host = if host.starts_with?('[') && (close = host.index(']'))
-                            host[1...close]
-                          else
-                            host.split(":").first?
-                          end
-            unless origin_host == server_host || origin_host == "localhost" || origin_host == "127.0.0.1" || origin_host == "::1"
-              context.response.status_code = 403
-              context.response.print "Forbidden: invalid origin"
-              return
-            end
+          # Fail closed when either header is missing. Browsers always send an
+          # Origin on a WebSocket handshake, so a same-origin live-reload client
+          # never trips this; an absent Origin means a non-browser or crafted
+          # request, which we reject rather than letting it skip the check
+          # entirely (the previous `if origin && host` silently accepted those).
+          unless origin && host
+            context.response.status_code = 403
+            context.response.print "Forbidden: missing origin or host"
+            return
+          end
+          # Fail closed on unparseable Origins: URI.parse raises on inputs
+          # like an oversized port ("http://h:99999999999" -> OverflowError),
+          # and an attacker-controlled header must never crash the handler
+          # or slip past the check.
+          origin_uri = begin
+            URI.parse(origin)
+          rescue
+            context.response.status_code = 403
+            context.response.print "Forbidden: invalid origin"
+            return
+          end
+          origin_host = origin_uri.host
+          # Strip brackets from IPv6 literals (e.g. "[::1]" -> "::1")
+          if origin_host && origin_host.starts_with?('[') && origin_host.ends_with?(']')
+            origin_host = origin_host[1..-2]
+          end
+          # Host may be a bracketed IPv6 literal ("[::1]:1313") whose colons
+          # would confuse a plain split-on-":" port strip.
+          server_host = if host.starts_with?('[') && (close = host.index(']'))
+                          host[1...close]
+                        else
+                          host.split(":").first?
+                        end
+          unless origin_host == server_host || origin_host == "localhost" || origin_host == "127.0.0.1" || origin_host == "::1"
+            context.response.status_code = 403
+            context.response.print "Forbidden: invalid origin"
+            return
           end
 
           ws = HTTP::WebSocketHandler.new do |socket, _ctx|

--- a/src/utils/path_utils.cr
+++ b/src/utils/path_utils.cr
@@ -35,6 +35,27 @@ module Hwaro
 
         parts.join("/")
       end
+
+      # True when `path`, with all symbolic links resolved, lies inside
+      # `root` (also fully resolved). Used to stop symlinked source files
+      # from publishing content that lives outside the project — e.g. a
+      # `static/leak -> ~/.ssh/id_rsa` symlink would otherwise be copied
+      # into the public output. In-repo symlinks resolve back within the
+      # root and are kept. Returns false on a dangling/unreadable path
+      # rather than raising.
+      def resolves_within?(path : String, root : String) : Bool
+        real_path = begin
+          File.realpath(path)
+        rescue File::Error
+          return false
+        end
+        real_root = begin
+          File.realpath(root)
+        rescue File::Error
+          return false
+        end
+        real_path == real_root || real_path.starts_with?(real_root + File::SEPARATOR)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Hardening from a security audit across four areas (dev server, build-time file writes, command execution, output escaping). The escaping, request-path traversal, and command-execution paths audited clean; these are the four reachable gaps found and fixed.

### Fixes

1. **Live-reload WebSocket Origin — fail closed.** The check was `if origin && host`, so a request *missing* the `Origin` header skipped validation entirely and was accepted (a Cross-Site WebSocket Hijacking gap for non-browser/crafted clients). Now returns `403` when either header is absent. Browsers always send `Origin` on a WS handshake, so same-origin live reload is unaffected.

2. **Symlink exfiltration into published output.** Copying static files and page-bundle assets followed symlinks; `static/leak -> ~/.ssh/id_rsa` would be resolved and published. For a repo accepting PRs this is a file-exfiltration primitive. Symlinks whose realpath escapes the project root are now skipped (with a warning); in-repo symlinks still resolve within the root and are copied. Adds `PathUtils.resolves_within?` (realpath-based).

3. **Catastrophic `rm_rf` guard.** A cold build clears `output_dir` via `rm_rf`. A mistyped or hostile value (`""`, `.`, `/`, an ancestor of cwd, or the home dir) would wipe the home directory or the project source. Now refused with `HwaroError(HWARO_E_CONFIG)` before deletion.

### Intentionally not guarded

Config-driven path escapes (e.g. `og.auto_image.output_dir = "../../etc"`) are left unguarded: config is a **trusted boundary** — `[build] hooks` already grant arbitrary code execution by design (documented; the remote-scaffold fetcher warns) — so a guard there blocks no real threat.

## Test plan

- New specs: `PathUtils.resolves_within?` (inside/outside/dangling), WS handshake with missing Origin → 403, `rm_rf` guard refusing cwd and an ancestor, static + bundle-asset symlink skip.
- `crystal tool format` + `./bin/ameba` (370 files) clean.
- Full affected spec files pass; functional build/static specs pass.