### PR TITLE
fix: dogfood cycle 3 — incremental (--cache) listing-page staleness

### DIFF
--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1193,41 +1193,8 @@ module Hwaro
           result = execute_write_phase(ctx, profiler)
           return result if result != Lifecycle::HookResult::Continue
 
-          # Prune outputs whose source page was deleted/renamed since the prior
-          # cached build, so `build --cache` matches a clean `build --full`.
-          # Skipped under fast-start (partial_render), where rendering is
-          # deferred and not-yet-written outputs must not be removed.
-          prune_orphaned_outputs(ctx) if ctx.options.cache && !ctx.partial_render
-
           # Phase: Finalize
           execute_finalize_phase(ctx, profiler)
-        end
-
-        # Delete output files whose source page no longer exists (deleted or
-        # renamed) on a `build --cache` run, then drop their dead cache entries.
-        # Mirrors the serve watcher's stale-output removal: every delete and
-        # empty-parent-dir cleanup is guarded by OutputGuard.within_output_dir?.
-        private def prune_orphaned_outputs(ctx : Lifecycle::BuildContext)
-          cache = @cache || return
-          output_dir = ctx.options.output_dir
-          removed = 0
-          cache.orphaned_outputs.each do |source_path, output_path|
-            if File.exists?(output_path) && Utils::OutputGuard.within_output_dir?(output_path, output_dir)
-              begin
-                File.delete(output_path)
-                removed += 1
-                dir = File.dirname(output_path)
-                while dir != output_dir && Utils::OutputGuard.within_output_dir?(dir, output_dir) && Dir.exists?(dir) && Dir.empty?(dir)
-                  Dir.delete(dir)
-                  dir = File.dirname(dir)
-                end
-              rescue ex
-                Logger.debug "  Could not remove orphaned output #{output_path}: #{ex.message}"
-              end
-            end
-            cache.invalidate(source_path)
-          end
-          Logger.info "  Removed #{removed} orphaned output(s)." if removed > 0
         end
       end
     end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1193,8 +1193,41 @@ module Hwaro
           result = execute_write_phase(ctx, profiler)
           return result if result != Lifecycle::HookResult::Continue
 
+          # Prune outputs whose source page was deleted/renamed since the prior
+          # cached build, so `build --cache` matches a clean `build --full`.
+          # Skipped under fast-start (partial_render), where rendering is
+          # deferred and not-yet-written outputs must not be removed.
+          prune_orphaned_outputs(ctx) if ctx.options.cache && !ctx.partial_render
+
           # Phase: Finalize
           execute_finalize_phase(ctx, profiler)
+        end
+
+        # Delete output files whose source page no longer exists (deleted or
+        # renamed) on a `build --cache` run, then drop their dead cache entries.
+        # Mirrors the serve watcher's stale-output removal: every delete and
+        # empty-parent-dir cleanup is guarded by OutputGuard.within_output_dir?.
+        private def prune_orphaned_outputs(ctx : Lifecycle::BuildContext)
+          cache = @cache || return
+          output_dir = ctx.options.output_dir
+          removed = 0
+          cache.orphaned_outputs.each do |source_path, output_path|
+            if File.exists?(output_path) && Utils::OutputGuard.within_output_dir?(output_path, output_dir)
+              begin
+                File.delete(output_path)
+                removed += 1
+                dir = File.dirname(output_path)
+                while dir != output_dir && Utils::OutputGuard.within_output_dir?(dir, output_dir) && Dir.exists?(dir) && Dir.empty?(dir)
+                  Dir.delete(dir)
+                  dir = File.dirname(dir)
+                end
+              rescue ex
+                Logger.debug "  Could not remove orphaned output #{output_path}: #{ex.message}"
+              end
+            end
+            cache.invalidate(source_path)
+          end
+          Logger.info "  Removed #{removed} orphaned output(s)." if removed > 0
         end
       end
     end

--- a/src/core/build/cache.cr
+++ b/src/core/build/cache.cr
@@ -295,6 +295,21 @@ module Hwaro
           end
         end
 
+        # Entries whose source file no longer exists on disk — i.e. a page that
+        # was deleted or renamed since the prior build. Returns {source_path,
+        # output_path} pairs so the caller can delete the orphaned output and
+        # drop the dead entry. (The cache retains the prior build's
+        # source→output map because unchanged pages are skipped, never updated.)
+        def orphaned_outputs : Array(Tuple(String, String))
+          @mutex.synchronize do
+            @entries.compact_map do |path, entry|
+              next if entry.output_path.empty?
+              next if File.exists?(path)
+              {path, entry.output_path}
+            end
+          end
+        end
+
         # Clear all cache entries
         def clear
           @mutex.synchronize do

