### PR TITLE
fix: register taxonomy pages into SEO surfaces + honor [content.files] in bundle assets

### DIFF
--- a/spec/unit/page_methods_spec.cr
+++ b/spec/unit/page_methods_spec.cr
@@ -527,6 +527,48 @@ describe Hwaro::Models::Page do
         assets.should_not contain("blog/other.markdown")
       end
     end
+
+    # Regression: a root `_index.md` bundle scoops the whole content tree, so
+    # without honoring [content.files] it republished arbitrary non-md files
+    # (e.g. content/public/robots.txt -> public/public/robots.txt). When
+    # `allow_extensions` is set, bundle assets must obey the same allowlist.
+    it "honors [content.files] allow/disallow when content_files is enabled" do
+      Dir.mktmpdir do |dir|
+        page_dir = File.join(dir, "public")
+        FileUtils.mkdir_p(page_dir)
+        File.write(File.join(dir, "_index.md"), "# Home")
+        File.write(File.join(page_dir, "robots.txt"), "User-agent: *")
+        File.write(File.join(dir, "photo.png"), "fake png")
+
+        page = Hwaro::Models::Page.new("_index.md")
+        page.is_index = true
+
+        content_files = Hwaro::Models::ContentFilesConfig.new
+        content_files.allow_extensions = Hwaro::Models::ContentFilesConfig.normalize_extensions(["png"])
+
+        assets = page.collect_assets(dir, content_files)
+        assets.should contain("photo.png")
+        assets.should_not contain("public/robots.txt")
+      end
+    end
+
+    it "collects every non-md file when content_files is not configured" do
+      Dir.mktmpdir do |dir|
+        page_dir = File.join(dir, "bundle")
+        FileUtils.mkdir_p(page_dir)
+        File.write(File.join(page_dir, "index.md"), "# Test")
+        File.write(File.join(page_dir, "notes.txt"), "notes")
+        File.write(File.join(page_dir, "image.png"), "fake png")
+
+        page = Hwaro::Models::Page.new("bundle/index.md")
+        page.is_index = true
+
+        # Disabled config (no allow_extensions) must preserve legacy behavior.
+        assets = page.collect_assets(dir, Hwaro::Models::ContentFilesConfig.new)
+        assets.should contain("bundle/notes.txt")
+        assets.should contain("bundle/image.png")
+      end
+    end
   end
 end
 

--- a/spec/unit/search_spec.cr
+++ b/spec/unit/search_spec.cr
@@ -93,6 +93,36 @@ describe Hwaro::Content::Search do
       end
     end
 
+    # Regression: auto-generated listing pages (taxonomy index/term pages) are
+    # registered into all_pages so they reach the sitemap, but they should not
+    # pollute the search index — mirrors the `!generated` guard in llms.cr.
+    it "excludes generated pages from search index" do
+      config = Hwaro::Models::Config.new
+      config.search.enabled = true
+      config.search.fields = ["title", "url"]
+
+      real = Hwaro::Models::Page.new("post.md")
+      real.title = "Real Post"
+      real.url = "/post/"
+      real.draft = false
+      real.raw_content = "Content"
+
+      tag_page = Hwaro::Models::Page.new("tags/crystal/index.md")
+      tag_page.title = "Tags: crystal"
+      tag_page.url = "/tags/crystal/"
+      tag_page.draft = false
+      tag_page.generated = true
+      tag_page.raw_content = "listing"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Search.generate([real, tag_page], config, output_dir)
+
+        content = File.read(File.join(output_dir, "search.json"))
+        content.should contain("/post/")
+        content.should_not contain("/tags/crystal/")
+      end
+    end
+
     it "excludes pages matching exclude patterns" do
       config = Hwaro::Models::Config.new
       config.search.enabled = true

