### PR TITLE
feat(cli): redesign terminal output with the ember "live status, calm receipt" identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Template dependency tracking: a static `extends`/`include`/`import`/shortcode graph means editing a template now only rebuilds the pages that render it — in `--cache` builds (per-page closure fingerprints) and `hwaro serve` (selective re-render instead of all pages). Dynamic references (`{% include some_var %}`) or `[build] template_deps = false` restore whole-site invalidation
 
 ### Changed
+- Terminal output redesign ("ember" identity): `build`, `serve`, `init`, `new`, and `doctor` now share one warm visual language — a live status line animates the build through its phases (TTY only) then collapses into a calm, aligned receipt, ending on a single ember outcome line (`▴ built 42 pages …`). The help banner wordmark moves from off-brand cyan to the ember accent, and durations are humanized (`1.18s` / `842ms`). Machine output is unchanged: `--json` payloads, the `hwaro serve` ready line, `--quiet`, and the `NO_COLOR`/non-TTY plain path are byte-for-byte preserved (no escapes, no `\r`). `HWARO_THEME=light` tunes the accent for light terminals; `COLORTERM` enables the 24-bit tier. NOTE: scripts that grep the *human* stdout (e.g. `Build complete!`, `[Watch] Change detected`) should switch to `--json` — the wording changed, the machine contracts did not
 - Template errors now report `templates/<file>:line:col` with a caret-marked source excerpt instead of an anonymous `<string>` template — applies to syntax errors, runtime errors, and user shortcode templates
 
 ## v0.15.3

--- a/spec/unit/logger_spec.cr
+++ b/spec/unit/logger_spec.cr
@@ -487,4 +487,88 @@ describe Hwaro::Logger do
       Hwaro::Logger::Level.values.size.should eq(4)
     end
   end
+
+  describe ".dur" do
+    it "formats sub-second values as whole ms" do
+      Hwaro::Logger.dur(0.0).should eq("0ms")
+      Hwaro::Logger.dur(999.4).should eq("999ms")
+    end
+
+    it "formats values >= 1s as seconds with two decimals" do
+      Hwaro::Logger.dur(1000.0).should eq("1.00s")
+      Hwaro::Logger.dur(1180.5).should eq("1.18s")
+    end
+  end
+
+  describe ".paint / .glyph fallbacks" do
+    it "returns raw text and ASCII glyphs when color is disabled" do
+      Hwaro::Logger.color_enabled = false
+      Hwaro::Logger.paint("x", Hwaro::Logger::Role::Accent).should eq("x")
+      Hwaro::Logger.glyph(:result).should eq("*")
+      Hwaro::Logger.glyph(:ok).should eq("[ok]")
+      Hwaro::Logger.glyph(:watch).should eq("~")
+    ensure
+      Hwaro::Logger.color_enabled = nil
+    end
+
+    it "uses unicode glyphs when color is enabled" do
+      Hwaro::Logger.color_enabled = true
+      Hwaro::Logger.glyph(:result).should contain("▴")
+      Hwaro::Logger.glyph(:heading).should contain("●")
+    ensure
+      Hwaro::Logger.color_enabled = nil
+    end
+  end
+
+  describe Hwaro::Logger::Receipt do
+    it "renders an escape-free plain summary, flattening · to , and skipping empty rows" do
+      r = Hwaro::Logger::Receipt.new("build")
+      r.row("read", "44 content files")
+      r.row("parse", "42 pages", emphasis: "2 skipped")
+      r.row("render", "42 pages · 0 cached")
+      r.row("write", "") # empty → skipped
+      r.outcome("built", "42 content pages", :result, 1180.5)
+
+      out = r.render_plain
+      out.should contain("hwaro: build")
+      out.should contain("read: 44 content files")
+      out.should contain("parse: 42 pages, 2 skipped")
+      out.should contain("render: 42 pages, 0 cached")
+      out.should_not contain("write:")
+      out.should contain("built: 42 content pages in 1.18s")
+      out.should_not contain("\e[")
+    end
+
+    it "includes the heading and outcome glyphs in the tty render" do
+      Hwaro::Logger.color_enabled = true
+      r = Hwaro::Logger::Receipt.new("build")
+      r.row("read", "x")
+      r.row("generate", "y")
+      r.outcome("built", "z")
+      tty = r.render_tty
+      tty.should contain("●")
+      tty.should contain("▴")
+      tty.should contain("─")
+    ensure
+      Hwaro::Logger.color_enabled = nil
+    end
+  end
+
+  describe ".outcome" do
+    it "prints a plain `verb: value` line when color is off" do
+      Hwaro::Logger.color_enabled = false
+      out = capture_logger_output { Hwaro::Logger.outcome("created", "content/x.md") }
+      out.should eq("created: content/x.md\n")
+    ensure
+      Hwaro::Logger.color_enabled = nil
+    end
+
+    it "is suppressed in quiet mode" do
+      Hwaro::Logger.quiet = true
+      out = capture_logger_output { Hwaro::Logger.outcome("created", "x") }
+      out.should eq("")
+    ensure
+      Hwaro::Logger.quiet = false
+    end
+  end
 end

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -2297,6 +2297,8 @@ describe "bind failure handling" do
         buffer = IO::Memory.new
         previous_io = Hwaro::Logger.io
         Hwaro::Logger.io = buffer
+        # Force plain output so the serve-receipt markers are deterministic.
+        Hwaro::Logger.color_enabled = false
 
         begin
           err = expect_raises(Hwaro::HwaroError) do
@@ -2309,12 +2311,15 @@ describe "bind failure handling" do
           err.exit_code.should eq(Hwaro::Errors::EXIT_IO)
           (err.message || "").downcase.should contain("bind")
 
+          # The serve receipt (heading + ready line) is printed only AFTER a
+          # successful bind, so a bind failure must show none of it.
           output = buffer.to_s
-          output.should_not contain("Serving site at")
-          output.should_not contain("Live reload enabled")
-          output.should_not contain("Watching for changes")
+          output.should_not contain("hwaro: serve")
+          output.should_not contain("ready: Ctrl+C to stop")
+          output.should_not contain("reload:")
         ensure
           Hwaro::Logger.io = previous_io
+          Hwaro::Logger.color_enabled = nil
           occupied.close
         end
       end

--- a/src/cli/commands/tool/doctor_command.cr
+++ b/src/cli/commands/tool/doctor_command.cr
@@ -192,7 +192,7 @@ module Hwaro
           private def render_human(issues : Array(Services::Issue), config_path : String)
             plain = plain_output?
 
-            Logger.info "Running diagnostics..."
+            Logger.heading("doctor")
             Logger.info ""
             Services::CHECK_GROUPS.each do |group|
               heading = group.key == :config ? config_path : group.default_heading