--- a/src/core/build/cache.cr
+++ b/src/core/build/cache.cr
@@ -79,7 +79,18 @@ module Hwaro
         property template_hash : String
         property config_hash : String
 
-        def initialize(@template_hash : String = "", @config_hash : String = "")
+        # Fingerprints of the global page/section sets. Listing pages (homepage,
+        # section indexes, archives, taxonomy widgets) render content derived
+        # from these sets even when their own source is unchanged, so a change
+        # here forces those pages to re-render on an incremental build. Default
+        # "" so older cache files (without these keys) load and rebuild once.
+        @[JSON::Field(key: "page_set_hash", emit_null: false)]
+        property page_set_hash : String = ""
+        @[JSON::Field(key: "section_set_hash", emit_null: false)]
+        property section_set_hash : String = ""
+
+        def initialize(@template_hash : String = "", @config_hash : String = "",
+                       @page_set_hash : String = "", @section_set_hash : String = "")
         end
       end
 
@@ -153,7 +164,33 @@ module Hwaro
           if invalidated || @metadata.template_hash != template_hash || @metadata.config_hash != config_hash
             @dirty = true
           end
-          @metadata = CacheMetadata.new(template_hash: template_hash, config_hash: config_hash)
+          # Preserve the page/section-set fingerprints loaded from the prior
+          # build so the render phase can compare against them before recording
+          # the current ones.
+          @metadata = CacheMetadata.new(template_hash: template_hash, config_hash: config_hash,
+            page_set_hash: @metadata.page_set_hash, section_set_hash: @metadata.section_set_hash)
+        end
+
+        # Has the global page set (content page metadata that listings render —
+        # path/url/title/date/weight/draft/section) changed since last build?
+        def page_set_changed?(fingerprint : String) : Bool
+          @metadata.page_set_hash != fingerprint
+        end
+
+        # Has the section set (section metadata that nav/menus render) changed?
+        def section_set_changed?(fingerprint : String) : Bool
+          @metadata.section_set_hash != fingerprint
+        end
+
+        # Record the current page/section-set fingerprints so the next build can
+        # detect a change; marks the cache dirty when either value moves.
+        def record_set_fingerprints(page_set : String, section_set : String) : Nil
+          return unless @enabled
+          if @metadata.page_set_hash != page_set || @metadata.section_set_hash != section_set
+            @dirty = true
+          end
+          @metadata = CacheMetadata.new(template_hash: @metadata.template_hash, config_hash: @metadata.config_hash,
+            page_set_hash: page_set, section_set_hash: section_set)
         end
 
         # Check if a file has changed since last build.

--- a/src/core/build/cache.cr
+++ b/src/core/build/cache.cr
@@ -295,21 +295,6 @@ module Hwaro
           end
         end
 
-        # Entries whose source file no longer exists on disk — i.e. a page that
-        # was deleted or renamed since the prior build. Returns {source_path,
-        # output_path} pairs so the caller can delete the orphaned output and
-        # drop the dead entry. (The cache retains the prior build's
-        # source→output map because unchanged pages are skipped, never updated.)
-        def orphaned_outputs : Array(Tuple(String, String))
-          @mutex.synchronize do
-            @entries.compact_map do |path, entry|
-              next if entry.output_path.empty?
-              next if File.exists?(path)
-              {path, entry.output_path}
-            end
-          end
-        end
-
         # Clear all cache entries
         def clear
           @mutex.synchronize do

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -33,7 +33,10 @@ module Hwaro::Core::Build::Phases::Render
     section_set_fp = cache_enabled ? compute_section_set_fingerprint(site.sections) : ""
     pages_to_build = if cache_enabled
                        filtered = filter_changed_pages(all_pages, output_dir, build_cache, templates, site, page_set_fp, section_set_fp)
-                       build_cache.record_set_fingerprints(page_set_fp, section_set_fp)
+                       # Don't record under fast-start: deferred listing pages
+                       # render in a later pass, so persisting the new fingerprint
+                       # now would let the next build skip them while stale.
+                       build_cache.record_set_fingerprints(page_set_fp, section_set_fp) unless ctx.options.fast_start
                        filtered
                      else
                        all_pages
