### PR TITLE
docs: correct streaming build default batch size

### DIFF
--- a/docs/content/features/streaming-build.md
+++ b/docs/content/features/streaming-build.md
@@ -94,8 +94,9 @@ hwaro build --stream --verbose
 Building site...
   Streaming mode enabled (batch size: 500)
   ...
-  Streaming batch 1 (123 pages)
-
+  Streaming batch 1 (500 pages)
+  Streaming batch 2 (500 pages)
+  Streaming batch 3 (234 pages)
   ...
 ```
 

--- a/docs/content/features/streaming-build.md
+++ b/docs/content/features/streaming-build.md
@@ -23,7 +23,7 @@ For most sites, the default build mode works well. Streaming build is useful whe
 
 ### `--stream` flag
 
-Enable streaming with a default batch size of 50 pages:
+Enable streaming with a default batch size of 500 pages:
 
 ```bash
 hwaro build --stream
@@ -64,7 +64,7 @@ hwaro build --stream --memory-limit 512M
 | `--stream` | `--memory-limit` | `HWARO_MEMORYLIMIT` | Result |
 |---|---|---|---|
 | - | - | - | Normal build |
-| yes | - | - | Streaming, batch=50 |
+| yes | - | - | Streaming, batch=500 |
 | - | 2G | - | Streaming, batch≈20000 |
 | - | - | 1G | Streaming, batch≈10000 |
 | yes | 512M | - | Streaming, batch≈5000 |
@@ -92,11 +92,10 @@ hwaro build --stream --verbose
 
 ```
 Building site...
-  Streaming mode enabled (batch size: 50)
+  Streaming mode enabled (batch size: 500)
   ...
-  Streaming batch 1 (50 pages)
-  Streaming batch 2 (50 pages)
-  Streaming batch 3 (23 pages)
+  Streaming batch 1 (123 pages)
+
   ...
 ```
 

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -214,14 +214,14 @@ hwaro build -i /path/to/my-site -o ./dist
 
 For sites with thousands of pages, loading all rendered HTML into memory at once can cause high memory usage. Streaming build processes pages in batches during the Render phase, releasing rendered HTML after each batch is written to disk.
 
-- `--stream` enables streaming with a default batch size of 50 pages.
+- `--stream` enables streaming with a default batch size of 500 pages.
 - `--memory-limit SIZE` enables streaming and calculates the batch size automatically based on the given limit (heuristic: ~50KB per page). Accepts `G`, `M`, `K` suffixes (e.g. `2G`, `512M`, `256K`).
 - You can also set the `HWARO_MEMORYLIMIT` environment variable as a fallback. The CLI flag overrides the env var.
 
 | `--stream` | `--memory-limit` | `HWARO_MEMORYLIMIT` | Result |
 |---|---|---|---|
 | - | - | - | Normal build |
-| yes | - | - | Streaming, batch=50 |
+| yes | - | - | Streaming, batch=500 |
 | - | 2G | - | Streaming, batch≈20000 |
 | - | - | 1G | Streaming, batch≈10000 |
 | yes | 512M | - | Streaming, batch≈5000 |


### PR DESCRIPTION
## Summery
-  Corrected the default batch size value in the streaming build documentation.
-  Updated related explanations and examples for consistency

## Changes
-  Fixed incorrect batch size references.
-  Improved documentation accuracy