--- a/spec/unit/taxonomy_hooks_spec.cr
+++ b/spec/unit/taxonomy_hooks_spec.cr
@@ -17,7 +17,10 @@ describe Hwaro::Content::Hooks::TaxonomyHooks do
 
       taxonomy_hook = hooks.find { |h| h.name == "taxonomy:generate" }
       taxonomy_hook.should_not be_nil
-      taxonomy_hook.not_nil!.priority.should eq(40)
+      # Priority 60 so it runs before seo:generate / pwa:generate (priority 50)
+      # and the generated taxonomy pages are registered before the SEO
+      # generators read ctx.all_pages.
+      taxonomy_hook.not_nil!.priority.should eq(60)
     end
   end
 
@@ -57,6 +60,18 @@ describe Hwaro::Content::Hooks::TaxonomyHooks do
         # Verify output
         File.exists?(File.join(output_dir, "tags", "index.html")).should be_true
         File.exists?(File.join(output_dir, "tags", "crystal", "index.html")).should be_true
+
+        # Regression (#2): generated taxonomy pages must be registered into
+        # ctx.sections so the SEO generators (sitemap/feeds/search/llms) can
+        # see them. Without this, taxonomy.sitemap/feed had no effect.
+        tax_sections = ctx.sections.select(&.generated)
+        tax_urls = tax_sections.map(&.url)
+        tax_urls.should contain("/tags/")
+        tax_urls.should contain("/tags/crystal/")
+        # in_sitemap reflects taxonomy.sitemap (defaults to true), so these
+        # pages will be picked up by the sitemap generator.
+        ctx.sections.find! { |s| s.url == "/tags/" }.in_sitemap.should be_true
+        ctx.all_pages.map(&.url).should contain("/tags/crystal/")
       end
     end
 

--- a/src/content/hooks/taxonomy_hooks.cr
+++ b/src/content/hooks/taxonomy_hooks.cr
@@ -12,7 +12,12 @@ module Hwaro
         include Core::Lifecycle::Hookable
 
         def register_hooks(manager : Core::Lifecycle::Manager)
-          manager.on(Core::Lifecycle::HookPoint::BeforeGenerate, priority: 40, name: "taxonomy:generate") do |ctx|
+          # Priority 60 so this runs BEFORE seo:generate / pwa:generate (both
+          # priority 50). Hooks run highest-priority-first, so the taxonomy
+          # pages must be generated and registered here before the SEO
+          # generators read ctx.all_pages — otherwise the sitemap/feeds are
+          # written without them and taxonomy.sitemap/feed have no effect.
+          manager.on(Core::Lifecycle::HookPoint::BeforeGenerate, priority: 60, name: "taxonomy:generate") do |ctx|
             generate_taxonomies(ctx)
             Core::Lifecycle::HookResult::Continue
           end
@@ -22,7 +27,15 @@ module Hwaro
           site = ctx.site
           return unless site
 
-          Content::Taxonomies.generate(site, ctx.output_dir, ctx.templates, ctx.options.verbose)
+          sections = Content::Taxonomies.generate(site, ctx.output_dir, ctx.templates, ctx.options.verbose)
+          return if sections.empty?
+
+          # Register the generated taxonomy pages so the SEO generators include
+          # them. Reassign through the setter so the all_pages cache is
+          # invalidated. This intentionally augments ctx.sections only, leaving
+          # site.sections (and thus the PWA precache, which reads the Site)
+          # untouched.
+          ctx.sections = ctx.sections + sections
         end
       end
     end

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -21,14 +21,13 @@ module Hwaro
           end
         end
 