@@ -294,7 +297,10 @@ module Hwaro::Core::Build::Phases::Render
         io << p.path << '\u0001' << p.url << '\u0001' << p.title << '\u0001'
         io << (p.description || "") << '\u0001'
         io << (p.date.try(&.to_unix) || 0_i64) << '\u0001' << p.weight << '\u0001'
-        io << (p.draft ? '1' : '0') << '\u0001' << p.section << '\u0002'
+        io << (p.draft ? '1' : '0') << '\u0001' << p.section << '\u0001'
+        io << p.tags.join(',') << '\u0001'
+        p.taxonomies.keys.sort!.each { |k| io << k << '=' << p.taxonomies[k].join(',') << ';' }
+        io << '\u0002'
       end
     end)
   end
@@ -303,7 +309,8 @@ module Hwaro::Core::Build::Phases::Render
   private def compute_section_set_fingerprint(sections : Array(Models::Section)) : String
     Digest::MD5.hexdigest(String.build do |io|
       sections.each do |s|
-        io << s.path << '\u0001' << s.url << '\u0001' << s.title << '\u0001' << s.weight << '\u0002'
+        io << s.path << '\u0001' << s.url << '\u0001' << s.title << '\u0001'
+        io << (s.description || "") << '\u0001' << (s.draft ? '1' : '0') << '\u0001' << s.weight << '\u0002'
       end
     end)
   end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -25,9 +25,16 @@ module Hwaro::Core::Build::Phases::Render
 
     all_pages = ctx.all_pages
 
-    # Filter pages for caching
+    # Filter pages for caching. Listing pages (homepage, section indexes,
+    # archives, taxonomy widgets) render content derived from the global
+    # page/section set even when their own source is unchanged, so fold a
+    # fingerprint of those sets into the rebuild decision.
+    page_set_fp = cache_enabled ? compute_page_set_fingerprint(site.pages) : ""
+    section_set_fp = cache_enabled ? compute_section_set_fingerprint(site.sections) : ""
     pages_to_build = if cache_enabled
-                       filter_changed_pages(all_pages, output_dir, build_cache, templates, site)
+                       filtered = filter_changed_pages(all_pages, output_dir, build_cache, templates, site, page_set_fp, section_set_fp)
+                       build_cache.record_set_fingerprints(page_set_fp, section_set_fp)
+                       filtered
                      else
                        all_pages
                      end
@@ -240,12 +247,65 @@ module Hwaro::Core::Build::Phases::Render
     total_count
   end
 
-  private def filter_changed_pages(pages : Array(Models::Page), output_dir : String, cache : Cache, templates : Hash(String, String), site : Models::Site) : Array(Models::Page)
+  # Markers in a page's resolved template closure that mean it renders content
+  # derived from the global page/section set, so it must re-render when that set
+  # changes (not only when its own source changes).
+  PAGE_SET_MARKERS    = ["site.pages", "__all_pages__", ".pages", "paginate", "site.taxonomies", "__taxonomies__", "get_taxonomy"]
+  SECTION_SET_MARKERS = ["site.sections", "__all_sections__", "get_section"]
+
+  private def filter_changed_pages(pages : Array(Models::Page), output_dir : String, cache : Cache, templates : Hash(String, String), site : Models::Site, page_set_fp : String = "", section_set_fp : String = "") : Array(Models::Page)
+    page_set_changed = cache.page_set_changed?(page_set_fp)
+    section_set_changed = cache.section_set_changed?(section_set_fp)
+    listing_memo = {} of String => Tuple(Bool, Bool)
     pages.select do |page|
       source_path = File.join("content", page.path)
       output_path = get_output_path(page, output_dir)
