### PR TITLE
fix: dogfood cycle 2 — 25 correctness fixes (markdown, SEO, AMP, PWA, scaffolds, feeds, permalinks)

### DIFF
--- a/spec/unit/amp_spec.cr
+++ b/spec/unit/amp_spec.cr
@@ -212,6 +212,95 @@ describe Hwaro::Content::Seo::Amp do
       result.should contain("<amp-iframe")
       result.should_not contain("<iframe")
     end
+
+    it "adds a sandbox attribute and amp-iframe extension script" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      config = Hwaro::Models::Config.new
+
+      html = %(<html><head></head><body><iframe src="https://example.com"></iframe></body></html>)
+      result = Hwaro::Content::Seo::Amp.convert_to_amp(html, page, config)
+      result.should contain("<amp-iframe")
+      result.should contain("sandbox=")
+      result.should contain(%(custom-element="amp-iframe"))
+      result.should contain("amp-iframe-0.1.js")
+    end
+
+    it "preserves an existing sandbox attribute on iframe" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      config = Hwaro::Models::Config.new
+
+      html = %(<html><head></head><body><iframe src="https://example.com" sandbox="allow-scripts"></iframe></body></html>)
+      result = Hwaro::Content::Seo::Amp.convert_to_amp(html, page, config)
+      result.should contain(%(sandbox="allow-scripts"))
+      # No duplicate sandbox attribute was appended.
+      result.scan(/sandbox=/).size.should eq(1)
+    end
+
+    it "adds amp-video extension script when video present" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      config = Hwaro::Models::Config.new
+
+      html = %(<html><head></head><body><video src="/v.mp4" width="640" height="360"></video></body></html>)
+      result = Hwaro::Content::Seo::Amp.convert_to_amp(html, page, config)
+      result.should contain("<amp-video")
+      result.should contain(%(custom-element="amp-video"))
+      result.should contain("amp-video-0.1.js")
+    end
+
+    it "injects missing extension scripts when boilerplate already present" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      config = Hwaro::Models::Config.new
+
+      html = "<html><head><style amp-boilerplate>body{}</style>" +
+             %(<script async src="https://cdn.ampproject.org/v0.js"></script>) +
+             "</head><body><iframe src=\"https://example.com\"></iframe></body></html>"
+      result = Hwaro::Content::Seo::Amp.convert_to_amp(html, page, config)
+      result.should contain(%(custom-element="amp-iframe"))
+      result.should contain("amp-iframe-0.1.js")
+    end
+
+    it "does not duplicate extension scripts already declared" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      config = Hwaro::Models::Config.new
+
+      html = "<html><head><style amp-boilerplate>body{}</style>" +
+             %(<script async src="https://cdn.ampproject.org/v0.js"></script>) +
+             %(<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>) +
+             "</head><body><iframe src=\"https://example.com\"></iframe></body></html>"
+      result = Hwaro::Content::Seo::Amp.convert_to_amp(html, page, config)
+      result.scan(/custom-element="amp-iframe"/).size.should eq(1)
+    end
+
+    it "strips a self-referencing amphtml link (idempotent across builds)" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      # Simulate the on-disk canonical HTML from a prior run already carrying an
+      # amphtml link.
+      html = %(<html><head><link rel="amphtml" href="https://example.com/amp/test/"></head><body>Hi</body></html>)
+      result = Hwaro::Content::Seo::Amp.convert_to_amp(html, page, config)
+      result.should_not contain(%(rel="amphtml"))
+    end
+
+    it "unwraps a paragraph whose sole child is an amp-img container" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/test/"
+      config = Hwaro::Models::Config.new
+
+      # Markdown wraps a standalone image in <p>...</p>.
+      html = %(<html><head></head><body><p><img src="/x.png" alt="x" /></p></body></html>)
+      result = Hwaro::Content::Seo::Amp.convert_to_amp(html, page, config)
+      result.should contain(%(<div class="amp-img-container">))
+      # The block container must not be nested directly inside <p>.
+      result.should_not match(/<p>\s*<div class="amp-img-container"/)
+    end
   end
 
   describe ".generate" do

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -1640,6 +1640,20 @@ describe Hwaro::Models::Config do
       config.permalinks["old/posts"].should eq("posts")
       config.permalinks["2023/drafts"].should eq("archive/2023")
     end
+
+    it "strips surrounding slashes from both source keys and targets" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [permalinks]
+        "/posts" = "/blog/"
+        TOML
+
+      # The slash-free key matches the slash-free directory path, and the
+      # slash-free target avoids double-slash URLs (http://host//blog//p/).
+      config.permalinks.has_key?("/posts").should be_false
+      config.permalinks["posts"].should eq("blog")
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -870,6 +870,94 @@ describe Hwaro::Services::Doctor do
         end
       end
 
+      # `[pwa] offline_page` / `precache_urls` are routes, not just static
+      # files: `/about/` builds to `public/about/index.html` from
+      # `content/about.md`. Resolving against `static/` alone produced a
+      # spurious "file not found" for valid routes.
+      it "does not warn on a [pwa] offline_page route backed by a content file" do
+        Dir.mktmpdir do |dir|
+          content_dir = File.join(dir, "content")
+          FileUtils.mkdir_p(content_dir)
+          File.write(File.join(content_dir, "about.md"), "+++\ntitle = \"About\"\n+++\n")
+
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, %(title = "T"\nbase_url = "http://x"\n[pwa]\nenabled = true\noffline_page = "/about/"\n))
+
+          doctor = Hwaro::Services::Doctor.new(
+            content_dir: content_dir,
+            config_path: config_path,
+            templates_dir: File.join(dir, "templates"),
+            static_dir: File.join(dir, "static"),
+          )
+          Dir.cd(dir) do
+            issues = doctor.run
+            issues.any? { |i| i.id == "config-path-missing" && i.message.includes?("offline_page") }.should be_false
+          end
+        end
+      end
+
+      it "does not warn on a [pwa] precache route backed by a built public page" do
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, %(title = "T"\nbase_url = "http://x"\n[pwa]\nenabled = true\nprecache_urls = ["/blog/"]\n))
+
+          # No content source, but the built output page exists.
+          FileUtils.mkdir_p(File.join(dir, "public", "blog"))
+          File.write(File.join(dir, "public", "blog", "index.html"), "<html></html>")
+
+          doctor = Hwaro::Services::Doctor.new(
+            content_dir: File.join(dir, "content"),
+            config_path: config_path,
+            templates_dir: File.join(dir, "templates"),
+            static_dir: File.join(dir, "static"),
+          )
+          Dir.cd(dir) do
+            issues = doctor.run
+            issues.any? { |i| i.id == "config-path-missing" && i.message.includes?("precache") }.should be_false
+          end
+        end
+      end
+
+      it "still warns on a genuinely-missing [pwa] precache route" do
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, %(title = "T"\nbase_url = "http://x"\n[pwa]\nenabled = true\nprecache_urls = ["/ghost/"]\n))
+
+          doctor = Hwaro::Services::Doctor.new(
+            content_dir: File.join(dir, "content"),
+            config_path: config_path,
+            templates_dir: File.join(dir, "templates"),
+            static_dir: File.join(dir, "static"),
+          )
+          Dir.cd(dir) do
+            issues = doctor.run
+            issues.any? do |i|
+              i.id == "config-path-missing" &&
+                i.message.includes?("precache_urls") &&
+                i.message.includes?("/ghost/")
+            end.should be_true
+          end
+        end
+      end
+
+      it "does not validate external [pwa] precache URLs" do
+        Dir.mktmpdir do |dir|
+          config_path = File.join(dir, "config.toml")
+          File.write(config_path, %(title = "T"\nbase_url = "http://x"\n[pwa]\nenabled = true\nprecache_urls = ["https://cdn.example.com/app.js"]\n))
+
+          doctor = Hwaro::Services::Doctor.new(
+            content_dir: File.join(dir, "content"),
+            config_path: config_path,
+            templates_dir: File.join(dir, "templates"),
+            static_dir: File.join(dir, "static"),
+          )
+          Dir.cd(dir) do
+            issues = doctor.run
+            issues.any? { |i| i.id == "config-path-missing" && i.message.includes?("precache") }.should be_false
+          end
+        end
+      end
+
       it "strips query string and fragment before resolving referenced paths" do
         # `/images/og.png?v=2` should resolve to /images/og.png on disk.
         # Without stripping, doctor would emit a spurious config-path-missing.

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -918,10 +918,14 @@ describe Hwaro::Services::Doctor do
         end
       end
 
-      it "still warns on a genuinely-missing [pwa] precache route" do
+      it "still warns on a genuinely-missing [pwa] precache asset (non-route path)" do
+        # Route-style values (trailing slash / no extension) are produced at
+        # build time and can't be validated pre-build, so doctor stays quiet on
+        # them and lets the authoritative build-time precache check catch misses.
+        # An asset-style path that resolves nowhere is still flagged here.
         Dir.mktmpdir do |dir|
           config_path = File.join(dir, "config.toml")
-          File.write(config_path, %(title = "T"\nbase_url = "http://x"\n[pwa]\nenabled = true\nprecache_urls = ["/ghost/"]\n))
+          File.write(config_path, %(title = "T"\nbase_url = "http://x"\n[pwa]\nenabled = true\nprecache_urls = ["/ghost.png"]\n))
 
           doctor = Hwaro::Services::Doctor.new(
             content_dir: File.join(dir, "content"),
@@ -934,7 +938,7 @@ describe Hwaro::Services::Doctor do
             issues.any? do |i|
               i.id == "config-path-missing" &&
                 i.message.includes?("precache_urls") &&
-                i.message.includes?("/ghost/")
+                i.message.includes?("/ghost.png")
             end.should be_true
           end
         end

--- a/spec/unit/feeds_spec.cr
+++ b/spec/unit/feeds_spec.cr
@@ -143,6 +143,35 @@ describe Hwaro::Content::Seo::Feeds do
       end
     end
 
+    it "does not generate language feed when the language has no content pages" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+
+      # fr has generate_feed=true (default) but no fr content pages — its
+      # feed's channel <link> would point at a non-existent /fr/ home (404).
+      config.languages["fr"] = Hwaro::Models::LanguageConfig.new("fr")
+
+      en_page = Hwaro::Models::Page.new("posts/hello.md")
+      en_page.title = "Hello World"
+      en_page.url = "/posts/hello/"
+      en_page.language = nil
+      en_page.draft = false
+      en_page.render = true
+      en_page.is_index = false
+      en_page.raw_content = "English content"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([en_page], config, output_dir)
+
+        File.exists?(File.join(output_dir, "fr", "rss.xml")).should be_false
+      end
+    end
+
     it "generates feeds for multiple non-default languages" do
       config = Hwaro::Models::Config.new
       config.feeds.enabled = true
@@ -1903,6 +1932,28 @@ describe Hwaro::Content::Seo::Feeds do
       )
 
       atom.should contain("C++ &amp; Java: &lt;Comparison&gt;")
