### PR TITLE
fix(security): harden importers, dev-server CORS, redirect & report sinks

### DIFF
--- a/spec/unit/importers/base_spec.cr
+++ b/spec/unit/importers/base_spec.cr
@@ -248,4 +248,49 @@ describe Hwaro::Services::Importers::Base do
       importer.test_strip_redundant_title_h1(body, "Title").should eq(body)
     end
   end
+
+  describe "#write_content_file path-traversal safety" do
+    it "writes a normal slug inside the output dir" do
+      Dir.mktmpdir do |tmpdir|
+        out_dir = File.join(tmpdir, "content")
+        importer = TestImporter.new
+        importer.test_write_content_file(out_dir, "posts", "hello-world", "+++\n+++", "Body").should be_true
+        File.exists?(File.join(out_dir, "posts", "hello-world.md")).should be_true
+      end
+    end
+
+    it "collapses a traversal slug to a basename and never writes outside the output dir" do
+      Dir.mktmpdir do |tmpdir|
+        out_dir = File.join(tmpdir, "content")
+        Dir.mkdir_p(out_dir)
+        # Where a naive File.join + File.write would have planted the file.
+        sentinel = File.expand_path(File.join(out_dir, "..", "hwaro_pwn.md"))
+        importer = TestImporter.new
+        # A malicious WordPress <wp:post_name> / Hugo front-matter slug.
+        importer.test_write_content_file(out_dir, "posts", "../../hwaro_pwn", "+++\n+++", "Body")
+        File.exists?(sentinel).should be_false
+        # The traversal is neutralised: the file lands safely inside output_dir.
+        File.exists?(File.join(out_dir, "posts", "hwaro_pwn.md")).should be_true
+      end
+    end
+
+    it "refuses a slug that is pure traversal (no real component)" do
+      Dir.mktmpdir do |tmpdir|
+        out_dir = File.join(tmpdir, "content")
+        importer = TestImporter.new
+        importer.test_write_content_file(out_dir, "posts", "../../..", "+++\n+++", "Body").should be_false
+      end
+    end
+
+    it "strips traversal from the section so output stays inside the output dir" do
+      Dir.mktmpdir do |tmpdir|
+        out_dir = File.join(tmpdir, "content")
+        escaped = File.expand_path(File.join(out_dir, "..", "..", "evil", "note.md"))
+        importer = TestImporter.new
+        importer.test_write_content_file(out_dir, "../../evil", "note", "+++\n+++", "Body")
+        File.exists?(escaped).should be_false
+        File.exists?(File.join(out_dir, "evil", "note.md")).should be_true
+      end
+    end
+  end
 end

--- a/spec/unit/importers/html_to_markdown_spec.cr
+++ b/spec/unit/importers/html_to_markdown_spec.cr
@@ -33,6 +33,22 @@ describe Hwaro::Services::Importers::HtmlToMarkdown do
       result.should eq("![Alt text](/img.png)")
     end
 
+    it "drops a javascript: link href but keeps the text (no live XSS in imported content)" do
+      result = Hwaro::Services::Importers::HtmlToMarkdown.convert(%(<a href="javascript:alert(document.cookie)">Click</a>))
+      result.should eq("Click")
+      result.should_not contain("javascript:")
+    end
+
+    it "drops a javascript: image src but keeps the alt text" do
+      result = Hwaro::Services::Importers::HtmlToMarkdown.convert(%(<img src="javascript:alert(1)" alt="x" />))
+      result.should_not contain("javascript:")
+    end
+
+    it "drops a non-image data: link" do
+      result = Hwaro::Services::Importers::HtmlToMarkdown.convert(%(<a href="data:text/html,<script>alert(1)</script>">x</a>))
+      result.should_not contain("data:text/html")
+    end
+
     it "converts unordered lists" do
       html = "<ul><li>One</li><li>Two</li></ul>"
       result = Hwaro::Services::Importers::HtmlToMarkdown.convert(html)

--- a/spec/unit/importers/wordpress_importer_spec.cr
+++ b/spec/unit/importers/wordpress_importer_spec.cr
@@ -432,6 +432,42 @@ describe Hwaro::Services::Importers::WordPressImporter do
       end
     end
 