-        # Filter out drafts, pages opted out of the index, and `render = false`
-        # pages. The `render` check keeps the search index in lockstep with the
-        # set of pages that actually emit HTML — the same guard sitemap.cr,
-        # feeds.cr, and llms.cr already apply. Without it, a section index with
-        # `render = false` (a common "navigation container, no landing page"
-        # pattern) is indexed even though no HTML is written for it, so the
-        # search hit 404s when clicked.
-        search_pages = pages.reject { |p| p.draft || !p.in_search_index || !p.render }
+        # Filter out drafts, pages opted out of the index, `render = false`
+        # pages, and auto-generated pages (e.g. taxonomy index/term listings).
+        # The `render` check keeps the index in lockstep with the pages that
+        # actually emit HTML; the `generated` check mirrors llms.cr so
+        # navigational listing pages don't pollute search results. Both match
+        # the guards sitemap.cr / feeds.cr / llms.cr already apply.
+        search_pages = pages.reject { |p| p.draft || !p.in_search_index || !p.render || p.generated }
 
         # Deduplicate by URL (keep last occurrence, matching build behavior)
         seen_urls = Set(String).new

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -18,9 +18,9 @@ require "../content/pagination/renderer"
 module Hwaro
   module Content
     class Taxonomies
-      def self.generate(site : Models::Site, output_dir : String, templates : Hash(String, String), verbose : Bool = false)
+      def self.generate(site : Models::Site, output_dir : String, templates : Hash(String, String), verbose : Bool = false) : Array(Models::Section)
         config = site.config
-        return if config.taxonomies.empty?
+        return [] of Models::Section if config.taxonomies.empty?
 
         build_taxonomy_index(site)
 
@@ -53,7 +53,15 @@ module Hwaro
         if root_language && (default_cfg = config.languages[root_language]?)
           root_taxonomies = config.taxonomies.select { |t| default_cfg.taxonomies.includes?(t.name) }
         end
-        generate_taxonomies_for_language(root_taxonomies, site, output_dir, templates, builder, verbose, global_vars, language: root_language, lang_prefix: "")
+
+        # Collect every generated taxonomy index/term page (each a
+        # Models::Section) so the caller can register them into the page set
+        # the SEO generators read. Without this, taxonomy pages are written to
+        # disk but never reach the sitemap/feeds/search/llms inputs, so
+        # `taxonomy.sitemap` / `taxonomy.feed` had no effect.
+        collected = [] of Models::Section
+
+        generate_taxonomies_for_language(root_taxonomies, site, output_dir, templates, builder, verbose, global_vars, collected, language: root_language, lang_prefix: "")
 
         # For multilingual sites, also generate language-prefixed taxonomy pages
         # (e.g. /en/tags/, /en/categories/) using only pages of that language.
@@ -72,10 +80,12 @@ module Hwaro
             next if lang_taxonomies.empty?
 
             lang_taxonomy_configs = config.taxonomies.select { |t| lang_cfg.taxonomies.includes?(t.name) }
-            generate_taxonomies_for_language(lang_taxonomy_configs, site, output_dir, templates, builder, verbose, global_vars,
+            generate_taxonomies_for_language(lang_taxonomy_configs, site, output_dir, templates, builder, verbose, global_vars, collected,
               language: lang_code, lang_prefix: "/#{lang_code}", lang_taxonomies: lang_taxonomies)
           end
         end
+
+        collected
       end
 
       # Generate taxonomy index + terms for a (possibly language-scoped) set of taxonomies.
@@ -87,6 +97,7 @@ module Hwaro
         builder : Core::Build::Builder,
         verbose : Bool,
         global_vars : Hash(String, Crinja::Value),
+        collected : Array(Models::Section),
         language : String?,
         lang_prefix : String,
         lang_taxonomies : Hash(String, Hash(String, Array(Models::Page)))? = nil,
@@ -133,6 +144,7 @@ module Hwaro
                           terms_map.keys
                         end
           render_taxonomy_index(index_page, index_terms.sort!, templates, site, output_dir, builder, verbose, global_vars, slug_map)
+          collected << index_page
 
           terms_map.each do |term, pages|
             # Filter pages to the requested language when doing per-lang generation
@@ -143,7 +155,7 @@ module Hwaro
                              end
             next if filtered_pages.empty?
 
-            render_taxonomy_term(taxonomy, term, filtered_pages, templates, site, output_dir, builder, verbose, global_vars, slug_map[term], lang_prefix: lang_prefix, language: language)
+            collected << render_taxonomy_term(taxonomy, term, filtered_pages, templates, site, output_dir, builder, verbose, global_vars, slug_map[term], lang_prefix: lang_prefix, language: language)
           end
         end
       end
@@ -260,7 +272,7 @@ module Hwaro
         slug : String,
         lang_prefix : String = "",
         language : String? = nil,
-      )
+      ) : Models::Section
         base_url = "#{lang_prefix}/#{taxonomy.name}/#{slug}/"
 
         index_page = Models::Section.new("taxonomies/#{taxonomy.name}/#{slug}/index.md")