+    end
+
+    it "emits <category term> per tag and per taxonomy term (gh#526)" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("post.md")
+      page.title = "Post"
+      page.url = "/post/"
+      page.tags = ["crystal", "atom"]
+      page.taxonomies = {
+        "categories" => ["programming"],
+      }
+      page.raw_content = "Body"
+
+      atom = Hwaro::Content::Seo::Feeds.generate_atom(
+        [page], config, "atom.xml", false, "Test", ""
+      )
+
+      atom.should contain("<category term=\"crystal\" />")
+      atom.should contain("<category term=\"atom\" />")
+      atom.should contain("<category term=\"programming\" />")
     end
 
     it "handles page URL without leading slash" do

--- a/spec/unit/image_hooks_spec.cr
+++ b/spec/unit/image_hooks_spec.cr
@@ -332,17 +332,21 @@ describe Hwaro::Content::Hooks::ImageHooks do
       end
     end
 
-    it "returns nil when any destination is missing" do
+    it "returns nil when a non-clamped variant is missing (config/output mismatch)" do
       Dir.mktmpdir do |dir|
         source = File.join(dir, "photo.jpg")
         File.write(source, "src")
         dest_dir = File.join(dir, "out")
         Dir.mkdir_p(dest_dir)
-        # Only the 320w variant exists
+        # The 320w and 1280w variants exist but the middle 640w is missing. The
+        # largest on-disk variant (1280) implies the source is >= 1280px, so
+        # 640w should exist and is NOT a clamp — the set is incomplete, so the
+        # image must be reprocessed.
         File.write(File.join(dest_dir, "photo_320w.jpg"), "320")
+        File.write(File.join(dest_dir, "photo_1280w.jpg"), "1280")
 
         Hwaro::Content::Hooks::ImageHooks
-          .reusable_widths(source, dest_dir, [320, 640])
+          .reusable_widths(source, dest_dir, [320, 640, 1280])
           .should be_nil
       end
     end

--- a/spec/unit/image_processor_spec.cr
+++ b/spec/unit/image_processor_spec.cr
@@ -346,7 +346,7 @@ describe Hwaro::Content::Processors::ImageProcessor do
       end
     end
 
-    it "copies file for widths larger than source" do
+    it "keys an upscale-clamped variant by the true source width, not the requested width" do
       Dir.mktmpdir do |dir|
         src = File.join(dir, "tiny.png")
         pixels = Bytes.new(4 * 4 * 3, 150_u8)
@@ -355,9 +355,13 @@ describe Hwaro::Content::Processors::ImageProcessor do
         out_dir = File.join(dir, "out")
         result = Hwaro::Content::Processors::ImageProcessor.resize_multi_widths(src, out_dir, [2, 1000], 85)
 
+        # width=2 downscales; width=1000 exceeds the 4px source, so rather than a
+        # dishonest "1000w" copy it is keyed at the true intrinsic width (4) — no
+        # false srcset descriptor, no byte-identical duplicate.
         result.size.should eq(2)
-        # width=1000 should be a copy (same size as original)
-        File.size(result[1000]).should eq(File.size(src))
+        result.has_key?(2).should be_true
+        result.has_key?(1000).should be_false
+        File.size(result[4]).should eq(File.size(src)) # full-size copy keyed by src width
       end
     end
 

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -294,6 +294,23 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       result.should contain("[1]")
     end
 
+    it "produces whitespace-free, matching anchors for keys with spaces" do
+      # `[^my note]` must not emit `id="fn-my note"` (invalid id/fragment).
+      # Forward (fnref/fn) and backward (backref) anchors must still match.
+      content = "Text[^my note].\n\n[^my note]: Note with a space"
+      pre = Hwaro::Content::Processors::MarkdownExtensions.preprocess_footnotes(content)
+      pre.should_not contain("fn-my note")
+      pre.should_not contain("fnref-my note")
+      pre.should contain("id=\"fnref-my-note\"")
+      pre.should contain("href=\"#fn-my-note\"")
+
+      html = "<p>#{pre}</p>"
+      post = Hwaro::Content::Processors::MarkdownExtensions.postprocess_footnotes(html)
+      post.should contain("id=\"fn-my-note\"")
+      post.should contain("href=\"#fnref-my-note\"")
+      post.should_not contain("my note\"")
+    end
+
     it "ignores undefined footnote references" do
       content = "Text[^undefined] here."
       result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_footnotes(content)
@@ -914,6 +931,22 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       html, _ = Hwaro::Processor::Markdown.render("| col |\n|-----|\n| $f([x])(y)$ |", markdown_config: make_config(math: true))
       html.should contain("\\(f([x])(y)\\)")
       html.should_not contain("<a href")
+    end
+  end
+
+  describe "emphasis chars inside inline math" do
+    it "keeps * inside inline math literal (no emphasis pairing across spans)" do
+      html, _ = Hwaro::Processor::Markdown.render("Two products: $a*b$ and $c*d$.", markdown_config: make_config(math: true))
+      html.should contain("\\(a*b\\)")
+      html.should contain("\\(c*d\\)")
+      html.should_not contain("<em>")
+    end
+
+    it "keeps _ inside inline math literal" do
+      html, _ = Hwaro::Processor::Markdown.render("Indices $a_i$ and $b_j$.", markdown_config: make_config(math: true))
+      html.should contain("\\(a_i\\)")
+      html.should contain("\\(b_j\\)")
+      html.should_not contain("<em>")
     end
   end
 

--- a/spec/unit/phases_transform_spec.cr
+++ b/spec/unit/phases_transform_spec.cr
@@ -452,7 +452,26 @@ describe Hwaro::Core::Build::Phases::Transform do
       builder.test_compute_series(site)
 
       published.series_index.should eq(1)
-      published.series_pages.size.should eq(1)
+      # Draft is excluded, leaving a single-member series, which renders no
+      # prev/next nav, so series_pages is left empty.
+      published.series_pages.size.should eq(0)
+    end
+
+    it "leaves series_pages empty for a single-post series" do
+      config = Hwaro::Models::Config.new
+      config.series.enabled = true
+      site = Hwaro::Models::Site.new(config)
+
+      lonely = make_page("lonely.md")
+      lonely.title = "Lonely"
+      lonely.series = "Lonely"
+
+      site.pages = [lonely]
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_compute_series(site)
+
+      lonely.series_index.should eq(1)
+      lonely.series_pages.size.should eq(0)
     end
   end
 
@@ -471,6 +490,21 @@ describe Hwaro::Core::Build::Phases::Transform do
       affected = builder.test_recompute_series_for_pages(site, [p1])
       affected.includes?("tutorial").should be_true
       affected.includes?("other").should be_false
+    end
+
+    it "leaves series_pages empty for a single-post series" do
+      config = Hwaro::Models::Config.new
+      config.series.enabled = true
+      site = Hwaro::Models::Site.new(config)
+
+      lonely = make_page("lonely.md"); lonely.title = "Lonely"; lonely.series = "Lonely"
+      site.pages = [lonely]
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_recompute_series_for_pages(site, [lonely])
+
+      lonely.series_index.should eq(1)
+      lonely.series_pages.size.should eq(0)
     end
   end
 

--- a/spec/unit/platform_config_spec.cr
+++ b/spec/unit/platform_config_spec.cr
@@ -209,6 +209,33 @@ describe Hwaro::Services::PlatformConfig do
         end
       end
 
+      # Regression: on a subpath deploy (base_url with a path component) the
+      # build writes redirect HTML pointing at `/myrepo/...`, so the platform
+      # config's alias redirects and asset cache rule must carry base_path too,
+      # otherwise they diverge from the build and point at the domain root.
+      it "carries base_path into redirect from/to and the cache header on subpath deploys" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+            File.write("content/moved.md", "---\ntitle: Moved\naliases:\n  - /old/\n---\nContent here\n")
+
+            config = Hwaro::Models::Config.new
+            config.base_url = "https://example.com/myrepo/"
+            generator = Hwaro::Services::PlatformConfig.new(config)
+
+            netlify = generator.generate("netlify")
+            netlify.should contain("from = \"/myrepo/old/\"")
+            netlify.should contain("to = \"/myrepo/moved/\"")
+            netlify.should contain("for = \"/myrepo/assets/*\"")
+
+            vercel = JSON.parse(generator.generate("vercel"))
+            vercel["redirects"][0]["source"].as_s.should eq("/myrepo/old/")
+            vercel["redirects"][0]["destination"].as_s.should eq("/myrepo/moved/")
+            vercel["headers"][0]["source"].as_s.should eq("/myrepo/assets/(.*)")
+          end
+        end
+      end
+
       it "maps a nested alias to root for an empty-target permalink without doubling slashes" do
         Dir.mktmpdir do |dir|
           Dir.cd(dir) do

--- a/spec/unit/pwa_spec.cr
+++ b/spec/unit/pwa_spec.cr
@@ -1,6 +1,28 @@
 require "../spec_helper"
 require "json"
 
+# Write a minimal valid PNG of the given dimensions. Only the 8-byte
+# signature + IHDR chunk matter for `sizes` inference, but we include a
+# tiny IDAT/IEND so the file is a structurally valid PNG.
+private def write_png(path : String, width : UInt32, height : UInt32)
+  io = IO::Memory.new
+  io.write(Bytes[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+  ihdr = IO::Memory.new
+  ihdr.write_bytes(width, IO::ByteFormat::BigEndian)
+  ihdr.write_bytes(height, IO::ByteFormat::BigEndian)
+  ihdr.write(Bytes[8, 6, 0, 0, 0]) # bit depth, color type, compression, filter, interlace
+  ihdr_bytes = ihdr.to_slice
+  io.write_bytes(ihdr_bytes.size.to_u32, IO::ByteFormat::BigEndian)
+  io.write("IHDR".to_slice)
+  io.write(ihdr_bytes)
+  io.write_bytes(0_u32, IO::ByteFormat::BigEndian) # placeholder CRC (not validated)
+  # IEND
+  io.write_bytes(0_u32, IO::ByteFormat::BigEndian)
+  io.write("IEND".to_slice)
+  io.write_bytes(0_u32, IO::ByteFormat::BigEndian)
+  File.write(path, io.to_slice)
+end
+
 private def make_site(pwa_toml : String = "", base_url : String = "https://example.com") : Hwaro::Models::Site
   config_str = <<-TOML
     title = "Test Site"
@@ -149,6 +171,61 @@ describe Hwaro::Content::Seo::Pwa do
       end
     end
 
+    # `sizes` must reflect the icon's REAL pixel dimensions, read from the
+    # PNG IHDR — not guessed from the filename. A 200x60 logo.png whose name
+    # carries no size hint used to be declared "512x512".
+    it "reads real PNG dimensions for icon sizes instead of guessing from the filename" do
+      Dir.mktmpdir do |dir|
+        write_png(File.join(dir, "logo.png"), 200_u32, 60_u32)
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          icons = ["static/logo.png"]
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        manifest = JSON.parse(File.read(File.join(dir, "manifest.json")))
+        manifest["icons"].as_a[0]["sizes"].as_s.should eq("200x60")
+      end
+    end
+
+    # Real dimensions win even when the filename contains a misleading number
+    # (e.g. a year), which the filename heuristic would have used.
+    it "prefers PNG header dimensions over a year-like number in the filename" do
+      Dir.mktmpdir do |dir|
+        write_png(File.join(dir, "icon-2024.png"), 192_u32, 192_u32)
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          icons = ["static/icon-2024.png"]
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        manifest = JSON.parse(File.read(File.join(dir, "manifest.json")))
+        manifest["icons"].as_a[0]["sizes"].as_s.should eq("192x192")
+      end
+    end
+
+    # When the PNG bytes can't be read (missing output file), fall back to the
+    # filename heuristic rather than crashing.
+    it "falls back to the filename-derived size when the PNG can't be read" do
+      Dir.mktmpdir do |dir|
+        # No icon-512.png file written to the output dir.
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          icons = ["static/icon-512.png"]
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        manifest = JSON.parse(File.read(File.join(dir, "manifest.json")))
+        manifest["icons"].as_a[0]["sizes"].as_s.should eq("512x512")
+      end
+    end
+
     it "normalizes icon paths with and without static/ prefix" do
       Dir.mktmpdir do |dir|
         site = make_site(<<-TOML)
@@ -212,6 +289,12 @@ describe Hwaro::Content::Seo::Pwa do
 
     it "includes precache_urls in service worker" do
       Dir.mktmpdir do |dir|
+        # Precache entries are only emitted when their output file exists
+        # (cache.addAll is all-or-nothing), so materialize them in the dir.
+        FileUtils.mkdir_p(File.join(dir, "css"))
+        FileUtils.mkdir_p(File.join(dir, "js"))
+        File.write(File.join(dir, "css", "main.css"), "body{}")
+        File.write(File.join(dir, "js", "app.js"), "console.log(1)")
         site = make_site(<<-TOML)
           [pwa]
           enabled = true
@@ -228,6 +311,7 @@ describe Hwaro::Content::Seo::Pwa do
 
     it "includes offline_page in service worker" do
       Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "offline.html"), "<html>offline</html>")
         site = make_site(<<-TOML)
           [pwa]
           enabled = true