+    it "rejects entity declarations hidden behind a SYSTEM literal containing brackets" do
+      Dir.mktmpdir do |tmpdir|
+        malicious = <<-XML
+          <?xml version="1.0"?>
+          <!DOCTYPE rss SYSTEM "ignore]me[here" [
+            <!ENTITY a "aa">
+            <!ENTITY b "&a;&a;">
+          ]>
+          <rss version="2.0" xmlns:wp="http://wordpress.org/export/1.2/"><channel></channel></rss>
+          XML
+        wxr_path = write_wxr(tmpdir, malicious)
+        output_dir = File.join(tmpdir, "content")
+
+        importer = Hwaro::Services::Importers::WordPressImporter.new
+        result = importer.run(make_options(wxr_path, output_dir))
+
+        result.success.should be_false
+        result.message.should contain("entit")
+      end
+    end
+
+    it "does not reject a post whose body merely mentions <!ENTITY (no DOCTYPE)" do
+      Dir.mktmpdir do |tmpdir|
+        ok = BASIC_WXR.sub("<![CDATA[<p>This is my first post.</p>]]>",
+          "<![CDATA[<p>Docs about <!ENTITY declarations.</p>]]>")
+        wxr_path = write_wxr(tmpdir, ok)
+        output_dir = File.join(tmpdir, "content")
+
+        importer = Hwaro::Services::Importers::WordPressImporter.new
+        result = importer.run(make_options(wxr_path, output_dir))
+
+        result.success.should be_true
+        result.imported_count.should eq(1)
+      end
+    end
+
     it "neutralises a traversal post_name so it cannot escape the output dir" do
       Dir.mktmpdir do |tmpdir|
         traversal = BASIC_WXR.sub("<wp:post_name>hello-world</wp:post_name>",

--- a/spec/unit/importers/wordpress_importer_spec.cr
+++ b/spec/unit/importers/wordpress_importer_spec.cr
@@ -409,5 +409,44 @@ describe Hwaro::Services::Importers::WordPressImporter do
         content.should contain("Some info about me.")
       end
     end
+
+    it "rejects a WXR that declares XML entities (entity-expansion DoS guard)" do
+      Dir.mktmpdir do |tmpdir|
+        malicious = <<-XML
+          <?xml version="1.0"?>
+          <!DOCTYPE rss [
+            <!ENTITY a "aa">
+            <!ENTITY b "&a;&a;">
+            <!ENTITY c "&b;&b;">
+          ]>
+          <rss version="2.0" xmlns:wp="http://wordpress.org/export/1.2/"><channel></channel></rss>
+          XML
+        wxr_path = write_wxr(tmpdir, malicious)
+        output_dir = File.join(tmpdir, "content")
+
+        importer = Hwaro::Services::Importers::WordPressImporter.new
+        result = importer.run(make_options(wxr_path, output_dir))
+
+        result.success.should be_false
+        result.message.should contain("entit")
+      end
+    end
+
+    it "neutralises a traversal post_name so it cannot escape the output dir" do
+      Dir.mktmpdir do |tmpdir|
+        traversal = BASIC_WXR.sub("<wp:post_name>hello-world</wp:post_name>",
+          "<wp:post_name>../../../hwaro_pwn</wp:post_name>")
+        wxr_path = write_wxr(tmpdir, traversal)
+        output_dir = File.join(tmpdir, "content")
+
+        importer = Hwaro::Services::Importers::WordPressImporter.new
+        importer.run(make_options(wxr_path, output_dir))
+
+        # Must NOT have escaped the output dir.
+        File.exists?(File.join(tmpdir, "hwaro_pwn.md")).should be_false
+        # The slug collapses to its basename inside posts/.
+        File.exists?(File.join(output_dir, "posts", "hwaro_pwn.md")).should be_true
+      end
+    end
   end
 end

--- a/spec/unit/redirect_html_spec.cr
+++ b/spec/unit/redirect_html_spec.cr
@@ -33,6 +33,25 @@ describe Hwaro::Utils::RedirectHtml do
       result.should contain("Redirecting to")
       result.should contain("<a href=")
     end
+
+    it "refuses a javascript: redirect (no live href, refresh, or navigation)" do
+      result = Hwaro::Utils::RedirectHtml.full_redirect("javascript:alert(document.cookie)")
+      result.should_not contain("href=\"javascript:")
+      result.should_not contain("http-equiv=\"refresh\"")
+      result.should_not contain("window.location.href")
+      result.should contain("blocked")
+    end
+
+    it "refuses a javascript: redirect even with obfuscated whitespace/case" do
+      result = Hwaro::Utils::RedirectHtml.full_redirect("JaVaScRiPt:alert(1)")
+      result.should_not contain("window.location.href")
+      result.should contain("blocked")
+    end
+
+    it "still allows ordinary http(s) and relative redirects" do
+      Hwaro::Utils::RedirectHtml.full_redirect("https://example.com/").should contain("window.location.href")
+      Hwaro::Utils::RedirectHtml.full_redirect("/blog/post/").should contain("window.location.href")
+    end
   end
 
   describe ".simple_redirect" do

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -250,60 +250,96 @@ describe Hwaro::Services::NotFoundHandler do
   end
 end
 
+private def cors_request(method : String, origin : String?, extra_headers = {} of String => String)
+  headers = HTTP::Headers.new
+  headers["Origin"] = origin if origin
+  extra_headers.each { |k, v| headers[k] = v }
+  HTTP::Request.new(method, "/search_index.json", headers)
+end
+
 describe Hwaro::Services::DevCorsHandler do
-  it "sets Access-Control-Allow-Origin on a normal request and passes through" do
+  it "reflects a loopback Origin and passes through" do
     handler = Hwaro::Services::DevCorsHandler.new
     dummy = DummyHandler.new
     handler.next = dummy
 
-    request = HTTP::Request.new("GET", "/search_index.json")
     io = IO::Memory.new
     response = HTTP::Server::Response.new(io)
-    context = HTTP::Server::Context.new(request, response)
+    context = HTTP::Server::Context.new(cors_request("GET", "http://localhost:3000"), response)
 
     handler.call(context)
 
-    response.headers["Access-Control-Allow-Origin"].should eq("*")
+    response.headers["Access-Control-Allow-Origin"].should eq("http://localhost:3000")
+    response.headers["Vary"].should eq("Origin")
     dummy.called.should be_true
   end
 
-  it "short-circuits OPTIONS preflight with 204 and CORS headers" do
+  it "does NOT grant CORS to an arbitrary internet Origin" do
     handler = Hwaro::Services::DevCorsHandler.new
     dummy = DummyHandler.new
     handler.next = dummy
 
-    request = HTTP::Request.new(
-      "OPTIONS",
-      "/search_index.json",
-      HTTP::Headers{"Access-Control-Request-Headers" => "content-type"},
-    )
     io = IO::Memory.new
     response = HTTP::Server::Response.new(io)
-    context = HTTP::Server::Context.new(request, response)
+    context = HTTP::Server::Context.new(cors_request("GET", "https://evil.example.com"), response)
+
+    handler.call(context)
+
+    response.headers["Access-Control-Allow-Origin"]?.should be_nil
+    dummy.called.should be_true
+  end
+
+  it "reflects the explicitly bound host Origin" do
+    handler = Hwaro::Services::DevCorsHandler.new(Set{"localhost", "127.0.0.1", "::1", "192.168.1.5"})
+    dummy = DummyHandler.new
+    handler.next = dummy
+
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(cors_request("GET", "http://192.168.1.5:3000"), response)
+
+    handler.call(context)
+
+    response.headers["Access-Control-Allow-Origin"].should eq("http://192.168.1.5:3000")
+  end
+
+  it "short-circuits OPTIONS preflight with 204 and CORS headers for a loopback Origin" do
+    handler = Hwaro::Services::DevCorsHandler.new
+    dummy = DummyHandler.new
+    handler.next = dummy
+
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(
+      cors_request("OPTIONS", "http://127.0.0.1:3000", {"Access-Control-Request-Headers" => "content-type"}),
+      response,
+    )
 
     handler.call(context)
 
     response.status_code.should eq(204)
-    response.headers["Access-Control-Allow-Origin"].should eq("*")
+    response.headers["Access-Control-Allow-Origin"].should eq("http://127.0.0.1:3000")
     response.headers["Access-Control-Allow-Methods"].should eq("GET, HEAD, OPTIONS")
     response.headers["Access-Control-Allow-Headers"].should eq("content-type")
     response.headers["Access-Control-Max-Age"].should eq("86400")
     dummy.called.should be_false
   end
 
-  it "falls back to * for Access-Control-Allow-Headers when preflight omits the request" do
+  it "returns 204 for an OPTIONS preflight from a disallowed Origin without CORS headers" do
     handler = Hwaro::Services::DevCorsHandler.new
     dummy = DummyHandler.new
     handler.next = dummy
 
-    request = HTTP::Request.new("OPTIONS", "/search_index.json")
     io = IO::Memory.new
     response = HTTP::Server::Response.new(io)
-    context = HTTP::Server::Context.new(request, response)
+    context = HTTP::Server::Context.new(cors_request("OPTIONS", "https://evil.example.com"), response)
 
     handler.call(context)
 
-    response.headers["Access-Control-Allow-Headers"].should eq("*")
+    response.status_code.should eq(204)
+    response.headers["Access-Control-Allow-Origin"]?.should be_nil
+    response.headers["Access-Control-Allow-Methods"]?.should be_nil
+    dummy.called.should be_false
   end
 end
 

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -176,14 +176,14 @@ module Hwaro
             else
               Logger.warn "✘ Found #{dead_total} dead links (out of #{total} total):"
               dead_external.each do |result|
-                Logger.error "[DEAD] #{result.link.file}"
-                Logger.error "  └─ URL: #{result.link.url}"
-                Logger.error "  └─ Status: #{result.status}#{result.error ? " (Error: #{result.error})" : ""}"
+                Logger.error "[DEAD] #{sanitize_for_terminal(result.link.file)}"
+                Logger.error "  └─ URL: #{sanitize_for_terminal(result.link.url)}"
+                Logger.error "  └─ Status: #{result.status}#{result.error ? " (Error: #{sanitize_for_terminal(result.error.to_s)})" : ""}"
               end
               dead_internal.each do |result|
-                Logger.error "[DEAD] #{result.link.file}"
-                Logger.error "  └─ URL: #{result.link.url} (internal)"
-                Logger.error "  └─ #{result.error}"
+                Logger.error "[DEAD] #{sanitize_for_terminal(result.link.file)}"
+                Logger.error "  └─ URL: #{sanitize_for_terminal(result.link.url)} (internal)"
+                Logger.error "  └─ #{sanitize_for_terminal(result.error.to_s)}"
               end
             end
             Logger.info "----------------------------------------"
@@ -204,6 +204,15 @@ module Hwaro
             content
               .gsub(/```[\s\S]*?```/, "")
               .gsub(/`[^`\n]*`/, "")
+          end
+
+          # Link URLs/paths come from semi-trusted content (e.g. a docs/blog
+          # PR) and are printed to the maintainer's terminal in the report.
+          # A URL carrying raw ANSI/control bytes (the link regex's `\s` does
+          # not exclude ESC) could repaint or spoof the console. Strip control
+          # characters before logging so the report can't inject escapes.
+          private def sanitize_for_terminal(s : String) : String
+            s.gsub { |c| c.control? ? "" : c }
           end
 
           private def find_external_links(dir : String) : Array(Link)

--- a/src/services/importers/base.cr
+++ b/src/services/importers/base.cr
@@ -3,6 +3,8 @@ require "../../config/options/import_options"
 require "../../utils/file_safe"
 require "../../utils/logger"
 require "../../utils/text_utils"
+require "../../utils/path_utils"
+require "../../utils/output_guard"
 
 module Hwaro
   module Services
@@ -106,11 +108,32 @@ module Hwaro
           verbose : Bool = false,
           force : Bool = false,
         ) : Bool
-          dir = section.empty? ? output_dir : File.join(output_dir, section)
-          Hwaro::Utils::FileSafe.mkdir_p(dir) unless Dir.exists?(dir)
+          # Importers consume third-party exports, so `section` and `slug` are
+          # UNTRUSTED. A malicious WordPress `<wp:post_name>` or Hugo front
+          # matter `slug` of "../../../etc/x" would otherwise let `File.write`
+          # escape `output_dir` and plant or overwrite files anywhere the
+          # running user can write. Neutralise traversal at this single sink so
+          # every current and future importer is protected.
+          safe_section = Utils::PathUtils.sanitize_path(section)
+          safe_slug = safe_filename_component(slug)
+          if safe_slug.empty?
+            Logger.warn "Skipped (unsafe slug #{slug.inspect})" if verbose
+            return false
+          end
 
-          filename = slug.ends_with?(".md") ? slug : "#{slug}.md"
+          dir = safe_section.empty? ? output_dir : File.join(output_dir, safe_section)
+
+          filename = safe_slug.ends_with?(".md") ? safe_slug : "#{safe_slug}.md"
           path = File.join(dir, filename)
+
+          # Belt-and-suspenders: refuse to write outside output_dir even if a
+          # component slipped past the sanitisers above.
+          unless Utils::OutputGuard.within_output_dir?(path, output_dir)
+            Logger.warn "Skipped (escapes output directory): #{path}"
+            return false
+          end
+
+          Hwaro::Utils::FileSafe.mkdir_p(dir) unless Dir.exists?(dir)
 
           if File.exists?(path) && !force
             Logger.warn "Skipped (already exists): #{path}" if verbose
@@ -123,6 +146,20 @@ module Hwaro
             Logger.debug(force ? "Overwrote: #{path}" : "Imported: #{path}")
           end
           true
+        end
+
+        # Collapse an untrusted slug to a single safe filename component so it
+        # can never traverse out of the section directory. Drops null bytes,
+        # splits on both `/` and `\` separators, removes "."/".."/empty
+        # segments, and keeps the last remaining segment (which may legitimately
+        # carry a trailing ".md"). Unicode is preserved. We intentionally do NOT
+        # URL-decode: the filesystem treats `%2f` as a literal, so decoding
+        # would only manufacture separators that aren't really there.
+        protected def safe_filename_component(value : String) : String
+          value.delete(Char::ZERO)
+            .split(/[\/\\]/)
+            .reject { |seg| seg.empty? || seg == "." || seg == ".." }
+            .last? || ""
         end
 
         # Parse a date string in common formats, returns nil on failure

--- a/src/services/importers/html_to_markdown.cr
+++ b/src/services/importers/html_to_markdown.cr
@@ -1,4 +1,6 @@
 require "xml"
+require "../../utils/logger"
+require "../../content/processors/inline_markdown"
 
 module Hwaro
   module Services
@@ -6,8 +8,20 @@ module Hwaro
       # Lightweight HTML-to-Markdown converter.
       # Handles common HTML elements produced by WordPress and other CMS exports.
       module HtmlToMarkdown
+        # Above this size the regex pipeline's lazy quantifiers (e.g. the anchor
+        # body `(.*?)</a>`) degrade to O(n^2) on adversarial markup (many
+        # unclosed tags). Imported exports are untrusted, so fall back to a
+        # cheap linear tag-strip rather than spend minutes of CPU on a single
+        # crafted item. The threshold is far above any real blog post.
+        MAX_REGEX_HTML_BYTES = 4 * 1024 * 1024
+
         def self.convert(html : String) : String
           return "" if html.empty?
+
+          if html.bytesize > MAX_REGEX_HTML_BYTES
+            Logger.warn "HTML content is very large (#{html.bytesize} bytes); converting as plain text to avoid excessive processing time."
+            return html.gsub(/<[^>]*>/, " ").gsub(/[ \t]+/, " ").strip
+          end
 
           result = html
 
@@ -95,13 +109,17 @@ module Hwaro
 
           # Inline elements
 
-          # Images (before links to avoid nested match issues)
-          result = result.gsub(/<img[^>]*\bsrc=["']([^"']+)["'][^>]*\balt=["']([^"']*)["'][^>]*\/?>/i) { "![#{$2}](#{$1})" }
-          result = result.gsub(/<img[^>]*\balt=["']([^"']*)["'][^>]*\bsrc=["']([^"']+)["'][^>]*\/?>/i) { "![#{$1}](#{$2})" }
-          result = result.gsub(/<img[^>]*\bsrc=["']([^"']+)["'][^>]*\/?>/i) { "![](#{$1})" }
+          # Images (before links to avoid nested match issues).
+          # Drop the URL (keep the alt text) when the scheme is unsafe so an
+          # untrusted export can't smuggle a live `javascript:`/`data:` src
+          # into content — the importer stays safe regardless of the markdown
+          # renderer's `safe` flag.
+          result = result.gsub(/<img[^>]*\bsrc=["']([^"']+)["'][^>]*\balt=["']([^"']*)["'][^>]*\/?>/i) { safe_media($1, $2, image: true) }
+          result = result.gsub(/<img[^>]*\balt=["']([^"']*)["'][^>]*\bsrc=["']([^"']+)["'][^>]*\/?>/i) { safe_media($2, $1, image: true) }
+          result = result.gsub(/<img[^>]*\bsrc=["']([^"']+)["'][^>]*\/?>/i) { safe_media($1, "", image: true) }
 
-          # Links
-          result = result.gsub(/<a[^>]*\bhref=["']([^"']+)["'][^>]*>(.*?)<\/a>/mi) { "[#{$2}](#{$1})" }
+          # Links — likewise drop a dangerous href but keep the link text.
+          result = result.gsub(/<a[^>]*\bhref=["']([^"']+)["'][^>]*>(.*?)<\/a>/mi) { safe_media($1, $2, image: false) }
 
           # Bold
           result = result.gsub(/<(?:strong|b)>(.*?)<\/(?:strong|b)>/mi) { "**#{$1}**" }
@@ -128,6 +146,15 @@ module Hwaro
 
         private def self.strip_tags(html : String) : String
           html.gsub(/<[^>]*>/, "")
+        end
+
+        # Emit a markdown link/image only when the URL scheme is safe; otherwise
+        # drop the URL and keep just the text/alt. Reuses the single source of
+        # truth for URL-scheme sanitisation so imported content can never carry
+        # a live `javascript:`/`vbscript:`/`file:`/non-image-`data:` reference.
+        private def self.safe_media(url : String, text : String, image : Bool) : String
+          return text unless Hwaro::Content::Processors::InlineMarkdown.safe_url?(url)
+          image ? "![#{text}](#{url})" : "[#{text}](#{url})"
         end
 
         private def self.decode_html_entities(text : String) : String

--- a/src/services/importers/wordpress_importer.cr
+++ b/src/services/importers/wordpress_importer.cr
@@ -89,19 +89,40 @@ module Hwaro
           node.children.each { |child| collect_items(child, items, depth + 1) }
         end
 
-        # True when the XML declares one or more entities in a DOCTYPE internal
-        # subset (`<!DOCTYPE ... [ <!ENTITY ... > ]>`). Scoped to the internal
-        # subset so a post that merely *mentions* the text "<!ENTITY" in its
-        # CDATA body is not a false positive. Linear-time (negated char
-        # classes only — no catastrophic backtracking on the guard itself).
+        # True when the XML declares one or more entities in its DOCTYPE
+        # (`<!DOCTYPE ... [ <!ENTITY ... > ]>`). We extract the full DOCTYPE
+        # declaration, skipping quoted SYSTEM/PUBLIC literals and tracking the
+        # `[ ... ]` internal subset so the terminating `>` is the real one, then
+        # scan only that span for `<!ENTITY`. Scoping to the DOCTYPE span (a)
+        # closes a bypass where a `]` inside a SYSTEM literal would truncate a
+        # naive `[`-to-`]` search, and (b) avoids false positives on `<!ENTITY`
+        # text in a post body, which lives after the DOCTYPE. DOCTYPE sits at
+        # the top of the file, so a bounded window keeps the scan cheap and
+        # linear.
         private def declares_xml_entities?(xml : String) : Bool
-          doctype = xml.index(/<!DOCTYPE/i)
-          return false unless doctype
-          window = xml[doctype, Math.min(xml.size - doctype, 1 << 16)]
-          open_bracket = window.index('[')
-          return false unless open_bracket
-          close = window.index(']', open_bracket) || window.size
-          window[open_bracket, close - open_bracket].matches?(/<!ENTITY/i)
+          start = xml.index(/<!DOCTYPE/i)
+          return false unless start
+
+          window = xml[start, 1 << 16]
+          in_quote : Char? = nil
+          depth = 0
+          doctype = String.build do |io|
+            window.each_char do |c|
+              io << c
+              if q = in_quote
+                in_quote = nil if c == q
+              elsif c == '"' || c == '\''
+                in_quote = c
+              elsif c == '['
+                depth += 1
+              elsif c == ']'
+                depth -= 1 if depth > 0
+              elsif c == '>' && depth == 0
+                break
+              end
+            end
+          end
+          doctype.matches?(/<!ENTITY/i)
         end
 
         CONTENT_NS = "http://purl.org/rss/1.0/modules/content/"

--- a/src/services/importers/wordpress_importer.cr
+++ b/src/services/importers/wordpress_importer.cr
@@ -21,6 +21,22 @@ module Hwaro
           end
 
           xml_content = File.read(wxr_path)
+
+          # Guard against XML entity-expansion / recursive-entity DoS. A
+          # malicious WXR can declare nested internal entities (e.g.
+          # `<!ENTITY a "&b;&b;">`); libxml2 (with NOENT off, NONET on — the
+          # Crystal default, so no XXE file-read/SSRF) still materialises a
+          # deeply nested / cyclic entity-reference node tree, and our recursive
+          # `collect_items` walk then overflows the stack (a fatal, unrescuable
+          # signal). Legitimate WordPress exports never declare custom entities,
+          # so refuse any WXR whose DOCTYPE internal subset declares one.
+          if declares_xml_entities?(xml_content)
+            return ImportResult.new(
+              success: false,
+              message: "WXR file declares XML entities (<!ENTITY> in DOCTYPE), which is unsupported and unsafe. Aborting import."
+            )
+          end
+
           doc = XML.parse(xml_content)
 
           imported = 0
@@ -59,11 +75,33 @@ module Hwaro
           items
         end
 
-        private def collect_items(node : XML::Node, items : Array(XML::Node))
+        # Maximum node depth for the item-collection walk. A real WXR nests
+        # only a handful of levels (rss > channel > item > field); a cap this
+        # generous never trips on legitimate input but stops a pathologically
+        # deep node tree from overflowing the stack.
+        MAX_NODE_DEPTH = 256
+
+        private def collect_items(node : XML::Node, items : Array(XML::Node), depth : Int32 = 0)
+          return if depth > MAX_NODE_DEPTH
           if node.element? && node.name == "item"
             items << node
           end
-          node.children.each { |child| collect_items(child, items) }
+          node.children.each { |child| collect_items(child, items, depth + 1) }
+        end
+
+        # True when the XML declares one or more entities in a DOCTYPE internal
+        # subset (`<!DOCTYPE ... [ <!ENTITY ... > ]>`). Scoped to the internal
+        # subset so a post that merely *mentions* the text "<!ENTITY" in its
+        # CDATA body is not a false positive. Linear-time (negated char
+        # classes only — no catastrophic backtracking on the guard itself).
+        private def declares_xml_entities?(xml : String) : Bool
+          doctype = xml.index(/<!DOCTYPE/i)
+          return false unless doctype
+          window = xml[doctype, Math.min(xml.size - doctype, 1 << 16)]
+          open_bracket = window.index('[')
+          return false unless open_bracket
+          close = window.index(']', open_bracket) || window.size
+          window[open_bracket, close - open_bracket].matches?(/<!ENTITY/i)
         end
 
         CONTENT_NS = "http://purl.org/rss/1.0/modules/content/"

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -934,7 +934,7 @@ module Hwaro
                 for (var j = 0; j < results.length; j++) {
                   var r = results[j].item;
                   var snippet = getSnippet(r.content, query.trim());
-                  html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+                  html += '<a class="search-result-item" href="' + encodeURI(r.url) + '" data-index="' + j + '">'
                     + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
                     + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
                     + '</a>';

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -1232,7 +1232,7 @@ module Hwaro
                 for (var j = 0; j < results.length; j++) {
                   var r = results[j].item;
                   var snippet = getSnippet(r.content, query.trim());
-                  html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+                  html += '<a class="search-result-item" href="' + encodeURI(r.url) + '" data-index="' + j + '">'
                     + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
                     + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
                     + '</a>';

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -1004,7 +1004,7 @@ module Hwaro
                 for (var j = 0; j < results.length; j++) {
                   var r = results[j].item;
                   var snippet = getSnippet(r.content, query.trim());
-                  html += '<a class="search-result-item" href="' + r.url + '" data-index="' + j + '">'
+                  html += '<a class="search-result-item" href="' + encodeURI(r.url) + '" data-index="' + j + '">'
                     + '<div class="search-result-title">' + highlightMatch(r.title, query.trim()) + '</div>'
                     + '<div class="search-result-snippet">' + highlightMatch(snippet, query.trim()) + '</div>'
                     + '</a>';

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -100,19 +100,49 @@ module Hwaro
     class DevCorsHandler
       include HTTP::Handler
 
+      # Allowed CORS origin hosts: loopback literals plus the host the server
+      # was bound to (when it's concrete, not a 0.0.0.0/:: wildcard).
+      def initialize(@allowed_hosts : Set(String) = Set{"localhost", "127.0.0.1", "::1"})
+      end
+
       def call(context)
-        context.response.headers["Access-Control-Allow-Origin"] = "*"
+        allowed_origin = allowed_cors_origin(context.request.headers["Origin"]?)
+        if allowed_origin
+          context.response.headers["Access-Control-Allow-Origin"] = allowed_origin
+          context.response.headers["Vary"] = "Origin"
+        end
 
         if context.request.method == "OPTIONS"
-          requested_headers = context.request.headers["Access-Control-Request-Headers"]?
-          context.response.headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
-          context.response.headers["Access-Control-Allow-Headers"] = requested_headers || "*"
-          context.response.headers["Access-Control-Max-Age"] = "86400"
+          if allowed_origin
+            requested_headers = context.request.headers["Access-Control-Request-Headers"]?
+            context.response.headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
+            context.response.headers["Access-Control-Allow-Headers"] = requested_headers || "*"
+            context.response.headers["Access-Control-Max-Age"] = "86400"
+          end
           context.response.status_code = 204
           return
         end
 
         call_next(context)
+      end
+
+      # Reflect the request Origin only when its host is a loopback literal or
+      # the exact host the dev server was bound to. Returns nil for any other
+      # origin so the browser's default same-origin policy applies — an
+      # arbitrary website the developer visits can no longer cross-origin read
+      # served content (e.g. `--drafts`). This keeps the legitimate
+      # localhost-vs-127.0.0.1 fetch() ergonomic while denying internet/LAN
+      # origins the blanket `*` previously granted.
+      private def allowed_cors_origin(origin : String?) : String?
+        return unless origin
+        host = begin
+          URI.parse(origin).host
+        rescue
+          nil
+        end
+        return unless host
+        host = host[1..-2] if host.starts_with?('[') && host.ends_with?(']')
+        @allowed_hosts.includes?(host) ? origin : nil
       end
     end
 
@@ -413,14 +443,21 @@ module Hwaro
 
         output_dir = sanitize_output_dir(build_options.output_dir)
 
+        # Loopback literals plus the concrete bound host (a 0.0.0.0/:: wildcard
+        # bind has no single host, so it contributes nothing here). The
+        # DevCorsHandler reflects a request Origin only when its host is in
+        # this set.
+        cors_hosts = Set{"localhost", "127.0.0.1", "::1"}
+        cors_hosts << host unless host.empty? || host == "0.0.0.0" || host == "::"
+
         handlers = [] of HTTP::Handler
         handlers << HTTP::LogHandler.new if access_log
-        # Set CORS headers first so they apply to every downstream response,
-        # including 301 redirects from IndexRewriteHandler and 404s from
-        # NotFoundHandler. Without this, opening the site via `localhost`
-        # while base_url is baked as `127.0.0.1` (or vice versa) makes
-        # browser fetch() calls fail same-origin checks.
-        handlers << DevCorsHandler.new
+        # Reflect CORS for loopback/bound origins first so it applies to every
+        # downstream response, including 301 redirects from IndexRewriteHandler
+        # and 404s from NotFoundHandler. This preserves the localhost-vs-
+        # 127.0.0.1 fetch() ergonomic without granting arbitrary websites
+        # cross-origin read access (the old blanket `*`).
+        handlers << DevCorsHandler.new(cors_hosts)
         # Run before StaticFileHandler so we can append `; charset=utf-8`
         # to text-shaped Content-Type headers after the static handler
         # sets them — Crystal's `HTTP::Server::Response` buffers the

--- a/src/utils/redirect_html.cr
+++ b/src/utils/redirect_html.cr
@@ -4,6 +4,8 @@
 # meta refresh tags, canonical links, and JavaScript fallbacks.
 
 require "html"
+require "./logger"
+require "../content/processors/inline_markdown"
 
 module Hwaro
   module Utils
@@ -18,6 +20,16 @@ module Hwaro
       #   # => "<!DOCTYPE html>..."
       #
       def full_redirect(url : String) : String
+        # `redirect_to` is read verbatim from page front matter (semi-trusted:
+        # a docs/blog PR contributor controls it). HTML-escaping alone keeps a
+        # `javascript:` scheme intact, so the emitted `<a href>` would execute
+        # script on click — stored XSS in published output. Reject dangerous
+        # schemes outright and emit an inert notice instead of a live link.
+        unless Hwaro::Content::Processors::InlineMarkdown.safe_url?(url)
+          Logger.warn "Refusing redirect to unsafe URL scheme: #{url.inspect}"
+          return blocked_redirect(url)
+        end
+
         html_escaped_url = TextUtils.escape_xml(url)
         # For JavaScript context: escape backslashes, quotes, newlines, and </script>
         js_escaped_url = url
@@ -41,6 +53,25 @@ module Hwaro
           <body>
             <p>Redirecting to <a href="#{html_escaped_url}">#{html_escaped_url}</a>...</p>
             <script>window.location.href = "#{js_escaped_url}";</script>
+          </body>
+          </html>
+          HTML
+      end
+
+      # Inert page shown when `redirect_to` carries an unsafe URL scheme. No
+      # meta-refresh, no `window.location`, no clickable link — just escaped
+      # text so the dangerous URL can never execute or auto-navigate.
+      private def blocked_redirect(url : String) : String
+        escaped_url = TextUtils.escape_xml(url)
+        <<-HTML
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="utf-8">
+            <title>Redirect blocked</title>
+          </head>
+          <body>
+            <p>This page was configured to redirect to a URL with an unsupported scheme, so the redirect was blocked: #{escaped_url}</p>
           </body>
           </html>
           HTML


### PR DESCRIPTION
## Summary

A multi-agent security audit (8 threat dimensions: dev-server, path/file safety, command exec, importers, output-XSS, template-SSTI, ReDoS/DoS, native/secrets — each finding adversarially re-verified against the project trust model) surfaced a set of confirmed issues. This PR fixes them. Every fix has a regression spec; full suite is green and ameba is clean.

Trust model used: `config.toml`/`templates/` are **trusted** (hooks already run arbitrary code by design); `content/*.md` is **semi-trusted** (docs/blog PR contributors); the `hwaro serve` dev server is **network-facing/untrusted**; `hwaro tool import` consumes **untrusted** third-party exports; generated output is **published**.

## Fixes

### HIGH
- **Importer path traversal → arbitrary file write** (`importers/base.cr`, `wordpress_importer.cr`, `hugo_importer.cr`). The raw WordPress `<wp:post_name>` and raw Hugo front-matter `slug` flowed into `File.write` with no containment check, so a malicious export with `slug = "../../../etc/x"` could plant/overwrite files outside the output dir. Added a single guard at the common sink `Base#write_content_file`: collapse the slug to a safe basename, sanitise the section, and verify `OutputGuard.within_output_dir?` before writing — this covers every current and future importer.
- **Stored XSS in the published search UI** (scaffolds `blog.cr`/`docs.cr`/`book.cr`). The search-result renderer inserted `r.url` — derived from author-controlled `path`/`slug` front matter — into an `innerHTML` href **without escaping** (title/snippet were escaped, the URL was not). A contributor could land `path = '"><img src=x onerror=...>'` in the index for site-wide stored XSS. The URL is now passed through `encodeURI` before insertion.

### MEDIUM
- **`redirect_to` `javascript:` XSS** (`utils/redirect_html.cr`). `redirect_to` was HTML-escaped but its scheme was never validated, so `javascript:…` survived into a clickable `<a href>` (stored XSS on click). Now validated via `InlineMarkdown.safe_url?`; unsafe schemes render an inert "redirect blocked" notice (no href, meta-refresh, or `window.location`).
- **`html_to_markdown` preserved dangerous URL schemes** (`importers/html_to_markdown.cr`). Imported `javascript:`/non-image `data:` href/src became **live** links because `markdown.safe` defaults to `false`. The importer now drops unsafe-scheme URLs at import time (keeping the link text/alt), making it safe regardless of the renderer flag.
- **WordPress XML entity-expansion DoS** (`wordpress_importer.cr`). A tiny crafted WXR with nested DOCTYPE entity declarations made libxml2 build a deep/cyclic node tree that overflowed the recursive `collect_items` walk (a fatal, unrescuable signal). We now reject WXR that declares entities in its DOCTYPE internal subset and bound the walk depth. (Classic XXE file-read/SSRF is **not** reachable — Crystal's `XML.parse` default is `NOENT` off, `NONET` on.)

### LOW
- **Dev-server blanket CORS** (`server/server.cr`). `Access-Control-Allow-Origin: *` was emitted on every response, letting any website the developer visits cross-origin-read served content (including `--drafts`). Now reflects the request `Origin` (with `Vary: Origin`) **only** when its host is a loopback literal or the bound host — this preserves the `localhost`↔`127.0.0.1` fetch() ergonomic while denying arbitrary internet/LAN origins.
- **Deadlink-checker terminal-escape injection** (`tool/deadlink_command.cr`). Content-derived URLs/paths were printed to the maintainer's terminal verbatim; a link carrying raw ANSI/control bytes could repaint or spoof the report. Control bytes are now stripped before logging.

## Audited and confirmed safe (no change)
Command execution (uses `shell_escape`/array-form; only config-sourced data reaches a shell), `search.json`/feeds/sitemap/JSON-LD/OG escaping, Crinja (markdown content is **not** compiled as a template → no SSTI), and the stb image C bindings (overflow/null-pointer guards present).

The WS live-reload DNS-rebinding finding (LOW; the socket carries only `reload`/`error` control messages, never page content) was intentionally left as-is: a strict Host allowlist would break legitimate custom-hostname live-reload (`mysite.local → 127.0.0.1`), which the existing tests encode as intended behaviour.

## Testing
- `crystal spec` — 5456 examples, 0 failures
- `crystal tool format` — clean
- `./bin/ameba` — 373 inspected, 0 failures
- `crystal build src/main.cr` — builds