### PR TITLE
fix: discovery-surface consistency (llms page-bundle, search render filter, strip_html raw-text)

### DIFF
--- a/spec/unit/llms_spec.cr
+++ b/spec/unit/llms_spec.cr
@@ -153,6 +153,55 @@ describe Hwaro::Content::Seo::Llms do
       end
     end
 
+    # Regression: page-bundle leaves (`foo/bar/index.md`) are `Models::Page`
+    # with `is_index == true`, indistinguishable from a section `_index.md`
+    # by `is_index` alone. The listing filter keyed off `is_index`, so on a
+    # site built entirely from page bundles (the dominant Hugo/Zola layout)
+    # every content page was dropped and llms.txt listed only the home page.
+    # Distinguish by type (`Models::Section`) instead.
+    it "lists page-bundle leaves and folds only section indexes into headings" do
+      config = Hwaro::Models::Config.new
+      config.llms.enabled = true
+      config.title = "Bundles"
+      config.base_url = "https://example.com"
+
+      home = Hwaro::Models::Section.new("_index.md")
+      home.title = "Home"
+      home.url = "/"
+      home.section = ""
+      home.is_index = true
+
+      blog_idx = Hwaro::Models::Section.new("blog/_index.md")
+      blog_idx.title = "Blog"
+      blog_idx.url = "/blog/"
+      blog_idx.section = "blog"
+      blog_idx.is_index = true
+
+      # page-bundle leaf: a real content page, NOT a section
+      post = Hwaro::Models::Page.new("blog/hello-world/index.md")
+      post.title = "Hello World"
+      post.url = "/blog/hello-world/"
+      post.section = "blog"
+      post.is_index = true
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Llms.generate(config, [home, blog_idx, post], output_dir)
+
+        content = File.read(File.join(output_dir, "llms.txt"))
+        # Section heading comes from the section's _index.md, not the leaf.
+        content.should contain("## Blog\n")
+        content.should_not contain("## Hello World")
+        # The page-bundle leaf is listed (this is the regression).
+        content.should contain("- [Hello World](https://example.com/blog/hello-world/)")
+        # The section index itself is folded into the heading, not listed.
+        content.should_not contain("- [Blog](https://example.com/blog/)")
+        # The root _index.md (a Section with empty section) stays as the home
+        # page under "Pages".
+        content.should contain("## Pages\n")
+        content.should contain("- [Home](https://example.com/)")
+      end
+    end
+
     it "skips drafts, hidden, and generated pages from the index" do
       config = Hwaro::Models::Config.new
       config.llms.enabled = true

--- a/spec/unit/search_spec.cr
+++ b/spec/unit/search_spec.cr
@@ -62,6 +62,37 @@ describe Hwaro::Content::Search do
       end
     end
 
+    # Regression: a section index with `render = false` emits no HTML, so a
+    # search hit pointing at its URL 404s. The search index must apply the
+    # same `render` filter that sitemap.cr / feeds.cr / llms.cr already do.
+    it "excludes render=false pages from search index" do
+      config = Hwaro::Models::Config.new
+      config.search.enabled = true
+      config.search.fields = ["title", "url"]
+
+      rendered = Hwaro::Models::Page.new("guide/intro.md")
+      rendered.title = "Intro"
+      rendered.url = "/guide/intro/"
+      rendered.draft = false
+      rendered.raw_content = "Content"
+
+      not_rendered = Hwaro::Models::Page.new("guide/_index.md")
+      not_rendered.title = "Guide"
+      not_rendered.url = "/guide/"
+      not_rendered.draft = false
+      not_rendered.render = false
+      not_rendered.raw_content = "Section container"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Search.generate([rendered, not_rendered], config, output_dir)
+
+        content = File.read(File.join(output_dir, "search.json"))
+        content.should contain("/guide/intro/")
+        content.should_not contain("\"/guide/\"")
+        content.should_not contain("Guide")
+      end
+    end
+
     it "excludes pages matching exclude patterns" do
       config = Hwaro::Models::Config.new
       config.search.enabled = true

--- a/spec/unit/text_utils_spec.cr
+++ b/spec/unit/text_utils_spec.cr
@@ -263,6 +263,39 @@ describe Hwaro::Utils::TextUtils do
       # so bare > in text gets consumed as a tag boundary
       Hwaro::Utils::TextUtils.strip_html("a > b").should eq("a b")
     end
