### PR TITLE
fix: feeds & base_url robustness (absolutize content, taxonomy feeds, RSS link)

### DIFF
--- a/spec/unit/feeds_spec.cr
+++ b/spec/unit/feeds_spec.cr
@@ -1364,8 +1364,44 @@ describe Hwaro::Content::Seo::Feeds do
       )
 
       rss.should contain("<title>My Blog</title>")
-      rss.should contain("<link>https://example.com</link>")
+      # Channel <link> ends with "/" to match the homepage canonical.
+      rss.should contain("<link>https://example.com/</link>")
       rss.should contain("<description>A developer blog</description>")
+    end
+
+    # Regression (#10/#11): with an empty base_url the channel <link> must not
+    # be an empty (invalid) element — it falls back to "/" (site root).
+    it "emits a non-empty channel link when base_url is empty" do
+      config = Hwaro::Models::Config.new
+      config.base_url = ""
+      config.title = "My Blog"
+
+      rss = Hwaro::Content::Seo::Feeds.generate_rss(
+        [] of Hwaro::Models::Page, config, "rss.xml", false, "My Blog", ""
+      )
+
+      rss.should contain("<link>/</link>")
+      rss.should_not contain("<link></link>")
+    end
+
+    # Regression (#6): full_content feed bodies must absolutize relative links
+    # so readers (which resolve content out of page context) don't break them.
+    it "absolutizes relative links in <content:encoded> against the page URL" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+      config.feeds.full_content = true
+
+      page = Hwaro::Models::Page.new("guide/config.md")
+      page.title = "Config"
+      page.url = "/guide/config/"
+      page.content = %(<p><a href="../quick-start/">start</a> <img src="/img/a.png"/></p>)
+
+      rss = Hwaro::Content::Seo::Feeds.generate_rss(
+        [page], config, "rss.xml", false, "Blog", ""
+      )
+
+      rss.should contain("https://example.com/guide/quick-start/")
+      rss.should contain("https://example.com/img/a.png")
     end
 
     it "includes self-referencing atom:link" do
@@ -1798,8 +1834,9 @@ describe Hwaro::Content::Seo::Feeds do
       )
 
       atom.should contain("<title>My Feed</title>")
-      atom.should contain("<link href=\"https://example.com\"")
-      atom.should contain("<id>https://example.com</id>")
+      # Atom alternate <link>/<id> end with "/" to match the homepage canonical.
+      atom.should contain("<link href=\"https://example.com/\"")
+      atom.should contain("<id>https://example.com/</id>")
       atom.should contain("<subtitle>Feed description</subtitle>")
       atom.should contain("<updated>")
     end

--- a/spec/unit/internal_link_resolver_spec.cr
+++ b/spec/unit/internal_link_resolver_spec.cr
@@ -169,4 +169,29 @@ describe Hwaro::Content::Processors::InternalLinkResolver do
       ).should eq %(<a href="/a/b/guide/intro/">Intro</a>)
     end
   end
+
+  describe ".absolutize_links" do
+    it "absolutizes document-relative and root-relative links against the page URL" do
+      html = %(<a href="../quick-start/">q</a> <img src="/img/a.png"/> <a href="./sub/">s</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.absolutize_links(
+        html, "https://h.com/guide/config/"
+      )
+      result.should contain(%(href="https://h.com/guide/quick-start/"))
+      result.should contain(%(src="https://h.com/img/a.png"))
+      result.should contain(%(href="https://h.com/guide/config/sub/"))
+    end
+
+    it "leaves absolute, protocol-relative, scheme, and anchor links untouched" do
+      html = %(<a href="https://ext.com/x">e</a> <a href="//cdn.com/y">c</a> <a href="mailto:a@b.com">m</a> <a href="#sec">s</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.absolutize_links(
+        html, "https://h.com/p/"
+      )
+      result.should eq(html)
+    end
+
+    it "is a no-op when the page URL has no host (empty base_url deploy)" do
+      html = %(<a href="../x/">x</a>)
+      Hwaro::Content::Processors::InternalLinkResolver.absolutize_links(html, "/p/").should eq(html)
+    end
+  end
 end

--- a/spec/unit/taxonomies_spec.cr
+++ b/spec/unit/taxonomies_spec.cr
@@ -15,6 +15,35 @@ describe Hwaro::Content::Taxonomies do
       end
     end
 
+    # Regression (#7): per-taxonomy feeds (feed = true) must still be emitted
+    # when base_url is empty — like the main/section feeds, which emit with
+    # relative URLs — instead of being silently dropped.
+    it "emits per-taxonomy feeds even when base_url is empty" do
+      config = Hwaro::Models::Config.new
+      config.base_url = ""
+      tax = Hwaro::Models::TaxonomyConfig.new("tags")
+      tax.feed = true
+      config.taxonomies = [tax]
+
+      site = Hwaro::Models::Site.new(config)
+      page = Hwaro::Models::Page.new("post.md")
+      page.title = "Post"
+      page.url = "/blog/post/"
+      page.tags = ["crystal"]
+      page.draft = false
+      page.generated = false
+      site.pages = [page]
+
+      Dir.mktmpdir do |output_dir|
+        templates = {
+          "taxonomy"      => "<html>{{ content }}</html>",
+          "taxonomy_term" => "<html>{{ content }}</html>",
+        }
+        Hwaro::Content::Taxonomies.generate(site, output_dir, templates)
+        File.exists?(File.join(output_dir, "tags", "crystal", "rss.xml")).should be_true
+      end
+    end
+
     it "builds taxonomy index from pages" do
       config = Hwaro::Models::Config.new
       taxonomy_config = Hwaro::Models::TaxonomyConfig.new("tags")

--- a/src/content/processors/internal_link_resolver.cr
+++ b/src/content/processors/internal_link_resolver.cr
@@ -26,6 +26,12 @@ module Hwaro
         # also allows a bare `/` (the homepage link).
         ROOT_RELATIVE_ATTR_REGEX = /\b(href|src)="(\/(?:[^\/"][^"]*)?)"/
 
+        # Matches any href/src attribute value (relative or absolute).
+        ANY_LINK_ATTR_REGEX = /\b(href|src)="([^"]*)"/
+
+        # A URI scheme prefix (e.g. `https:`, `mailto:`, `tel:`, `data:`).
+        SCHEME_PREFIX_REGEX = /\A[a-zA-Z][a-zA-Z0-9+.\-]*:/
+
         # Resolve internal `@/` links in HTML to actual page URLs.
         #
         # - `html` — rendered HTML string