@@ -204,7 +204,7 @@ module Hwaro
             end
 
             if issues.empty?
-              Logger.info "#{ok_glyph(plain)} No issues found. Your site looks great!"
+              Logger.outcome("checked", "no issues found — your site looks great")
               return
             end
 
@@ -245,12 +245,17 @@ module Hwaro
               Logger.info ""
             end
 
-            # Summary
+            # Summary — one severity-aware outcome line: the lead glyph reflects
+            # the worst level found (✗ error / ⚠ warning / ▴ clean).
             errors = issues.count { |i| i.level == :error }
             warnings = issues.count { |i| i.level == :warning }
             infos = issues.count { |i| i.level == :info }
 
-            Logger.info "Found #{errors} error(s), #{warnings} warning(s), #{infos} info(s)"
+            worst = errors > 0 ? :err : (warnings > 0 ? :warn : :result)
+            summary = "#{errors} #{errors == 1 ? "error" : "errors"} · " \
+                      "#{warnings} #{warnings == 1 ? "warning" : "warnings"} · " \
+                      "#{infos} info"
+            Logger.outcome("checked", summary, worst)
             Logger.info ""
             Logger.info "Tip: Use 'hwaro tool validate' for content checks"
           end
@@ -288,17 +293,20 @@ module Hwaro
               else               "[ok]  "
               end
             else
+              # Route through the shared ember palette. Same colors as before
+              # except :info, which moves off the off-brand :cyan to a recessive
+              # dim role. truecolor terminals get the warm 24-bit tier for free.
               case level
-              when :error   then "✗".colorize(:red).to_s
-              when :warning then "⚠".colorize(:yellow).to_s
-              when :info    then "ℹ".colorize(:cyan).to_s
-              else               "✓".colorize(:green).to_s
+              when :error   then Logger.paint("✗", Logger::Role::Error)
+              when :warning then Logger.paint("⚠", Logger::Role::Warn)
+              when :info    then Logger.paint("ℹ", Logger::Role::Dim)
+              else               Logger.paint("✓", Logger::Role::Success)
               end
             end
           end
 
           private def ok_glyph(plain : Bool) : String
-            plain ? "[ok]" : "✓".colorize(:green).to_s
+            plain ? "[ok]" : Logger.paint("✓", Logger::Role::Success)
           end
 
           private def run_fix(doctor : Services::Doctor, approve_sections : Bool, dry_run : Bool, json_output : Bool)
@@ -322,7 +330,7 @@ module Hwaro
             unless summary.value_fixes.empty?
               Logger.success "#{verb_updated} #{summary.value_fixes.size} value(s) in config.toml:"
               summary.value_fixes.each do |fix|
-                arrow = plain ? "->" : "→".colorize(:green).to_s
+                arrow = plain ? "->" : Logger.paint("→", Logger::Role::Success)
                 Logger.info "  #{fix.field}: #{fix.before} #{arrow} #{fix.after}"
               end
               Logger.info ""
@@ -334,7 +342,7 @@ module Hwaro
               else
                 Logger.success "#{verb_added} #{summary.sections_added.size} config section(s):"
               end
-              plus = plain ? "+" : "＋".colorize(:green).to_s
+              plus = plain ? "+" : Logger.paint("＋", Logger::Role::Success)
               summary.sections_added.each do |key|
                 Logger.info "  #{plus} [#{key}]"
               end

--- a/src/cli/runner.cr
+++ b/src/cli/runner.cr
@@ -266,8 +266,10 @@ module Hwaro
           "                    ",
         ]
 