@@ -300,9 +312,9 @@ module Hwaro
           end
         end
 
-        return unless taxonomy.feed
+        generate_taxonomy_feed(taxonomy, term, pages, site, output_dir, base_url, verbose) if taxonomy.feed
 
-        generate_taxonomy_feed(taxonomy, term, pages, site, output_dir, base_url, verbose)
+        index_page
       end
 
       private def self.paginate_taxonomy(

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -520,15 +520,20 @@ module Hwaro
           cache.save if options.cache
 
           # --- 5. Regenerate taxonomy index/term pages ---
-          Content::Taxonomies.generate(site, output_dir, templates, verbose)
+          # Merge the generated taxonomy pages into the page set the SEO
+          # generators read so taxonomy.sitemap/feed take effect on incremental
+          # rebuilds too (mirrors the lifecycle taxonomy hook). `all_pages` is
+          # left intact for the rebuild summary below.
+          taxonomy_sections = Content::Taxonomies.generate(site, output_dir, templates, verbose)
+          seo_pages = taxonomy_sections.empty? ? all_pages : all_pages + taxonomy_sections
 
           # --- 6. Regenerate lightweight SEO / search files in parallel ---
           seo_tasks = [
-            -> { Content::Seo::Sitemap.generate(all_pages, site, output_dir, verbose); nil },
-            -> { Content::Seo::Feeds.generate(all_pages, site.config, output_dir, verbose); nil },
+            -> { Content::Seo::Sitemap.generate(seo_pages, site, output_dir, verbose); nil },
+            -> { Content::Seo::Feeds.generate(seo_pages, site.config, output_dir, verbose); nil },
             -> { Content::Seo::Robots.generate(site.config, output_dir, verbose); nil },
-            -> { Content::Seo::Llms.generate(site.config, all_pages, output_dir, verbose); nil },
-            -> { Content::Search.generate(all_pages, site.config, output_dir, verbose); nil },
+            -> { Content::Seo::Llms.generate(site.config, seo_pages, output_dir, verbose); nil },
+            -> { Content::Search.generate(seo_pages, site.config, output_dir, verbose); nil },
           ] of Proc(Nil)
           ParallelHelper.execute(seo_tasks, options.parallel)
 
@@ -823,7 +828,12 @@ module Hwaro
           # only cover the priority subset. Per-taxonomy RSS feeds and tag
           # listing pages pull from `page.content` too, so they have to be
           # regenerated for the same reason — matches `run_rerender`.
-          all_pages = (site.pages + site.sections).as(Array(Models::Page))
+          # Regenerate taxonomy pages BEFORE the SEO surfaces and merge them
+          # into the page set. Previously taxonomy generation ran after the
+          # sitemap, so its pages never appeared in it (taxonomy.sitemap/feed
+          # had no effect on this deferred pass).
+          taxonomy_sections = Content::Taxonomies.generate(site, output_dir, templates, verbose)
+          all_pages = (site.pages + site.sections + taxonomy_sections).as(Array(Models::Page))
           seo_tasks = [
             -> { Content::Seo::Sitemap.generate(all_pages, site, output_dir, verbose); nil },
             -> { Content::Seo::Feeds.generate(all_pages, site.config, output_dir, verbose); nil },
@@ -831,7 +841,6 @@ module Hwaro
             -> { Content::Search.generate(all_pages, site.config, output_dir, verbose); nil },
           ] of Proc(Nil)
           ParallelHelper.execute(seo_tasks, options.parallel)
-          Content::Taxonomies.generate(site, output_dir, templates, verbose)
 
           # Persist cache updates from the deferred pass. The initial build
           # already saved once; without this second save, killing the server

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -207,12 +207,14 @@ module Hwaro::Core::Build::Phases::Transform
 
   # Collect assets for each section and page
   private def collect_assets(ctx : Lifecycle::BuildContext)
+    content_files = ctx.config.try(&.content_files)
+
     ctx.sections.each do |section|
-      section.collect_assets("content")
+      section.collect_assets("content", content_files)
     end
 
     ctx.pages.each do |page|
-      page.collect_assets("content")
+      page.collect_assets("content", content_files)
     end
   end
 

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -194,7 +194,16 @@ module Hwaro
       end
 
       # Collect assets from page directory
-      def collect_assets(content_dir : String) : Array(String)
+      #
+      # When `content_files` is configured (`[content.files]` with
+      # `allow_extensions`), co-located bundle assets are filtered through the
+      # SAME allow/disallow rules as standalone content files. Without this, a
+      # root `_index.md` turns the whole `content/` tree into one recursive
+      # bundle and republishes arbitrary non-markdown files (e.g.
+      # `content/public/robots.txt`) to the output regardless of
+      # `allow_extensions`. When `[content.files]` is not configured, every
+      # non-markdown file is collected (unchanged behavior).
+      def collect_assets(content_dir : String, content_files : ContentFilesConfig? = nil) : Array(String)
         # Assets are only collected for page bundles (directories)
         # This usually means the page is an index.md (either _index.md or index.md)
         return [] of String unless @is_index
@@ -204,12 +213,16 @@ module Hwaro
 
         return [] of String unless Dir.exists?(page_dir)
 
-        @assets = Dir.glob(File.join(page_dir, "**", "*")).select do |file|
-          File.file?(file) &&
-            !file.ends_with?(".md") &&
-            !file.ends_with?(".markdown")
-        end.map do |file|
-          Path[file].relative_to(content_dir).to_s
+        @assets = Dir.glob(File.join(page_dir, "**", "*")).compact_map do |file|
+          next unless File.file?(file)
+          next if file.ends_with?(".md") || file.ends_with?(".markdown")
+
+          relative = Path[file].relative_to(content_dir).to_s
+          # Honor [content.files] allow/disallow rules when configured so the
+          # bundle path can't bypass the user's publishing allowlist.
+          next if content_files && content_files.enabled? && !content_files.publish?(relative)
+
+          relative
         end
 
         @assets


### PR DESCRIPTION
Supersedes #648-stacked PR (auto-closed when its base branch merged & was deleted). Now rebased onto `main`.

## #2 — Taxonomy pages never reached sitemap/feeds/search/llms
`Taxonomies.generate` built each page as a `Models::Section`, set `in_sitemap = taxonomy.sitemap`, wrote it to disk, but never added it to `all_pages` — so the flags were dead code. Also an ordering bug (hooks run highest-priority-first, so seo at 50 ran before taxonomy at 40).

**Fix:** `Taxonomies.generate` returns the generated Sections; lifecycle hook → priority 60 + `ctx.sections = ctx.sections + sections`; incremental builder paths merge the return before SEO (deferred pass reordered). `search.cr` gains `!p.generated` (feeds already excludes Section, llms already excludes generated). → taxonomy pages in sitemap iff `taxonomy.sitemap`.

## #4 — Bundle-asset collector bypassed `[content.files]`
`collect_assets` filtered only `.md`. **Fix:** thread `ContentFilesConfig?` and gate through `publish?` when configured. → noir `public/public/*` leak gone.

Full suite green; ameba + format clean. Regression specs included.