@@ -238,6 +322,96 @@ describe Hwaro::Content::Seo::Pwa do
 
         content = File.read(File.join(dir, "sw.js"))
         content.should contain("/offline.html")
+      end
+    end
+
+    # cache.addAll() is all-or-nothing: one 404 aborts the whole SW install.
+    # A precache URL with no backing output file must be dropped from
+    # PRECACHE_URLS (the build emits a warning).
+    it "drops precache URLs that have no matching output file" do
+      Dir.mktmpdir do |dir|
+        # Only one of the two precached files exists in the output dir.
+        File.write(File.join(dir, "real.css"), "body{}")
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          precache_urls = ["/real.css", "/ghost.css"]
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        content = File.read(File.join(dir, "sw.js"))
+        content.should contain("/real.css")
+        content.should_not contain("/ghost.css")
+      end
+    end
+
+    # The launch URL is always kept even when its output file isn't present
+    # in the dir we generate into (it's the navigation fallback target).
+    it "keeps the start_url in precache even without a backing file" do
+      Dir.mktmpdir do |dir|
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        content = File.read(File.join(dir, "sw.js"))
+        content.should contain(%("/"))
+      end
+    end
+
+    # External http(s):// precache URLs aren't our files, so they bypass the
+    # existence check and stay in the list.
+    it "keeps external precache URLs without trying to resolve them on disk" do
+      Dir.mktmpdir do |dir|
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          precache_urls = ["https://cdn.example.com/lib.js"]
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        content = File.read(File.join(dir, "sw.js"))
+        content.should contain("https://cdn.example.com/lib.js")
+      end
+    end
+
+    # A missing offline_page must not become the navigation fallback (it would
+    # 404 offline). Fall back to the launch URL instead.
+    it "falls back the navigation offline target to start_url when offline_page is missing" do
+      Dir.mktmpdir do |dir|
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          offline_page = "/nope-offline.html"
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        content = File.read(File.join(dir, "sw.js"))
+        # The missing offline page is dropped from precache...
+        content.should_not contain("/nope-offline.html")
+        # ...and the navigation fallback uses the root instead.
+        content.should contain(%(caches.match("/")))
+      end
+    end
+
+    it "uses a real offline_page as the navigation target when its file exists" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "offline.html"), "<html>offline</html>")
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          offline_page = "/offline.html"
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        content = File.read(File.join(dir, "sw.js"))
+        content.should contain(%(caches.match("/offline.html")))
       end
     end
 
@@ -267,6 +441,10 @@ describe Hwaro::Content::Seo::Pwa do
 
       it "prefixes precache URLs, offline page, and the navigation fallback in sw.js" do
         Dir.mktmpdir do |dir|
+          # Output files are addressed by the base_path-stripped relative path.
+          FileUtils.mkdir_p(File.join(dir, "css"))
+          File.write(File.join(dir, "css", "main.css"), "body{}")
+          File.write(File.join(dir, "offline.html"), "<html>offline</html>")
           site = make_site(<<-TOML, base_url: "https://user.github.io/myrepo/")
             [pwa]
             enabled = true
@@ -290,6 +468,8 @@ describe Hwaro::Content::Seo::Pwa do
 
       it "leaves URLs untouched for a domain-root base_url" do
         Dir.mktmpdir do |dir|
+          FileUtils.mkdir_p(File.join(dir, "css"))
+          File.write(File.join(dir, "css", "main.css"), "body{}")
           site = make_site(<<-TOML, base_url: "https://example.com")
             [pwa]
             enabled = true

--- a/spec/unit/scaffolds_book_spec.cr
+++ b/spec/unit/scaffolds_book_spec.cr
@@ -123,6 +123,47 @@ describe Hwaro::Services::Scaffolds::Book do
       sidebar.should contain(%q(rejectattr("name", "equalto", "")))
       sidebar.should_not match(/{%\s*if\s+sec\.name\s*!=\s*""\s*%}/)
     end
+
+    # The sidebar's top-level chapter order must match the prev/next
+    # reading chain, which transform.cr orders by weight with a path
+    # tiebreak. Crinja sort is stable, so `sort(attribute="path")` then
+    # `sort(attribute="weight")` yields weight-asc, path-tiebroken order.
+    # A path-only sort (the old behavior) diverged from the reading chain
+    # whenever chapter weights didn't follow alphabetical paths.
+    it "orders top-level chapters by weight with a path tiebreak (matches reading chain)" do
+      files = Hwaro::Services::Scaffolds::Book.new.template_files
+      sidebar = files["partials/sidebar.html"]
+      sidebar.should contain(%q(| sort(attribute="path") | sort(attribute="weight")))
+    end
+
+    # Nested sections (name like "parent/child") also appear flat in
+    # `site.sections`, so the outer loop skips them and renders them one
+    # level deeper from the parent's `subsections` — mirroring the
+    # depth-first nesting of the prev/next reading chain. Without the
+    # skip they rendered as bogus top-level chapter groups.
+    it "renders nested subsections beneath their parent, not as flat chapters" do
+      files = Hwaro::Services::Scaffolds::Book.new.template_files
+      sidebar = files["partials/sidebar.html"]
+      # Skip nested sections in the top-level loop ("/" is in sec.name).
+      sidebar.should contain(%q({% if "/" is in sec.name %}))
+      # Render each parent's subsections nested beneath it.
+      sidebar.should contain("{% for sub in sec.subsections")
+      sidebar.should contain("{% for sp in sub.pages")
+    end
+  end
+
+  describe "#section_template" do
+    # An empty chapter (a section with no non-index child pages) used to
+    # render an orphan "In This Chapter" heading over an empty <ul>. The
+    # heading + list are now guarded so they only appear when the section
+    # has at least one listable child page.
+    it "guards the chapter listing so empty chapters don't show an orphan heading" do
+      files = Hwaro::Services::Scaffolds::Book.new.template_files
+      section = files["section.html"]
+      section.should contain(%q({% if section.pages | rejectattr("is_index") | length %}))
+      # The heading and list live inside the guard.
+      section.should match(/{%\s*if\s+section\.pages.*%}.*In This Chapter.*{%\s*endif\s*%}/m)
+    end
   end
 
   describe "#static_files" do

--- a/spec/unit/scaffolds_book_spec.cr
+++ b/spec/unit/scaffolds_book_spec.cr
@@ -144,8 +144,9 @@ describe Hwaro::Services::Scaffolds::Book do
     it "renders nested subsections beneath their parent, not as flat chapters" do
       files = Hwaro::Services::Scaffolds::Book.new.template_files
       sidebar = files["partials/sidebar.html"]
-      # Skip nested sections in the top-level loop ("/" is in sec.name).
-      sidebar.should contain(%q({% if "/" is in sec.name %}))
+      # The top-level loop filters to top_level sections (so loop.index chapter
+      # numbering stays contiguous even when a nested section sorts earlier).
+      sidebar.should contain(%q(selectattr("top_level")))
       # Render each parent's subsections nested beneath it.
       sidebar.should contain("{% for sub in sec.subsections")
       sidebar.should contain("{% for sp in sub.pages")

--- a/spec/unit/scaffolds_docs_spec.cr
+++ b/spec/unit/scaffolds_docs_spec.cr
@@ -101,6 +101,17 @@ describe Hwaro::Services::Scaffolds::Docs do
       sidebar.should_not contain("/reference/cli/")
     end
 
+    # On a multilingual site the sidebar must only list sections for the
+    # current page's language; without a `sec.language == page_language`
+    # guard a /ko/ page listed every language's sections (3 × 3 = 9
+    # entries) with hrefs jumping across languages.
+    it "filters sidebar sections by the current page language" do
+      scaffold = Hwaro::Services::Scaffolds::Docs.new
+      sidebar = scaffold.template_files["partials/sidebar.html"]
+
+      sidebar.should contain("sec.language == page_language")
+    end
+
     it "nav partial includes Documentation span in logo" do
       scaffold = Hwaro::Services::Scaffolds::Docs.new
       nav = scaffold.template_files["partials/nav.html"]

--- a/spec/unit/series_spec.cr
+++ b/spec/unit/series_spec.cr
@@ -116,7 +116,10 @@ describe "Series support" do
     builder.test_compute_series(site)
 
     p1.series_pages.size.should eq(2)
-    p2.series_pages.size.should eq(1)
+    # A single-post series carries no series_pages (so the scaffold renders no
+    # orphan series-nav box); Series B independence still holds — it never
+    # absorbs Series A's posts.
+    p2.series_pages.size.should eq(0)
     p3.series_pages.size.should eq(2)
   end
 
@@ -143,7 +146,10 @@ describe "Series support" do
 
     builder.test_compute_series(site)
 
-    p1.series_pages.size.should eq(1)
+    # The draft is excluded, leaving a single real member — so series_pages is
+    # empty (no nav). If the draft had leaked in, the series would have 2 members
+    # and series_pages.size would be 2, so this still guards draft exclusion.
+    p1.series_pages.size.should eq(0)
     p1.series_index.should eq(1)
   end
 

--- a/src/content/hooks/image_hooks.cr
+++ b/src/content/hooks/image_hooks.cr
@@ -254,20 +254,39 @@ module Hwaro
           widths : Array(Int32),
         ) : Hash(Int32, String)?
           return unless File.exists?(source_path)
