### PR TITLE
fix(markdown): keep pipes inside table code spans from splitting cells

### DIFF
--- a/spec/unit/table_parser_spec.cr
+++ b/spec/unit/table_parser_spec.cr
@@ -397,6 +397,64 @@ describe Hwaro::Content::Processors::TableParser do
       result.should_not contain("<strong>")
     end
 
+    it "does not split a cell on a pipe inside an inline code span" do
+      content = <<-MD
+        | A | B | C |
+        |---|---|---|
+        | p | a `b|c` d | q |
+        MD
+
+      result = Hwaro::Content::Processors::TableParser.process(content)
+      # The pipe inside the code span is literal, so the row stays 3 columns
+      # and the code span renders intact (no dangling backticks).
+      result.should contain("<td>p</td>")
+      result.should contain("<td>a <code>b|c</code> d</td>")
+      result.should contain("<td>q</td>")
+      result.should_not contain("`b")
+      result.should_not contain("c`")
+    end
+
+    it "does not split a cell on a pipe inside a multi-backtick code span" do
+      content = <<-MD
+        | A | B |
+        |---|---|
+        | x | ``a | b`` |
+        MD
+
+      result = Hwaro::Content::Processors::TableParser.process(content)
+      # A run of N backticks closes on the next run of N, so the interior
+      # pipe stays in one cell: the row keeps exactly two body columns
+      # instead of being split into three.
+      result.should contain("<td>x</td>")
+      result.scan(/<td/).size.should eq(2)
+      result.should contain("a | b")
+    end
+
+    it "unescapes an escaped pipe inside a code span (GFM table escape)" do
+      content = <<-MD
+        | A | B |
+        |---|---|
+        | x | `b\\|c` |
+        MD
+
+      result = Hwaro::Content::Processors::TableParser.process(content)
+      result.should contain("<td><code>b|c</code></td>")
+      result.should_not contain("b\\|c")
+    end
+
+    it "still splits on a bare pipe when a backtick span is never closed" do
+      content = <<-MD
+        | A | B |
+        |---|---|
+        | a `unclosed | b |
+        MD
+
+      result = Hwaro::Content::Processors::TableParser.process(content)
+      # No closing backtick, so the `|` after it still delimits the columns.
+      result.should contain("<td>a `unclosed</td>")
+      result.should contain("<td>b</td>")
+    end
+
     it "renders underscore bold and italic" do
       content = <<-MD
         | Header |

--- a/src/content/processors/table_parser.cr
+++ b/src/content/processors/table_parser.cr
@@ -185,7 +185,14 @@ module Hwaro
           end
         end
 
-        # Split a table row into cells
+        # Split a table row into cells.
+        #
+        # A `|` only delimits columns when it is "bare": escaped pipes (`\|`)
+        # and pipes that sit inside an inline code span (`` `a|b` ``) are
+        # literal cell content, matching GFM / markdown-it. Without the
+        # code-span guard a cell like `` `a|b` `` gets split mid-span, which
+        # corrupts the code span (dangling backticks) and pushes a stray extra
+        # `<td>` past the column count.
         private def split_row(line : String) : Array(String)
           stripped = line.strip
 
@@ -195,7 +202,6 @@ module Hwaro
           # Remove trailing pipe if present
           stripped = stripped.rchop('|') if stripped.ends_with?('|')
 
-          # Split by pipe, handling escaped pipes
           cells = [] of String
           current = String::Builder.new
           i = 0
@@ -207,6 +213,32 @@ module Hwaro
               # Escaped pipe - include literal pipe
               current << '|'
               i += 2
+            elsif char == '`'
+              # Inline code span: keep an interior `|` from splitting the cell.
+              # An opening run of N backticks is closed by the next run of
+              # exactly N; with no closer the backtick is literal and scanning
+              # resumes from the next character. `\|` is still unescaped to a
+              # bare pipe inside the span (GFM tables collapse it before the
+              # code span is rendered — see the spec's `b `\|` az` example).
+              run_len = backtick_run_length(chars, i)
+              close = find_closing_backtick_run(chars, i + run_len, run_len)
+              if close
+                end_index = close + run_len
+                k = i
+                while k < end_index
+                  if chars[k] == '\\' && k + 1 < end_index && chars[k + 1] == '|'
+                    current << '|'
+                    k += 2
+                  else
+                    current << chars[k]
+                    k += 1
+                  end
+                end
+                i = end_index
+              else
+                run_len.times { current << '`' }
+                i += run_len
+              end
             elsif char == '|'
               cells << current.to_s
               current = String::Builder.new