+
+    # Raw-text elements: <style>/<script> bodies are code, not display text,
+    # and must be dropped along with their tags. Otherwise the CSS/JS source
+    # leaks into search indexes, feed summaries, and excerpts.
+    it "drops <style> element bodies, keeping surrounding text" do
+      input = "<style>.gallery { display: grid; gap: 10px; }</style><p>Real text</p>"
+      Hwaro::Utils::TextUtils.strip_html(input).should eq("Real text")
+    end
+
+    it "drops <script> element bodies, keeping surrounding text" do
+      input = "<p>Before</p><script>console.log(\"x\"); var y = 1;</script><p>After</p>"
+      Hwaro::Utils::TextUtils.strip_html(input).should eq("Before After")
+    end
+
+    it "drops multi-line and attributed <style>/<script> blocks" do
+      input = <<-HTML
+        <style type="text/css">
+          .a { color: red; }
+          .b { color: blue; }
+        </style>
+        <h1>Heading</h1>
+        <script src="x.js">
+          if (a < b) { doThing(); }
+        </script>
+        Tail
+        HTML
+      Hwaro::Utils::TextUtils.strip_html(input).should eq("Heading Tail")
+    end
+
+    it "is case-insensitive for raw-text element names" do
+      input = "<STYLE>.x{}</STYLE><p>Kept</p><SCRIPT>bad()</SCRIPT>"
+      Hwaro::Utils::TextUtils.strip_html(input).should eq("Kept")
+    end
   end
 
   describe ".cjk_char?" do

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -21,8 +21,14 @@ module Hwaro
           end
         end
 
-        # Filter out draft pages and pages with in_search_index = false
-        search_pages = pages.reject { |p| p.draft || !p.in_search_index }
+        # Filter out drafts, pages opted out of the index, and `render = false`
+        # pages. The `render` check keeps the search index in lockstep with the
+        # set of pages that actually emit HTML — the same guard sitemap.cr,
+        # feeds.cr, and llms.cr already apply. Without it, a section index with
+        # `render = false` (a common "navigation container, no landing page"
+        # pattern) is indexed even though no HTML is written for it, so the
+        # search hit 404s when clicked.
+        search_pages = pages.reject { |p| p.draft || !p.in_search_index || !p.render }
 
         # Deduplicate by URL (keep last occurrence, matching build behavior)
         seen_urls = Set(String).new

--- a/src/content/seo/llms.cr
+++ b/src/content/seo/llms.cr
@@ -1,5 +1,6 @@
 require "../../models/config"
 require "../../models/page"
+require "../../models/section"
 require "../../utils/logger"
 
 module Hwaro
@@ -57,23 +58,30 @@ module Hwaro
 
           eligible = pages.select { |p| p.render && !p.draft && p.in_search_index && !p.generated }
 
-          # Group by section, keyed by display heading. Section index
-          # pages double as the section's heading source — find the
-          # corresponding `_index.md` (`is_index && section.match`) and
-          # use its title; fall back to the section directory's basename.
+          # Group by section, keyed by display heading. A section's heading
+          # comes from its `_index.md`, which is the only page modeled as a
+          # `Models::Section`. Key off the *type*, NOT `is_index`: a
+          # page-bundle leaf (`foo/bar/index.md`) is also `is_index == true`,
+          # so testing `is_index` here let an arbitrary leaf's title clobber
+          # the section heading.
           headings = {} of String => String
           eligible.each do |p|
-            next unless p.is_index
+            next unless p.is_a?(Models::Section)
             next if p.section.empty?
             headings[p.section] = p.title unless p.title.empty? || p.title == "Untitled"
           end
 
-          # Section-level `_index.md` pages are folded into the section
-          # heading, so they don't need their own listing. Root-level
-          # `index.md` (the home page) has nowhere else to live, so it
-          # stays in the listing under "Pages".
+          # Fold section-level `_index.md` pages (a `Models::Section` with a
+          # non-empty section) into their heading, so they don't get their own
+          # listing. Everything else stays listed — in particular page-bundle
+          # leaves (`foo/index.md`), which are `Models::Page` with
+          # `is_index == true`: they are real content pages. Filtering on
+          # `is_index` here dropped every page-bundle leaf and left only the
+          # home page(s). The root `_index.md` (a `Models::Section` with an
+          # empty section) is the home page and has nowhere else to live, so
+          # the `!section.empty?` guard keeps it under "Pages".
           by_section = eligible
-            .reject { |p| p.is_index && !p.section.empty? }
+            .reject { |p| p.is_a?(Models::Section) && !p.section.empty? }
             .group_by(&.section)
 
           String.build do |str|