-          source_info = File.info(source_path)
-          source_mtime = source_info.modification_time
+          return unless Dir.exists?(dest_dir)
+          source_mtime = File.info(source_path).modification_time
 
           ext = File.extname(source_path)
           basename = File.basename(source_path, ext)
+
+          # resize_and_lqip clamps any requested width larger than the source to
+          # the source's true width (writing a single `_<src_w>w` variant), so a
+          # `_<width>w` file does NOT exist for every configured width. Read the
+          # variants that ARE on disk, infer the clamp ceiling from the largest
+          # one, then require the on-disk set to match exactly what the CURRENT
+          # config would produce — otherwise the config changed and we reprocess.
+          variant_re = /\A#{Regex.escape(basename)}_(\d+)w#{Regex.escape(ext)}\z/
+          on_disk = {} of Int32 => String
+          Dir.each_child(dest_dir) do |name|
+            if m = variant_re.match(name)
+              on_disk[m[1].to_i] = name
+            end
+          end
+          return if on_disk.empty?
+
+          src_w = on_disk.keys.max
+          expected = widths.map { |w| Math.min(w, src_w) }.uniq!
+          return unless expected.sort == on_disk.keys.sort!
+
           result = {} of Int32 => String
-          widths.each do |width|
-            filename = "#{basename}_#{width}w#{ext}"
-            dest = File.join(dest_dir, filename)
-            return unless File.exists?(dest)
-            dest_info = File.info(dest)
+          expected.each do |w|
+            filename = on_disk[w]?
+            return unless filename
+            dest_info = File.info(File.join(dest_dir, filename))
             return if dest_info.modification_time < source_mtime
             return if dest_info.size == 0
-            result[width] = filename
+            result[w] = filename
           end
           result
         end

--- a/src/content/processors/image_processor.cr
+++ b/src/content/processors/image_processor.cr
@@ -303,14 +303,22 @@ module Hwaro
               out_w, out_h = calculate_dimensions(src_w.to_i32, src_h.to_i32, width, 0)
               next if out_w <= 0 || out_h <= 0
 
-              dest = File.join(dest_dir, "#{basename}_#{width}w#{ext}")
-
               if out_w >= src_w && out_h >= src_h
-                FileUtils.cp(source, dest)
-                result_map[width] = dest
+                # Source is smaller than the requested width — don't upscale.
+                # Key the variant by the TRUE intrinsic width (src_w) and write a
+                # single copy reused across all larger requested widths, so the
+                # srcset descriptor is honest (never a "1280w" pointing at a
+                # 500px file) and no byte-identical duplicates are emitted.
+                actual = src_w.to_i32
+                unless result_map.has_key?(actual)
+                  dest = File.join(dest_dir, "#{basename}_#{actual}w#{ext}")
+                  FileUtils.cp(source, dest)
+                  result_map[actual] = dest
+                end
                 next
               end
 
+              dest = File.join(dest_dir, "#{basename}_#{width}w#{ext}")
               pixel_count = out_w.to_i64 * out_h.to_i64
               next if pixel_count > MAX_PIXELS
               buf_size = pixel_count * channels.to_i64

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -526,17 +526,17 @@ module Hwaro
                   "<span class=\"math math-inline\">\\(#{escaped}\\)</span>"
                 else
                   # Normal inline context: the body still flows through Markd's