-        use_color = Logger.color_enabled?
-        brand = use_color ? "Hwaro".colorize(:cyan).bold.to_s : "Hwaro"
+        # Wordmark and H-art both wear the warm ember accent (the brand color),
+        # not the previous off-brand :cyan / :light_red. `paint` returns raw
+        # text when color is disabled, so the banner stays clean when piped.
+        brand = Logger.paint("Hwaro", Logger::Role::Accent, bold: true)
         info = [
           "",
           "",
@@ -285,7 +287,7 @@ module Hwaro
         Logger.info ""
         art.each_with_index do |line, i|
           right = info[i]? || ""
-          art_line = use_color ? line.colorize(:light_red).to_s : line
+          art_line = Logger.paint(line, Logger::Role::Accent)
           Logger.info "#{art_line}#{right}"
         end
 

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -80,7 +80,7 @@ module Hwaro
         search_path = File.join(output_dir, filename)
         File.write(search_path, content)
         Logger.action :create, search_path if verbose
-        Logger.info "  Generated search index with #{search_pages.size} pages."
+        Logger.info "  Generated search index with #{search_pages.size} pages." if verbose
       end
 
       private def self.build_search_data(pages : Array(Models::Page), config : Models::Config) : Array(Hash(String, String | Array(String)))

--- a/src/content/seo/llms.cr
+++ b/src/content/seo/llms.cr
@@ -30,7 +30,7 @@ module Hwaro
           file_path = File.join(output_dir, filename)
           File.write(file_path, build_index(config, pages))
           Logger.action :create, file_path if verbose
-          Logger.info "  Generated #{filename}"
+          Logger.info "  Generated #{filename}" if verbose
 
           generate_full(pages, config, output_dir, verbose)
         end
@@ -140,7 +140,7 @@ module Hwaro
 
           File.write(file_path, content)
           Logger.action :create, file_path if verbose
-          Logger.info "  Generated #{filename}"
+          Logger.info "  Generated #{filename}" if verbose
         end
 
         private def self.build_full_document(pages : Array(Models::Page), config : Models::Config) : String

--- a/src/content/seo/robots.cr
+++ b/src/content/seo/robots.cr
@@ -49,7 +49,7 @@ module Hwaro
           file_path = File.join(output_dir, filename)
           File.write(file_path, content)
           Logger.action :create, file_path if verbose
-          Logger.info "  Generated robots.txt"
+          Logger.info "  Generated robots.txt" if verbose
         end
       end
     end

--- a/src/content/seo/sitemap.cr
+++ b/src/content/seo/sitemap.cr
@@ -116,7 +116,7 @@ module Hwaro
           sitemap_path = Path[output_dir, filename].to_s
           File.write(sitemap_path, xml_content)
           Logger.action :create, sitemap_path if verbose
-          Logger.info "  Generated sitemap with #{sitemap_pages.size} URLs."
+          Logger.info "  Generated sitemap with #{sitemap_pages.size} URLs." if verbose
         end
       end
     end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -272,7 +272,7 @@ module Hwaro
             return run(options)
           end
 
-          Logger.info "Incremental build for #{changed_content_files.size} changed file(s)..."
+          Logger.info "Incremental build for #{changed_content_files.size} changed file(s)..." if options.verbose
           start_time = Time.instant
 
           output_dir = options.output_dir
@@ -533,7 +533,7 @@ module Hwaro
           ParallelHelper.execute(seo_tasks, options.parallel)
 
           elapsed = Time.instant - start_time
-          Logger.success "Incremental build complete! Rendered #{render_list.size}/#{all_pages.size} pages in #{elapsed.total_milliseconds.round(2)}ms."
+          Logger.outcome("rebuilt", "#{render_list.size} / #{all_pages.size} pages", :result, elapsed.total_milliseconds)
           if options.verbose
             @cache_manager.report_verbose
           else
@@ -674,9 +674,9 @@ module Hwaro
               return
             end
             affected_templates = deps.dependents_closure(changed)
-            Logger.info "Template change detected (#{changed.join(", ")}). Re-rendering affected pages..." unless changed.empty?
+            Logger.info "Template change detected (#{changed.join(", ")}). Re-rendering affected pages..." if options.verbose && !changed.empty?
           else
-            Logger.info "Template change detected. Re-rendering all pages..."
+            Logger.info "Template change detected. Re-rendering all pages..." if options.verbose
           end
 
           pages_to_render = if affected_templates && deps
@@ -696,7 +696,7 @@ module Hwaro
                               renderable_pages
                             end
 
-          if affected_templates && pages_to_render.size < renderable_pages.size
+          if options.verbose && affected_templates && pages_to_render.size < renderable_pages.size
             Logger.info "  #{pages_to_render.size} of #{renderable_pages.size} pages affected."
           end
 
@@ -731,7 +731,7 @@ module Hwaro
           cache.save if options.cache
 
           elapsed = Time.instant - start_time
-          Logger.success "Re-render complete! Rendered #{count} pages in #{elapsed.total_milliseconds.round(2)}ms."
+          Logger.outcome("rebuilt", "#{count} pages · re-render", :result, elapsed.total_milliseconds)
           if verbose
             @cache_manager.report_verbose
           else
@@ -844,7 +844,7 @@ module Hwaro
           @deferred_pages = nil
 
           elapsed = Time.instant - start_time
-          Logger.success "Fast-start: deferred render complete (#{count} pages in #{elapsed.total_milliseconds.round(2)}ms)."
+          Logger.outcome("rendered", "#{count} deferred pages", :result, elapsed.total_milliseconds)
           count
         end
 
@@ -869,7 +869,7 @@ module Hwaro
             FileUtils.cp(src_path, dest_path)
             copied += 1
           end
-          Logger.success "Copied #{copied} static file(s)." if copied > 0
+          Logger.outcome("copied", "#{copied} static #{copied == 1 ? "file" : "files"}") if copied > 0
         end
 
         # Republish non-Markdown content assets (images, etc.) to the output
@@ -915,7 +915,7 @@ module Hwaro
             Logger.action :copy, dest_path, :blue if verbose
             copied += 1
           end
-          Logger.success "Copied #{copied} content file(s)." if copied > 0
+          Logger.outcome("copied", "#{copied} content #{copied == 1 ? "file" : "files"}") if copied > 0
         end
 
         # Map source paths that were removed from disk to the output files
@@ -990,7 +990,8 @@ module Hwaro
             end
           end
 
-          Logger.info "Building site..."
+          # The build runs quietly; its story is told by the closing receipt
+          # (and, under -Dpreview_mt TTY, the live status line in Phase 3).
           start_time = Time.instant
 
           # Initialize profiler
@@ -1039,8 +1040,16 @@ module Hwaro
           @cache_manager.clear_runtime
           @created_dirs.clear
 
-          # Execute build phases through lifecycle
-          result = execute_phases(ctx, profiler)
+          # Execute build phases through lifecycle. The live status region
+          # animates the current phase on a TTY; `ensure` guarantees the
+          # spinner is torn down (and its line cleared) on every exit path
+          # before the receipt prints.
+          Logger.status_start(verbose: options.verbose)
+          begin
+            result = execute_phases(ctx, profiler)
+          ensure
+            Logger.status_finish
+          end
 
           ctx.stats.end_time = Time.instant
 
@@ -1054,7 +1063,7 @@ module Hwaro
           # "content pages" rather than just "pages" — taxonomy/archive/section
           # index files are also written to disk, so a bare "N pages" count
           # misleads users who diff this number against `find public -name '*.html'`.
-          Logger.success "Build complete! Generated #{ctx.stats.pages_rendered} content pages#{raw_msg} in #{elapsed.total_milliseconds.round(2)}ms."
+          emit_build_receipt(ctx, raw_msg, elapsed.total_milliseconds)
           # Only warn about an empty site when nothing was built at all. Under
           # `--cache`, unchanged pages are skipped (counted as `cache_hits`)
           # rather than re-rendered, so `pages_rendered` is 0 on a no-op rebuild
@@ -1121,6 +1130,29 @@ module Hwaro
               @section_assets_crinja_cache.delete(section_name)
             end
           end
+        end
+
+        # Emit the calm closing receipt: an aligned per-phase summary plus the
+        # one ember "built" outcome line. Rows are skipped when their value is
+        # empty, so cached/no-op rebuilds stay terse. Falls back to plain
+        # "label: value" lines (no color, no rule) when color is off.
+        private def emit_build_receipt(ctx : Lifecycle::BuildContext, raw_msg : String, elapsed_ms : Float64)
+          stats = ctx.stats
+          receipt = Logger::Receipt.new("build")
+          receipt.row("read", stats.pages_read > 0 ? "#{stats.pages_read} content files" : "")
+          parsed = stats.pages_read - stats.pages_skipped
+          receipt.row("parse", parsed > 0 ? "#{parsed} pages" : "",
+            emphasis: stats.pages_skipped > 0 ? "#{stats.pages_skipped} skipped" : nil)
+          render_val =
+            if stats.cache_hits > 0
+              "#{stats.pages_rendered} pages · #{stats.cache_hits} cached"
+            else
+              "#{stats.pages_rendered} pages"
+            end
+          receipt.row("render", render_val)
+          receipt.row("write", stats.raw_files_processed > 0 ? "#{stats.raw_files_processed} raw files" : "")
+          receipt.outcome("built", "#{stats.pages_rendered} content pages#{raw_msg}", :result, elapsed_ms)
+          receipt.emit
         end
 
         # Execute all build phases with lifecycle hooks

--- a/src/core/build/phases/generate.cr
+++ b/src/core/build/phases/generate.cr
@@ -7,6 +7,7 @@ module Hwaro::Core::Build::Phases::Generate
   private def execute_generate_phase(ctx : Lifecycle::BuildContext, profiler : Profiler) : Lifecycle::HookResult
     profiler.start_phase("Generate")
     result = @lifecycle.run_phase(Lifecycle::Phase::Generate, ctx) do
+      Logger.status_phase("generate")
       # Default generation if no SEO hooks registered
       unless @lifecycle.has_hooks?(Lifecycle::HookPoint::BeforeGenerate)
         site = @site || raise "Site not initialized"

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -9,6 +9,7 @@ module Hwaro::Core::Build::Phases::ParseContent
   private def execute_parse_content_phase(ctx : Lifecycle::BuildContext, profiler : Profiler) : Lifecycle::HookResult
     profiler.start_phase("ParseContent")
     result = @lifecycle.run_phase(Lifecycle::Phase::ParseContent, ctx) do
+      Logger.status_phase("parse")
       # Default parsing if no hooks registered
       unless @lifecycle.has_hooks?(Lifecycle::HookPoint::BeforeParseContent)
         parse_content_default(ctx)
@@ -106,10 +107,16 @@ module Hwaro::Core::Build::Phases::ParseContent
       ctx.invalidate_all_pages_cache
     end
 
+    # The skipped total feeds the receipt's "parse … N skipped" emphasis; the
+    # per-reason breakdown stays available under --verbose. Parse errors remain
+    # a warning regardless, since they signal broken content.
+    ctx.stats.pages_skipped = draft_count + future_count + expired_count
     Logger.warn "  #{failed_count} page(s) skipped due to parse errors." if failed_count > 0
-    Logger.info "  #{draft_count} page(s) skipped (draft) — excluded from sitemap, feeds & search by default." if draft_count > 0
-    Logger.info "  #{future_count} page(s) skipped (future-dated)." if future_count > 0
-    Logger.info "  Excluded #{expired_count} expired page#{"s" if expired_count > 1}" if expired_count > 0
+    if ctx.options.verbose
+      Logger.info "  #{draft_count} page(s) skipped (draft) — excluded from sitemap, feeds & search by default." if draft_count > 0
+      Logger.info "  #{future_count} page(s) skipped (future-dated)." if future_count > 0
+      Logger.info "  Excluded #{expired_count} expired page#{"s" if expired_count > 1}" if expired_count > 0
+    end
 
     # Show included draft content paths when --drafts flag is used
     if include_drafts

--- a/src/core/build/phases/read_content.cr
+++ b/src/core/build/phases/read_content.cr
@@ -10,8 +10,11 @@ module Hwaro::Core::Build::Phases::ReadContent
   private def execute_read_content_phase(ctx : Lifecycle::BuildContext, profiler : Profiler) : Lifecycle::HookResult
     profiler.start_phase("ReadContent")
     result = @lifecycle.run_phase(Lifecycle::Phase::ReadContent, ctx) do
+      Logger.status_phase("read")
       collect_content_paths(ctx, ctx.options.drafts)
-      Logger.info "  Found #{ctx.all_pages.size} pages."
+      # Count surfaces in the closing build receipt's "read" row instead of an
+      # inline line, keeping the build quiet until the summary.
+      ctx.stats.pages_read = ctx.all_pages.size
     end
     profiler.end_phase
     result

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -33,8 +33,9 @@ module Hwaro::Core::Build::Phases::Render
                      end
 
     if cache_enabled && pages_to_build.size < all_pages.size
+      # Surfaced as the receipt's "render … · N cached" detail instead of an
+      # inline line.
       ctx.stats.cache_hits = all_pages.size - pages_to_build.size
-      Logger.info "  Skipping #{ctx.stats.cache_hits} unchanged pages."
     end
 
     # Determine if syntax highlighting should be used
@@ -92,6 +93,7 @@ module Hwaro::Core::Build::Phases::Render
 
     profiler.start_phase("Render")
     result = @lifecycle.run_phase(Lifecycle::Phase::Render, ctx) do
+      Logger.status_phase(pages_to_build.size > 0 ? "render #{pages_to_build.size} pages" : "render")
       global_vars = build_global_vars(site, ctx.options.cache_busting)
       @pages_by_path = build_pages_by_path(site)
       count = if ctx.options.streaming?

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -8,6 +8,7 @@ module Hwaro::Core::Build::Phases::Transform
   private def execute_transform_phase(ctx : Lifecycle::BuildContext, profiler : Profiler) : Lifecycle::HookResult
     profiler.start_phase("Transform")
     result = @lifecycle.run_phase(Lifecycle::Phase::Transform, ctx) do
+      Logger.status_phase("transform")
       # Hooks handle transformation (Markdown → HTML)
     end
     profiler.end_phase

--- a/src/core/build/phases/write.cr
+++ b/src/core/build/phases/write.cr
@@ -8,6 +8,7 @@ module Hwaro::Core::Build::Phases::Write
   private def execute_write_phase(ctx : Lifecycle::BuildContext, profiler : Profiler) : Lifecycle::HookResult
     profiler.start_phase("Write")
     result = @lifecycle.run_phase(Lifecycle::Phase::Write, ctx) do
+      Logger.status_phase("write")
       site = @site || raise "Site not initialized"
       templates = @templates || raise "Templates not loaded"
       output_dir = ctx.options.output_dir

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -400,7 +400,7 @@ module Hwaro
         end
 
         File.write(full_path, content)
-        Logger.info "Created new content: #{full_path}"
+        Logger.outcome("created", full_path)
         full_path
       end
 

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -17,6 +17,10 @@ require "./config_snippets"
 module Hwaro
   module Services
     class Initializer
+      # Counts files/directories actually created so the closing receipt can
+      # report "N files" (existing entries left in place are not counted).
+      @created_count = 0
+
       def run(options : Config::Options::InitOptions)
         scaffold = if remote = options.scaffold_remote
                      Scaffolds::Remote.new(remote)
@@ -86,9 +90,8 @@ module Hwaro
           exit(1)
         end
 
-        target_label = target_path == "." ? "current directory" : "'#{target_path}'"
-        Logger.info "Initializing new Hwaro project in #{target_label}..."
-        Logger.info "Using scaffold: #{scaffold.description}"
+        Logger.heading("init", target_path == "." ? nil : target_path)
+        Logger.info "  #{Logger.paint("scaffold", Logger::Role::Dim)}  #{Logger.paint(scaffold.description, Logger::Role::Dim)}"
 
         is_multilingual = multilingual_languages.size > 1
 
@@ -185,8 +188,10 @@ module Hwaro
           end
         end
 
-        Logger.success "Done! Run `hwaro build` to generate the site."
-        Logger.info "Tip: update `base_url` in config.toml before deploying (defaults to http://localhost:3000)."
+        display_target = target_path == "." ? "." : "#{target_path}/"
+        Logger.outcome("created", "#{@created_count} files · #{display_target}")
+        Logger.info "Run `hwaro build` to generate the site, then `hwaro serve` to preview."
+        Logger.info "Set `base_url` in config.toml before deploying (defaults to http://localhost:3000)."
       end
 
       private def create_scaffold_content(target_path : String, scaffold : Scaffolds::Base, skip_taxonomies : Bool)
@@ -592,18 +597,20 @@ module Hwaro
 
       private def create_directory(path : String)
         if Dir.exists?(path)
-          Logger.action :exist, path, :blue
+          Logger.action :exist, path, :light_gray
         else
           Hwaro::Utils::FileSafe.mkdir_p(path)
+          @created_count += 1
           Logger.action :create, path
         end
       end
 
       private def create_file(path : String, content : String)
         if File.exists?(path)
-          Logger.action :exist, path, :blue
+          Logger.action :exist, path, :light_gray
         else
           File.write(path, content)
+          @created_count += 1
           Logger.action :create, path
         end
       end

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -396,11 +396,7 @@ module Hwaro
       end
 
       private def run_with_options(host : String, port : Int32, open_browser : Bool, access_log : Bool, live_reload : Bool, build_options : Config::Options::BuildOptions, json_output : Bool = false, headers : Hash(String, String) = {} of String => String)
-        if build_options.fast_start
-          Logger.info "Performing fast-start initial build (priority pages only)..."
-        else
-          Logger.info "Performing initial build..."
-        end
+        # The initial build prints its own receipt; no preamble needed.
         @builder.run(build_options)
 
         # Watch-triggered rebuilds should preserve the already-built output
@@ -468,9 +464,15 @@ module Hwaro
         end
 
         url = "http://#{host}:#{port}"
-        Logger.success "Serving site at #{url}"
-        Logger.info "Press Ctrl+C to stop."
-        Logger.info "Live reload enabled" if live_reload
+        # Calm serve receipt: where it's live, reload state, what's watched,
+        # then the ember "ready" beat. The machine-readable ready line emitted
+        # later by `emit_ready_signal` is intentionally left untouched.
+        serve_receipt = Logger::Receipt.new("serve")
+        serve_receipt.row("url", url, Logger::Role::Accent)
+        serve_receipt.row("reload", live_reload ? "enabled" : "disabled")
+        serve_receipt.row("watch", "content · templates · static · config")
+        serve_receipt.outcome("ready", "Ctrl+C to stop", :ready)
+        serve_receipt.emit
 
         if open_browser
           spawn do
@@ -612,7 +614,7 @@ module Hwaro
       end
 
       private def watch_for_changes(build_options : Config::Options::BuildOptions)
-        Logger.info "Watching for changes in content/, templates/, static/ and config.toml..."
+        # Watched roots are shown in the serve receipt's "watch" row.
         last_mtimes = scan_mtimes
 
         loop do
@@ -760,7 +762,11 @@ module Hwaro
       # Choose the cheapest rebuild strategy for a given ChangeSet and execute it.
       private def apply_changeset(changeset : ChangeSet, build_options : Config::Options::BuildOptions)
         strategy = changeset.rebuild_strategy
-        Logger.info "\n[Watch] Change detected (#{changeset.description}). Strategy: #{strategy}..."
+        # Calm watch timeline: one ember "↻ time  changed  <what>" event, then
+        # the rebuild's own "▴ rebuilt …" outcome line below it. The strategy is
+        # implied by that outcome (incremental N/M, re-render, full).
+        timestamp = Time.local.to_s("%H:%M:%S")
+        Logger.info "\n#{Logger.glyph(:watch)} #{Logger.paint(timestamp, Logger::Role::Dim)}  changed  #{Logger.paint(changeset.description, Logger::Role::Dim)}"
 
         # Resolve removed sources to their output files BEFORE the rebuild
         # swaps in a site that no longer knows the deleted page's URL.

--- a/src/utils/logger.cr
+++ b/src/utils/logger.cr
@@ -145,7 +145,7 @@ module Hwaro
       start = Time.instant
       result = yield
       elapsed = Time.instant - start
-      info "#{message} (#{elapsed.total_milliseconds.round(2)}ms)"
+      info "#{message} (#{dur(elapsed.total_milliseconds)})"
       result
     end
 
@@ -413,21 +413,31 @@ module Hwaro
         @start = Time.instant
         @frame = 0
         @stopped = Atomic(Int32).new(0)
-        @done = Channel(Nil).new
+        # Buffered (capacity 1) so the timer fiber's final send never blocks,
+        # even if `stop` is never reached — no parked/leaked fiber.
+        @done = Channel(Nil).new(1)
         @active = false
+        # Serializes terminal writes and shared-state (@label/@frame) access
+        # between the timer fiber and the main fiber under -Dpreview_mt.
+        @mutex = Mutex.new
       end
 
       def start : Nil
         @active = true
-        io = @io
         spawn do
-          until @stopped.get == 1
-            draw
-            sleep INTERVAL
+          begin
+            until @stopped.get == 1
+              draw
+              sleep INTERVAL
+            end
+          ensure
+            # Always erase our line and signal `stop`, even if `draw` raised
+            # (e.g. the TTY went away mid-build). Without this, `stop`'s
+            # `@done.receive` — reached from the build's `ensure` — would
+            # deadlock the whole process.
+            erase
+            @done.send(nil)
           end
-          io.print "\r\e[K"
-          io.flush
-          @done.send(nil)
         end
       end
 
@@ -437,12 +447,12 @@ module Hwaro
       # points); the timer still adds animation whenever the build yields.
       def phase(label : String) : Nil
         return unless @active
-        @label = label
+        @mutex.synchronize { @label = label }
         draw
       end
 
       # Stop the timer fiber and wait for it to erase its line, so subsequent
-      # output (the receipt) prints on a clean line.
+      # output (the receipt) prints on a clean line. Idempotent.
       def stop : Nil
         return unless @active
         @active = false
@@ -455,20 +465,36 @@ module Hwaro
       # spinner simply redraws below it on its next tick.
       def clear_line : Nil
         return unless @active
-        @io.print "\r\e[K"
-        @io.flush
+        erase
+      end
+
+      private def erase : Nil
+        write "\r\e[K"
       end
 
       private def draw : Nil
-        frame = SPINNER[@frame % SPINNER.size]
-        @frame += 1
-        elapsed = Logger.dur((Time.instant - @start).total_milliseconds)
-        body = @label.empty? ? "working" : @label
-        line = "#{Logger.paint(frame, Role::Accent)} " \
-               "#{Logger.paint(body, Role::Dim)} " \
-               "#{Logger.paint("· #{elapsed}", Role::Dim)}"
-        @io.print "\r\e[K#{line}"
-        @io.flush
+        line = @mutex.synchronize do
+          frame = SPINNER[@frame % SPINNER.size]
+          @frame += 1
+          elapsed = Logger.dur((Time.instant - @start).total_milliseconds)
+          body = @label.empty? ? "working" : @label
+          "\r\e[K#{Logger.paint(frame, Role::Accent)} " \
+          "#{Logger.paint(body, Role::Dim)} " \
+          "#{Logger.paint("· #{elapsed}", Role::Dim)}"
+        end
+        write line
+      end
+
+      # Single guarded terminal writer. If the TTY disappears mid-build
+      # (SIGHUP / EPIPE / EIO), stop the spinner instead of raising into the
+      # build or spinning uselessly — the receipt still prints afterwards.
+      private def write(s : String) : Nil
+        @mutex.synchronize do
+          @io.print s
+          @io.flush
+        end
+      rescue IO::Error
+        @stopped.set(1)
       end
     end
 

--- a/src/utils/logger.cr
+++ b/src/utils/logger.cr
@@ -27,6 +27,21 @@ module Hwaro
       Error
     end
 
+    # Semantic color roles for the unified "ember" terminal identity.
+    # Each role resolves to a truecolor RGB (when COLORTERM advertises it),
+    # a 16-color named fallback, or raw text when color is disabled. This is
+    # the single source of truth for brand color — callers name a role, never
+    # a raw colorize symbol, so the palette stays consistent across commands.
+    enum Role : UInt8
+      Accent  # warm ember (#ec7a66 dark / #b35454 light) — headings, outcomes, URLs
+      Success # green — a check passed
+      Warn    # yellow
+      Error   # red
+      Dim     # recessive gray — labels, timings, paths, rules
+      Heading # ember (alias of Accent, kept distinct for intent)
+      Plain   # no color (default foreground)
+    end
+
     @@level : Level = Level::Info
     @@quiet : Bool = false
     @@color_enabled : Bool? = nil
@@ -86,31 +101,37 @@ module Hwaro
     def self.debug(message : String)
       return if @@level > Level::Debug
       return if @@quiet
+      clear_active_line
       @@io.puts colorize("[DEBUG] #{message}", :light_gray)
     end
 
     def self.info(message : String)
       return if @@level > Level::Info
       return if @@quiet
+      clear_active_line
       @@io.puts message
     end
 
     def self.error(message : String)
+      clear_active_line
       @@err_io.puts colorize(message, :red)
     end
 
     def self.warn(message : String)
       return if @@level > Level::Warn
+      clear_active_line
       @@err_io.puts colorize("[WARN] #{message}", :yellow)
     end
 
     def self.success(message : String)
       return if @@quiet
+      clear_active_line
       @@io.puts colorize(message, :green)
     end
 
     def self.action(label : String | Symbol, message : String, color : Symbol = :green)
       return if @@quiet
+      clear_active_line
       label_s = label.to_s.rjust(12)
       if color_enabled?
         @@io.puts "#{label_s.colorize(color).bold}  #{message}"
@@ -147,6 +168,342 @@ module Hwaro
       bar = "█" * filled + "░" * (bar_width - filled)
       @@io.print "\r#{prefix}[#{bar}] #{percent}% (#{current}/#{total})"
       @@io.puts if current >= total
+    end
+
+    # ---------------------------------------------------------------------
+    # Ember theme: roles, glyphs, and humanized durations
+    # ---------------------------------------------------------------------
+
+    # True only when the terminal advertises 24-bit color *and* color is
+    # otherwise enabled. Gates the truecolor tier; everything degrades to the
+    # 16-color named fallback below it, then to raw text.
+    def self.truecolor? : Bool
+      return false unless color_enabled?
+      v = ENV["COLORTERM"]?
+      v == "truecolor" || v == "24bit"
+    end
+
+    # Background brightness for the ember accent. Not auto-detected (terminals
+    # don't report it reliably); default to the dark-bg ember and let users
+    # override with `HWARO_THEME=light`.
+    def self.dark? : Bool
+      ENV["HWARO_THEME"]? != "light"
+    end
+
+    # Truecolor RGB for a role, honoring `dark?`. `nil` for Plain.
+    private def self.role_rgb(role : Role) : Tuple(UInt8, UInt8, UInt8)?
+      dark = dark?
+      case role
+      when .accent?, .heading? then dark ? {236_u8, 122_u8, 102_u8} : {179_u8, 84_u8, 84_u8}
+      when .success?           then dark ? {184_u8, 187_u8, 38_u8} : {90_u8, 130_u8, 80_u8}
+      when .warn?              then dark ? {250_u8, 189_u8, 47_u8} : {181_u8, 118_u8, 58_u8}
+      when .error?             then dark ? {251_u8, 73_u8, 52_u8} : {192_u8, 57_u8, 43_u8}
+      when .dim?               then dark ? {146_u8, 131_u8, 116_u8} : {138_u8, 128_u8, 118_u8}
+      end
+    end
+
+    # 16-color named fallback for a role. `nil` for Plain.
+    private def self.role_named(role : Role) : Symbol?
+      case role
+      when .accent?, .heading? then :light_red # distinct from Error's :red
+      when .success?           then :green
+      when .warn?              then :yellow
+      when .error?             then :red
+      when .dim?               then :light_gray
+      end
+    end
+
+    # Paint `text` in a semantic role. Returns raw text (no escapes) when
+    # color is disabled, so scripts / CI / pipes stay clean. Prefers truecolor,
+    # falls back to the 16-color name, then to plain.
+    def self.paint(text : String, role : Role, bold : Bool = false) : String
+      unless color_enabled?
+        return text
+      end
+      colored =
+        if (rgb = role_rgb(role)) && truecolor?
+          text.colorize(Colorize::ColorRGB.new(rgb[0], rgb[1], rgb[2]))
+        elsif named = role_named(role)
+          text.colorize(named)
+        else
+          text.colorize
+        end
+      (bold ? colored.bold : colored).to_s
+    end
+
+    # Glyph registry: {unicode, ascii-fallback, role}. The ASCII fallback is
+    # used whenever color/unicode is disabled — the same gate the rest of the
+    # CLI uses — so plain output never emits a stray multibyte glyph.
+    GLYPHS = {
+      :ok      => {"✓", "[ok]", Role::Success},
+      :warn    => {"⚠", "[warn]", Role::Warn},
+      :err     => {"✗", "[err]", Role::Error},
+      :info    => {"ℹ", "[info]", Role::Dim},
+      :result  => {"▴", "*", Role::Accent},
+      :heading => {"●", "#", Role::Accent},
+      :ready   => {"◇", ">", Role::Accent},
+      :watch   => {"↻", "~", Role::Accent},
+    }
+
+    # Resolve a glyph by key: colorized unicode when color is on, else the
+    # plain ASCII fallback.
+    def self.glyph(key : Symbol) : String
+      uni, ascii, role = GLYPHS[key]
+      color_enabled? ? paint(uni, role) : ascii
+    end
+
+    # Humanized duration: ">= 1s" renders as seconds with two decimals
+    # ("1.18s"), below a second as whole milliseconds ("842ms"). Replaces the
+    # scattered `.round(2)}ms` so timings read consistently everywhere.
+    def self.dur(ms : Float64) : String
+      return "#{"%.2f" % (ms / 1000.0)}s" if ms >= 1000.0
+      "#{ms.round.to_i}ms"
+    end
+
+    # Total visible width of a receipt heading / divider rule.
+    RECEIPT_WIDTH = 48
+
+    # TTY form of a command heading: "  ● kind  title ───────". The glyph and
+    # rule are dim/ember; the trailing rule fills to RECEIPT_WIDTH. Used by
+    # `heading` and by `Receipt`.
+    def self.heading_str(kind : String, title : String? = nil) : String
+      head = "#{glyph(:heading)} #{paint(kind, Role::Dim, bold: true)}"
+      visible = 4 + kind.size # 2 indent + glyph + space + kind
+      if t = title
+        head = "#{head} #{paint(t, Role::Plain, bold: true)}"
+        visible += 1 + t.size
+      end
+      fill = RECEIPT_WIDTH - visible - 1
+      fill > 0 ? "  #{head} #{paint("─" * fill, Role::Dim)}" : "  #{head}"
+    end
+
+    # Print a command heading. No-ops in quiet; degrades to "hwaro: kind title"
+    # when color is off (no glyph, no rule).
+    def self.heading(kind : String, title : String? = nil) : Nil
+      return if @@quiet
+      clear_active_line
+      if color_enabled?
+        @@io.puts heading_str(kind, title)
+      else
+        @@io.puts(title ? "hwaro: #{kind} #{title}" : "hwaro: #{kind}")
+      end
+    end
+
+    # Build the single outcome line. `col` left-pads the verb so it aligns with
+    # a receipt's row labels. Plain form is "verb: value[ in dur]" with the
+    # middot separators flattened to commas.
+    def self.outcome_str(verb : String, value : String, glyph : Symbol, ms : Float64?, col : Int32, plain : Bool) : String
+      if plain
+        line = "#{verb}: #{value.gsub(" · ", ", ")}"
+        line += " in #{dur(ms)}" if ms
+        line
+      else
+        line = "  #{self.glyph(glyph)} #{paint(verb.ljust(col), Role::Accent, bold: true)}  #{value}"
+        line += "#{paint("  ·  ", Role::Dim)}#{paint(dur(ms), Role::Dim)}" if ms
+        line
+      end
+    end
+
+    # Print a standalone outcome line — the one warm ember beat a command ends
+    # on (`▴ created  path`). The glyph signals severity (`:result` ember,
+    # `:warn`/`:err` for problems) while the verb is always ember.
+    def self.outcome(verb : String, value : String, glyph : Symbol = :result, ms : Float64? = nil, col : Int32 = 0) : Nil
+      return if @@quiet
+      clear_active_line
+      @@io.puts outcome_str(verb, value, glyph, ms, col, !color_enabled?)
+    end
+
+    # A calm, aligned summary block: a heading, key/value rows, a divider, and
+    # one ember outcome line. Pure data → string, so it renders identically and
+    # testably without a live terminal. `render_tty` is emitted only when color
+    # is on; `render_plain` is the escape-free fallback for pipes / CI.
+    class Receipt
+      private record Row,
+        label : String,
+        value : String,
+        role : Role,
+        emphasis : String?,
+        emphasis_role : Role
+
+      @rows : Array(Row)
+      @outcome : NamedTuple(verb: String, value: String, glyph: Symbol, ms: Float64?)?
+
+      def initialize(@kind : String, @title : String? = nil)
+        @rows = [] of Row
+        @outcome = nil
+      end
+
+      # Append a key/value row. Skipped when empty so the summary never prints
+      # noise like "0 drafts". `emphasis` is an optional differently-colored
+      # suffix (e.g. a yellow "2 drafts skipped").
+      def row(label : String, value : String, role : Role = Role::Plain, emphasis : String? = nil, emphasis_role : Role = Role::Warn) : self
+        @rows << Row.new(label, value, role, emphasis, emphasis_role) unless value.empty? && emphasis.nil?
+        self
+      end
+
+      def outcome(verb : String, value : String, glyph : Symbol = :result, ms : Float64? = nil) : self
+        @outcome = {verb: verb, value: value, glyph: glyph, ms: ms}
+        self
+      end
+
+      # Print using the renderer that matches the current terminal.
+      def emit(io : IO = Logger.io) : Nil
+        return if Logger.quiet?
+        io.puts(Logger.color_enabled? ? render_tty : render_plain)
+      end
+
+      # Label column width: the longest row label, also covering the outcome
+      # verb so row values and the outcome value share one column.
+      private def col : Int32
+        w = @rows.max_of?(&.label.size) || 0
+        if o = @outcome
+          w = {w, o[:verb].size}.max
+        end
+        w
+      end
+
+      def render_tty : String
+        width = col
+        lines = [Logger.heading_str(@kind, @title)]
+        @rows.each do |r|
+          cell = Logger.paint(r.value, r.role)
+          if e = r.emphasis
+            cell = "#{cell}#{Logger.paint(" · ", Role::Dim)}#{Logger.paint(e, r.emphasis_role)}"
+          end
+          lines << "    #{Logger.paint(r.label.ljust(width), Role::Dim)}  #{cell}"
+        end
+        if o = @outcome
+          lines << "  #{Logger.paint("─" * (RECEIPT_WIDTH - 2), Role::Dim)}"
+          lines << Logger.outcome_str(o[:verb], o[:value], o[:glyph], o[:ms], width, false)
+        end
+        lines.join("\n")
+      end
+
+      def render_plain : String
+        lines = [@title ? "hwaro: #{@kind} #{@title}" : "hwaro: #{@kind}"]
+        @rows.each do |r|
+          val = r.value.gsub(" · ", ", ")
+          val = "#{val}, #{r.emphasis}" if r.emphasis
+          lines << "#{r.label}: #{val}"
+        end
+        if o = @outcome
+          lines << Logger.outcome_str(o[:verb], o[:value], o[:glyph], o[:ms], 0, true)
+        end
+        lines.join("\n")
+      end
+    end
+
+    # ---------------------------------------------------------------------
+    # Live status region (TTY only)
+    # ---------------------------------------------------------------------
+    #
+    # A single \r-overwriting line that breathes the current phase while work
+    # runs, then erases itself so the calm receipt is all that remains in
+    # scrollback. It is the ONLY place that emits `\r` / cursor escapes, and it
+    # never activates unless STDOUT is a TTY with color and non-quiet output —
+    # so pipes, CI, NO_COLOR, and tests are completely untouched (no fiber, no
+    # escapes). Animation is driven by a timer fiber, decoupled from the build's
+    # (possibly parallel) work so motion stays smooth regardless of phase.
+    class Status
+      SPINNER  = %w[◐ ◓ ◑ ◒]
+      INTERVAL = 90.milliseconds
+
+      def initialize(@io : IO)
+        @label = ""
+        @start = Time.instant
+        @frame = 0
+        @stopped = Atomic(Int32).new(0)
+        @done = Channel(Nil).new
+        @active = false
+      end
+
+      def start : Nil
+        @active = true
+        io = @io
+        spawn do
+          until @stopped.get == 1
+            draw
+            sleep INTERVAL
+          end
+          io.print "\r\e[K"
+          io.flush
+          @done.send(nil)
+        end
+      end
+
+      # Update the label and redraw immediately. The synchronous redraw is what
+      # makes phase progression visible even when CPU-bound work starves the
+      # timer fiber (Crystal's scheduler only services the sleep timer at yield
+      # points); the timer still adds animation whenever the build yields.
+      def phase(label : String) : Nil
+        return unless @active
+        @label = label
+        draw
+      end
+
+      # Stop the timer fiber and wait for it to erase its line, so subsequent
+      # output (the receipt) prints on a clean line.
+      def stop : Nil
+        return unless @active
+        @active = false
+        @stopped.set(1)
+        @done.receive
+      end
+
+      # Erase the spinner's current line without stopping it — used by the
+      # logging methods so an interleaved warning/info prints cleanly and the
+      # spinner simply redraws below it on its next tick.
+      def clear_line : Nil
+        return unless @active
+        @io.print "\r\e[K"
+        @io.flush
+      end
+
+      private def draw : Nil
+        frame = SPINNER[@frame % SPINNER.size]
+        @frame += 1
+        elapsed = Logger.dur((Time.instant - @start).total_milliseconds)
+        body = @label.empty? ? "working" : @label
+        line = "#{Logger.paint(frame, Role::Accent)} " \
+               "#{Logger.paint(body, Role::Dim)} " \
+               "#{Logger.paint("· #{elapsed}", Role::Dim)}"
+        @io.print "\r\e[K#{line}"
+        @io.flush
+      end
+    end
+
+    @@active_status : Status? = nil
+
+    # Begin a live status region for a unit of work. No-ops (and spawns no
+    # fiber) unless output is an interactive, colored, non-quiet TTY. `verbose`
+    # disables it too, since verbose mode streams its own per-file lines that
+    # would fight the spinner.
+    def self.status_start(verbose : Bool = false) : Nil
+      return if @@active_status # never nest
+      return if verbose || @@quiet
+      return unless @@io.tty? && color_enabled?
+      status = Status.new(@@io)
+      @@active_status = status
+      status.start
+    end
+
+    # Update the active status label (e.g. "render"). No-op when inactive.
+    def self.status_phase(label : String) : Nil
+      @@active_status.try(&.phase(label))
+    end
+
+    # Stop and tear down the active status region. Idempotent.
+    def self.status_finish : Nil
+      if status = @@active_status
+        @@active_status = nil
+        status.stop
+      end
+    end
+
+    # Erase the active spinner line before other output prints. Called by the
+    # logging methods so the live region coexists with normal log lines.
+    private def self.clear_active_line : Nil
+      @@active_status.try(&.clear_line)
     end
 
     # Colorize helper that respects `color_enabled?`. Returns the raw string


### PR DESCRIPTION
## What & why

hwaro's CLI output was functional but flat and inconsistent: `build` ran ~8 phases nearly silent then printed one green sentence; `serve`/`init`/`new` each used different vocabularies; the help banner wordmark was off-brand **cyan**. This unifies everything into the warm **"ember"** identity (PR #624) with a *live status, calm receipt* model.

## What it looks like

`hwaro build` — a live status line animates through the phases (TTY only)…
```
◐ render 502 pages · 88ms
```
…then collapses to a calm receipt ending on one ember beat:
```
  ● build  ───────────────────────────────────
    read       502 content files
    parse      502 pages
    render     502 pages
  ─────────────────────────────────────────────
  ▴ built      502 content pages  ·  220ms
```
`serve` gets a receipt (url/reload/watch) + `◇ ready`; watch rebuilds read as a calm `↻ time  changed …` → `▴ rebuilt` timeline. `init`/`new`/`doctor` all end on the same `▴ <verb>` ember outcome.

## How

All in `Hwaro::Logger`:
- `Role` enum + `paint`/`glyph`/`dur` — truecolor → 16-color → plain cascade. Ember `#ec7a66` dark / `#b35454` light → `:light_red` (distinct from error red).
- `Receipt` — pure data → `render_tty`/`render_plain` (escape-free).
- `Status` — TTY-only live region, the **only** writer of `\r`/cursor escapes; no-ops unless `tty && color && !quiet && !verbose`. Animates via a synchronous redraw on each phase boundary (Crystal's single-threaded scheduler starves a pure timer fiber during CPU-bound render).

## Machine contracts preserved (byte-for-byte)
- `--json` payloads (build/new/doctor), the `serve` ready line, `--quiet`, and `NO_COLOR`/non-TTY plain output (verified: **0 escapes, 0 `\r`**). Build output is unchanged (`diff -r` identical) — logging-only.
- `HWARO_THEME=light` tunes the accent; `COLORTERM` enables the 24-bit tier.

⚠️ **Behavior note:** scripts that grep the *human* stdout (`Build complete!`, `[Watch] Change detected`) should switch to `--json` — wording changed, machine contracts did not. Called out in CHANGELOG.

## Tests
- `crystal spec`: **5406 examples, 0 failures** (8 new for `dur`/`paint`/`glyph`/`Receipt`/`outcome`).
- `crystal tool format` + `./bin/ameba`: clean.
- Verified the colored TTY path, the serve receipt + watch timeline, and all machine contracts via real-pty + piped runs.