--- a/src/utils/text_utils.cr
+++ b/src/utils/text_utils.cr
@@ -164,12 +164,26 @@ module Hwaro
         false
       end
 
+      # Raw-text HTML elements whose *content* is code, not display text.
+      # `<style>`/`<script>` bodies must be dropped along with their tags;
+      # otherwise the CSS/JS source survives tag-stripping and pollutes
+      # search indexes, feed summaries, and excerpts (a page with an inline
+      # `<style>` gallery block had its whole search entry replaced by CSS).
+      # `[\s\S]` matches across newlines (CSS/JS span multiple lines) without
+      # relying on a dotall flag; `\1` ties the close tag to the open tag.
+      # A self-closing or unterminated tag won't match and is left to the
+      # tag stripper below.
+      RAW_TEXT_ELEMENT = /<(script|style)(?:\s[^>]*)?>[\s\S]*?<\/\1\s*>/i
+
       # Strip HTML tags from text (single-pass)
       #
       # Example:
       #   strip_html("<p>Hello <b>World</b></p>")  # => "Hello World"
       #
       def strip_html(text : String) : String
+        # Remove raw-text element bodies (<style>/<script>) before stripping
+        # tags so their CSS/JS contents don't leak through as "text".
+        text = text.gsub(RAW_TEXT_ELEMENT, " ")
         String.build(text.bytesize) do |io|
           in_tag = false
           last_was_space = true # suppress leading space


### PR DESCRIPTION
## Summary

Three correctness bugs surfaced by dogfooding the `justfile` friend sites (`noir`, `termisu`, `chei-l`) with the v0.15.3 binary. All three are *discovery-surface* inconsistencies — the generated `llms.txt` / `search.json` disagreeing with the set of pages hwaro actually emits. Each site builds green (exit 0); the bugs live in the output.

### 1. `llms.txt` drops every page-bundle content page (High)
`build_index` keyed the "fold section index into a heading" logic off `is_index`. But a **page-bundle leaf** (`foo/bar/index.md`) is also `is_index == true`, so on a site built entirely from page bundles (the dominant Hugo/Zola layout) **every content page was rejected** and only the home page survived.
- noir: `llms.txt` listed **2 of 130** pages.
- Fix: distinguish a true section `_index.md` (`Models::Section`) from a leaf by **type**, keeping the `!section.empty?` guard so a root `_index.md` home page (a `Section` with empty section) still appears under `## Pages`.
- This mirrors the same `is_index`-vs-`Models::Section` fix already applied to `og:type` in `render.cr` (gh#601).
- After: noir `llms.txt` **2 → 102** entries (section headings + EN/KO home preserved, Korean entries intact).

### 2. `search.json` indexes `render = false` pages → 404 search hits (Medium)
The search filter rejected `draft` / `!in_search_index` but **not** `render`. A section index with `render = false` (a common "navigation container, no landing page" pattern) was indexed even though no HTML is written for it, so clicking the search result 404s.
- termisu: 3 of 21 entries (`/guide/`, `/getting-started/`, `/reference/`) were dead.
- Fix: add the `!p.render` guard that `sitemap.cr`, `feeds.cr`, and `llms.cr` already apply.
- After: termisu search **21 → 18** entries, no phantom URLs.

### 3. `strip_html` leaks `<style>`/`<script>` bodies into search/feeds/excerpts (Medium)
`strip_html` removed tags but not the **content** of raw-text elements, so CSS/JS source survived as "text".
- chei-l: `/games/`, `/drawings/`, `/ai_drawings/` search entries were **pure CSS** instead of page text. The same shared helper backs feed summaries and excerpts.
- Fix: drop `<style>`/`<script>` element bodies (case-insensitive, multi-line) before stripping tags.
- After: chei-l `/games/` no longer indexed as CSS; prose pages (incl. CJK) keep their content.

## Testing
- Added regression specs to `llms_spec`, `search_spec`, `text_utils_spec`.
- Full suite: **5465 examples, 0 failures**; `ameba` + `crystal tool format --check` clean.
- Re-verified every fix against the actual friend-site output.

## Notes
Found during a broader friends-site audit; the remaining medium/low findings (taxonomy pages missing from sitemap/feeds, bundle-asset `[content.files]` bypass, RSS full-content relative links, CJK OG tofu, empty-`base_url` handling) are intentionally left for follow-up PRs.

No linked issues — these were newly discovered.