@@ -219,6 +251,33 @@ module Hwaro
           cells << current.to_s
 
           cells
+        end
+
+        # Number of consecutive backticks starting at `start`.
+        private def backtick_run_length(chars : Array(Char), start : Int32) : Int32
+          run = 0
+          while start + run < chars.size && chars[start + run] == '`'
+            run += 1
+          end
+          run
+        end
+
+        # Index where a closing backtick run of exactly `run_len` backticks
+        # begins, scanning from `start`. Returns nil when the span is never
+        # closed (the opening run is then treated as literal text). Runs of a
+        # different length are skipped, per CommonMark's code-span rule.
+        private def find_closing_backtick_run(chars : Array(Char), start : Int32, run_len : Int32) : Int32?
+          i = start
+          while i < chars.size
+            if chars[i] == '`'
+              run = backtick_run_length(chars, i)
+              return i if run == run_len
+              i += run
+            else
+              i += 1
+            end
+          end
+          nil
         end
 
         # Parse alignment from separator cell


### PR DESCRIPTION
## Summary

While building several sites with the freshly compiled binary (all 8 scaffolds, the docs site, a multilingual blog, and a markdown stress page), I hit a reproducible table-rendering bug: **a `|` inside an inline code span in a table cell is treated as a column delimiter.**

A cell like `` a `b|c` d `` was split mid-span, which:
- corrupted the code span into dangling backticks (`` a `b `` / `` c` d ``), and
- pushed a **stray extra `<td>`** past the column count (a 3-column table rendered a 4th cell in that row).

This diverges from GFM / markdown-it, where a pipe inside backticks is literal content.

## Reproduction

```markdown
| A | B | C |
|---|---|---|
| p | a `b|c` d | q |
```

**Before** — 4 cells, broken code span:
```html
<td>p</td>
<td>a `b</td>
<td>c` d</td>
<td>q</td>
```

**After** — 3 cells, intact code span:
```html
<td>p</td>
<td>a <code>b|c</code> d</td>
<td>q</td>
```

## Root cause

`TableParser#split_row` scanned for `|` delimiters knowing only about backslash-escaped pipes (`\|`). It had no notion of inline code spans, so it split right through them — before the per-cell `InlineMarkdown.render` (which *does* stash code spans) ever ran.

## Fix

`split_row` now skips over inline code spans while scanning for delimiters:

- An opening run of **N** backticks is closed by the next run of **exactly N** (CommonMark rule); a pipe between them is literal cell content.
- An **unclosed** run is treated as a literal backtick, so a real `|` after it still delimits columns.
- Escaped pipes inside a span are still collapsed to a bare pipe, preserving the prior GFM table-escape behavior (`` `b\|c` `` → `<code>b|c</code>`, per the spec's `` b `\|` az `` example) — so this is a pure fix with no rendering regression for previously-working content.

## Testing

- Added 4 specs (unescaped pipe, multi-backtick span, escaped-pipe GFM escape, unclosed-backtick guard).
- `crystal spec spec/unit/table_parser_spec.cr` → **69 examples, 0 failures**.
- Full suite: only the 2 pre-existing `frontmatter_converter` "read-only file" cases fail, and they fail on `main` too (artifact of running specs as root — `chmod 0400` doesn't block root writes); unrelated to this change.
- `crystal tool format --check` and `ameba` both clean on the changed files.
- Verified end-to-end against a rebuilt binary on a real multilingual blog post table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01579yEtxCxSh1vrRUfRUujb

---
_Generated by [Claude Code](https://claude.ai/code/session_01579yEtxCxSh1vrRUfRUujb)_