@@ -111,6 +117,53 @@ module Hwaro
           end
         rescue URI::Error
           html
+        end
+
+        # Make every relative href/src in `html` absolute against `page_url`
+        # (an absolute URL like "https://host/blog/post/").
+        #
+        # Feed bodies (RSS <content:encoded>, Atom <content>) are consumed out
+        # of the page's URL context, so document-relative ("../x/") and
+        # root-relative ("/img.svg") links must be absolutized — otherwise a
+        # reader resolves them against the feed/reader URL and they break.
+        # Absolute URLs, protocol-relative (`//host`), scheme links
+        # (`mailto:`/`tel:`/`data:`), and pure in-page anchors (`#x`) are left
+        # untouched. A no-op when `page_url` is not an absolute URL (no host
+        # to resolve against — e.g. an empty base_url deploy).
+        def absolutize_links(html : String, page_url : String) : String
+          return html if page_url.empty?
+          return html unless html.includes?("href=\"") || html.includes?("src=\"")
+
+          base = URI.parse(page_url)
+          return html if base.host.nil?
+
+          html.gsub(ANY_LINK_ATTR_REGEX) do |match|
+            attr = $1
+            value = $2
+            if value.empty? || absolute_or_anchor?(value)
+              match
+            else
+              begin
+                # `value` came from already-rendered HTML, so its entities
+                # (e.g. `&amp;` in a query) are escaped; URI#resolve preserves
+                # them literally, so re-escaping here would double-encode.
+                "#{attr}=\"#{base.resolve(value)}\""
+              rescue URI::Error
+                match
+              end
+            end
+          end
+        rescue URI::Error
+          html
+        end
+
+        # True for href/src values that must NOT be resolved against the page
+        # URL: absolute URLs (scheme:), protocol-relative (//host), and pure
+        # in-page anchors (#section).
+        private def absolute_or_anchor?(value : String) : Bool
+          value.starts_with?('#') ||
+            value.starts_with?("//") ||
+            value.matches?(SCHEME_PREFIX_REGEX)
         end
       end
     end

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -191,8 +191,25 @@ module Hwaro
         # points at the right page and carries a unique IRI (RFC 4287).
         private def self.feed_home_url(config : Models::Config, base_path : String) : String
           base_url = config.base_url.rstrip('/')
-          return base_url if base_path.empty?
+          # End with "/" so the channel <link> / Atom <id> match the homepage
+          # canonical (base_url + "/") and the per-language branch below. When
+          # base_url is empty this yields "/" rather than an empty (invalid)
+          # <link> element.
+          return "#{base_url}/" if base_path.empty?
           Utils::TextUtils.encode_url_path("#{base_url}/#{base_path.strip("/")}/")
+        end
+
+        # Absolutize feed-body links so RSS <content:encoded> / Atom <content>
+        # render correctly in readers (which consume the HTML out of the page's
+        # URL context). Falls back to the subpath-prefix pass when base_url is
+        # empty (no host to absolutize against).
+        private def self.absolutize_feed_html(html : String, page : Models::Page, config : Models::Config) : String
+          base_url = config.base_url.rstrip('/')
+          if base_url.empty?
+            Processors::InternalLinkResolver.prefix_root_relative_links(html, config.base_url)
+          else
+            Processors::InternalLinkResolver.absolutize_links(html, page_full_url(page, base_url))
+          end
         end
 
         # Build the full absolute URL for a page.
@@ -426,12 +443,12 @@ module Hwaro
         # (gh#526).
         private def self.full_content_for_feed(page : Models::Page, config : Models::Config) : String
           html = page.content.empty? ? Processor::Markdown.render_body_cached(page.raw_content) : page.content