-                  # CommonMark inline parser, so `*`/`_` inside the math would be
-                  # (mis)read as emphasis delimiters and pair across math spans
-                  # (e.g. `$a*b$ and $c*d$` → `\(a<em>b\)…\(</em>d\)`).
-                  # Backslash-escape those active chars so Markd ships them
-                  # literally. (`~` is left alone: GFM strikethrough is handled
-                  # by hwaro's own preprocessor, which already skips math spans,
-                  # so escaping it here would leak a stray backslash into the
-                  # rendered body.)
-                  inline_escaped = escaped
-                    .gsub('*', "\\*")
-                    .gsub('_', "\\_")
+                  # CommonMark inline parser, which would (a) read `*`/`_` as
+                  # emphasis and pair them across math spans, (b) start code
+                  # spans on backticks, (c) form links on `[`/`]`, and (d)
+                  # CONSUME a backslash before any ASCII punctuation — stripping
+                  # the LaTeX escapes in e.g. `$\{x\}$` or `$a \& b$`. Backslash-
+                  # escape each of those active chars (backslash itself FIRST, so
+                  # `\{` survives as `\{` rather than being eaten) so Markd ships
+                  # the formula body verbatim to KaTeX/MathJax. (`~` is left
+                  # alone: GFM strikethrough is handled by hwaro's own
+                  # preprocessor, which already skips math spans.)
+                  inline_escaped = escaped.gsub(/[\\`*_\[\]]/) { |c| "\\#{c}" }
                   "<span class=\"math math-inline\">\\\\(#{inline_escaped}\\\\)</span>"
                 end
               end

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -211,6 +211,15 @@ module Hwaro
         FOOTNOTE_COMMENT_RE = /<!--HWARO-FN:([^:]+):(\d+)(?:\.(\d+))?:(.+?)-->/
         FOOTNOTE_BLOCK_RE   = /\n?<!--HWARO-FOOTNOTES-START-->.*?<!--HWARO-FOOTNOTES-END-->\n?/m
 
+        # Derive an id-safe token from a footnote key. The key can contain ASCII
+        # whitespace (`[^my note]`), which is invalid in an `id`/fragment, so
+        # collapse runs of whitespace to a single `-` before HTML-escaping the
+        # rest. Must be applied identically on the reference side and the
+        # li/backref side so forward and backward anchors still match.
+        def footnote_id_token(key : String) : String
+          HTML.escape(key.gsub(/\s+/, "-"))
+        end
+
         def preprocess_footnotes(content : String) : String
           # Neutralize any author-typed HWARO FOOTNOTE markers up front so page
           # content that literally contains the engine's internal comment markers
@@ -262,7 +271,7 @@ module Hwaro
                 num = ref_order[key]
                 ref_occurrences[key] += 1
                 occ = ref_occurrences[key]
-                escaped_key = HTML.escape(key)
+                escaped_key = footnote_id_token(key)
                 ref_id = occ == 1 ? "fnref-#{escaped_key}" : "fnref-#{escaped_key}-#{occ}"
                 "<sup class=\"footnote-ref\"><a href=\"#fn-#{escaped_key}\" id=\"#{ref_id}\">[#{num}]</a></sup>"
               end
@@ -316,7 +325,7 @@ module Hwaro
           section = String.build do |str|
             str << "<section class=\"footnotes\">\n<hr>\n<ol>\n"
             footnotes.sort_by { |fn| fn[:num] }.each do |fn|
-              escaped_key = HTML.escape(fn[:key])
+              escaped_key = footnote_id_token(fn[:key])
               rendered_text = InlineMarkdown.render(fn[:text], math: math)
               str << "<li id=\"fn-#{escaped_key}\">\n"
               # One backref per reference occurrence so every `fnref-\u2026` id is
@@ -516,7 +525,19 @@ module Hwaro
                 elsif raw_context
                   "<span class=\"math math-inline\">\\(#{escaped}\\)</span>"
                 else
-                  "<span class=\"math math-inline\">\\\\(#{escaped}\\\\)</span>"
+                  # Normal inline context: the body still flows through Markd's
+                  # CommonMark inline parser, so `*`/`_` inside the math would be
+                  # (mis)read as emphasis delimiters and pair across math spans
+                  # (e.g. `$a*b$ and $c*d$` → `\(a<em>b\)…\(</em>d\)`).
+                  # Backslash-escape those active chars so Markd ships them
+                  # literally. (`~` is left alone: GFM strikethrough is handled
+                  # by hwaro's own preprocessor, which already skips math spans,
+                  # so escaping it here would leak a stray backslash into the
+                  # rendered body.)
+                  inline_escaped = escaped
+                    .gsub('*', "\\*")
+                    .gsub('_', "\\_")
+                  "<span class=\"math math-inline\">\\\\(#{inline_escaped}\\\\)</span>"
                 end
               end
             end

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -484,8 +484,11 @@ module Hwaro
 
             base_url = env.resolve("base_url").to_s
 
-            # Normalize path to start with /
-            normalized = path.starts_with?("/") ? path : "/#{path}"
+            # Normalize path to start with /. The resize/LQIP maps are keyed by
+            # the decoded filesystem path, so decode any percent-encoding from
+            # the incoming URL before the lookup; the returned variant is
+            # re-encoded below so the emitted .url is a valid href.
+            normalized = URI.decode(path.starts_with?("/") ? path : "/#{path}")
 
             # Try to find a resized variant from the image hooks map
             resized_url = if width > 0
@@ -493,9 +496,9 @@ module Hwaro
                           end
 
             final_url = if resized = resized_url
-                          base_url.rstrip("/") + resized
+                          base_url.rstrip("/") + URI.encode_path(resized)
                         else
-                          base_url.rstrip("/") + normalized
+                          base_url.rstrip("/") + URI.encode_path(normalized)
                         end
 
             # Look up LQIP data

--- a/src/content/seo/amp.cr
+++ b/src/content/seo/amp.cr
@@ -78,6 +78,12 @@ module Hwaro
         def self.convert_to_amp(html : String, page : Models::Page, config : Models::Config) : String
           result = html
 
+          # Strip any self-referencing <link rel="amphtml"> left over from a
+          # prior build (the on-disk canonical HTML may already carry one). An
+          # AMP page must never reference an amphtml variant of itself, so make
+          # the conversion idempotent across repeat/cached builds.
+          result = result.gsub(/<link\b[^>]*rel=["']amphtml["'][^>]*>\s*/i, "")
+
           # Add AMP boilerplate to <html> tag
           result = result.sub(/<html([^>]*)>/i, %(<html amp\\1>))
 
@@ -131,22 +137,64 @@ module Hwaro
             end
           end
 
+          # A block-level <div class="amp-img-container"> placed directly inside
+          # a <p> (Markdown wraps a standalone image in a paragraph) is invalid
+          # HTML. Unwrap any <p> whose sole child is that container div.
+          result = result.gsub(/<p>(\s*<div class="amp-img-container">[\s\S]*?<\/div>\s*)<\/p>/mi) { $1 }
+
           # Convert <video> to <amp-video>
+          needs_amp_video = false
           result = result.gsub(/<video([^>]*)>(.*?)<\/video>/mi) do
+            needs_amp_video = true
             %(<amp-video#{$1} layout="responsive">#{$2}</amp-video>)
           end
 
           # Convert <iframe> to <amp-iframe>
+          needs_amp_iframe = false
           result = result.gsub(/<iframe([^>]*)>(.*?)<\/iframe>/mi) do
+            needs_amp_iframe = true
             attrs = $1
             unless attrs.includes?("layout=")
               attrs += %( layout="responsive")
             end
+            # amp-iframe requires a sandbox attribute; add a sane default when
+            # the source <iframe> didn't carry one.
+            unless attrs.includes?("sandbox=")
+              attrs += %( sandbox="allow-scripts allow-same-origin allow-popups")
+            end
             %(<amp-iframe#{attrs}>#{$2}</amp-iframe>)
           end
 
+          # Mandatory extension scripts for amp-iframe / amp-video. These must be
+          # present in <head> whenever the corresponding element is used.
+          amp_iframe_script = %(<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>)
+          amp_video_script = %(<script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>)
+          extension_scripts = ""
+          extension_scripts += "\n#{amp_iframe_script}" if needs_amp_iframe
+          extension_scripts += "\n#{amp_video_script}" if needs_amp_video
+
           # Inject AMP boilerplate CSS in <head> if not already present
-          unless result.includes?("amp-boilerplate")
+          if result.includes?("amp-boilerplate")
+            # Boilerplate already present (e.g. theme-supplied). The mandatory
+            # amp-iframe / amp-video extension scripts may still be missing —
+            # inject any that are needed but not already declared.
+            missing = ""
+            if needs_amp_iframe && !result.includes?(%(custom-element="amp-iframe"))
+              missing += "\n#{amp_iframe_script}"
+            end
+            if needs_amp_video && !result.includes?(%(custom-element="amp-video"))
+              missing += "\n#{amp_video_script}"
+            end
+            unless missing.empty?
+              if result.matches?(/<\/head>/i)
+                result = result.sub(/<\/head>/i, "#{missing}\n</head>")
+              elsif result.matches?(/<\/body>/i)
+                result = result.sub(/<\/body>/i, "#{missing}\n</body>")
+              else
+                result = "#{result}#{missing}"
+              end
+            end
+          else
             # AMP permits exactly one <style amp-custom> (plus the two mandatory
             # <style amp-boilerplate> blocks). Theme templates inline a bare
             # <style> in <head>; left in place it becomes a second custom
@@ -166,7 +214,7 @@ module Hwaro
             amp_boilerplate = <<-HTML
               <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
               <style amp-custom>.amp-img-container{position:relative;width:100%;min-height:200px}#{extracted_css}</style>
-              <script async src="https://cdn.ampproject.org/v0.js"></script>
+              <script async src="https://cdn.ampproject.org/v0.js"></script>#{extension_scripts}
               HTML
             # The AMP runtime/boilerplate is mandatory. If the theme rendered no
             # </head>, fall back to </body> (then end-of-doc) and warn rather than

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -104,6 +104,10 @@ module Hwaro
               }
             end
 
+            # Don't emit a feed for a language with no content — its channel
+            # <link> would point at a non-existent /{lang}/ home (404).
+            next if lang_pages.empty?
+
             # Build the output directory: output_dir/{lang}/
             lang_output_dir = File.join(output_dir, lang_code)
             Hwaro::Utils::FileSafe.mkdir_p(lang_output_dir)
@@ -366,6 +370,12 @@ module Hwaro
               page.authors.each do |author|
                 next if author.strip.empty?
                 str << "    <author><name>#{Utils::TextUtils.escape_xml(author)}</name></author>\n"
+              end
+
+              # Frontmatter taxonomies become Atom <category> elements,
+              # mirroring the RSS feed's per-term <category> output (gh#526).
+              feed_categories(page).each do |term|
+                str << "    <category term=\"#{Utils::TextUtils.escape_xml(term)}\" />\n"
               end
 
               content = get_content_for_feed(page, config)

--- a/src/content/seo/jsonld.cr
+++ b/src/content/seo/jsonld.cr
@@ -70,9 +70,13 @@ module Hwaro
         # not articles, so they use schema.org CollectionPage with a `name`
         # instead of Article/`headline`, keeping JSON-LD consistent with the
         # og:type="website" emitted on the same page (gh#522 follow-up).
-        def collection_page(page : Models::Page, config : Models::Config) : String
+        def collection_page(page : Models::Page, config : Models::Config, url_override : String? = nil) : String
           base = config.base_url_stripped
-          url = page.permalink || "#{base}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+          url = if u = url_override
+                  "#{base}#{u.starts_with?("/") ? u : "/#{u}"}"
+                else
+                  page.permalink || "#{base}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+                end
 
           json = JSON.build do |j|
             j.object do
@@ -95,12 +99,15 @@ module Hwaro
 
           items = [] of Hash(String, String | Int32)
 
-          # Home
+          # Home — language-prefixed so a non-default-language page's Home crumb
+          # points at the localized homepage (/ko/, /ja/) rather than the
+          # default-language root, matching the localized ancestor crumbs below.
+          lang_prefix = (l = page.language) && l != config.default_language && config.multilingual? ? "/#{l}" : ""
           items << {
             "@type"    => "ListItem",
             "position" => 1,
             "name"     => config.title,
-            "item"     => "#{base}/",
+            "item"     => "#{base}#{lang_prefix}/",
           }
 
           # Ancestors

--- a/src/content/seo/pwa.cr
+++ b/src/content/seo/pwa.cr
@@ -20,7 +20,7 @@ module Hwaro
           pwa = config.pwa
 
           icons = pwa.icons.map do |icon_path|
-            size = extract_icon_size(icon_path)
+            size = icon_size(icon_path, output_dir)
             url_path = config.with_base_path(normalize_icon_path(icon_path))
             {
               "src"   => url_path,
@@ -72,6 +72,7 @@ module Hwaro
 
           # Build precache URL list (each entry is a site-internal root-relative
           # path that must carry the subpath prefix, same as start_url).
+          base_path = config.base_path
           precache_urls = pwa.precache_urls.map { |u| config.with_base_path(u) }
           precache_urls << resolved_start unless precache_urls.includes?(resolved_start)
           if offline = pwa.offline_page
@@ -79,9 +80,34 @@ module Hwaro
             precache_urls << resolved_offline unless precache_urls.includes?(resolved_offline)
           end
 
+          # cache.addAll() is all-or-nothing: a single 404 aborts the whole
+          # service-worker install. Drop any site-internal precache URL whose
+          # resolved output file does not exist (external http(s):// URLs are
+          # not our files, so we trust them) but always keep the launch URL.
+          precache_urls = precache_urls.select do |u|
+            next true if external_url?(u)
+            next true if u == resolved_start
+            if precache_file_exists?(u, output_dir, base_path)
+              true
+            else
+              Logger.warn "PWA: precache URL #{u.inspect} has no matching output file — dropping it from sw.js precache (cache.addAll is all-or-nothing)"
+              false
+            end
+          end
+
           precache_json = precache_urls.map(&.inspect).join(",\n  ")
+
+          # The navigation fallback must point at a page that actually exists,
+          # otherwise the offline experience breaks. Fall back to the launch URL
+          # when offline_page resolves to nothing on disk.
           offline_url = if op = pwa.offline_page
-                          config.with_base_path(op).inspect
+                          resolved_offline = config.with_base_path(op)
+                          if external_url?(resolved_offline) || precache_file_exists?(resolved_offline, output_dir, base_path)
+                            resolved_offline.inspect
+                          else
+                            Logger.warn "PWA: offline_page #{resolved_offline.inspect} has no matching output file — falling back to start_url #{resolved_start.inspect}"
+                            resolved_start.inspect
+                          end
                         else
                           resolved_start.inspect
                         end
@@ -92,17 +118,13 @@ module Hwaro
           # edit to any precached page/asset changes the hash and busts the
           # cache on deploy (correct invalidation). The PWA hook runs after the
           # render/write phase, so the precached output files already exist.
-          base_path = config.base_path
           cache_hash = Digest::SHA1.hexdigest do |ctx|
             ctx.update(pwa.cache_strategy)
             precache_urls.each do |u|
               ctx.update("\n")
               ctx.update(u)
-              rel = u
-              rel = rel[base_path.size..] if !base_path.empty? && rel.starts_with?(base_path)
-              rel = rel.lchop('/')
-              fpath = File.join(output_dir, rel)
-              fpath = File.join(fpath, "index.html") if rel.empty? || rel.ends_with?('/')
+              next if external_url?(u)
+              fpath = precache_file_path(u, output_dir, base_path)
               ctx.update(File.read(fpath)) if File.file?(fpath)
             end
           end
@@ -220,6 +242,71 @@ module Hwaro
               );
             });
             JS
+        end
+
+        # True for external absolute URLs we don't control (no local file to
+        # validate or hash).
+        private def self.external_url?(url : String) : Bool
+          url.starts_with?("http://") || url.starts_with?("https://")
+        end
+
+        # Map a site-internal (possibly base_path-prefixed) URL to the output
+        # file it should resolve to: strip base_path, drop the leading slash,
+        # join under output_dir, and append index.html for directory-like URLs.
+        private def self.precache_file_path(url : String, output_dir : String, base_path : String) : String
+          rel = url
+          rel = rel[base_path.size..] if !base_path.empty? && rel.starts_with?(base_path)
+          rel = rel.lchop('/')
+          fpath = File.join(output_dir, rel)
+          fpath = File.join(fpath, "index.html") if rel.empty? || rel.ends_with?('/')
+          fpath
+        end
+
+        # Does the output file backing this precache URL exist on disk?
+        private def self.precache_file_exists?(url : String, output_dir : String, base_path : String) : Bool
+          File.file?(precache_file_path(url, output_dir, base_path))
+        end
+
+        # Resolve an icon's declared `sizes`. Prefer the real pixel dimensions
+        # read from the PNG header so a 200x60 logo isn't mislabeled "512x512";
+        # fall back to the filename heuristic for non-PNG icons or unparsable
+        # bytes.
+        private def self.icon_size(icon_path : String, output_dir : String) : String
+          if File.extname(icon_path).downcase == ".png"
+            if dims = png_dimensions(resolve_icon_file(icon_path, output_dir))
+              return "#{dims[0]}x#{dims[1]}"
+            end
+            Logger.warn "PWA: could not read PNG dimensions for icon #{icon_path.inspect}; falling back to filename-derived size #{extract_icon_size(icon_path).inspect}"
+          end
+          extract_icon_size(icon_path)
+        end
+
+        # Map an icon path (config value) to the built output file it lands at.
+        # `static/foo.png` and `/foo.png` both copy to `<output>/foo.png`.
+        private def self.resolve_icon_file(icon_path : String, output_dir : String) : String
+          rel = normalize_icon_path(icon_path).lchop('/')
+          File.join(output_dir, rel)
+        end
+
+        # Read width/height from a PNG's IHDR chunk. Verifies the 8-byte PNG
+        # signature, then reads two big-endian UInt32s at offsets 16 (width)
+        # and 20 (height). Returns nil when the file is missing, too short, or
+        # not a PNG so the caller can fall back to the filename heuristic.
+        PNG_SIGNATURE = Bytes[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+
+        private def self.png_dimensions(path : String) : {UInt32, UInt32}?
+          return unless File.file?(path)
+          header = Bytes.new(24)
+          read = File.open(path, &.read(header))
+          return if read < 24
+          return unless header[0, 8] == PNG_SIGNATURE
+          width = IO::ByteFormat::BigEndian.decode(UInt32, header[16, 4])
+          height = IO::ByteFormat::BigEndian.decode(UInt32, header[20, 4])
+          return if width.zero? || height.zero?
+          {width, height}
+        rescue ex : IO::Error | File::Error
+          Logger.debug "PWA: failed reading PNG header for #{path}: #{ex.message}"
+          nil
         end
 
         # Normalize icon path to a URL path.

--- a/src/content/seo/pwa.cr
+++ b/src/content/seo/pwa.cr
@@ -272,7 +272,9 @@ module Hwaro
         # fall back to the filename heuristic for non-PNG icons or unparsable
         # bytes.
         private def self.icon_size(icon_path : String, output_dir : String) : String
-          if File.extname(icon_path).downcase == ".png"
+          # A remote icon (http(s)://) has no local file to read — use the
+          # filename heuristic directly instead of warning on every build.
+          if File.extname(icon_path).downcase == ".png" && !external_url?(icon_path)
             if dims = png_dimensions(resolve_icon_file(icon_path, output_dir))
               return "#{dims[0]}x#{dims[1]}"
             end

--- a/src/content/seo/tags.cr
+++ b/src/content/seo/tags.cr
@@ -9,12 +9,17 @@ module Hwaro
         extend self
 
         # Compute the canonical URL for a page (absolute URL with base_url).
-        def canonical_url(page : Models::Page, config : Models::Config) : String
+        # `url_override` (the paginator's page-aware URL) self-canonicalizes
+        # paginated pages instead of collapsing them onto page 1.
+        def canonical_url(page : Models::Page, config : Models::Config, url_override : String? = nil) : String
+          if u = url_override
+            return "#{config.base_url_stripped}#{u.starts_with?("/") ? u : "/#{u}"}"
+          end
           page.permalink || "#{config.base_url_stripped}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
         end
 
-        def canonical_tag(page : Models::Page, config : Models::Config) : String
-          url = canonical_url(page, config)
+        def canonical_tag(page : Models::Page, config : Models::Config, url_override : String? = nil) : String
+          url = canonical_url(page, config, url_override)
           # Fast path: skip HTML.escape when URL has no escapable chars (common case for URLs)
           escaped = url.includes?('&') || url.includes?('"') || url.includes?('<') || url.includes?('>') ? HTML.escape(url) : url
           %(<link rel="canonical" href="#{escaped}">)

--- a/src/content/seo/tags.cr
+++ b/src/content/seo/tags.cr
@@ -12,6 +12,10 @@ module Hwaro
         # `url_override` (the paginator's page-aware URL) self-canonicalizes
         # paginated pages instead of collapsing them onto page 1.
         def canonical_url(page : Models::Page, config : Models::Config, url_override : String? = nil) : String
+          # The paginator's page-aware override wins so paginated pages
+          # self-canonicalize. `page.permalink` is the generated absolute URL
+          # (base_url + page.url), i.e. the page-1/section URL — using it for a
+          # paginated render would point every page at page 1.
           if u = url_override
             return "#{config.base_url_stripped}#{u.starts_with?("/") ? u : "/#{u}"}"
           end

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -286,10 +286,12 @@ module Hwaro
 
         paginated_pages.each do |paginated_page|
           list_html = build_page_list(paginated_page.pages, site.config.base_url)
-          pagination_html = Content::Pagination::Renderer.new(site.config).render_pagination_nav(paginated_page)
+          renderer = Content::Pagination::Renderer.new(site.config)
+          pagination_html = renderer.render_pagination_nav(paginated_page)
+          seo_links = renderer.render_seo_links(paginated_page)
           html_content = list_html + pagination_html
 
-          final_html = apply_template(template_content, html_content, index_page, site, templates, paginated_page, builder: builder, global_vars: global_vars, template_name: template_name)
+          final_html = apply_template(template_content, html_content, index_page, site, templates, paginated_page, builder: builder, global_vars: global_vars, template_name: template_name, pagination_seo_links: seo_links)
 
           if paginated_page.page_number == 1
             write_output(index_page, output_dir, final_html, verbose)
@@ -389,6 +391,7 @@ module Hwaro
         builder : Core::Build::Builder? = nil,
         global_vars : Hash(String, Crinja::Value)? = nil,
         template_name : String? = nil,
+        pagination_seo_links : String = "",
       ) : String
         return html_content unless template_content
 
@@ -416,7 +419,8 @@ module Hwaro
           page_url_override: current_url,
           paginator: paginator,
           global_vars: global_vars,
-          template_name: template_name
+          template_name: template_name,
+          pagination_seo_links: pagination_seo_links
         )
       end
 

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -76,7 +76,13 @@ module Hwaro::Core::Build::Phases::Initialize
         # Hash the effective merged config (+ env + base_url override), not the
         # raw config.toml bytes, so env-override files and ${ENV_VAR} changes
         # correctly invalidate the per-page cache.
+        #
+        # Fold in a digest of the `data/` tree so editing a data file (which
+        # feeds `site.data` into any page) invalidates the cache the same way a
+        # config edit does. Without this, `build --cache` keeps serving stale
+        # `site.data` values and diverges from `--full` (see I-cache-data).
         config_hash = Cache.compute_config_hash(config, ctx.options.env)
+        config_hash = "#{config_hash}-#{compute_data_hash}"
         build_cache.set_global_checksums(@global_templates_hash, config_hash,
           invalidate_on_template_change: !@per_page_template_hash)
       end
@@ -310,6 +316,32 @@ module Hwaro::Core::Build::Phases::Initialize
     getter children : Hash(String, DataTreeNode) = {} of String => DataTreeNode
     property value : Crinja::Value? = nil
     property source_path : String? = nil
+  end
+
+  # Compute a content digest of the `data/` directory for cache invalidation.
+  #
+  # Globs every supported data file, sorts the paths for determinism, and folds
+  # both the path and the raw bytes of each file into an MD5. It is deliberately
+  # mtime-independent (content-only) so a touch-without-edit doesn't churn the
+  # cache, while any real edit, add, or rename changes the digest and triggers
+  # the existing "config change invalidates all entries" path. Returns "" when
+  # there is no `data/` directory.
+  private def compute_data_hash : String
+    return "" unless Dir.exists?("data")
+
+    paths = [] of String
+    Dir.glob("data/**/*.{yml,yaml,json,toml}") do |path|
+      next if File.directory?(path)
+      paths << path
+    end
+    return "" if paths.empty?
+
+    digest = Digest::MD5.new
+    paths.sort!.each do |path|
+      digest.update(path)
+      digest.update(File.read(path))
+    end
+    digest.final.hexstring
   end
 
   # Load data files from `data/`, preserving directory structure.

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1242,6 +1242,7 @@ module Hwaro::Core::Build::Phases::Render
       hash = {
         "path"               => Crinja::Value.new(s.path),
         "name"               => Crinja::Value.new(s.section),
+        "top_level"          => Crinja::Value.new(!s.section.includes?("/")),
         "title"              => Crinja::Value.new(s.title),
         "description"        => Crinja::Value.new(s.description || ""),
         "url"                => Crinja::Value.new(s.url),
@@ -1973,11 +1974,14 @@ module Hwaro::Core::Build::Phases::Render
   private def og_type_for(page : Models::Page, effective_url : String) : String?
     # 404 page is synthesized in write phase with `path = "404.html"`.
     return "website" if page.path == "404.html"
-    # Explicit per-page override via `[extra] og_type` — lets a custom listing
+    # Explicit per-page `[extra] og_type = "website"` lets a custom listing
     # template (e.g. the blog scaffold's archives page, a plain Page with no
-    # Section/taxonomy signal) declare itself a "website"/collection.
-    if ot = page.extra["og_type"]?.try(&.as?(String))
-      return ot unless ot.empty?
+    # Section/taxonomy signal) declare itself a collection. Only "website" is
+    # honored — it flips og:type AND the JSON-LD type to collection together;
+    # any other value would desync og:type from the (Article) JSON-LD, so it
+    # falls through to the default.
+    if page.extra["og_type"]?.try(&.as?(String)) == "website"
+      return "website"
     end
     # Taxonomy listings (`/tags/`, `/tags/<term>/`, …).
     return "website" if page.taxonomy_name

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -44,7 +44,7 @@ module Hwaro::Core::Build::Phases::Render
 
     error_overlay = ctx.options.error_overlay
 
-    # Detect duplicate output paths (slug collisions)
+    # Detect duplicate output paths (slug collisions and alias collisions)
     seen_urls = Hash(String, String).new
     all_pages.each do |page|
       url = page.url
@@ -52,6 +52,18 @@ module Hwaro::Core::Build::Phases::Render
         Logger.warn "Duplicate output path '#{url}' — '#{page.path}' overwrites '#{prev_path}'"
       else
         seen_urls[url] = page.path
+      end
+      # Alias destinations also produce output files; a second page claiming the
+      # same alias (or an alias clashing with a real page URL) would otherwise
+      # overwrite silently and render-order-dependently.
+      page.aliases.each do |a|
+        norm = a.starts_with?("/") ? a : "/#{a}"
+        norm = "#{norm}/" unless norm.ends_with?("/") || norm.ends_with?(".html") || norm.ends_with?(".htm")
+        if prev_path = seen_urls[norm]?
+          Logger.warn "Duplicate alias output path '#{norm}' — '#{page.path}' overwrites '#{prev_path}'"
+        else
+          seen_urls[norm] = page.path
+        end
       end
     end
 
@@ -812,6 +824,9 @@ module Hwaro::Core::Build::Phases::Render
               base = page.url.ends_with?("/") ? page.url : "#{page.url}/"
               "#{base}#{src}".gsub("//", "/")
             end
+      # Markdown emits percent-encoded URLs (spaces/unicode), but the resize map
+      # is keyed by the decoded filesystem path — decode before the lookup.
+      key = URI.decode(key)
       # prefix_root_relative_links runs before this pass and may already have
       # rewritten a root-relative src with the subpath, but the resize map is
       # keyed by bare root-relative paths — strip the base_path back off so the
@@ -826,7 +841,7 @@ module Hwaro::Core::Build::Phases::Render
       # Prefix each candidate with the subpath (base_path) so responsive
       # images resolve on subpath deployments; the resize map stores bare
       # root-relative paths. Mirrors the resize_image() template helper.
-      srcset = widths.to_a.sort_by { |(w, _)| w }.map { |(w, url)| "#{config.with_base_path(url)} #{w}w" }.join(", ")
+      srcset = widths.to_a.sort_by { |(w, _)| w }.map { |(w, url)| "#{URI.encode_path(config.with_base_path(url))} #{w}w" }.join(", ")
       additions = %( srcset="#{srcset}")
       additions += %( sizes="100vw") unless tag =~ /\ssizes\s*=/
       tag.sub("<img", "<img#{additions}")
@@ -1839,14 +1854,16 @@ module Hwaro::Core::Build::Phases::Render
     vars["twitter_tags"] = Crinja::Value.new(twitter_tags)
     vars["og_all_tags"] = Crinja::Value.new(og_all_tags)
 
-    # Canonical and Hreflang tags
-    canonical_tag = Content::Seo::Tags.canonical_tag(page, config)
+    # Canonical and Hreflang tags. Pass page_url_override so paginated pages
+    # (page/2/ …) self-canonicalize instead of all pointing at page 1, keeping
+    # canonical consistent with og:url and rel=prev/next.
+    canonical_tag = Content::Seo::Tags.canonical_tag(page, config, page_url_override)
     hreflang_tags = Content::Seo::Tags.hreflang_tags(page, config)
     vars["canonical_tag"] = Crinja::Value.new(canonical_tag)
     vars["hreflang_tags"] = Crinja::Value.new(hreflang_tags)
 
     # Structured SEO object for custom meta tag markup
-    canonical_url = Content::Seo::Tags.canonical_url(page, config)
+    canonical_url = Content::Seo::Tags.canonical_url(page, config, page_url_override)
     seo_image = config.og.resolve_image_url(page.image, config.base_url) || ""
     seo_obj = {
       "canonical_url"   => Crinja::Value.new(canonical_url),
@@ -1876,11 +1893,13 @@ module Hwaro::Core::Build::Phases::Render
                        # Listing pages (section index, taxonomy index/term,
                        # author term) are collections, not articles — keep the
                        # JSON-LD @type consistent with og:type="website".
-                       Content::Seo::JsonLd.collection_page(page, config)
+                       Content::Seo::JsonLd.collection_page(page, config, page_url_override)
                      else
                        Content::Seo::JsonLd.article(page, config, site)
                      end
-    needs_breadcrumb = !page.ancestors.empty? || !page.is_index
+    # The synthesized 404 page carries no page-level structured data (matching
+    # the Article/CollectionPage suppression above) — skip its breadcrumb too.
+    needs_breadcrumb = page.path != "404.html" && (!page.ancestors.empty? || !page.is_index)
     jsonld_breadcrumb = needs_breadcrumb ? Content::Seo::JsonLd.breadcrumb(page, config) : ""
 
     # Extended schema types (FAQ, HowTo) auto-detected from extra.schema_type
@@ -1954,6 +1973,12 @@ module Hwaro::Core::Build::Phases::Render
   private def og_type_for(page : Models::Page, effective_url : String) : String?
     # 404 page is synthesized in write phase with `path = "404.html"`.
     return "website" if page.path == "404.html"
+    # Explicit per-page override via `[extra] og_type` — lets a custom listing
+    # template (e.g. the blog scaffold's archives page, a plain Page with no
+    # Section/taxonomy signal) declare itself a "website"/collection.
+    if ot = page.extra["og_type"]?.try(&.as?(String))
+      return ot unless ot.empty?
+    end
     # Taxonomy listings (`/tags/`, `/tags/<term>/`, …).
     return "website" if page.taxonomy_name
     # Section landings come from `_index.md`, which read_content parses into

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -420,7 +420,10 @@ module Hwaro::Core::Build::Phases::Transform
 
       sorted.each_with_index do |page, idx|
         page.series_index = idx + 1
-        page.series_pages = sorted
+        # A single-post series has no prev/next, so leave series_pages empty
+        # to keep the template's `page.series_pages` guard from rendering an
+        # orphan series-nav box.
+        page.series_pages = sorted.size > 1 ? sorted : ([] of Models::Page)
       end
     end
 
@@ -653,7 +656,10 @@ module Hwaro::Core::Build::Phases::Transform
 
       sorted.each_with_index do |page, idx|
         page.series_index = idx + 1
-        page.series_pages = sorted
+        # A single-post series has no prev/next, so leave series_pages empty
+        # to keep the template's `page.series_pages` guard from rendering an
+        # orphan series-nav box.
+        page.series_pages = sorted.size > 1 ? sorted : ([] of Models::Page)
       end
     end
   end

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1642,7 +1642,13 @@ module Hwaro
 
         s.each do |k, v|
           if target = v.as_s?
-            config.permalinks[k] = target
+            # Strip surrounding slashes from BOTH the source key and the target.
+            # resolve_permalink_dir matches against slash-free directory paths
+            # and interpolates the target as `/#{effective_dir}/`, so a key or
+            # target written with leading/trailing slashes (e.g. `"/blog/"`)
+            # would otherwise silently never match (source) or produce
+            # double-slash URLs like `http://host//blog//p/` (target).
+            config.permalinks[k.strip("/")] = target.strip("/")
           end
         end
       end

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -507,11 +507,10 @@ module Hwaro
             # =============================================================================
             # Permalinks (Optional)
             # =============================================================================
-            # Override the output path for specific sections or taxonomies
+            # Remap a content directory to a different output path
 
             # [permalinks]
-            # posts = "/posts/:year/:month/:slug/"
-            # tags = "/topic/:slug/"
+            # "old/posts" = "posts"
 
             TOML
         else
@@ -520,12 +519,12 @@ module Hwaro
             # =============================================================================
             # Permalinks (Optional)
             # =============================================================================
-            # Override the output path for specific sections or taxonomies.
-            # Placeholders: :year, :month, :day, :title, :slug, :section
+            # Remap a content directory to a different output path. The matched
+            # directory prefix is rewritten and any deeper path is preserved
+            # (e.g. "old/posts" => "posts" moves content/old/posts/x.md to /posts/x/).
 
             # [permalinks]
-            # posts = "/posts/:year/:month/:slug/"
-            # tags = "/topic/:slug/"
+            # "old/posts" = "posts"
 
             TOML
         end

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -833,10 +833,33 @@ module Hwaro
           )
         end
 
+        # PWA offline_page / precache_urls are routes, not just static files:
+        # `/about/` builds to `public/about/index.html` from `content/about.md`,
+        # so resolving them against `static/` alone yields false "file not
+        # found" warnings. Use a route-aware check that also accepts a matching
+        # content source or a built output page.
+        emit_route = ->(label : String, value : String) do
+          stripped = strip_query_hash(value)
+          return if stripped.empty?
+          return if path_resolves?(stripped) || route_resolves?(stripped)
+          issues << Issue.new(
+            id: "config-path-missing",
+            level: :warning,
+            category: "config",
+            file: @config_path,
+            message: "#{label}: #{value} — file not found",
+          )
+        end
+
         config.og.default_image.try { |v| emit_file.call("[og] default_image", v) }
         config.og.auto_image.logo.try { |v| emit_file.call("[og.auto_image] logo", v) }
         config.og.auto_image.background_image.try { |v| emit_file.call("[og.auto_image] background_image", v) }
-        config.pwa.offline_page.try { |v| emit_file.call("[pwa] offline_page", v) }
+        config.pwa.offline_page.try { |v| emit_route.call("[pwa] offline_page", v) }
+        config.pwa.precache_urls.each_with_index do |url, idx|
+          # Only validate site-internal routes; external URLs aren't ours.
+          next if url.starts_with?("http://") || url.starts_with?("https://")
+          emit_route.call("[pwa] precache_urls[#{idx}]", url)
+        end
         config.pwa.icons.each_with_index do |icon, idx|
           emit_file.call("[pwa] icons[#{idx}]", icon)
         end
@@ -895,6 +918,42 @@ module Hwaro
       # Same lookup strategy as `path_resolves?`, but for directories.
       private def dir_resolves?(path : String) : Bool
         candidates(path).any? { |c| Dir.exists?(c) }
+      end
+
+      # Decide whether a route-shaped value (e.g. `/about/`, `/offline.html`)
+      # corresponds to a page the site builds, even when no matching static
+      # file exists. A route is considered valid when:
+      #   - a content source exists (`content/about.md` or
+      #     `content/about/index.md` for `/about/`), or
+      #   - the built output page exists (`public/about/index.html`).
+      # This keeps doctor from flagging valid routes as "file not found" while
+      # still catching genuinely-missing pages.
+      private def route_resolves?(path : String) : Bool
+        # Normalize to a slug: drop a leading slash, strip a trailing slash,
+        # and remove a trailing `index.html` so `/about/` and
+        # `/about/index.html` resolve the same way.
+        slug = path.lchop("/")
+        slug = slug.rchop("index.html") if slug.ends_with?("index.html")
+        slug = slug.rstrip("/")
+
+        # Content sources that would render to this route.
+        content_candidates = if slug.empty?
+                               ["_index.md", "_index.markdown", "index.md", "index.markdown"]
+                             else
+                               [
+                                 "#{slug}.md",
+                                 "#{slug}.markdown",
+                                 File.join(slug, "index.md"),
+                                 File.join(slug, "index.markdown"),
+                                 File.join(slug, "_index.md"),
+                                 File.join(slug, "_index.markdown"),
+                               ]
+                             end
+        return true if content_candidates.any? { |c| File.exists?(File.join(@content_dir, c)) }
+
+        # The built output page (build output dir is conventionally `public/`).
+        output_file = path.ends_with?(".html") ? path.lchop("/") : File.join(slug, "index.html")
+        File.exists?(File.join("public", output_file))
       end
 
       private def candidates(path : String) : Array(String)

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -951,9 +951,20 @@ module Hwaro
                              end
         return true if content_candidates.any? { |c| File.exists?(File.join(@content_dir, c)) }
 
-        # The built output page (build output dir is conventionally `public/`).
-        output_file = path.ends_with?(".html") ? path.lchop("/") : File.join(slug, "index.html")
-        File.exists?(File.join("public", output_file))
+        # A prior build's output (conventionally `public/`): a pretty route lands
+        # at `<slug>/index.html`, while an explicit file (an `.html` alias or a
+        # pipeline-built asset such as `/css/app.css`) lands at the path itself.
+        if Dir.exists?("public")
+          return true if File.exists?(File.join("public", slug, "index.html"))
+          return true if File.exists?(File.join("public", path.lchop("/")))
+        end
+
+        # Otherwise it's a pretty route or listing (taxonomy/section page)
+        # produced at build time — doctor runs BEFORE the build (often on a clean
+        # checkout) so it can't see these. Treat route-style values as valid
+        # rather than false-positive; the build-time PWA precache validation is
+        # authoritative for genuinely-missing entries.
+        path.ends_with?("/") || File.extname(slug).empty?
       end
 
       private def candidates(path : String) : Array(String)

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -87,11 +87,21 @@ module Hwaro
         # Headers for caching. Target the configured asset output dir rather
         # than a hardcoded /assets/ so a customized [assets] output_dir is honored.
         lines << "[[headers]]"
-        lines << "  for = \"/#{assets_url_dir}/*\""
+        lines << "  for = \"#{with_base_path("/#{assets_url_dir}/*")}\""
         lines << "  [headers.values]"
         lines << "    Cache-Control = \"public, max-age=31536000, immutable\""
 
         lines.join("\n") + "\n"
+      end
+
+      # Prefix a site-internal path with the configured `base_path` so generated
+      # redirects/headers resolve under a subpath deployment, matching the
+      # build's own redirect HTML. Normalizes to a leading slash first because
+      # Config#with_base_path only prefixes root-relative paths (aliases may be
+      # authored without one). A no-op when base_path is empty.
+      private def with_base_path(path : String) : String
+        normalized = path.starts_with?("/") ? path : "/#{path}"
+        @config.with_base_path(normalized)
       end
 
       # URL path segment where the asset pipeline emits fingerprinted files,
@@ -121,7 +131,7 @@ module Hwaro
         # Headers for caching
         header_entries = [
           JSON::Any.new({
-            "source"  => JSON::Any.new("/#{assets_url_dir}/(.*)"),
+            "source"  => JSON::Any.new(with_base_path("/#{assets_url_dir}/(.*)")),
             "headers" => JSON::Any.new([
               JSON::Any.new({
                 "key"   => JSON::Any.new("Cache-Control"),
@@ -329,7 +339,13 @@ module Hwaro
         target_url = calculate_page_url(relative_path, data[:slug], data[:custom_path])
 
         aliases.each do |alias_path|
-          redirects << {alias_path, target_url}
+          # Carry base_path so generated redirects match the build's own
+          # redirect HTML (`url=/myrepo/moved/`) on subpath deploys. Ensure a
+          # leading slash first since with_base_path only prefixes root-relative
+          # paths; a no-op when base_path is empty (domain-root deploy).
+          from = with_base_path(alias_path)
+          to = with_base_path(target_url)
+          redirects << {from, to}
         end
       end
 

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -1471,6 +1471,8 @@ module Hwaro
             title = "Archives"
             template = "archives"
             description = "Every blog post, sorted by date."
+            [extra]
+            og_type = "website"
             +++
 
             Browse every post by date.

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -1371,7 +1371,21 @@ module Hwaro
                   <li><a href="{{ base_url }}{{ lang_prefix }}/">Welcome</a></li>
                 </ul>
               </div>
-              {% for sec in site.sections | rejectattr("name", "equalto", "") | sort(attribute="path") %}
+              {# Iterate TOP-LEVEL sections as chapters. Nested sections
+                 (name like "parent/child") also appear flat in `site.sections`,
+                 but they are rendered beneath their parent below, so they are
+                 skipped here via the `is in` test ("/" is in sec.name). The
+                 sort is weight with a path tiebreak to match the prev/next
+                 reading chain in transform.cr; Crinja sort is stable, so
+                 sorting by path then by weight yields weight-asc, path-tiebroken
+                 order. (Crinja here has no namespace/accumulator and no
+                 substring filter, so nested sections can't be dropped from the
+                 sequence up front — the inner skip keeps `loop.index` chapter
+                 numbering exact for the common case where nested sections sort
+                 last by weight, and for the default book scaffold, which has
+                 none.) #}
+              {% for sec in site.sections | rejectattr("name", "equalto", "") | sort(attribute="path") | sort(attribute="weight") %}
+              {% if "/" is in sec.name %}{% else %}
               {% set chapter_index = loop.index %}
               <div class="chapter-group">
                 <span class="chapter-title">{{ sec.title | e }}</span>
@@ -1383,8 +1397,17 @@ module Hwaro
                   {% for p in sec.pages | rejectattr("is_index") %}
                   <li><a href="{{ base_url }}{{ p.url }}"><span class="num">{{ chapter_index }}.{{ loop.index }}</span> {{ p.title | e }}</a></li>
                   {% endfor %}
+                  {# Nested subsections render one level deeper, mirroring the
+                     prev/next chain's depth-first nesting. #}
+                  {% for sub in sec.subsections | sort(attribute="path") | sort(attribute="weight") %}
+                  <li><a href="{{ base_url }}{{ sub.url }}"><span class="num">{{ chapter_index }}.{{ loop.index }}</span> {{ sub.title | e }}</a></li>
+                  {% for sp in sub.pages | rejectattr("is_index") %}
+                  <li><a href="{{ base_url }}{{ sp.url }}"><span class="num">{{ chapter_index }}.{{ loop.index }}</span> {{ sp.title | e }}</a></li>
+                  {% endfor %}
+                  {% endfor %}
                 </ul>
               </div>
+              {% endif %}
               {% endfor %}
             </aside>
             HTML
@@ -1446,10 +1469,15 @@ module Hwaro
                   {% if page.title is present %}<h1>{{ page.title | e }}</h1>{% endif %}
                   {{ content }}
 
+                  {# Only render the chapter listing when the section has at
+                     least one non-index child page — an empty chapter would
+                     otherwise show an orphan heading over an empty list. #}
+                  {% if section.pages | rejectattr("is_index") | length %}
                   <h2>In This Chapter</h2>
                   <ul class="section-list">
                     {{ section.list }}
                   </ul>
+                  {% endif %}
                   {{ pagination }}
                 </div>
             {% include "footer.html" %}

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -1371,21 +1371,16 @@ module Hwaro
                   <li><a href="{{ base_url }}{{ lang_prefix }}/">Welcome</a></li>
                 </ul>
               </div>
-              {# Iterate TOP-LEVEL sections as chapters. Nested sections
-                 (name like "parent/child") also appear flat in `site.sections`,
-                 but they are rendered beneath their parent below, so they are
-                 skipped here via the `is in` test ("/" is in sec.name). The
-                 sort is weight with a path tiebreak to match the prev/next
-                 reading chain in transform.cr; Crinja sort is stable, so
-                 sorting by path then by weight yields weight-asc, path-tiebroken
-                 order. (Crinja here has no namespace/accumulator and no
-                 substring filter, so nested sections can't be dropped from the
-                 sequence up front — the inner skip keeps `loop.index` chapter
-                 numbering exact for the common case where nested sections sort
-                 last by weight, and for the default book scaffold, which has
-                 none.) #}
-              {% for sec in site.sections | rejectattr("name", "equalto", "") | sort(attribute="path") | sort(attribute="weight") %}
-              {% if "/" is in sec.name %}{% else %}
+              {# Iterate TOP-LEVEL sections as chapters. Nested sections also
+                 appear flat in `site.sections`, but `top_level` is false for
+                 them and they render beneath their parent below — filtering them
+                 out of the loop (rather than skipping inside) keeps `loop.index`
+                 chapter numbering contiguous even when a nested section sorts
+                 before a top-level chapter by weight. The sort is weight with a
+                 path tiebreak to match the prev/next reading chain in
+                 transform.cr; Crinja sort is stable, so sort-by-path then
+                 sort-by-weight yields weight-asc, path-tiebroken order. #}
+              {% for sec in site.sections | rejectattr("name", "equalto", "") | selectattr("top_level") | sort(attribute="path") | sort(attribute="weight") %}
               {% set chapter_index = loop.index %}
               <div class="chapter-group">
                 <span class="chapter-title">{{ sec.title | e }}</span>
@@ -1407,7 +1402,6 @@ module Hwaro
                   {% endfor %}
                 </ul>
               </div>
-              {% endif %}
               {% endfor %}
             </aside>
             HTML

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -1134,7 +1134,7 @@ module Hwaro
         private def docs_sidebar_html : String
           <<-HTML
             <aside class="docs-sidebar">
-              {% for sec in site.sections | sort(attribute="path") %}{% if sec.name != "" %}
+              {% for sec in site.sections | sort(attribute="path") %}{% if sec.name != "" and sec.language == page_language %}
               <div class="sidebar-section">
                 <div class="sidebar-title">{{ sec.title | e }}</div>
                 <ul class="sidebar-links">


### PR DESCRIPTION
## Summary

Second adversarial dogfood pass (cycle 2) on top of #640: a 12-profile discovery sweep — regression-hunting the #640 fixes, probing deeper feature combinations, and building realistic multilingual/portfolio sites — surfaced **36 confirmed bugs** (each independently reproduced before fixing). This PR fixes **25** of them; the deep `--cache` cluster is deferred (see below).

Implementation was parallelized: 12 agents each owned a disjoint set of files and verified in isolation; the cross-cutting render/SEO hotspot was done by hand. Every fix is verified end-to-end against its minimal repro; full suite green (5442 examples).

## Fixes by area

**Markdown**
- Inline math `$a*b$ and $c*d$` was corrupted into `\(a<em>b\)…\(</em>d\)` — Markd read `*`/`_` inside the math body as emphasis and paired across spans. Now escaped.
- Footnote keys with spaces produced invalid `id="fn-my note"`. Now id-safe.

**Render / SEO**
- Responsive `srcset` advertised **false width descriptors** (a 500px source as 640w/1024w/1280w via byte-identical copies). Keyed by true source width now.
- Percent-encoded image URLs (spaces/unicode) missed the resize map → orphaned variants. Decode on lookup, encode on emit.
- Paginated pages collapsed canonical + JSON-LD onto page 1 while `og:url`/`rel=next` were page-aware. Self-canonical now.
- Blog **archives** mistyped as `Article`/`og:type=article` → now `CollectionPage`/`website`.
- 404 page still emitted BreadcrumbList JSON-LD; suppressed.
- Breadcrumb Home crumb pointed at the default-language root on ko/ja pages; language-prefixed now.
- Duplicate-alias output collisions now warn.

**AMP**
- `<iframe>`/`<video>` lacked the required `amp-iframe`/`amp-video` extension scripts (+ `sandbox`) → invalid AMP. Added.
- `convert_to_amp` now strips stale self-referencing `rel="amphtml"` (idempotent across `--cache`/rebuilds).
- A standalone content image no longer produces invalid `<p><div>…</div></p>`.

**PWA**
- An unbuilt `precache_url`/`offline_page` (e.g. a typo) broke the **entire** SW install (`cache.addAll` is all-or-nothing). Now dropped with a warning.
- `doctor` offline_page check is route-aware (no more false "file not found" on `/about/`).
- manifest icon `sizes` read from the real PNG, not guessed from the filename.

**Scaffolds**
- **book**: sidebar chapter order matches the prev/next chain (weight, not path); nested subsections nest; empty chapters drop the orphan heading.
- **docs**: multilingual sidebar filtered to the page's language (was listing every language).

**Feeds / Taxonomies / Permalinks / Platform / Incremental**
- Empty-language feeds (declared but no content) are no longer emitted with a dangling `<link>`.
- Atom feeds now emit `<category>` (parity with RSS).
- Paginated **taxonomy** pages now emit `<link rel="prev/next">` in `<head>`.
- Permalink targets with surrounding slashes (`/blog/`) no longer produce `//blog//` URLs; the `--full-config` scaffold stops advertising unimplemented `:year`/`:slug` placeholders.
- `tool platform` redirects/cache headers now carry the subpath base_path.
- Editing a `data/` file now correctly invalidates `build --cache`.

**Regression of #640 fixed**
- A single-post series no longer renders an orphan empty series-nav box (engine now leaves `series_pages` empty for single-member series).

## Deferred (dedicated follow-up)
The deep **`--cache` cross-page invalidation cluster** — stale homepage/section/archives listings on add/retitle, orphan output not pruned on delete/rename, raw shortcode leaking into feeds/search on cache hits — and the related **taxonomy-pages-not-in-`all_pages`** issue (no taxonomy entries in `sitemap.xml`, no auto OG image for taxonomy/author pages). These share an architectural root (the CLI `--cache` path lacks the cross-page dependency tracking + orphan pruning the serve path has); a rushed fix risks regressing worse than the bug. Tracked for cycle 3. A full `hwaro build` is always correct.

## Verification
- `crystal tool format` + `./bin/ameba` clean; full suite green (5442 examples, 0 failures).
- Each fix reproduced + confirmed against its minimal repro with the release binary.
