### PR TITLE
Addded unit test for method - taxonomy_values

### DIFF
--- a/spec/unit/page_methods_spec.cr
+++ b/spec/unit/page_methods_spec.cr
@@ -590,3 +590,36 @@ describe "#has_redirect?" do
     page.has_redirect?.should be_true
   end
 end
+
+# test case for taxonomy_values method:
+describe "#taxonomy_values" do
+  it "returns values from @taxonomies when the key exists" do
+    page = Hwaro::Models::Page.new("test.md")
+    page.taxonomies["categories"] = ["news", "tech"]
+    page.taxonomy_values("categories").should eq(["news", "tech"])
+  end
+
+  it "falls back to @tags when name is 'tags' and not in taxonomies" do
+    page = Hwaro::Models::Page.new("test.md")
+    page.tags = ["crystal", "oss"]
+    page.taxonomy_values("tags").should eq(["crystal", "oss"])
+  end
+
+  it "falls back to @authors when name is 'authors' and not in taxonomies" do
+    page = Hwaro::Models::Page.new("test.md")
+    page.authors = ["A", "B"]
+    page.taxonomy_values("authors").should eq(["A", "B"])
+  end
+
+  it "returns an empty array for an unknown taxonomy name" do
+    page = Hwaro::Models::Page.new("test.md")
+    page.taxonomy_values("series").should eq([] of String)
+  end
+
+  it "@taxonomies entry wins over @tags when both are set" do
+    page = Hwaro::Models::Page.new("test.md")
+    page.tags = ["from-field"]
+    page.taxonomies["tags"] = ["from-taxonomies"]
+    page.taxonomy_values("tags").should eq(["from-taxonomies"])
+  end
+end


### PR DESCRIPTION
closes #628

I had ran the test you mentioned - **crystal spec spec/unit/page_methods_spec.cr** - No error was encountered in my method, but I hit upon an error in method - collect-assets.
This was the message: 
Failures:

  1) Hwaro::Models::Page #collect_assets collects non-markdown files from page directory
     Failure/Error: assets.should contain("blog/image.png")

       Expected:   []
       to include: "blog/image.png"

     # spec\unit\page_methods_spec.cr:524

Finished in 90.8 milliseconds
82 examples, 1 failures, 0 errors, 0 pending

Failed examples:

crystal spec spec\unit\page_methods_spec.cr:509 # Hwaro::Models::Page #collect_assets collects non-markdown files from page directory

The other **./bin/ameba** passed.

Please review it, and mention if I need to do any changes :)