-      cache.changed?(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
+      next true if cache.changed?(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
+      # Page's own source is unchanged: only re-render it if a set it depends on
+      # changed. Skip the (cheap) marker scan entirely when nothing moved.
+      next false unless page_set_changed || section_set_changed
+      entry = determine_template(page, templates, site)
+      pdep, sdep = (listing_memo[entry]? || (listing_memo[entry] = listing_template_deps(entry, templates)))
+      # A section index renders its section's page list even via {{ section.list }}
+      # (no template marker), so treat every Section as page-set dependent.
+      page_dep = pdep || page.is_a?(Models::Section)
+      (page_dep && page_set_changed) || (sdep && section_set_changed)
     end
+  end
+
+  # Scan a page's resolved template-closure SOURCE for global-iteration markers.
+  # Returns {depends_on_page_set, depends_on_section_set}. With dependency
+  # tracking off, conservatively scans all templates.
+  private def listing_template_deps(entry_template : String, templates : Hash(String, String)) : Tuple(Bool, Bool)
+    sources = if deps = @template_deps
+                deps.closure(entry_template).compact_map { |n| templates[n]? }
+              else
+                templates.values
+              end
+    blob = sources.join("\n")
+    {PAGE_SET_MARKERS.any? { |m| blob.includes?(m) }, SECTION_SET_MARKERS.any? { |m| blob.includes?(m) }}
+  end
+
+  # Fingerprint the global page set — the content-page metadata that listing
+  # pages render (membership, urls, titles, dates, weights, draft, section).
+  private def compute_page_set_fingerprint(pages : Array(Models::Page)) : String
+    Digest::MD5.hexdigest(String.build do |io|
+      pages.each do |p|
+        io << p.path << '\u0001' << p.url << '\u0001' << p.title << '\u0001'
+        io << (p.description || "") << '\u0001'
+        io << (p.date.try(&.to_unix) || 0_i64) << '\u0001' << p.weight << '\u0001'
+        io << (p.draft ? '1' : '0') << '\u0001' << p.section << '\u0002'
+      end
+    end)
+  end
+
+  # Fingerprint the section set — the metadata nav/menus render.
+  private def compute_section_set_fingerprint(sections : Array(Models::Section)) : String
+    Digest::MD5.hexdigest(String.build do |io|
+      sections.each do |s|
+        io << s.path << '\u0001' << s.url << '\u0001' << s.title << '\u0001' << s.weight << '\u0002'
+      end
+    end)
   end
 
   # Template closure fingerprint stored in this page's cache entry. With


### PR DESCRIPTION
## Summary

Final dogfood round (cycle 3), targeting the deferred **`build --cache` cross-page-invalidation cluster**. Driven by an investigation that mapped the CLI `--cache` path against the (already-correct) serve incremental path.

This PR fixes the headline `--cache` correctness bug: **stale listing pages**.

### Stale listing pages (homepage / section index / archives / taxonomy widgets)
`build --cache` rebuilt a page only when its **own** source/template/cascade fingerprint changed. Listing pages render content derived from the **global page set**, so adding, removing, retitling, redating, reordering, or **retagging** a post left them stale (the on-disk HTML kept the old list) — while feeds/sitemap, which regenerate unconditionally, picked up the change, producing an internally inconsistent site.

**Fix:** fold a fingerprint of the global page set (path/url/title/description/date/weight/draft/section/**tags/taxonomies**) and section set (path/url/title/description/draft/weight) into the cache decision. A page is force-rebuilt on a set change **only when it actually depends on that set** — a structural check (every `Models::Section` renders its page list, even via `{{ section.list }}`) plus a marker scan of the page's *resolved template closure* (`site.pages`/`.pages`/`paginate`/`get_taxonomy`/`site.taxonomies` → page set; `site.sections`/`get_section` → section set). Leaf pages keep their cache entry, so a no-op rebuild renders nothing and editing one post body rebuilds only that post + genuine listings. (Recording is skipped under fast-start, where listing pages render in a later pass.)

**Verified:** `diff -r` between `build --cache` and `build --full` is **identical** for add / retitle / reorder; a no-op rebuild renders 0 pages; editing one post body doesn't pull every page into the rebuild.

## Scoped follow-ups (documented, not in this PR)
The investigation mapped the rest of the cluster — each a **separate subsystem** with a distinct fix point, deferred to keep this PR focused and low-risk in the build pipeline:
- **Orphan output pruning** (deleted/renamed page's old HTML lingers on `--cache`). An initial cache-driven prune was implemented and then **reverted after review**: it could delete a *live* page's output when a URL is reclaimed, and missed paginated/alias/static outputs and config-change-cleared caches. A correct version needs a full **build-output manifest** (every path written this build) so it can safely diff prior-vs-current outputs.
- **Feed/search content leak**: on a `--cache` hit (or `--stream`), `page.content` is empty so feeds/search fall back to a markdown-only render that skips shortcode expansion. Fix: persist the rendered body in the Cache and rehydrate before Generate.
- **Taxonomy pages absent from `sitemap.xml`** (and no auto OG image) + **orphan taxonomy term dirs** on `--cache`: taxonomy pages bypass `all_pages` and the cache entirely. Fix: collect the generated Sections, reorder the taxonomy hook before the SEO hook, and add a taxonomy-output manifest.

A full `hwaro build` is always correct.

## Verification
- `crystal tool format` + `./bin/ameba` clean; full suite green (5442 examples).
- Reproduced + confirmed (incl. `diff -r` cache-vs-full) with the release binary.