-          # Defensive: on an incremental (--cache) build the render phase only
-          # rewrites base_path into page.content for pages it re-renders, so
-          # cached pages keep root-relative links. Re-apply here (idempotent —
-          # already-prefixed links are skipped) so the feed <content:encoded>
-          # stays subpath-correct regardless of cache state.
-          Processors::InternalLinkResolver.prefix_root_relative_links(html, config.base_url)
+          # Absolutize body links so <content:encoded> resolves out of page
+          # context (root-relative AND document-relative). On an incremental
+          # (--cache) build the render phase only rewrites links for pages it
+          # re-renders; doing it here keeps the feed correct regardless of
+          # cache state.
+          absolutize_feed_html(html, page, config)
         end
 
         # Collect taxonomy terms that should appear as `<category>`
@@ -497,11 +514,10 @@ module Hwaro
               text_content # Return plain text even if not truncated for consistency
             end
           else
-            # Full HTML (Atom <content type="html">). Apply the subpath prefix
-            # defensively (idempotent) so cached pages — whose page.content the
-            # render phase never rewrote — still emit subpath-correct links,
-            # matching full_content_for_feed on the RSS path.
-            Processors::InternalLinkResolver.prefix_root_relative_links(html_content, config.base_url)
+            # Full HTML (Atom <content type="html">). Absolutize body links so
+            # they resolve out of page context, matching full_content_for_feed
+            # on the RSS path.
+            absolutize_feed_html(html_content, page, config)
           end
         end
       end

--- a/src/content/seo/sitemap.cr
+++ b/src/content/seo/sitemap.cr
@@ -42,7 +42,7 @@ module Hwaro
           end
 
           if site.config.base_url.empty?
-            Logger.warn "base_url is empty. Sitemap will contain relative URLs instead of absolute URLs."
+            Logger.warn "base_url is empty. Sitemap, feeds, robots.txt, and SEO/social (canonical, og:url) URLs will use relative (or omitted) URLs instead of absolute ones. Set base_url for production deploys."
           end
 
           # Pre-compute config values once outside the loop

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -445,8 +445,9 @@ module Hwaro
         base_url : String,
         verbose : Bool = false,
       )
-        return if site.config.base_url.empty?
-
+        # No base_url guard: like the main and section feeds, taxonomy feeds
+        # emit with relative URLs when base_url is empty (the user opted in via
+        # `feed = true`) rather than being silently dropped.
         feed_output_dir = File.join(output_dir, base_url.lchop("/"))
         Hwaro::Utils::FileSafe.mkdir_p(feed_output_dir)
         feed_title = "#{site.config.title} - #{taxonomy.name.capitalize}: #{term}"


### PR DESCRIPTION
## Summary

Four feeds/base_url correctness bugs from the friends-site audit.

> **Stacked on #649** (base = `fix/taxonomy-registration-and-bundle-assets`, which touches `taxonomies.cr`/`search.cr`). Merge after #648 → #649, or retarget to `main` once they land.

### #6 — Feed full-content embedded relative links (Medium)
RSS `<content:encoded>` / Atom `<content>` embed the page's rendered HTML, but the only fixup (`prefix_root_relative_links`) **no-ops when `base_url` has an empty path** (custom-domain root, e.g. dalfox) and **never absolutizes document-relative (`../x/`) links**. Feed readers resolve content out of the page's URL context, so ~half the links broke.

**Fix:** new `InternalLinkResolver.absolutize_links` resolves every relative `href`/`src` against the page's absolute URL (Crystal `URI#resolve`). Feeds use it for full-content bodies when `base_url` is set (falls back to the subpath-prefix pass for empty `base_url`). Absolute / protocol-relative / scheme (`mailto:`…) / anchor links are left untouched. → dalfox `content:encoded` now has **0** relative links (`…/getting-started/quick-start/`).

### #7 — Per-taxonomy feeds dropped on empty base_url (Medium)
`generate_taxonomy_feed` had `return if base_url.empty?`, unlike the main/section feeds (which emit relative URLs). So `feed = true` taxonomies silently produced nothing. **Fix:** removed the guard. → chei-l now emits its **8** tag feeds.

### #10 — RSS channel `<link>` / Atom `<id>` missing trailing slash (Low)
On subpath/custom-domain sites the feed home URL was `…/noir` while the canonical is `…/noir/`. **Fix:** `feed_home_url` ends the empty-base_path home URL with `/`. → noir `<link>…/noir/</link>`.

### #11 — Empty base_url emitted an invalid empty `<link></link>` (Low)
The #10 fix makes it fall back to `/` (non-empty). Also broadened the sitemap's empty-`base_url` warning to note feeds/robots/SEO URLs degrade too. → chei-l `<link>/</link>`, no empty element.

## Testing
- Regression specs: `absolutize_links` (relative→absolute, leaves absolute/anchor/scheme, no-op without host); taxonomy feed with empty base_url; non-empty channel link on empty base_url; `content:encoded` absolutization.
- Updated two existing `generate_rss`/`generate_atom` assertions to the trailing-slash form (#10).
- Full suite: **5474 examples, 0 failures**; ameba + format clean. Re-verified against dalfox/chei-l/noir.

No linked issues — found during the audit.