### PR TITLE
Stability: fix 10 edge-case bugs + add 191 regression/coverage tests

### DIFF
--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -380,6 +380,29 @@ describe "hwaro tool convert" do
       err.should contain("unknown format")
     end
   end
+
+  it "exits 1 and emits a failing ConversionResult JSON for a missing content dir" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(
+        ["tool", "convert", "to-yaml", "-c", "does-not-exist", "--json"],
+        chdir: project_dir
+      )
+      status.exit_code.should eq(1)
+      parsed = JSON.parse(output.strip)
+      parsed["success"].as_bool.should be_false
+      parsed["message"].as_s.should contain("not found")
+    end
+  end
+
+  it "exits 1 for a missing content dir without --json" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(
+        ["tool", "convert", "to-yaml", "-c", "does-not-exist"],
+        chdir: project_dir
+      )
+      status.exit_code.should eq(1)
+    end
+  end
 end
 
 describe "hwaro tool list" do

--- a/spec/functional/edge_cases_spec.cr
+++ b/spec/functional/edge_cases_spec.cr
@@ -434,3 +434,44 @@ describe "Edge Cases: Page with multiple aliases" do
     end
   end
 end
+
+# ---------------------------------------------------------------------------
+# 13. Duplicate output path / alias collision detection
+# ---------------------------------------------------------------------------
+describe "Edge Cases: Duplicate output path detection" do
+  it "warns when two pages resolve to the same URL (slug collision)" do
+    # Both pages live in the same directory and share slug 'dup', so both
+    # resolve to /posts/dup/ — one silently overwrites the other in render
+    # order. The render phase detects this and warns so users see the data loss.
+    log = with_captured_log do
+      build_site(
+        BASIC_CONFIG,
+        content_files: {
+          "posts/a.md" => "---\ntitle: A\nslug: dup\n---\nA",
+          "posts/b.md" => "---\ntitle: B\nslug: dup\n---\nB",
+        },
+        template_files: {"page.html" => "{{ content }}"},
+      ) { }
+    end
+
+    log.should contain("Duplicate output path")
+  end
+
+  it "warns when an alias collides with an already-seen alias" do
+    # Two pages declare the same alias. The first page registers /shared/ as an
+    # alias; the second page's identical alias then collides with the
+    # already-seen alias path and is reported as 'Duplicate alias output path'.
+    log = with_captured_log do
+      build_site(
+        BASIC_CONFIG,
+        content_files: {
+          "one.md" => "---\ntitle: One\naliases:\n  - /shared/\n---\nOne",
+          "two.md" => "---\ntitle: Two\naliases:\n  - /shared/\n---\nTwo",
+        },
+        template_files: {"page.html" => "{{ content }}"},
+      ) { }
+    end
+
+    log.should contain("Duplicate alias output path")
+  end
+end

--- a/spec/functional/template_deps_spec.cr
+++ b/spec/functional/template_deps_spec.cr
@@ -83,6 +83,27 @@ describe "TemplateDeps graph" do
     deps.shortcodes_used_in("has {{ badge() }} inline").should eq(Set{"shortcodes/badge"})
     deps.shortcodes_used_in("no shortcode here").should be_empty
   end
+
+  it "terminates with a finite closure on a circular template reference" do
+    # A user can author a circular extends (a→b, b→a) by mistake. The
+    # closure DFS relies on `result.add?` to break the cycle; a regression
+    # to a plain `<<` would loop forever and hang the build. Pin termination
+    # and finiteness.
+    deps = Hwaro::Core::Build::TemplateDeps.new({
+      "a" => %({% extends "b.html" %}),
+      "b" => %({% extends "a.html" %}),
+    })
+
+    deps.closure("a").should eq(Set{"a", "b"})
+
+    hash = deps.closure_hash("a")
+    hash.should_not be_empty
+    hash.size.should eq(32)
+
+    affected = deps.dependents_closure(Set{"a"})
+    affected.should contain("a")
+    affected.should contain("b")
+  end
 end
 
 describe "Template deps: cached builds" do

--- a/spec/unit/amp_spec.cr
+++ b/spec/unit/amp_spec.cr
@@ -396,6 +396,64 @@ describe Hwaro::Content::Seo::Amp do
       end
     end
 
+    # A blank/slash-only path_prefix collapses amp_output_path onto the
+    # canonical path, which would overwrite every page with its AMP variant.
+    # The guard must skip generation, leaving canonical HTML untouched.
+    it "skips generation when path_prefix is slash-only to avoid clobbering canonical pages" do
+      Dir.mktmpdir do |dir|
+        config = make_amp_config(<<-TOML)
+          [amp]
+          enabled = true
+          path_prefix = "/"
+          TOML
+
+        page = Hwaro::Models::Page.new("test.md")
+        page.url = "/posts/hello/"
+        page.section = "posts"
+        page.render = true
+
+        canonical_dir = File.join(dir, "posts", "hello")
+        FileUtils.mkdir_p(canonical_dir)
+        original = "<html><head></head><body><p>Hello World</p></body></html>"
+        canonical_path = File.join(canonical_dir, "index.html")
+        File.write(canonical_path, original)
+
+        Hwaro::Content::Seo::Amp.generate([page], config, dir)
+
+        # Canonical page is unchanged (not AMP-converted, not clobbered).
+        content = File.read(canonical_path)
+        content.should eq(original)
+        content.should_not contain("<html amp")
+      end
+    end
+
+    it "skips generation when path_prefix is empty to avoid clobbering canonical pages" do
+      Dir.mktmpdir do |dir|
+        config = make_amp_config(<<-TOML)
+          [amp]
+          enabled = true
+          path_prefix = ""
+          TOML
+
+        page = Hwaro::Models::Page.new("test.md")
+        page.url = "/posts/hello/"
+        page.section = "posts"
+        page.render = true
+
+        canonical_dir = File.join(dir, "posts", "hello")
+        FileUtils.mkdir_p(canonical_dir)
+        original = "<html><head></head><body><p>Hello World</p></body></html>"
+        canonical_path = File.join(canonical_dir, "index.html")
+        File.write(canonical_path, original)
+
+        Hwaro::Content::Seo::Amp.generate([page], config, dir)
+
+        content = File.read(canonical_path)
+        content.should eq(original)
+        content.should_not contain("<html amp")
+      end
+    end
+
     it "skips draft pages" do
       Dir.mktmpdir do |dir|
         config = make_amp_config(<<-TOML)

--- a/spec/unit/asset_pipeline_spec.cr
+++ b/spec/unit/asset_pipeline_spec.cr
@@ -844,4 +844,89 @@ describe Hwaro::Assets::Pipeline do
       end
     end
   end
+
+  # ===========================================================================
+  # Source-path traversal guard — files must stay within source_dir
+  # ===========================================================================
+  describe "source path traversal guard" do
+    it "skips a `../`-traversal source file and warns" do
+      Dir.mktmpdir do |dir|
+        static_dir = File.join(dir, "static")
+        output_dir = File.join(dir, "public")
+        FileUtils.mkdir_p(static_dir)
+        FileUtils.mkdir_p(output_dir)
+
+        # File written one level ABOVE source_dir; referenced via `../`.
+        File.write(File.join(dir, "outside.css"), ".secret { color: leak; }")
+
+        config = make_config(source_dir: static_dir)
+        config.bundles << Hwaro::Models::AssetBundleConfig.new(
+          name: "evil.css", files: ["../outside.css"]
+        )
+
+        pipeline = Hwaro::Assets::Pipeline.new(config, "")
+        log = with_captured_log do
+          pipeline.process(output_dir)
+        end
+
+        # Only file was traversal-skipped → empty bundle → not created.
+        pipeline.manifest.has_key?("evil.css").should be_false
+        File.exists?(File.join(output_dir, "assets", "evil.css")).should be_false
+        log.should contain("outside source directory")
+      end
+    end
+
+    it "does not include outside-source content when mixed with a valid file" do
+      Dir.mktmpdir do |dir|
+        static_dir = File.join(dir, "static")
+        output_dir = File.join(dir, "public")
+        FileUtils.mkdir_p(static_dir)
+        FileUtils.mkdir_p(output_dir)
+
+        File.write(File.join(dir, "outside.css"), ".secret { color: leak; }")
+        File.write(File.join(static_dir, "inside.css"), ".ok { color: green; }")
+
+        config = make_config(source_dir: static_dir)
+        config.bundles << Hwaro::Models::AssetBundleConfig.new(
+          name: "mixed.css", files: ["../outside.css", "inside.css"]
+        )
+
+        pipeline = Hwaro::Assets::Pipeline.new(config, "")
+        log = with_captured_log do
+          pipeline.process(output_dir)
+        end
+
+        pipeline.manifest.has_key?("mixed.css").should be_true
+        content = File.read(File.join(output_dir, "assets", "mixed.css"))
+        content.should contain("color: green")
+        content.should_not contain("color: leak")
+        log.should contain("outside source directory")
+      end
+    end
+
+    it "allows legitimate nested files within source_dir" do
+      Dir.mktmpdir do |dir|
+        static_dir = File.join(dir, "static")
+        output_dir = File.join(dir, "public")
+        FileUtils.mkdir_p(File.join(static_dir, "css", "vendor"))
+        FileUtils.mkdir_p(output_dir)
+
+        File.write(File.join(static_dir, "css", "vendor", "lib.css"), ".lib { color: blue; }")
+
+        config = make_config(source_dir: static_dir)
+        config.bundles << Hwaro::Models::AssetBundleConfig.new(
+          name: "nested.css", files: ["css/vendor/lib.css"]
+        )
+
+        pipeline = Hwaro::Assets::Pipeline.new(config, "")
+        log = with_captured_log do
+          pipeline.process(output_dir)
+        end
+
+        pipeline.manifest.has_key?("nested.css").should be_true
+        File.read(File.join(output_dir, "assets", "nested.css")).should contain("color: blue")
+        log.should_not contain("outside source directory")
+      end
+    end
+  end
 end

--- a/spec/unit/bugfix_regression_spec.cr
+++ b/spec/unit/bugfix_regression_spec.cr
@@ -110,6 +110,12 @@ describe "bugfix regressions" do
       Hwaro::Utils::TextUtils.escape_xml("a<b").should eq("a&lt;b") # slow path agrees
     end
 
+    it "drops a NUL while still escaping an ampersand on the same input" do
+      # NUL (0x00) is an XML-illegal C0 control: dropped on the slow path while
+      # the ampersand on the same string is still escaped.
+      Hwaro::Utils::TextUtils.escape_xml("a\u{0}&b").should eq("a&amp;b")
+    end
+
     it "still escapes the five XML special characters" do
       Hwaro::Utils::TextUtils.escape_xml("a & b < c > \"d\" 'e'").should eq("a &amp; b &lt; c &gt; &quot;d&quot; &apos;e&apos;")
     end

--- a/spec/unit/cache_spec.cr
+++ b/spec/unit/cache_spec.cr
@@ -240,6 +240,72 @@ describe Hwaro::Core::Build::Cache do
       end
     end
 
+    it "returns false when cascade_hash and template_hash both match" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+
+        cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        cache.update(test_file, "", cascade_hash: "c1", template_hash: "t1")
+        cache.changed?(test_file, "", cascade_hash: "c1", template_hash: "t1").should be_false
+      end
+    end
+
+    it "returns true when cascade_hash changes (parent _index cascade edit)" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+
+        cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        cache.update(test_file, "", cascade_hash: "c1", template_hash: "t1")
+        cache.changed?(test_file, "", cascade_hash: "c2", template_hash: "t1").should be_true
+      end
+    end
+
+    it "returns true when template_hash changes (closure template edit)" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+
+        cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        cache.update(test_file, "", cascade_hash: "c1", template_hash: "t1")
+        cache.changed?(test_file, "", cascade_hash: "c1", template_hash: "t2").should be_true
+      end
+    end
+
+    it "skips the template comparison when template_hash is nil" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+
+        cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        # Stored with a non-empty template_hash...
+        cache.update(test_file, "", template_hash: "t1")
+        # ...but a nil reader skips the template branch entirely, so the only
+        # remaining checks (mtime/content/output) match → not changed.
+        cache.changed?(test_file, "", template_hash: nil).should be_false
+        # Distinct from a mismatching non-nil hash, which does invalidate.
+        cache.changed?(test_file, "", template_hash: "t2").should be_true
+      end
+    end
+
+    it "returns true when stored cascade_hash defaults empty but a value is checked" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+
+        cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        # update with default cascade_hash ("")
+        cache.update(test_file)
+        cache.changed?(test_file, "", cascade_hash: "c1").should be_true
+      end
+    end
+
     it "handles large files" do
       Dir.mktmpdir do |dir|
         cache_path = File.join(dir, ".hwaro_cache.json")
@@ -828,6 +894,69 @@ describe Hwaro::Core::Build::Cache do
         c3.stats[:total].should eq(2)
       end
     end
+
+    it "does not rewrite the cache file on a no-op second save" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+
+        cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        cache.update(test_file)
+        cache.save # first write, clears @dirty
+
+        first_bytes = File.read(cache_path)
+        first_mtime = File.info(cache_path).modification_time
+
+        sleep 10.milliseconds
+        cache.save # no mutation since last save → guard skips rewrite
+
+        # Bytes are unchanged and (since @dirty stayed false) the file was not
+        # touched at all, so mtime is identical too.
+        File.read(cache_path).should eq(first_bytes)
+        File.info(cache_path).modification_time.should eq(first_mtime)
+      end
+    end
+
+    it "rewrites the cache file when an entry is added after save" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        f1 = File.join(dir, "f1.md")
+        f2 = File.join(dir, "f2.md")
+        File.write(f1, "one")
+        File.write(f2, "two")
+
+        cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        cache.update(f1)
+        cache.save
+        File.read(cache_path).includes?(f2).should be_false
+
+        cache.update(f2) # real mutation → marks dirty
+        cache.save
+        File.read(cache_path).includes?(f2).should be_true
+      end
+    end
+
+    it "upgrades a legacy-format cache file to the metadata format on next save" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+        mtime = File.info(test_file).modification_time.to_unix_ms
+
+        legacy_json = %([{"path":"#{test_file}","mtime":#{mtime},"hash":"","output_path":""}])
+        File.write(cache_path, legacy_json)
+
+        # Legacy load marks @dirty=true so the first save upgrades the format
+        # even on an otherwise no-op build.
+        cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        cache.save
+
+        data = Hwaro::Core::Build::CacheData.from_json(File.read(cache_path))
+        data.entries.size.should eq(1)
+        data.metadata.should be_a(Hwaro::Core::Build::CacheMetadata)
+      end
+    end
   end
 
   # ===========================================================================
@@ -1222,6 +1351,113 @@ describe Hwaro::Core::Build::Cache, "global checksums" do
       cache3.changed?(test_file).should be_false
     end
   end
+
+  it "does not invalidate on template change when invalidate_on_template_change is false" do
+    Dir.mktmpdir do |dir|
+      cache_path = File.join(dir, ".hwaro_cache.json")
+      test_file = File.join(dir, "test.md")
+      File.write(test_file, "content")
+
+      cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+      cache.set_global_checksums("tmpl_v1", "cfg_v1")
+      cache.update(test_file)
+      cache.save
+
+      # Template-dependency-tracking mode: a template edit must NOT wipe the
+      # whole cache — per-page closure hashes decide invalidation instead.
+      cache2 = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+      cache2.set_global_checksums("tmpl_v2", "cfg_v1", invalidate_on_template_change: false)
+
+      cache2.changed?(test_file).should be_false
+    end
+  end
+
+  it "still invalidates on config change even when invalidate_on_template_change is false" do
+    Dir.mktmpdir do |dir|
+      cache_path = File.join(dir, ".hwaro_cache.json")
+      test_file = File.join(dir, "test.md")
+      File.write(test_file, "content")
+
+      cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+      cache.set_global_checksums("tmpl_v1", "cfg_v1")
+      cache.update(test_file)
+      cache.save
+
+      # Config-change invalidation is ungated and fires regardless of the flag.
+      cache2 = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+      cache2.set_global_checksums("tmpl_v1", "cfg_v2", invalidate_on_template_change: false)
+
+      cache2.changed?(test_file).should be_true
+    end
+  end
+end
+
+# ===========================================================================
+# page/section-set fingerprints (listing-page invalidation)
+# ===========================================================================
+describe Hwaro::Core::Build::Cache, "set fingerprints" do
+  it "reports a change against fresh (empty) fingerprints" do
+    Dir.mktmpdir do |dir|
+      cache_path = File.join(dir, ".hwaro_cache.json")
+      cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+      cache.page_set_changed?("fp1").should be_true
+      cache.section_set_changed?("sfp1").should be_true
+    end
+  end
+
+  it "records fingerprints and compares them on subsequent calls" do
+    Dir.mktmpdir do |dir|
+      cache_path = File.join(dir, ".hwaro_cache.json")
+      cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+      cache.record_set_fingerprints("fp1", "sfp1")
+
+      cache.page_set_changed?("fp1").should be_false
+      cache.page_set_changed?("fp2").should be_true
+      cache.section_set_changed?("sfp1").should be_false
+      cache.section_set_changed?("sfp2").should be_true
+    end
+  end
+
+  it "persists fingerprints across save/load" do
+    Dir.mktmpdir do |dir|
+      cache_path = File.join(dir, ".hwaro_cache.json")
+      cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+      cache.record_set_fingerprints("fp1", "sfp1")
+      cache.save
+
+      reloaded = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+      reloaded.page_set_changed?("fp1").should be_false
+      reloaded.section_set_changed?("sfp1").should be_false
+      reloaded.page_set_changed?("fp2").should be_true
+    end
+  end
+
+  it "does not flip dirty (no rewrite) when recording identical fingerprints" do
+    Dir.mktmpdir do |dir|
+      cache_path = File.join(dir, ".hwaro_cache.json")
+      cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+      cache.record_set_fingerprints("fp1", "sfp1")
+      cache.save # clears @dirty
+
+      first_bytes = File.read(cache_path)
+      first_mtime = File.info(cache_path).modification_time
+
+      sleep 10.milliseconds
+      # Identical values → @dirty stays false → save is a no-op.
+      cache.record_set_fingerprints("fp1", "sfp1")
+      cache.save
+
+      File.read(cache_path).should eq(first_bytes)
+      File.info(cache_path).modification_time.should eq(first_mtime)
+    end
+  end
+
+  it "is a no-op when caching is disabled" do
+    cache = Hwaro::Core::Build::Cache.new(enabled: false)
+    cache.record_set_fingerprints("fp1", "sfp1")
+    # Early return on @enabled means the metadata never updates.
+    cache.page_set_changed?("fp1").should be_true
+  end
 end
 
 # ===========================================================================
@@ -1312,6 +1548,49 @@ describe Hwaro::Core::Build::Cache, "compute helpers" do
       h2 = Hwaro::Core::Build::Cache.compute_config_hash(config_path)
       h1.should eq(h2)
     end
+  end
+
+  # --- effective-config overload: compute_config_hash(config, env) ---------
+  it "folds the active env into the effective config hash" do
+    config = Hwaro::Models::Config.new
+    prod = Hwaro::Core::Build::Cache.compute_config_hash(config, env: "prod")
+    dev = Hwaro::Core::Build::Cache.compute_config_hash(config, env: "dev")
+    prod.should_not eq(dev)
+  end
+
+  it "folds base_url into the effective config hash without touching raw" do
+    config = Hwaro::Models::Config.new
+    config.base_url = "https://example.com"
+    before = Hwaro::Core::Build::Cache.compute_config_hash(config, env: "prod")
+
+    config.base_url = "https://other.example.com"
+    after = Hwaro::Core::Build::Cache.compute_config_hash(config, env: "prod")
+
+    before.should_not eq(after)
+  end
+
+  it "is stable across repeated calls with the same config" do
+    config = Hwaro::Models::Config.new
+    config.base_url = "https://example.com"
+    config.raw = TOML.parse("title = \"site\"\ndescription = \"d\"")
+
+    h1 = Hwaro::Core::Build::Cache.compute_config_hash(config, env: "prod")
+    h2 = Hwaro::Core::Build::Cache.compute_config_hash(config, env: "prod")
+    h1.should eq(h2)
+  end
+
+  it "is independent of raw key insertion order" do
+    c1 = Hwaro::Models::Config.new
+    c1.base_url = "https://example.com"
+    c1.raw = TOML.parse("title = \"site\"\ndescription = \"d\"\nauthor = \"a\"")
+
+    c2 = Hwaro::Models::Config.new
+    c2.base_url = "https://example.com"
+    c2.raw = TOML.parse("author = \"a\"\ndescription = \"d\"\ntitle = \"site\"")
+
+    Hwaro::Core::Build::Cache.compute_config_hash(c1, env: "prod").should eq(
+      Hwaro::Core::Build::Cache.compute_config_hash(c2, env: "prod")
+    )
   end
 end
 

--- a/spec/unit/cli_runner_spec.cr
+++ b/spec/unit/cli_runner_spec.cr
@@ -104,6 +104,29 @@ describe Hwaro::CLI::Runner do
         Hwaro::CLI::Runner.json_mode = previous_json
       end
     end
+
+    # The JSON branch of emit_hwaro_error writes to the hardcoded STDOUT
+    # constant (not the io: parameter), so it cannot be captured via an
+    # IO::Memory sink in-process. Drive the built binary instead: an unknown
+    # command plus --json triggers the ARGV.includes?("--json") branch (no
+    # parser has run yet), so this also covers the ARGV-detection path.
+    it "emits the structured JSON payload to stdout under --json (ARGV detection)" do
+      bin = File.expand_path("../../bin/hwaro", __DIR__)
+      next unless File.exists?(bin) && File::Info.executable?(bin)
+
+      stdout_sink = IO::Memory.new
+      stderr_sink = IO::Memory.new
+      status = Process.run(bin, ["boguscmd", "--json"], output: stdout_sink, error: stderr_sink)
+
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      stdout = stdout_sink.to_s
+      # No human-form "Error [CODE]" line leaks to stdout under --json.
+      stdout.should_not contain("Error [")
+      parsed = JSON.parse(stdout)
+      parsed["status"].as_s.should eq("error")
+      parsed["error"]["code"].as_s.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      parsed["error"]["message"].as_s.should contain("unknown command")
+    end
   end
 
   describe ".print_help" do

--- a/spec/unit/completion_command_spec.cr
+++ b/spec/unit/completion_command_spec.cr
@@ -173,6 +173,51 @@ describe Hwaro::CLI::Commands::CompletionCommand do
       output.should contain("export")
     end
   end
+
+  describe "shell-metacharacter escaping" do
+    # Register a synthetic command whose flag descriptions contain the exact
+    # metacharacters escape_zsh ([ ] ') and escape_fish (" $) handle. Real
+    # flag descriptions contain parens/colons/commas but none of these chars,
+    # so without a synthetic flag the gsub branches stay uncovered.
+    before_each do
+      ensure_commands_registered
+      Hwaro::CLI::CommandRegistry.register(
+        Hwaro::CLI::CommandInfo.new(
+          name: "synthescape",
+          description: "synthetic",
+          flags: [
+            Hwaro::CLI::FlagInfo.new(
+              short: nil,
+              long: "--meta",
+              description: %q(brackets [x] and quote ' and dollar $ and dquote "z"),
+            ),
+          ],
+        )
+      ) { |_| }
+    end
+
+    it "escapes ' [ ] in the generated zsh script so the _arguments line stays well-formed" do
+      cmd = Hwaro::CLI::Commands::CompletionCommand.new
+      output = cmd.generate_zsh_for_test
+
+      # The raw description must not appear verbatim — brackets and the quote
+      # are escaped before interpolation into the '[...]' description slot.
+      output.should contain("\\[x\\]")
+      output.should contain("'\\''")
+      # No unescaped raw "[x]" leaks into the script.
+      output.should_not contain("brackets [x] and")
+    end
+
+    it "escapes \" and $ in the generated fish script" do
+      cmd = Hwaro::CLI::Commands::CompletionCommand.new
+      output = cmd.generate_fish_for_test
+
+      # $ and embedded double-quotes are escaped before going into the -d "..."
+      output.should contain("dollar \\$")
+      output.should contain("dquote \\\"z\\\"")
+      output.should_not contain("dollar $ and")
+    end
+  end
 end
 
 # Test helper to expose private generate_ methods

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -192,6 +192,54 @@ describe Hwaro::Models::Config do
       config.base_url = "https://example.com/two"
       config.base_path.should eq("/two")
     end
+
+    it "returns an empty string when the URI parse path is just \"/\"" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com/"
+      config.base_path.should eq("")
+    end
+
+    it "returns an empty string for a malformed base_url (URI::Error rescue)" do
+      config = Hwaro::Models::Config.new
+      # A bracketed host with no closing bracket is not a parseable URI; the
+      # rescue must swallow URI::Error and fall back to "".
+      config.base_url = "http://[::1"
+      config.base_path.should eq("")
+    end
+  end
+
+  describe "#with_base_path" do
+    it "prefixes a root-relative path under a subpath deployment" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://x.com/repo"
+      config.with_base_path("/posts/a/").should eq("/repo/posts/a/")
+    end
+
+    it "leaves protocol-relative URLs untouched" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://x.com/repo"
+      # Without the // guard this would become /repo//cdn.example.com/x.
+      config.with_base_path("//cdn.example.com/x").should eq("//cdn.example.com/x")
+    end
+
+    it "leaves absolute http(s) URLs untouched" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://x.com/repo"
+      config.with_base_path("http://y.com/z").should eq("http://y.com/z")
+      config.with_base_path("https://y.com/z").should eq("https://y.com/z")
+    end
+
+    it "leaves a non-leading-slash path unchanged" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://x.com/repo"
+      config.with_base_path("posts/a/").should eq("posts/a/")
+    end
+
+    it "is a no-op when base_path is empty (domain-root deploy)" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://x.com"
+      config.with_base_path("/posts/").should eq("/posts/")
+    end
   end
 
   describe "#initialize" do
@@ -2336,6 +2384,20 @@ describe "Hwaro::Models::Config#resolve_permalink_dir" do
 
     it "falls back to the default for a wrong-typed numeric value" do
       load_config("[pagination]\nper_page = \"twenty\"").pagination.per_page.should eq(10)
+    end
+
+    it "clamps an oversized integer [pagination] per_page to Int32::MAX (int_value)" do
+      # 9999999999 > Int32::MAX. int_value uses as_i64?+clamp so this yields a
+      # clamped Int32 instead of raising OverflowError out of as_i?/to_i.
+      load_config("[pagination]\nper_page = 9999999999").pagination.per_page.should eq(Int32::MAX)
+    end
+
+    it "clamps an oversized float [feeds] limit to Int32::MAX (int_value)" do
+      load_config("[feeds]\nlimit = 1e30").feeds.limit.should eq(Int32::MAX)
+    end
+
+    it "clamps an oversized integer [deployment] max_deletes to Int32::MAX (int_or_nil)" do
+      load_config("[deployment]\nmax_deletes = 99999999999").deployment.max_deletes.should eq(Int32::MAX)
     end
   end
 end

--- a/spec/unit/content_files_config_spec.cr
+++ b/spec/unit/content_files_config_spec.cr
@@ -123,6 +123,24 @@ describe Hwaro::Models::ContentFilesConfig do
       config.publish?("file.tmp").should be_false
       config.publish?("file.jpg").should be_true
     end
+
+    it "skips a malformed disallow_paths glob instead of raising (BadPatternError swallow)" do
+      # "[bad" is an unterminated character set; File.match? raises
+      # File::BadPatternError. publish? must swallow it and treat the pattern
+      # as non-matching rather than crashing mid asset collection.
+      config = Hwaro::Models::ContentFilesConfig.new
+      config.allow_extensions = [".pdf"]
+      config.disallow_paths = ["[bad"]
+      config.publish?("a/b/secret.pdf").should be_true
+    end
+
+    it "still applies valid disallow patterns after skipping a malformed one" do
+      config = Hwaro::Models::ContentFilesConfig.new
+      config.allow_extensions = [".pdf"]
+      config.disallow_paths = ["[bad", "**/secret.*"]
+      config.publish?("a/b/secret.pdf").should be_false
+      config.publish?("a/b/keep.pdf").should be_true
+    end
   end
 
   describe ".normalize_extensions" do

--- a/spec/unit/content_lister_spec.cr
+++ b/spec/unit/content_lister_spec.cr
@@ -286,6 +286,25 @@ describe Hwaro::Services::ContentLister do
     end
   end
 
+  describe "JSON frontmatter parsing" do
+    it "parses title, draft, and date from JSON frontmatter" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "post.md"), "{\"title\": \"JSON Post\", \"draft\": true, \"date\": \"2024-06-15\"}\n\n# body")
+
+        lister = Hwaro::Services::ContentLister.new(content_dir)
+        result = lister.list_content(Hwaro::Services::ContentFilter::All)
+
+        result.size.should eq(1)
+        result.first.title.should eq("JSON Post")
+        result.first.draft.should be_true
+        result.first.date.should_not be_nil
+      end
+    end
+  end
+
   describe "no frontmatter" do
     it "handles files without any frontmatter" do
       Dir.mktmpdir do |dir|

--- a/spec/unit/content_stats_spec.cr
+++ b/spec/unit/content_stats_spec.cr
@@ -116,6 +116,24 @@ describe Hwaro::Services::ContentStats do
       end
     end
 
+    it "buckets monthly frequency from TOML native and string dates" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        # Unquoted TOML date parses to a native Time value (distinct branch
+        # from quoted/string dates).
+        File.write(File.join(content_dir, "native.md"), "+++\ntitle = \"X\"\ndate = 2024-03-15T10:00:00Z\ntags = [\"a\"]\n+++\n\nword word\n")
+        File.write(File.join(content_dir, "string.md"), "+++\ntitle = \"Y\"\ndate = \"2024-04-01\"\n+++\n\nword word\n")
+
+        stats = Hwaro::Services::ContentStats.new(content_dir)
+        result = stats.run
+
+        result.monthly["2024-03"].should eq(1)
+        result.monthly["2024-04"].should eq(1)
+      end
+    end
+
     it "works with TOML frontmatter" do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -474,6 +474,94 @@ describe Hwaro::Services::Creator do
       end
     end
 
+    # The default generators (no archetype) hand-roll escape_string for
+    # backslash-before-quote ordering. An adversarial title (`C:\` style
+    # backslash + embedded quote) must still produce front matter that
+    # round-trips through a real parser back to the original string —
+    # otherwise the next `hwaro build` chokes on unparseable TOML/YAML.
+    it "round-trips an adversarial title through the default TOML generator" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+
+          adversarial = %(My "Quoted" \\ Post)
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: adversarial)
+          Hwaro::Services::Creator.new.run(options)
+
+          content = File.read("content/post.md")
+          fm = content.lines.reject { |l| l.strip == "+++" }.join("\n")
+          parsed = TOML.parse(fm)
+          parsed["title"].as_s.should eq(adversarial)
+        end
+      end
+    end
+
+    it "round-trips an adversarial title through the default YAML generator" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+
+          config = Hwaro::Models::Config.new
+          config.content_new.front_matter_format = "yaml"
+
+          adversarial = %(My "Quoted" \\ Post)
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: adversarial)
+          Hwaro::Services::Creator.new.run(options, config)
+
+          content = File.read("content/post.md")
+          fm = content.lines.reject { |l| l.strip == "---" }.join("\n")
+          parsed = YAML.parse(fm)
+          parsed["title"].as_s.should eq(adversarial)
+        end
+      end
+    end
+
+    # JSON is correct by construction (JSON::Any.to_pretty_json), but keep a
+    # cheap round-trip as an extra guard.
+    it "round-trips an adversarial title through the default JSON generator" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+
+          config = Hwaro::Models::Config.new
+          config.content_new.front_matter_format = "json"
+
+          adversarial = %(My "Quoted" \\ Post)
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: adversarial)
+          Hwaro::Services::Creator.new.run(options, config)
+
+          content = File.read("content/post.md")
+          end_idx = content.index!("}\n") + 1
+          parsed = JSON.parse(content[0, end_idx])
+          parsed["title"].as_s.should eq(adversarial)
+        end
+      end
+    end
+
+    # When no <path> is given and the title slugifies to empty (all
+    # punctuation/emoji), the slug-empty guard must raise a classified usage
+    # error rather than writing a stray hidden `content/.md` file.
+    it "fails fast with HwaroError(HWARO_E_USAGE) when title slugifies to empty (no path)" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/drafts")
+
+          options = Hwaro::Config::Options::NewOptions.new(title: "!!!")
+          creator = Hwaro::Services::Creator.new
+
+          err = expect_raises(Hwaro::HwaroError) do
+            creator.run(options)
+          end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+          (err.message || "").should match(/filename-safe/)
+
+          # No stray hidden file written.
+          File.exists?("content/.md").should be_false
+          File.exists?("content/drafts/.md").should be_false
+        end
+      end
+    end
+
     it "honours custom default_fields from config" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do

--- a/spec/unit/css_minifier_spec.cr
+++ b/spec/unit/css_minifier_spec.cr
@@ -712,5 +712,14 @@ describe Hwaro::Utils::CssMinifier do
       result = Hwaro::Utils::CssMinifier.minify(css)
       result.should contain("color:red")
     end
+
+    it "leaves a counterfeit out-of-range PRESERVE placeholder token intact" do
+      # The counterfeit token sits inside a real string literal so Step 2 stashes
+      # the surrounding string; Step 7's restore regex then re-matches the embedded
+      # \x00PRESERVE_999\x00 with an out-of-range index. The bounds guard emits it
+      # unchanged rather than raising IndexError (which would crash the pipeline).
+      result = Hwaro::Utils::CssMinifier.minify("a{content:\"\u{0}PRESERVE_999\u{0}\"}")
+      result.should contain("PRESERVE_999") # bogus token survives verbatim
+    end
   end
 end

--- a/spec/unit/deadlink_command_spec.cr
+++ b/spec/unit/deadlink_command_spec.cr
@@ -213,6 +213,63 @@ describe Hwaro::CLI::Commands::Tool::DeadlinkCommand do
     end
   end
 
+  describe "#sanitize_for_terminal (terminal-injection protection)" do
+    it "strips raw ANSI/control bytes from semi-trusted URLs/paths" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      out = cmd.sanitize_for_terminal_for_test("\e[31mred\e[0m/page")
+
+      # The ESC byte itself is a control char and is removed; the printable
+      # `[31m...` residue remains — assert on absence of the control byte.
+      out.includes?('\e').should be_false
+      out.should eq("[31mred[0m/page")
+    end
+
+    it "removes embedded CR and BEL control bytes while preserving printable text" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      out = cmd.sanitize_for_terminal_for_test("/posts\r\x07/hello")
+
+      out.includes?('\r').should be_false
+      out.includes?('\a').should be_false
+      out.should eq("/posts/hello")
+    end
+
+    it "leaves a fully-printable URL untouched" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      cmd.sanitize_for_terminal_for_test("https://example.com/path").should eq(
+        "https://example.com/path"
+      )
+    end
+  end
+
+  describe "#run option validation" do
+    it "rejects --timeout 0 with HWARO_E_USAGE" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      ex = expect_raises(Hwaro::HwaroError) do
+        cmd.run(["--timeout", "0"])
+      end
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.not_nil!.should contain("Invalid --timeout")
+    end
+
+    it "rejects a non-numeric --concurrency with HWARO_E_USAGE" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      ex = expect_raises(Hwaro::HwaroError) do
+        cmd.run(["--concurrency", "abc"])
+      end
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.not_nil!.should contain("Invalid --concurrency")
+    end
+
+    it "rejects a non-positive --concurrency with HWARO_E_USAGE" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      ex = expect_raises(Hwaro::HwaroError) do
+        cmd.run(["--concurrency", "-1"])
+      end
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.not_nil!.should contain("Invalid --concurrency")
+    end
+  end
+
   describe "#private_host? (SSRF protection)" do
     it "blocks localhost" do
       cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
@@ -448,5 +505,9 @@ class Hwaro::CLI::Commands::Tool::DeadlinkCommand
 
   def private_172_for_test?(ip : String) : Bool
     private_172?(ip)
+  end
+
+  def sanitize_for_terminal_for_test(s : String) : String
+    sanitize_for_terminal(s)
   end
 end

--- a/spec/unit/deploy_command_spec.cr
+++ b/spec/unit/deploy_command_spec.cr
@@ -44,6 +44,18 @@ describe Hwaro::CLI::Commands::DeployCommand do
       options.max_deletes.should eq(-1)
     end
 
+    it "raises HwaroError(HWARO_E_USAGE) when --max-deletes is not an integer" do
+      cmd = Hwaro::CLI::Commands::DeployCommand.new
+
+      ["abc", "", "1.5", "10x"].each do |bad|
+        err = expect_raises(Hwaro::HwaroError) do
+          cmd.parse_options(["--max-deletes", bad])
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        err.message.to_s.should contain("Invalid --max-deletes")
+      end
+    end
+
     it "parses list targets" do
       cmd = Hwaro::CLI::Commands::DeployCommand.new
       _, list_targets, _ = cmd.parse_options(["--list-targets"])

--- a/spec/unit/deployer_service_spec.cr
+++ b/spec/unit/deployer_service_spec.cr
@@ -205,6 +205,38 @@ describe Hwaro::Services::Deployer do
         File.read(dest_file).should eq("Foo Content")
       end
     end
+
+    # When strip_index_html is on, `foo/index.html` strips to the file `foo`
+    # while `foo/bar/index.html` yields the path `foo/bar` — writing a file and
+    # a directory at the same `foo` corrupts the destination, so the validator
+    # must raise HWARO_E_CONFIG before any copy happens.
+    it "raises HwaroError(HWARO_E_CONFIG) when strip_index_html produces a file/dir collision" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(File.join(src_dir, "foo", "bar"))
+        File.write(File.join(src_dir, "foo", "index.html"), "Foo")
+        File.write(File.join(src_dir, "foo", "bar", "index.html"), "Bar")
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{dest_dir}"
+        target.strip_index_html = true
+        config.deployment.targets << target
+
+        deployer = Hwaro::Services::Deployer.new
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: src_dir,
+          targets: ["local"]
+        )
+
+        err = expect_raises(Hwaro::HwaroError) { deployer.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain("stripIndexHTML cannot be used")
+      end
+    end
+
     it "auto-generates command for s3:// URL in dry_run" do
       Dir.mktmpdir do |dir|
         src_dir = File.join(dir, "src")
@@ -457,6 +489,14 @@ describe "Deployer private helpers" do
       result.should eq("az storage blob sync --source {source} --container 'my-container'")
     end
 
+    it "returns nil for az:// URL with an empty container" do
+      deployer = Hwaro::Services::Deployer.new
+      # An az:// URL with no container must not emit a command targeting an
+      # empty container; it falls through to the unsupported-scheme path.
+      result = deployer.test_auto_command_for_url("az://", "/tmp")
+      result.should be_nil
+    end
+
     it "returns nil for unknown scheme" do
       deployer = Hwaro::Services::Deployer.new
       result = deployer.test_auto_command_for_url("https://example.com", "/tmp")
@@ -584,6 +624,21 @@ describe "Deployer private helpers" do
         config.deployment.targets << target
 
         options = Hwaro::Config::Options::DeployOptions.new(source_dir: dir, targets: ["unknown"])
+        err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain("Unsupported deploy target URL scheme")
+      end
+    end
+
+    it "raises HwaroError(HWARO_E_CONFIG) for az:// with an empty container (no auto command)" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "az-empty"
+        target.url = "az://"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: dir, targets: ["az-empty"])
         err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.run(options, config) }
         err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
         (err.message || "").should contain("Unsupported deploy target URL scheme")

--- a/spec/unit/exporters/base_spec.cr
+++ b/spec/unit/exporters/base_spec.cr
@@ -193,5 +193,26 @@ describe Hwaro::Services::Exporters::Base do
       )
       out.should eq("[a](/a) and [b](/b)")
     end
+
+    it "strips .md before an anchor fragment" do
+      out = TestExporter.new.test_rewrite_internal_links(
+        "see [x](@/guide/intro.md#setup) here"
+      )
+      out.should eq("see [x](/guide/intro#setup) here")
+    end
+
+    it "strips _index before an anchor fragment" do
+      out = TestExporter.new.test_rewrite_internal_links(
+        "[s](@/blog/_index.md#latest)"
+      )
+      out.should eq("[s](/blog/#latest)")
+    end
+
+    it "strips .md before a query string" do
+      out = TestExporter.new.test_rewrite_internal_links(
+        "[x](@/page.md?ref=home)"
+      )
+      out.should eq("[x](/page?ref=home)")
+    end
   end
 end

--- a/spec/unit/exporters/hugo_exporter_spec.cr
+++ b/spec/unit/exporters/hugo_exporter_spec.cr
@@ -286,5 +286,32 @@ describe Hwaro::Services::Exporters::HugoExporter do
         result.skipped_count.should eq(1)
       end
     end
+
+    it "quotes a frontmatter key containing a space so the TOML stays parseable" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(content_dir)
+
+        # A space-containing key is valid in YAML but bare-invalid in TOML;
+        # it must be emitted as a quoted key, not `my key = "value"`.
+        File.write(File.join(content_dir, "post.md"), "---\ntitle: Post\n\"my key\": value\n---\n\nBody\n")
+
+        exporter = Hwaro::Services::Exporters::HugoExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(
+          target_type: "hugo",
+          content_dir: content_dir,
+          output_dir: output_dir,
+        )
+        result = exporter.run(options)
+        result.success.should be_true
+
+        content = File.read(File.join(output_dir, "content", "post.md"))
+        fm = content.split("+++")[1]
+        parsed = TOML.parse(fm)
+        parsed["my key"].as_s.should eq("value")
+        fm.should contain(%("my key" = "value"))
+      end
+    end
   end
 end

--- a/spec/unit/exporters/jekyll_exporter_spec.cr
+++ b/spec/unit/exporters/jekyll_exporter_spec.cr
@@ -271,5 +271,28 @@ describe Hwaro::Services::Exporters::JekyllExporter do
         content.should contain("- tech")
       end
     end
+
+    it "preserves a scalar tags/categories shorthand as a single-item list" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(content_dir)
+
+        # `tags: crystal` (scalar, not a list) must not be silently dropped —
+        # that would lose the post's taxonomy membership in the migration.
+        File.write(File.join(content_dir, "post.md"), "---\ntitle: Post\ndate: \"2024-01-01\"\ntags: crystal\ncategories: news\n---\n\nBody\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
+        result = exporter.run(options)
+        result.success.should be_true
+
+        content = File.read(Dir.glob(File.join(output_dir, "_posts", "*.md")).first)
+        content.should contain("tags:")
+        content.should contain("- crystal")
+        content.should contain("categories:")
+        content.should contain("- news")
+      end
+    end
   end
 end

--- a/spec/unit/filters_spec.cr
+++ b/spec/unit/filters_spec.cr
@@ -280,6 +280,16 @@ describe "StringFilters" do
       result = render_filter("{{ text | truncate_words(length=1) }}", vars)
       result.strip.should eq("hello")
     end
+
+    it "returns only the ending for a non-positive length (pinned contract)" do
+      # length <= 0 is nonsensical input (e.g. a dynamically-computed length
+      # that hits 0). Pin the current behavior so a future fix is a deliberate
+      # change rather than an accidental flip — both 0 and -1 collapse to just
+      # the ending today.
+      vars = {"text" => Crinja::Value.new("one two three")}
+      render_filter("{{ text | truncate_words(length=0) }}", vars).strip.should eq("...")
+      render_filter("{{ text | truncate_words(length=-1) }}", vars).strip.should eq("...")
+    end
   end
 
   describe "slugify" do
@@ -685,6 +695,34 @@ describe "UrlFilters" do
       result.strip.should eq("/subdir/about/")
     end
   end
+
+  describe "empty base_url (pre-deploy state)" do
+    it "absolute_url returns the path unchanged and never emits a // prefix" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+      config.base_url = ""
+
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+      context.add("my_url", "/about/")
+
+      result = Hwaro::Content::Processors::Template.process("{{ my_url | absolute_url }}", context).strip
+      result.should eq("/about/")
+      result.starts_with?("//").should be_false
+    end
+
+    it "relative_url returns the path unchanged and never emits a // prefix" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+      config.base_url = ""
+
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+      context.add("my_url", "/about/")
+
+      result = Hwaro::Content::Processors::Template.process("{{ my_url | relative_url }}", context).strip
+      result.should eq("/about/")
+      result.starts_with?("//").should be_false
+    end
+  end
 end
 
 # =============================================================================
@@ -1019,6 +1057,29 @@ describe "I18nFilters" do
       result = render_filter("{{ \"title\" | t }}", vars)
       result.should eq("Title")
     end
+
+    it "falls back to the key when a language entry is not a hash" do
+      # A translations file where a language maps to a scalar/array instead of
+      # a table must not crash render (the blanket rescue returns the key).
+      translations = {
+        Crinja::Value.new("en") => Crinja::Value.new("not-a-hash"),
+      }
+      vars = {
+        "_i18n_translations"     => Crinja::Value.new(translations),
+        "page_language"          => Crinja::Value.new("en"),
+        "_i18n_default_language" => Crinja::Value.new("en"),
+      }
+      render_filter("{{ \"k\" | t }}", vars).should eq("k")
+    end
+
+    it "falls back to the key when the translations table itself is not a hash" do
+      vars = {
+        "_i18n_translations"     => Crinja::Value.new("not-a-hash"),
+        "page_language"          => Crinja::Value.new("en"),
+        "_i18n_default_language" => Crinja::Value.new("en"),
+      }
+      render_filter("{{ \"k\" | t }}", vars).should eq("k")
+    end
   end
 
   describe "pluralize" do
@@ -1050,6 +1111,19 @@ describe "I18nFilters" do
       vars = {"count" => Crinja::Value.new("abc")}
       result = render_filter("{{ count | pluralize(\"item\", \"items\") }}", vars)
       result.should eq("items")
+    end
+
+    it "selects plural for a fractional count above 1 (no truncation to singular)" do
+      # 1.9 must not be truncated to 1 and wrongly rendered singular.
+      vars = {"count" => Crinja::Value.new(1.9)}
+      result = render_filter("{{ count | pluralize(\"item\", \"items\") }}", vars)
+      result.should eq("items")
+    end
+
+    it "treats an exact 1.0 as singular" do
+      vars = {"count" => Crinja::Value.new(1.0)}
+      result = render_filter("{{ count | pluralize(\"item\", \"items\") }}", vars)
+      result.should eq("item")
     end
   end
 end

--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -1673,6 +1673,63 @@ describe Hwaro::Content::Processors::Markdown do
       result = processor.parse(raw)
       result[:date].should be_nil
     end
+
+    it "treats an out-of-range YAML date as nil without dropping the rest of the front matter" do
+      # "2024-13-45" is format-valid but value-invalid, so Time.parse raises
+      # ArgumentError (not Time::Format::Error). parse_time must swallow it and
+      # return nil for the date while title/tags survive — one bad date must
+      # not blank out the whole page (which previously fell through to the
+      # broad rescue and produced an "Untitled" page).
+      raw = <<-MD
+        ---
+        title: Post
+        date: "2024-13-45"
+        ---
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:date].should be_nil
+      result[:title].should eq("Post")
+    end
+
+    it "treats an impossible calendar date (Feb 30) as nil and keeps the title" do
+      raw = <<-MD
+        ---
+        title: Feb
+        date: "2024-02-30"
+        ---
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:date].should be_nil
+      result[:title].should eq("Feb")
+    end
+
+    it "treats an out-of-range TOML quoted date as nil and keeps the title" do
+      raw = <<-MD
+        +++
+        title = "T"
+        date = "2024-13-45"
+        +++
+        Body
+        MD
+
+      result = processor.parse(raw, "content/post.md")
+      result[:date].should be_nil
+      result[:title].should eq("T")
+    end
+  end
+
+  describe "malformed cascade" do
+    it "warns and ignores a scalar cascade value instead of raising" do
+      log = with_captured_log do
+        result = processor.parse("+++\ntitle = \"S\"\ncascade = \"oops\"\n+++\nbody", "content/_index.md")
+        result[:cascade].empty?.should be_true
+      end
+      log.should contain("`cascade` must be a table")
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/unit/html_minifier_spec.cr
+++ b/spec/unit/html_minifier_spec.cr
@@ -249,6 +249,24 @@ describe Hwaro::Utils::HtmlMinifier do
         result.should contain("<svg><path/></svg>")
         result.should_not contain("\n  <button")
       end
+
+      it "leaves a counterfeit out-of-range preserve token intact without raising" do
+        # A real <pre> makes the preserves array non-empty so the restore gsub
+        # actually runs; the forged token's index (999) is out of range, so it
+        # must be emitted unchanged rather than indexing past the array.
+        html = "<pre>real</pre><p>\u{0}HW_HTML_PB_999\u{0}</p>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("<pre>real</pre>")
+        result.should contain("\u{0}HW_HTML_PB_999\u{0}")
+      end
+
+      it "does not raise on a counterfeit token whose index overflows Int32" do
+        # $1.to_i would raise ArgumentError on a 20-digit index; to_i? makes it
+        # fall through to $0 (the token left verbatim).
+        html = "<pre>real</pre><p>\u{0}HW_HTML_PB_99999999999999999999\u{0}</p>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should contain("\u{0}HW_HTML_PB_99999999999999999999\u{0}")
+      end
     end
 
     describe "edge cases" do

--- a/spec/unit/i18n_spec.cr
+++ b/spec/unit/i18n_spec.cr
@@ -83,6 +83,72 @@ describe Hwaro::Content::I18n do
         translations.has_key?("ja").should be_false
       end
     end
+
+    # Resilience: a single syntactically broken i18n file must NOT abort the
+    # build. The rescue in load_translations logs a warning and continues with
+    # the remaining languages, so a typo in one translation file degrades
+    # gracefully (that language is skipped) instead of crashing the whole build.
+    it "skips a malformed TOML file with a warning and keeps valid languages" do
+      Dir.mktmpdir do |dir|
+        i18n_dir = File.join(dir, "i18n")
+        FileUtils.mkdir_p(i18n_dir)
+
+        File.write(File.join(i18n_dir, "en.toml"), <<-TOML)
+          greeting = "Hi"
+          TOML
+
+        File.write(File.join(i18n_dir, "ko.toml"), <<-TOML)
+          this = = broken
+          TOML
+
+        config = Hwaro::Models::Config.new
+        config.default_language = "en"
+        config.languages = {"ko" => Hwaro::Models::LanguageConfig.new("ko")}
+
+        translations = Hwaro::Content::I18n.load_translations(i18n_dir, config)
+
+        log = with_captured_log do
+          translations = Hwaro::Content::I18n.load_translations(i18n_dir, config)
+        end
+
+        log.should contain("Failed to parse i18n file")
+        translations.has_key?("en").should be_true
+        translations["en"]["greeting"].should eq("Hi")
+        translations.has_key?("ko").should be_false
+      end
+    end
+
+    # The Array branch of flatten_toml indexes list items as key.0, key.1, etc.
+    # List-valued i18n keys (e.g. nav menus) are a plausible multilingual
+    # pattern; a cast regression would silently drop them. Covers string items,
+    # the non-string scalar to_s fallback, and the recursive table-in-array case.
+    it "flattens TOML array values into indexed keys" do
+      Dir.mktmpdir do |dir|
+        i18n_dir = File.join(dir, "i18n")
+        FileUtils.mkdir_p(i18n_dir)
+
+        File.write(File.join(i18n_dir, "en.toml"), <<-TOML)
+          items = ["Home", "About"]
+          counts = [1, 2]
+          [[menu]]
+          label = "First"
+          [[menu]]
+          label = "Second"
+          TOML
+
+        config = Hwaro::Models::Config.new
+        config.default_language = "en"
+
+        translations = Hwaro::Content::I18n.load_translations(i18n_dir, config)
+
+        translations["en"]["items.0"].should eq("Home")
+        translations["en"]["items.1"].should eq("About")
+        translations["en"]["counts.0"].should eq("1")
+        translations["en"]["counts.1"].should eq("2")
+        translations["en"]["menu.0.label"].should eq("First")
+        translations["en"]["menu.1.label"].should eq("Second")
+      end
+    end
   end
 
   describe ".translate" do

--- a/spec/unit/image_hooks_spec.cr
+++ b/spec/unit/image_hooks_spec.cr
@@ -377,6 +377,41 @@ describe Hwaro::Content::Hooks::ImageHooks do
       end
     end
 
+    it "reuses when a configured width exceeds the source (clamped to _<src_w>w)" do
+      # #389 clamp branch: config asks for 9999 but the source is only 640px,
+      # so resize_and_lqip wrote a single photo_640w.jpg. The on-disk set
+      # {320, 640} must still match what the current config produces (9999
+      # clamps to 640), so the image is reused — not re-decoded every rebuild.
+      Dir.mktmpdir do |dir|
+        source = File.join(dir, "photo.jpg")
+        File.write(source, "src")
+        dest_dir = File.join(dir, "out")
+        Dir.mkdir_p(dest_dir)
+        File.write(File.join(dest_dir, "photo_320w.jpg"), "320")
+        File.write(File.join(dest_dir, "photo_640w.jpg"), "640")
+
+        result = Hwaro::Content::Hooks::ImageHooks.reusable_widths(source, dest_dir, [320, 640, 9999])
+        result.should_not be_nil
+        result.not_nil!.should eq({320 => "photo_320w.jpg", 640 => "photo_640w.jpg"})
+      end
+    end
+
+    it "reuses when two configured widths collapse onto one source width (.uniq!)" do
+      # Both 640 and 1280 clamp to the 640px source, so .uniq! collapses them
+      # to [640] — which matches the lone photo_640w.jpg on disk → reuse.
+      Dir.mktmpdir do |dir|
+        source = File.join(dir, "photo.jpg")
+        File.write(source, "src")
+        dest_dir = File.join(dir, "out")
+        Dir.mkdir_p(dest_dir)
+        File.write(File.join(dest_dir, "photo_640w.jpg"), "640")
+
+        result = Hwaro::Content::Hooks::ImageHooks.reusable_widths(source, dest_dir, [640, 1280])
+        result.should_not be_nil
+        result.not_nil!.should eq({640 => "photo_640w.jpg"})
+      end
+    end
+
     it "returns nil when a destination is zero bytes" do
       # Defends against a killed serve leaving a half-written resized file:
       # mtime is valid but the file is empty, and reusing it would serve a

--- a/spec/unit/importers/astro_importer_spec.cr
+++ b/spec/unit/importers/astro_importer_spec.cr
@@ -49,6 +49,77 @@ describe Hwaro::Services::Importers::AstroImporter do
       end
     end
 
+    it "extracts src from a structured heroImage object" do
+      # Astro's official starter blog ships `heroImage: { src, alt }` (a YAML
+      # mapping), exercising the `when Hash` branch and the image["src"]?
+      # YAML::Any indexing. A regression mapping the wrong key would silently
+      # drop the cover image on every imported Astro post using that shape.
+      Dir.mktmpdir do |dir|
+        blog_dir = File.join(dir, "src", "content", "blog")
+        FileUtils.mkdir_p(blog_dir)
+
+        post_content = <<-ASTRO
+          ---
+          title: "Structured Hero"
+          heroImage:
+            src: /images/hero.jpg
+            alt: Hero
+          ---
+          Content.
+          ASTRO
+
+        File.write(File.join(blog_dir, "structured-hero.md"), post_content)
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "astro",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::AstroImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(1)
+        content = File.read(File.join(output_dir, "blog", "structured-hero.md"))
+        content.should contain("image = \"/images/hero.jpg\"")
+      end
+    end
+
+    it "emits no image when a structured heroImage object lacks src" do
+      # Object with only `alt:` — no src to extract, so no image field and
+      # no crash on the YAML::Any indexing path.
+      Dir.mktmpdir do |dir|
+        blog_dir = File.join(dir, "src", "content", "blog")
+        FileUtils.mkdir_p(blog_dir)
+
+        post_content = <<-ASTRO
+          ---
+          title: "Alt Only Hero"
+          heroImage:
+            alt: Just alt text
+          ---
+          Content.
+          ASTRO
+
+        File.write(File.join(blog_dir, "alt-only-hero.md"), post_content)
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "astro",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::AstroImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(1)
+        content = File.read(File.join(output_dir, "blog", "alt-only-hero.md"))
+        content.should_not contain("image =")
+      end
+    end
+
     it "maps pubDate to date" do
       Dir.mktmpdir do |dir|
         blog_dir = File.join(dir, "src", "content", "blog")

--- a/spec/unit/importers/eleventy_importer_spec.cr
+++ b/spec/unit/importers/eleventy_importer_spec.cr
@@ -243,6 +243,87 @@ describe Hwaro::Services::Importers::EleventyImporter do
       end
     end
 
+    it "round-trips nested .11tydata.json directory data through YAML dump/reparse" do
+      # Regression guard for json_any_to_yaml_any's recursive Array/Hash
+      # branches and the .11tydata.json precedence path: nested objects/arrays
+      # in dir-data must survive YAML.dump/reparse so the merged tags appear.
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "posts")
+        FileUtils.mkdir_p(posts_dir)
+
+        # .11tydata.json takes precedence over posts.json (untested before).
+        File.write(
+          File.join(posts_dir, "posts.11tydata.json"),
+          %({"tags": ["a", "b"], "meta": {"k": "v"}})
+        )
+
+        File.write(File.join(posts_dir, "nested-merge.md"), <<-ELEVENTY
+          ---
+          title: "Nested Merge"
+          ---
+          Content.
+          ELEVENTY
+        )
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "eleventy",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::EleventyImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(1)
+        content = File.read(File.join(output_dir, "posts", "nested-merge.md"))
+        content.should contain("title = \"Nested Merge\"")
+        # The nested array tags survive the dump/reparse round trip.
+        content.should contain("tags = [\"a\", \"b\"]")
+      end
+    end
+
+    it "lets file frontmatter win over directory data on a type conflict" do
+      # dir-data provides tags as an array, the file provides a scalar string.
+      # File overrides win; the merge must not error.
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "posts")
+        FileUtils.mkdir_p(posts_dir)
+
+        File.write(
+          File.join(posts_dir, "posts.json"),
+          %({"tags": ["a", "b"]})
+        )
+
+        File.write(File.join(posts_dir, "type-conflict.md"), <<-ELEVENTY
+          ---
+          title: "Type Conflict"
+          tags: solo
+          ---
+          Content.
+          ELEVENTY
+        )
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "eleventy",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::EleventyImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(1)
+        result.error_count.should eq(0)
+        content = File.read(File.join(output_dir, "posts", "type-conflict.md"))
+        # File's scalar value wins over the dir-data array.
+        content.should contain("tags = [\"solo\"]")
+        content.should_not contain("\"a\"")
+        content.should_not contain("\"b\"")
+      end
+    end
+
     it "returns error result for non-existent directory" do
       options = Hwaro::Config::Options::ImportOptions.new(
         source_type: "eleventy",

--- a/spec/unit/importers/html_to_markdown_spec.cr
+++ b/spec/unit/importers/html_to_markdown_spec.cr
@@ -90,6 +90,20 @@ describe Hwaro::Services::Importers::HtmlToMarkdown do
       result.should eq("& < > \"")
     end
 
+    it "decodes an in-range numeric entity to its codepoint" do
+      result = Hwaro::Services::Importers::HtmlToMarkdown.convert("a &#128512; b")
+      result.should eq("a 😀 b")
+    end
+
+    it "drops a numeric entity that overflows Int32 instead of crashing" do
+      # &#99999999999999999999; would raise ArgumentError on to_i; it must be
+      # dropped (out of Unicode range) while the surrounding text survives.
+      result = Hwaro::Services::Importers::HtmlToMarkdown.convert("<p>x &#99999999999999999999; y</p>")
+      result.should contain("x")
+      result.should contain("y")
+      result.should_not contain("9999")
+    end
+
     it "strips unknown tags" do
       result = Hwaro::Services::Importers::HtmlToMarkdown.convert("<div><span>text</span></div>")
       result.should eq("text")

--- a/spec/unit/importers/jekyll_importer_spec.cr
+++ b/spec/unit/importers/jekyll_importer_spec.cr
@@ -553,6 +553,98 @@ describe Hwaro::Services::Importers::JekyllImporter do
       end
     end
 
+    it "silently drops one of two source files that collide on the same slug" do
+      # Two distinct posts whose date-stripped slug is identical ("hello")
+      # both map to posts/hello.md. Under no-force, the first (sorted) input
+      # is imported and the second is skipped — silent data loss in a one-shot
+      # migration. This pins the current behavior and would catch a regression
+      # (or motivate a de-dup / slug-suffix fix).
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "_posts")
+        FileUtils.mkdir_p(posts_dir)
+
+        File.write(File.join(posts_dir, "2024-01-01-hello.md"), <<-JEKYLL
+          ---
+          title: "First Hello"
+          ---
+          First post body.
+          JEKYLL
+        )
+        File.write(File.join(posts_dir, "2024-06-02-hello.md"), <<-JEKYLL
+          ---
+          title: "Second Hello"
+          ---
+          Second post body.
+          JEKYLL
+        )
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "jekyll",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::JekyllImporter.new
+        result = importer.run(options)
+
+        # Exactly one survives; the other is silently dropped.
+        result.imported_count.should eq(1)
+        result.skipped_count.should eq(1)
+
+        # Dir.glob yields sorted paths, so the 2024-01-01 file wins.
+        output_file = File.join(output_dir, "posts", "hello.md")
+        File.exists?(output_file).should be_true
+        content = File.read(output_file)
+        content.should contain("First post body.")
+        content.should_not contain("Second post body.")
+      end
+    end
+
+    it "counts a malformed-YAML post as an error while still importing valid posts" do
+      # Jekyll's YAML.parse has no local rescue, so a malformed `---` block
+      # raises YAML::ParseException and the entire post (body included) is
+      # dropped via run's per-file rescue (error_count++). The valid post in
+      # the same run still imports. Unlike Hugo, the broken-YAML body is lost.
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "_posts")
+        FileUtils.mkdir_p(posts_dir)
+
+        File.write(File.join(posts_dir, "2024-01-01-bad.md"), <<-JEKYLL
+          ---
+          title: "unterminated
+          ---
+          Bad post body.
+          JEKYLL
+        )
+        File.write(File.join(posts_dir, "2024-01-02-good.md"), <<-JEKYLL
+          ---
+          title: "Good Post"
+          ---
+          Good post body.
+          JEKYLL
+        )
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "jekyll",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::JekyllImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(1)
+        result.error_count.should eq(1)
+        # success = imported > 0 || errors == 0 -> true here.
+        result.success.should be_true
+
+        File.exists?(File.join(output_dir, "posts", "good.md")).should be_true
+        File.exists?(File.join(output_dir, "posts", "bad.md")).should be_false
+      end
+    end
+
     it "handles post without frontmatter" do
       Dir.mktmpdir do |dir|
         posts_dir = File.join(dir, "_posts")

--- a/spec/unit/initializer_spec.cr
+++ b/spec/unit/initializer_spec.cr
@@ -334,6 +334,22 @@ describe Hwaro::Services::Initializer do
         end
       end
 
+      it "writes a parseable multilingual config.toml in default mode (real loader)" do
+        # build_balanced_default_config assembles the [languages] block via raw
+        # String concatenation (a prior duplicate-key TOML bug lived here). A
+        # substring check can't catch a missing newline / duplicate key, so load
+        # the generated file with the real config loader end-to-end.
+        Dir.mktmpdir do |dir|
+          target = File.join(dir, "site")
+          Hwaro::Services::Initializer.new.run(target, multilingual_languages: ["en", "ko"])
+
+          config = Hwaro::Models::Config.load(File.join(target, "config.toml"))
+          config.default_language.should eq("en")
+          config.languages.has_key?("en").should be_true
+          config.languages.has_key?("ko").should be_true
+        end
+      end
+
       it "enables languages in --full-config mode (regression: full config dropped multilingual)" do
         Dir.mktmpdir do |dir|
           target = File.join(dir, "site")

--- a/spec/unit/internal_link_resolver_spec.cr
+++ b/spec/unit/internal_link_resolver_spec.cr
@@ -112,6 +112,34 @@ describe Hwaro::Content::Processors::InternalLinkResolver do
       )
       result.should eq %(<a href="/a/b/docs/">docs</a>)
     end
+
+    it "resolves a @/ link carrying a query string (ampersand escaped once)" do
+      pages = {"blog/post.md" => make_page("blog/post.md", "/blog/post/")}
+      html = %(<a href="@/blog/post.md?page=2&sort=asc">link</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.resolve(html, pages, "index.md")
+      result.should eq %(<a href="/blog/post/?page=2&amp;sort=asc">link</a>)
+    end
+
+    it "resolves a @/ link carrying both a query string and an anchor (query before anchor)" do
+      pages = {"blog/post.md" => make_page("blog/post.md", "/blog/post/")}
+      html = %(<a href="@/blog/post.md?page=2&sort=asc#sec">link</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.resolve(html, pages, "index.md")
+      result.should eq %(<a href="/blog/post/?page=2&amp;sort=asc#sec">link</a>)
+    end
+
+    it "ignores a host-only base_url instead of prefixing it onto links" do
+      pages = {"a.md" => make_page("a.md", "/a/")}
+      html = %(<a href="@/a.md">x</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.resolve(html, pages, "src.md", "example.com")
+      result.should eq %(<a href="/a/">x</a>)
+    end
+
+    it "does not raise or embed a malformed base_url into resolved links" do
+      pages = {"a.md" => make_page("a.md", "/a/")}
+      html = %(<a href="@/a.md">x</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.resolve(html, pages, "src.md", "not a url")
+      result.should eq %(<a href="/a/">x</a>)
+    end
   end
 
   describe ".prefix_root_relative_links" do
@@ -192,6 +220,18 @@ describe Hwaro::Content::Processors::InternalLinkResolver do
     it "is a no-op when the page URL has no host (empty base_url deploy)" do
       html = %(<a href="../x/">x</a>)
       Hwaro::Content::Processors::InternalLinkResolver.absolutize_links(html, "/p/").should eq(html)
+    end
+
+    it "leaves an empty href value untouched" do
+      html = %(<a href="">empty</a>)
+      Hwaro::Content::Processors::InternalLinkResolver.absolutize_links(html, "https://h.com/p/").should eq(html)
+    end
+
+    it "resolves a relative link carrying an encoded entity without double-encoding it" do
+      html = %(<a href="sub/?a=1&amp;b=2">q</a>)
+      result = Hwaro::Content::Processors::InternalLinkResolver.absolutize_links(html, "https://h.com/p/")
+      result.should contain(%(href="https://h.com/p/sub/?a=1&amp;b=2"))
+      result.should_not contain("&amp;amp;")
     end
   end
 end

--- a/spec/unit/js_minifier_spec.cr
+++ b/spec/unit/js_minifier_spec.cr
@@ -603,5 +603,15 @@ describe Hwaro::Utils::JsMinifier do
       result = Hwaro::Utils::JsMinifier.minify(js)
       result.should contain("(a + b) / c")
     end
+
+    it "leaves a counterfeit out-of-range JSPL placeholder token intact" do
+      # A real template literal makes protected_spans non-empty so the restore
+      # gsub actually runs; the bogus \x00JSPL999\x00 token has an out-of-range
+      # index, so the bounds guard emits it unchanged rather than raising.
+      # If the guard regressed, minify would raise IndexError here and fail.
+      result = Hwaro::Utils::JsMinifier.minify("var t = `hi`; var s = \"\u{0}JSPL999\u{0}\";")
+      result.should contain("\u{0}JSPL999\u{0}") # bogus token survives verbatim
+      result.should contain("`hi`")              # real template literal restored
+    end
   end
 end

--- a/spec/unit/json_xml_processors_spec.cr
+++ b/spec/unit/json_xml_processors_spec.cr
@@ -126,6 +126,28 @@ describe Hwaro::Content::Processors::Json do
       result.error.should_not be_nil
     end
 
+    it "round-trips a max-Int64 integer losslessly" do
+      processor = Hwaro::Content::Processors::Json.new
+      context = Hwaro::Content::Processors::ProcessorContext.new
+
+      input = %q({"n":9223372036854775807})
+      result = processor.process(input, context)
+      result.error.should be_nil
+      result.content.should eq(input)
+    end
+
+    it "reports an error for an integer larger than Int64 (pinned parser limit)" do
+      # Crystal's JSON parser cannot represent integers beyond Int64, so a
+      # valid-but-huge literal currently fails to minify rather than being
+      # preserved. Pin this so a future numeric-preserving fix is deliberate.
+      processor = Hwaro::Content::Processors::Json.new
+      context = Hwaro::Content::Processors::ProcessorContext.new
+
+      input = %q({"n": 123456789012345678901234567890})
+      result = processor.process(input, context)
+      result.error.should_not be_nil
+    end
+
     it "handles JSON with special characters in strings" do
       processor = Hwaro::Content::Processors::Json.new
       context = Hwaro::Content::Processors::ProcessorContext.new
@@ -303,6 +325,26 @@ describe Hwaro::Content::Processors::Xml do
       input = "<root><item>value</item></root>"
       result = processor.process(input, context)
       result.content.should eq(input)
+    end
+
+    it "preserves whitespace and newlines inside a CDATA section" do
+      # CDATA is raw character data (RSS <content:encoded>, embedded scripts,
+      # pre-formatted code) — its internal whitespace must not be collapsed.
+      processor = Hwaro::Content::Processors::Xml.new
+      context = Hwaro::Content::Processors::ProcessorContext.new
+
+      input = "<root>\n  <![CDATA[ keep   these    spaces\n  and newline ]]>\n</root>"
+      result = processor.process(input, context)
+      result.content.should contain("<![CDATA[ keep   these    spaces\n  and newline ]]>")
+    end
+
+    it "preserves whitespace and newlines inside an XML comment" do
+      processor = Hwaro::Content::Processors::Xml.new
+      context = Hwaro::Content::Processors::ProcessorContext.new
+
+      input = "<root>\n  <!-- keep   these    spaces\n  and newline -->\n</root>"
+      result = processor.process(input, context)
+      result.content.should contain("<!-- keep   these    spaces\n  and newline -->")
     end
 
     it "minifies XML with attributes" do

--- a/spec/unit/jsonld_extended_spec.cr
+++ b/spec/unit/jsonld_extended_spec.cr
@@ -40,6 +40,33 @@ describe Hwaro::Content::Seo::JsonLd do
 
       Hwaro::Content::Seo::JsonLd.faq_page(page, config).should eq("")
     end
+
+    # The documented primary form `[[extra.faq]]` parses to an Array of
+    # Hash(String, ExtraValue). Malformed entries (missing answer, or a
+    # non-hash element) must be silently dropped, not crash.
+    it "builds FAQPage from a table-array hash form, dropping malformed entries" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/faq/"
+
+      arr = [
+        {"question" => "A?".as(Hwaro::Models::ExtraValue), "answer" => "B".as(Hwaro::Models::ExtraValue)}.as(Hwaro::Models::ExtraValue),
+        {"question" => "C?".as(Hwaro::Models::ExtraValue)}.as(Hwaro::Models::ExtraValue), # missing answer
+        "bare-string".as(Hwaro::Models::ExtraValue),                                      # non-hash element
+      ] of Hwaro::Models::ExtraValue
+      page.extra["faq"] = arr.as(Hwaro::Models::ExtraValue)
+
+      config = Hwaro::Models::Config.new
+      result = Hwaro::Content::Seo::JsonLd.faq_page(page, config)
+
+      json_str = result.gsub(/<\/?script[^>]*>/, "")
+      json = JSON.parse(json_str)
+      json["@type"].as_s.should eq("FAQPage")
+      entities = json["mainEntity"].as_a
+      entities.size.should eq(1)
+      entities[0]["@type"].as_s.should eq("Question")
+      entities[0]["name"].as_s.should eq("A?")
+      entities[0]["acceptedAnswer"]["text"].as_s.should eq("B")
+    end
   end
 
   describe ".how_to" do
@@ -74,6 +101,35 @@ describe Hwaro::Content::Seo::JsonLd do
       config = Hwaro::Models::Config.new
 
       Hwaro::Content::Seo::JsonLd.how_to(page, config).should eq("")
+    end
+
+    # The documented primary form `[[extra.howto_steps]]` parses to an Array
+    # of Hash(String, ExtraValue). Malformed entries (missing text, or a
+    # non-hash element) must be silently dropped, not crash.
+    it "builds HowTo from a table-array hash form, dropping malformed entries" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/tutorial/"
+      page.title = "Getting Started"
+
+      arr = [
+        {"name" => "Install".as(Hwaro::Models::ExtraValue), "text" => "Run install command.".as(Hwaro::Models::ExtraValue)}.as(Hwaro::Models::ExtraValue),
+        {"name" => "Configure".as(Hwaro::Models::ExtraValue)}.as(Hwaro::Models::ExtraValue), # missing text
+        "bare-string".as(Hwaro::Models::ExtraValue),                                         # non-hash element
+      ] of Hwaro::Models::ExtraValue
+      page.extra["howto_steps"] = arr.as(Hwaro::Models::ExtraValue)
+
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+      result = Hwaro::Content::Seo::JsonLd.how_to(page, config)
+
+      json_str = result.gsub(/<\/?script[^>]*>/, "")
+      json = JSON.parse(json_str)
+      json["@type"].as_s.should eq("HowTo")
+      steps = json["step"].as_a
+      steps.size.should eq(1)
+      steps[0]["@type"].as_s.should eq("HowToStep")
+      steps[0]["name"].as_s.should eq("Install")
+      steps[0]["text"].as_s.should eq("Run install command.")
     end
   end
 

--- a/spec/unit/lifecycle_context_spec.cr
+++ b/spec/unit/lifecycle_context_spec.cr
@@ -291,6 +291,16 @@ describe Hwaro::Core::Lifecycle::BuildContext do
       ctx.set("count", 5)
       ctx.get_bool("count", false).should be_false
     end
+
+    it "returns a stored false even when the default is true" do
+      # Regression: `value || default` would collapse a stored false to the
+      # truthy default, inverting a flag a previous hook intentionally set.
+      options = Hwaro::Config::Options::BuildOptions.new
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+
+      ctx.set("flag", false)
+      ctx.get_bool("flag", true).should be_false
+    end
   end
 
   describe "#set and #get_int" do
@@ -308,6 +318,14 @@ describe Hwaro::Core::Lifecycle::BuildContext do
 
       ctx.get_int("missing").should eq(0)
       ctx.get_int("missing", 99).should eq(99)
+    end
+
+    it "returns a stored 0 even when the default is non-zero" do
+      options = Hwaro::Config::Options::BuildOptions.new
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+
+      ctx.set("n", 0)
+      ctx.get_int("n", 99).should eq(0)
     end
 
     it "returns default when value is not an int" do

--- a/spec/unit/lifecycle_manager_spec.cr
+++ b/spec/unit/lifecycle_manager_spec.cr
@@ -117,6 +117,21 @@ describe Hwaro::Core::Lifecycle::Manager do
       manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeInitialize, ctx)
       second_ran.should be_false
     end
+
+    it "re-raises a HwaroError unchanged instead of downgrading to Abort" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(Hwaro::Config::Options::BuildOptions.new)
+
+      manager.on(Hwaro::Core::Lifecycle::HookPoint::BeforeInitialize, name: "classified-raiser") do |_|
+        raise Hwaro::HwaroError.new(Hwaro::Errors::HWARO_E_CONFIG, "bad config")
+      end
+
+      error = expect_raises(Hwaro::HwaroError) do
+        manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeInitialize, ctx)
+      end
+      error.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+      error.exit_code.should eq(Hwaro::Errors::EXIT_CONFIG)
+    end
   end
 
   describe "#trigger" do
@@ -222,6 +237,25 @@ describe Hwaro::Core::Lifecycle::Manager do
       end
 
       result.should eq(Hwaro::Core::Lifecycle::HookResult::Abort)
+      after_ran.should be_false
+    end
+
+    it "re-raises a HwaroError from the action and does not run after hooks" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(Hwaro::Config::Options::BuildOptions.new)
+      after_ran = false
+
+      manager.after(Hwaro::Core::Lifecycle::Phase::ParseContent, name: "after") do |_|
+        after_ran = true
+        Hwaro::Core::Lifecycle::HookResult::Continue
+      end
+
+      error = expect_raises(Hwaro::HwaroError) do
+        manager.run_phase(Hwaro::Core::Lifecycle::Phase::ParseContent, ctx) do
+          raise Hwaro::HwaroError.new(Hwaro::Errors::HWARO_E_CONTENT, "boom")
+        end
+      end
+      error.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
       after_ran.should be_false
     end
 

--- a/spec/unit/llms_spec.cr
+++ b/spec/unit/llms_spec.cr
@@ -236,6 +236,26 @@ describe Hwaro::Content::Seo::Llms do
         content.should_not contain("Tag: foo")
       end
     end
+
+    # A title with `[`, `]`, or `\` would break the `- [label](url)` Markdown
+    # link unless escaped. Backslash is escaped first, then the brackets.
+    it "escapes brackets and backslashes in page titles for the link label" do
+      config = Hwaro::Models::Config.new
+      config.llms.enabled = true
+      config.title = "T"
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("guide.md")
+      page.title = "Guide [v2] \\ stuff"
+      page.url = "/guide/"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Llms.generate(config, [page], output_dir)
+
+        content = File.read(File.join(output_dir, "llms.txt"))
+        content.should contain("- [Guide \\[v2\\] \\\\ stuff](https://example.com/guide/)")
+      end
+    end
   end
 
   describe ".generate (with pages)" do

--- a/spec/unit/multilingual_utils_spec.cr
+++ b/spec/unit/multilingual_utils_spec.cr
@@ -219,6 +219,22 @@ describe Hwaro::Content::Multilingual do
       key = Hwaro::Content::Multilingual.translation_key("blog\\post.ko.md", config)
       key.should eq("blog/post.md")
     end
+
+    # Regression: only the FIRST matching language suffix may be stripped. For a
+    # filename with two stacked codes ("post.en.ko.md") the loop (iterating
+    # languages in insertion order: ko first) strips ".ko.md" -> "post.en.md"
+    # and breaks. Stripping both would over-strip to "post.md" and mis-group two
+    # unrelated files as translations of each other (wrong switcher links).
+    it "strips only the first matching language suffix for stacked codes" do
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+      config.languages["en"] = Hwaro::Models::LanguageConfig.new("en")
+
+      key = Hwaro::Content::Multilingual.translation_key("post.en.ko.md", config)
+      key.should eq("post.en.md")
+      key.should_not eq("post.md")
+    end
   end
 
   describe ".link_translations!" do

--- a/spec/unit/new_command_spec.cr
+++ b/spec/unit/new_command_spec.cr
@@ -218,6 +218,40 @@ describe Hwaro::CLI::Commands::NewCommand do
       end
     end
 
+    it "rejects `..`-escaping --section with HWARO_E_USAGE" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = ""\n))
+          FileUtils.mkdir_p("content")
+          # Benign path arg isolates the --section guard (the section
+          # validate_and_normalize_path! block).
+          err = expect_raises(Hwaro::HwaroError) do
+            Hwaro::CLI::Commands::NewCommand.new.run(["post.md", "--section", "../escape"])
+          end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+
+          # `--section ..` must not write a file outside content/.
+          File.exists?(File.join(dir, "escape", "post.md")).should be_false
+          File.exists?("escape/post.md").should be_false
+        end
+      end
+    end
+
+    it "sanitizes a URL-unsafe --section to a safe on-disk directory" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = ""\n))
+          FileUtils.mkdir_p("content")
+          Hwaro::CLI::Commands::NewCommand.new.run(["post.md", "--section", "my section!"])
+
+          # The space/`!` are rewritten before the section becomes a directory,
+          # so the file lands under a sanitized dir, not a literal "my section!".
+          Dir.exists?("content/my section!").should be_false
+          File.exists?("content/my-section/post.md").should be_true
+        end
+      end
+    end
+
     it "normalizes double slashes in the input path" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do

--- a/spec/unit/og_image_hooks_spec.cr
+++ b/spec/unit/og_image_hooks_spec.cr
@@ -76,5 +76,88 @@ describe Hwaro::Content::Hooks::OgImageHooks do
         result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
       end
     end
+
+    # Guards that gate the expensive OgImage.generate call. A regression here
+    # would re-render every PNG on each keystroke rebuild during dev (the cost
+    # these guards avoid), or invert and ship pages with a missing og:image.
+    it "skips generation when options.skip_og_image is true (--skip-og-image)" do
+      Dir.mktmpdir do |output_dir|
+        config = Hwaro::Models::Config.new
+        config.og.auto_image.enabled = true
+
+        site = Hwaro::Models::Site.new(config)
+        options = Hwaro::Config::Options::BuildOptions.new(
+          output_dir: output_dir,
+          skip_og_image: true,
+        )
+
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options: options)
+        ctx.output_dir = output_dir
+        ctx.site = site
+
+        manager = Hwaro::Core::Lifecycle::Manager.new
+        hooks = Hwaro::Content::Hooks::OgImageHooks.new
+        hooks.register_hooks(manager)
+
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeRender, ctx)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+        Dir.glob(File.join(output_dir, "**", "*.png")).should be_empty
+      end
+    end
+
+    it "skips generation in serve mode when lazy_generate is enabled" do
+      Dir.mktmpdir do |output_dir|
+        config = Hwaro::Models::Config.new
+        config.og.auto_image.enabled = true
+        config.og.auto_image.lazy_generate = true
+
+        site = Hwaro::Models::Site.new(config)
+        options = Hwaro::Config::Options::BuildOptions.new(
+          output_dir: output_dir,
+          serve_mode: true,
+        )
+
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options: options)
+        ctx.output_dir = output_dir
+        ctx.site = site
+
+        manager = Hwaro::Core::Lifecycle::Manager.new
+        hooks = Hwaro::Content::Hooks::OgImageHooks.new
+        hooks.register_hooks(manager)
+
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeRender, ctx)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+        Dir.glob(File.join(output_dir, "**", "*.png")).should be_empty
+      end
+    end
+
+    it "does NOT skip generation when lazy_generate is enabled but not in serve mode" do
+      # Contrast: lazy_generate alone (without serve_mode) does not gate
+      # generation. With zero pages OgImage.generate is a cheap no-op, so the
+      # hook still returns Continue and writes nothing — confirming the guard
+      # requires BOTH lazy_generate AND serve_mode.
+      Dir.mktmpdir do |output_dir|
+        config = Hwaro::Models::Config.new
+        config.og.auto_image.enabled = true
+        config.og.auto_image.lazy_generate = true
+
+        site = Hwaro::Models::Site.new(config)
+        options = Hwaro::Config::Options::BuildOptions.new(
+          output_dir: output_dir,
+          serve_mode: false,
+        )
+
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options: options)
+        ctx.output_dir = output_dir
+        ctx.site = site
+
+        manager = Hwaro::Core::Lifecycle::Manager.new
+        hooks = Hwaro::Content::Hooks::OgImageHooks.new
+        hooks.register_hooks(manager)
+
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeRender, ctx)
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+      end
+    end
   end
 end

--- a/spec/unit/og_image_spec.cr
+++ b/spec/unit/og_image_spec.cr
@@ -845,6 +845,85 @@ describe Hwaro::Content::Seo::OgImage do
       end
     end
 
+    # Two distinct URLs that collapse to the same slug after gsub("/", "-")
+    # (/posts/foo/ and /posts-foo/ both -> "posts-foo") must each own a
+    # distinct on-disk path. The first to claim the slug keeps the bare slug;
+    # the second gets a SHA256(url)[0,8] suffix. Without this disambiguation,
+    # both pages would write to ONE path (torn file under -Dpreview_mt) and one
+    # page would advertise an OG image rendered for the other.
+    it "disambiguates colliding URL slugs with a stable URL-hash suffix" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.og.auto_image.enabled = true
+        config.og.auto_image.format = "svg"
+
+        page1 = Hwaro::Models::Page.new("a.md")
+        page1.title = "Slashed Foo"
+        page1.url = "/posts/foo/"
+        page1.render = true
+
+        page2 = Hwaro::Models::Page.new("b.md")
+        page2.title = "Hyphen Foo"
+        page2.url = "/posts-foo/"
+        page2.render = true
+
+        Hwaro::Content::Seo::OgImage.generate([page1, page2], config, dir)
+
+        # First-seen page keeps the bare slug.
+        bare_path = File.join(dir, "og-images", "posts-foo.svg")
+        File.exists?(bare_path).should be_true
+        page1.image.should eq("/og-images/posts-foo.svg")
+
+        # Second-seen colliding page gets the SHA256(url)[0,8] suffix.
+        suffix = Digest::SHA256.hexdigest(page2.url)[0, 8]
+        suffixed_path = File.join(dir, "og-images", "posts-foo-#{suffix}.svg")
+        File.exists?(suffixed_path).should be_true
+        page2.image.should eq("/og-images/posts-foo-#{suffix}.svg")
+
+        # The two pages own distinct files (no overwrite).
+        page1.image.should_not eq(page2.image)
+        File.read(bare_path).should contain("Slashed Foo")
+        File.read(suffixed_path).should contain("Hyphen Foo")
+      end
+    end
+
+    # When the PNG renderer fails (e.g. stbi_write_png cannot open the target
+    # path) generate() must fall back to writing an SVG, still set page.image,
+    # and log a warning. Force the failure by pre-creating <slug>.png as a
+    # directory so stbi_write_png returns 0.
+    it "falls back to SVG and warns when PNG rendering fails" do
+      next unless Hwaro::Content::Seo::OgPngRenderer.available?
+
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.og.auto_image.enabled = true
+        config.og.auto_image.format = "png"
+
+        page = Hwaro::Models::Page.new("test.md")
+        page.title = "Fallback Title"
+        page.url = "/posts/png-test/"
+        page.render = true
+
+        # Block the PNG write: create <slug>.png as a directory.
+        img_dir = File.join(dir, "og-images")
+        Dir.mkdir_p(img_dir)
+        Dir.mkdir_p(File.join(img_dir, "posts-png-test.png"))
+
+        log = with_captured_log do
+          Hwaro::Content::Seo::OgImage.generate([page], config, dir)
+        end
+
+        page.image.not_nil!.ends_with?(".svg").should be_true
+        page.image.should eq("/og-images/posts-png-test.svg")
+
+        svg_path = File.join(img_dir, "posts-png-test.svg")
+        File.exists?(svg_path).should be_true
+        File.read(svg_path).should contain("Fallback Title")
+
+        log.should contain("PNG render failed")
+      end
+    end
+
     it "generates an image when png format is set" do
       Dir.mktmpdir do |dir|
         config = Hwaro::Models::Config.new

--- a/spec/unit/og_png_renderer_spec.cr
+++ b/spec/unit/og_png_renderer_spec.cr
@@ -317,6 +317,160 @@ describe Hwaro::Content::Seo::OgPngRenderer do
         result.should be_true
       end
     end
+
+    # config.cr only rejects non-finite opacity; a finite but out-of-range
+    # value (e.g. 1.8 or -0.5) passes through from TOML. Every opacity branch
+    # relies on .clamp(0.0,1.0) before .to_u8 (the gradient branch even carries
+    # a comment that a missing clamp raises OverflowError). These render with
+    # out-of-range opacities to pin that no OverflowError aborts the build.
+    {1.8, -0.5}.each do |opacity|
+      it "renders dots style with out-of-range pattern_opacity #{opacity} without OverflowError" do
+        next unless Hwaro::Content::Seo::OgPngRenderer.available?
+
+        Dir.mktmpdir do |dir|
+          page = Hwaro::Models::Page.new("test.md")
+          page.title = "Dots Opacity"
+
+          config = Hwaro::Models::Config.new
+          config.og.auto_image.style = "dots"
+          config.og.auto_image.pattern_opacity = opacity
+
+          png_path = File.join(dir, "dots-opacity.png")
+          result = Hwaro::Content::Seo::OgPngRenderer.render_png(page, config, png_path)
+          result.should be_true
+          data = File.open(png_path, "rb", &.getb_to_end)
+          data[0].should eq(0x89_u8) # PNG magic byte
+        end
+      end
+
+      it "renders gradient style with out-of-range pattern_opacity #{opacity} without OverflowError" do
+        next unless Hwaro::Content::Seo::OgPngRenderer.available?
+
+        Dir.mktmpdir do |dir|
+          page = Hwaro::Models::Page.new("test.md")
+          page.title = "Gradient Opacity"
+
+          config = Hwaro::Models::Config.new
+          config.og.auto_image.style = "gradient"
+          config.og.auto_image.pattern_opacity = opacity
+
+          png_path = File.join(dir, "gradient-opacity.png")
+          result = Hwaro::Content::Seo::OgPngRenderer.render_png(page, config, png_path)
+          result.should be_true
+          data = File.open(png_path, "rb", &.getb_to_end)
+          data[0].should eq(0x89_u8) # PNG magic byte
+        end
+      end
+    end
+
+    it "renders a background overlay with out-of-range overlay_opacity without OverflowError" do
+      next unless Hwaro::Content::Seo::OgPngRenderer.available?
+
+      Dir.mktmpdir do |dir|
+        bg_path = File.join(dir, "bg.png")
+        pixel = Pointer(UInt8).malloc(4)
+        pixel[0] = 0_u8; pixel[1] = 0_u8; pixel[2] = 255_u8; pixel[3] = 255_u8
+        LibStb.stbi_write_png(bg_path, 1, 1, 4, pixel.as(Void*), 4)
+        GC.free(pixel.as(Void*))
+
+        page = Hwaro::Models::Page.new("test.md")
+        page.title = "Overlay Opacity"
+
+        config = Hwaro::Models::Config.new
+        config.og.auto_image.background_image = bg_path
+        config.og.auto_image.overlay_opacity = 2.0
+
+        png_path = File.join(dir, "overlay-opacity.png")
+        result = Hwaro::Content::Seo::OgPngRenderer.render_png(page, config, png_path, nil, bg_path)
+        result.should be_true
+        data = File.open(png_path, "rb", &.getb_to_end)
+        data[0].should eq(0x89_u8) # PNG magic byte
+      end
+    end
+
+    # render_png's only failure signal is the boolean return from
+    # stbi_write_png. Writing into a read-only directory makes the write fail;
+    # render_png must return false (not raise) and leave no file behind.
+    it "returns false without raising when the png cannot be written" do
+      next unless Hwaro::Content::Seo::OgPngRenderer.available?
+      next if LibC.getuid == 0 # root bypasses chmod-based unwritability
+
+      Dir.mktmpdir do |dir|
+        ro_dir = File.join(dir, "readonly")
+        Dir.mkdir_p(ro_dir)
+        File.chmod(ro_dir, 0o500)
+        begin
+          page = Hwaro::Models::Page.new("test.md")
+          page.title = "Write Failure"
+
+          config = Hwaro::Models::Config.new
+
+          png_path = File.join(ro_dir, "out.png")
+          result = Hwaro::Content::Seo::OgPngRenderer.render_png(page, config, png_path)
+          result.should be_false
+          File.exists?(png_path).should be_false
+        ensure
+          File.chmod(ro_dir, 0o700) # restore so mktmpdir cleanup succeeds
+        end
+      end
+    end
+
+    # An empty / whitespace-only title yields title_lines == [] from
+    # word_wrap_measured. The terminal-cursor branch (!title_lines.empty?) and
+    # the hero ghost branch (page.title.split.first? / unless empty?) are
+    # load-bearing guards; render must no-op those branches without raising.
+    ["", "   "].each do |blank|
+      label = blank.empty? ? "empty" : "whitespace-only"
+
+      it "renders terminal style with an #{label} title without raising" do
+        next unless Hwaro::Content::Seo::OgPngRenderer.available?
+
+        Dir.mktmpdir do |dir|
+          page = Hwaro::Models::Page.new("test.md")
+          page.title = blank
+
+          config = Hwaro::Models::Config.new
+          config.og.auto_image.style = "terminal"
+
+          png_path = File.join(dir, "terminal-blank.png")
+          result = Hwaro::Content::Seo::OgPngRenderer.render_png(page, config, png_path)
+          result.should be_true
+        end
+      end
+
+      it "renders hero style with an #{label} title without raising" do
+        next unless Hwaro::Content::Seo::OgPngRenderer.available?
+
+        Dir.mktmpdir do |dir|
+          page = Hwaro::Models::Page.new("test.md")
+          page.title = blank
+
+          config = Hwaro::Models::Config.new
+          config.og.auto_image.style = "hero"
+
+          png_path = File.join(dir, "hero-blank.png")
+          result = Hwaro::Content::Seo::OgPngRenderer.render_png(page, config, png_path)
+          result.should be_true
+        end
+      end
+    end
+  end
+
+  describe ".load_image" do
+    # load_image decodes/resizes logo & bg images via stb. Its failure guards
+    # must each return nil cleanly (and free the source buffer) rather than
+    # raise or segfault on a user-supplied corrupt or missing image.
+    it "returns nil for a corrupt (non-image) file" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "corrupt.png")
+        File.write(path, "this is not an image")
+        Hwaro::Content::Seo::OgPngRenderer.load_image(path, 48, 48).should be_nil
+      end
+    end
+
+    it "returns nil for a nonexistent path" do
+      Hwaro::Content::Seo::OgPngRenderer.load_image("/nonexistent/logo.png", 48, 48).should be_nil
+    end
   end
 
   describe "integration with OgImage.generate" do

--- a/spec/unit/page_methods_spec.cr
+++ b/spec/unit/page_methods_spec.cr
@@ -79,6 +79,24 @@ describe Hwaro::Models::Page do
       page.calculate_word_count
       page.word_count.should eq(3)
     end
+
+    it "counts space-separated CJK runs as whitespace-delimited words (documented limitation)" do
+      # The single-pass scanner counts any run of non-delimiter chars as one
+      # word, so a space-separated CJK string counts space-runs as 3 words
+      # (a space-less CJK paragraph would collapse to 1). Pin the contract.
+      page = Hwaro::Models::Page.new("test.md")
+      page.raw_content = "한국어 테스트 문서"
+      page.calculate_word_count.should eq(3)
+    end
+
+    it "does not raise on an opened-but-never-closed real tag (swallows the tail)" do
+      # `<a` flips into tag mode; with no closing '>' the rest of the document
+      # is swallowed. This pins graceful degradation (count of pre-tag words,
+      # no crash) on truncated/malformed HTML.
+      page = Hwaro::Models::Page.new("test.md")
+      page.raw_content = "hello <a href=foo and more text"
+      page.calculate_word_count.should eq(1)
+    end
   end
 
   describe "#calculate_reading_time" do

--- a/spec/unit/phases_parse_content_spec.cr
+++ b/spec/unit/phases_parse_content_spec.cr
@@ -157,6 +157,24 @@ describe Hwaro::Core::Build::Phases::ParseContent do
         missing.parse_failed.should be_false
       end
     end
+
+    it "re-raises classified frontmatter errors (HWARO_E_CONTENT) to abort the build" do
+      # Unterminated TOML string between `+++` fences reliably raises from
+      # TOML.parse and is classified as HWARO_E_CONTENT (markdown.cr). Unlike a
+      # generic parse failure, this must propagate so CI/scripts see exit 5.
+      with_content_dir({
+        "bad.md" => "+++\ntitle = \"x\nbroken toml\n+++\nbody",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        bad = Hwaro::Models::Page.new("bad.md")
+        ex = expect_raises(Hwaro::HwaroError) do
+          builder.test_parse_content_sequential([bad])
+        end
+        ex.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+      end
+    end
   end
 
   describe "#parse_content_parallel" do
@@ -173,6 +191,35 @@ describe Hwaro::Core::Build::Phases::ParseContent do
         builder.test_parse_content_parallel(pages)
 
         pages.map(&.title).sort!.should eq(["A", "B", "C"])
+      end
+    end
+
+    it "re-raises a classified frontmatter error after draining all workers" do
+      # The parallel path records the first HWARO_E_CONTENT under a mutex, keeps
+      # draining the queue, and re-raises after every worker joins. A bad page
+      # mixed with good pages must still abort (not hang, not swallow) while the
+      # good pages are still parsed. Crystal's spec timeout guards against a hang.
+      with_content_dir({
+        "good1.md" => "---\ntitle: Good1\n---\nx",
+        "good2.md" => "---\ntitle: Good2\n---\nx",
+        "good3.md" => "---\ntitle: Good3\n---\nx",
+        "good4.md" => "---\ntitle: Good4\n---\nx",
+        "bad.md"   => "+++\ntitle = \"x\nbroken toml\n+++\nbody",
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        good = ["good1.md", "good2.md", "good3.md", "good4.md"].map { |p| Hwaro::Models::Page.new(p) }
+        bad = Hwaro::Models::Page.new("bad.md")
+        pages = [good[0], good[1], bad, good[2], good[3]]
+
+        ex = expect_raises(Hwaro::HwaroError) do
+          builder.test_parse_content_parallel(pages)
+        end
+        ex.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+
+        # Good pages were still parsed before the build aborted.
+        good.map(&.title).sort!.should eq(["Good1", "Good2", "Good3", "Good4"])
       end
     end
   end

--- a/spec/unit/phases_write_spec.cr
+++ b/spec/unit/phases_write_spec.cr
@@ -54,6 +54,25 @@ describe Hwaro::Core::Build::Phases::Write do
         end
       end
     end
+
+    it "raises HWARO_E_TEMPLATE when the 404 template is malformed" do
+      # A broken templates/404.html must abort the Write phase (fail loud)
+      # rather than ship a green build. apply_template wraps the Crinja parse
+      # error as HWARO_E_TEMPLATE; generate_404_page has no rescue around it.
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("public")
+          site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+          templates = {"404" => "{{ unclosed"}
+
+          builder = Hwaro::Core::Build::Builder.new
+          err = expect_raises(Hwaro::HwaroError) do
+            builder.test_generate_404_page(site, templates, "public", false, false)
+          end
+          err.code.should eq(Hwaro::Errors::HWARO_E_TEMPLATE)
+        end
+      end
+    end
   end
 
   describe "#process_raw_files" do

--- a/spec/unit/platform_config_spec.cr
+++ b/spec/unit/platform_config_spec.cr
@@ -104,6 +104,48 @@ describe Hwaro::Services::PlatformConfig do
 
         result.should contain("name = \"my-cool-blog\"")
       end
+
+      # A symbol-only or empty title sanitizes to an empty string; without the
+      # fallback wrangler emits `name = ""` which Cloudflare rejects.
+      it "falls back to 'my-site' when the title sanitizes to empty" do
+        config = Hwaro::Models::Config.new
+        config.title = "!!!"
+        generator = Hwaro::Services::PlatformConfig.new(config)
+        result = generator.generate("cloudflare")
+
+        result.should contain("name = \"my-site\"")
+        result.should_not contain("name = \"\"")
+      end
+
+      it "collapses symbol runs and strips leading/trailing dashes from the project name" do
+        config = Hwaro::Models::Config.new
+        config.title = "--Hi  There!!--"
+        generator = Hwaro::Services::PlatformConfig.new(config)
+        result = generator.generate("cloudflare")
+
+        result.should contain("name = \"hi-there\"")
+      end
+
+      # _redirects is space-delimited; an alias with whitespace or a quote would
+      # split into the wrong number of fields and corrupt the file, so such
+      # entries are skipped while well-formed ones are kept.
+      it "skips redirect aliases containing whitespace or quotes" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            File.write("content/posts/p.md", "---\ntitle: P\naliases:\n  - /old url/\n  - \"/qu\\\"ote/\"\n  - /clean/\n---\nContent here\n")
+
+            config = Hwaro::Models::Config.new
+            generator = Hwaro::Services::PlatformConfig.new(config)
+            result = generator.generate("cloudflare")
+
+            # Clean alias is emitted as a `# from to 301` comment line.
+            result.should contain("# /clean/ /posts/p/ 301")
+            result.should_not contain("/old url/")
+            result.should_not contain("/qu\"ote/")
+          end
+        end
+      end
     end
 
     describe "aliases" do
@@ -232,6 +274,35 @@ describe Hwaro::Services::PlatformConfig do
             vercel["redirects"][0]["source"].as_s.should eq("/myrepo/old/")
             vercel["redirects"][0]["destination"].as_s.should eq("/myrepo/moved/")
             vercel["headers"][0]["source"].as_s.should eq("/myrepo/assets/(.*)")
+          end
+        end
+      end
+
+      # An alias is arbitrary user frontmatter; a quote or backslash must be
+      # TOML-escaped or the emitted netlify.toml is unparseable, breaking the
+      # user's deploy. Exercise both gsub branches (quote and backslash).
+      it "escapes TOML-special characters in netlify redirect from/to so the block stays parseable" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            # YAML double-quoted scalars inject a literal quote and backslash
+            # into the alias values.
+            File.write("content/posts/p.md", "---\ntitle: P\naliases:\n  - \"/we\\\"ird/\"\n  - \"/back\\\\slash/\"\n---\nContent here\n")
+
+            config = Hwaro::Models::Config.new
+            generator = Hwaro::Services::PlatformConfig.new(config)
+            result = generator.generate("netlify")
+
+            # The quote is escaped as \" and the backslash as \\.
+            result.should contain("from = \"/we\\\"ird/\"")
+            result.should contain("from = \"/back\\\\slash/\"")
+
+            # The emitted netlify.toml must parse as valid TOML, and the
+            # escaped values must round-trip back to the original aliases.
+            parsed = TOML.parse(result)
+            froms = parsed["redirects"].as_a.map(&.["from"].as_s)
+            froms.should contain("/we\"ird/")
+            froms.should contain("/back\\slash/")
           end
         end
       end

--- a/spec/unit/processors_gaps_spec.cr
+++ b/spec/unit/processors_gaps_spec.cr
@@ -40,6 +40,22 @@ private class GapHigherProcessor < GapTestProcessor
   end
 end
 
+# Forces Markdown#process down its rescue branch by raising from the inherited
+# render. The override matches render's full signature so process's
+# render(content) call dispatches here.
+private class FailingMarkdown < Hwaro::Content::Processors::Markdown
+  def render(
+    content : String,
+    highlight : Bool = true,
+    safe : Bool = false,
+    lazy_loading : Bool = false,
+    emoji : Bool = false,
+    markdown_config : Hwaro::Models::MarkdownConfig? = nil,
+  ) : Tuple(String, Array(Hwaro::Models::TocHeader))
+    raise "boom"
+  end
+end
+
 # Capture and restore the registry around each test so we don't pollute other
 # specs that depend on the default-registered processors (markdown, html, ...).
 #
@@ -141,6 +157,18 @@ describe Hwaro::Content::Processors::Markdown do
       result.success.should be_true
       result.content.should contain("<ul")
       result.content.should contain("<strong>")
+    end
+
+    it "wraps a render failure into an error ProcessorResult (degrade, not crash)" do
+      md = FailingMarkdown.new
+      ctx = Hwaro::Content::Processors::ProcessorContext.new
+      result = md.process("# Hello\n\nWorld", ctx)
+
+      result.success.should be_false
+      result.content.should eq("")
+      result.error.should_not be_nil
+      result.error.not_nil!.starts_with?("Markdown processing failed:").should be_true
+      result.error.not_nil!.should contain("boom")
     end
   end
 

--- a/spec/unit/pwa_spec.cr
+++ b/spec/unit/pwa_spec.cr
@@ -226,6 +226,43 @@ describe Hwaro::Content::Seo::Pwa do
       end
     end
 
+    # A present-but-corrupt PNG (bad signature) must fall back to the filename
+    # heuristic rather than emitting a bogus size or raising.
+    it "falls back to the filename-derived size for a non-PNG file with the .png extension" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "icon-256.png"), "not a png at all")
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          icons = ["static/icon-256.png"]
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        manifest = JSON.parse(File.read(File.join(dir, "manifest.json")))
+        manifest["icons"].as_a[0]["sizes"].as_s.should eq("256x256")
+      end
+    end
+
+    # A truncated PNG (<24 bytes, even with a valid signature) is too short to
+    # hold an IHDR; the read<24 guard must trigger the filename fallback.
+    it "falls back to the filename-derived size for a truncated PNG (under 24 bytes)" do
+      Dir.mktmpdir do |dir|
+        # Valid 8-byte signature only — not enough bytes for the IHDR dims.
+        File.write(File.join(dir, "icon-256.png"), Bytes[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          icons = ["static/icon-256.png"]
+          TOML
+
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+
+        manifest = JSON.parse(File.read(File.join(dir, "manifest.json")))
+        manifest["icons"].as_a[0]["sizes"].as_s.should eq("256x256")
+      end
+    end
+
     it "normalizes icon paths with and without static/ prefix" do
       Dir.mktmpdir do |dir|
         site = make_site(<<-TOML)

--- a/spec/unit/redirect_html_spec.cr
+++ b/spec/unit/redirect_html_spec.cr
@@ -52,6 +52,25 @@ describe Hwaro::Utils::RedirectHtml do
       Hwaro::Utils::RedirectHtml.full_redirect("https://example.com/").should contain("window.location.href")
       Hwaro::Utils::RedirectHtml.full_redirect("/blog/post/").should contain("window.location.href")
     end
+
+    it "escapes U+2028/U+2029 line terminators in the JS string literal" do
+      # A bare U+2028/U+2029 would terminate the JS string on pre-ES2019 engines,
+      # breaking the redirect. They must be \u-escaped in the <script> context.
+      r1 = Hwaro::Utils::RedirectHtml.full_redirect("/path\u{2028}x")
+      r1.should contain("\\u2028")
+      r1.should contain("window.location.href") # treated as safe relative URL
+      r2 = Hwaro::Utils::RedirectHtml.full_redirect("/path\u{2029}x")
+      r2.should contain("\\u2029")
+      r2.should contain("window.location.href")
+    end
+
+    it "escapes newline and carriage return in the JS string literal" do
+      r1 = Hwaro::Utils::RedirectHtml.full_redirect("/a\nb")
+      r1.should contain("window.location.href = \"/a\\nb\";") # JS literal escaped, no raw newline
+      r2 = Hwaro::Utils::RedirectHtml.full_redirect("/a\rb")
+      r2.should contain("\\r")
+      r2.should contain("window.location.href")
+    end
   end
 
   describe ".simple_redirect" do

--- a/spec/unit/remote_scaffold_spec.cr
+++ b/spec/unit/remote_scaffold_spec.cr
@@ -55,6 +55,20 @@ describe Hwaro::Services::Scaffolds::Remote do
       subpath.should eq("docs")
     end
 
+    it "routes git://github.com/owner/repo through the URL parser (not git: shorthand)" do
+      owner, repo, subpath = Hwaro::Services::Scaffolds::Remote.parse_source("git://github.com/hahwul/hwaro-starter-blog")
+      owner.should eq("hahwul")
+      repo.should eq("hwaro-starter-blog")
+      subpath.should eq("")
+    end
+
+    it "parses git://github.com/owner/repo/subpath via the URL parser" do
+      owner, repo, subpath = Hwaro::Services::Scaffolds::Remote.parse_source("git://github.com/owner/repo/docs")
+      owner.should eq("owner")
+      repo.should eq("repo")
+      subpath.should eq("docs")
+    end
+
     it "parses https://github.com/owner/repo URL" do
       owner, repo, subpath = Hwaro::Services::Scaffolds::Remote.parse_source("https://github.com/hahwul/hwaro-starter-blog")
       owner.should eq("hahwul")
@@ -239,6 +253,31 @@ describe Hwaro::Services::Scaffolds::Remote do
       err.code.should eq(Hwaro::Errors::HWARO_E_NETWORK)
       err.exit_code.should eq(7)
       err.message.not_nil!.should contain("HTTP 500")
+    end
+
+    it "raises HwaroError(HWARO_E_NETWORK) when a 200 body is missing 'default_branch'" do
+      TestRemoteHelper.stub_response(200, %({"name":"repo"}))
+      helper = TestRemoteHelper.new
+
+      err = expect_raises(Hwaro::HwaroError) do
+        helper.do_fetch_default_branch("some-owner", "some-repo")
+      end
+
+      err.code.should eq(Hwaro::Errors::HWARO_E_NETWORK)
+      err.exit_code.should eq(7)
+      err.message.not_nil!.should contain("missing 'default_branch'")
+    end
+
+    # A non-JSON 200 body crashes in JSON.parse BEFORE the `|| raise`, so it
+    # surfaces as a bare JSON::ParseException (not a classified HwaroError).
+    # This pins the current unguarded behavior.
+    it "raises JSON::ParseException on a non-JSON 200 body (unguarded)" do
+      TestRemoteHelper.stub_response(200, "<html>not json</html>")
+      helper = TestRemoteHelper.new
+
+      expect_raises(JSON::ParseException) do
+        helper.do_fetch_default_branch("some-owner", "some-repo")
+      end
     end
   end
 end

--- a/spec/unit/robots_spec.cr
+++ b/spec/unit/robots_spec.cr
@@ -296,6 +296,29 @@ describe Hwaro::Content::Seo::Robots do
       end
     end
 
+    it "collapses newlines in user_agent/disallow to prevent directive injection" do
+      config = Hwaro::Models::Config.new
+      config.robots.enabled = true
+
+      rule = Hwaro::Models::RobotsRule.new("Bot\nDisallow: /secret")
+      rule.allow = [] of String
+      rule.disallow = ["/a\n/b"]
+      config.robots.rules = [rule]
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Robots.generate(config, output_dir)
+
+        content = File.read(File.join(output_dir, "robots.txt"))
+        # The embedded newline collapses to a space, keeping it one line.
+        content.should contain("User-agent: Bot Disallow: /secret")
+        # No standalone injected directive line was forged.
+        content.lines.any? { |l| l.strip == "Disallow: /secret" }.should be_false
+        # The disallow path's newline collapses to a single line too.
+        content.should contain("Disallow: /a /b")
+        content.lines.any? { |l| l.strip == "/b" }.should be_false
+      end
+    end
+
     it "separates multiple rules with blank lines" do
       config = Hwaro::Models::Config.new
       config.robots.enabled = true

--- a/spec/unit/scaffolds_spec.cr
+++ b/spec/unit/scaffolds_spec.cr
@@ -776,3 +776,81 @@ describe Hwaro::Services::Scaffolds::Registry do
     end
   end
 end
+
+# Helper to drive the protected prepend_translation_notice without a network
+# hop, mirroring the TestRemoteHelper wrapper pattern in remote_scaffold_spec.cr.
+class TestNoticeScaffold < Hwaro::Services::Scaffolds::Simple
+  def do_prepend(body : String, lang : String) : String
+    prepend_translation_notice(body, lang)
+  end
+end
+
+describe "minimal_config_content multilingual parseability" do
+  # minimal_config_content assembles the [languages] block via raw String
+  # concatenation; a missing newline / duplicate key / TOML-special char in a
+  # language_name would slip past substring checks but break the first
+  # `hwaro build`. Parse it with the real config loader to catch that.
+  it "produces parseable multilingual TOML with [languages.en]/[languages.ko] tables for every built-in scaffold" do
+    Hwaro::Services::Scaffolds::Registry.all.each do |scaffold|
+      toml = scaffold.minimal_config_content(multilingual_languages: ["en", "ko"])
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.toml")
+        File.write(path, toml)
+        config = Hwaro::Models::Config.load(path)
+
+        config.default_language.should eq("en")
+        config.languages.has_key?("en").should be_true
+        config.languages.has_key?("ko").should be_true
+      end
+    end
+  end
+
+  it "produces parseable multilingual TOML with skip_taxonomies for every built-in scaffold" do
+    Hwaro::Services::Scaffolds::Registry.all.each do |scaffold|
+      toml = scaffold.minimal_config_content(skip_taxonomies: true, multilingual_languages: ["en", "ko"])
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "config.toml")
+        File.write(path, toml)
+        config = Hwaro::Models::Config.load(path)
+
+        config.languages.has_key?("en").should be_true
+        config.languages.has_key?("ko").should be_true
+        # No global [[taxonomies]] block when skipped.
+        toml.should_not contain("[[taxonomies]]")
+      end
+    end
+  end
+end
+
+describe "prepend_translation_notice" do
+  # The built-in scaffolds all ship TOML (+++) front matter, so the YAML
+  # (---) branch and the unclosed-delimiter fallback are never exercised by
+  # built-in content. Drive them directly.
+  it "inserts the notice after a closing YAML (---) delimiter, before the body" do
+    body = "---\ntitle: X\n---\n\nbody"
+    result = TestNoticeScaffold.new.do_prepend(body, "ko")
+
+    notice_at = result.index!("<!-- TODO: Translate")
+    close_at = result.index!("---", 4) # closing delimiter, past the opening one
+    body_at = result.index!("body")
+
+    notice_at.should be > close_at
+    notice_at.should be < body_at
+    # The front-matter block at the top of the result still parses cleanly
+    # (the notice did not get injected between the delimiters).
+    lines = result.lines
+    second_delim = lines[1..].index!("---") + 1
+    inner = lines[1...second_delim].join("\n")
+    YAML.parse(inner)["title"].as_s.should eq("X")
+  end
+
+  it "prepends the notice at the top when the YAML delimiter is unclosed (fallback)" do
+    body = "---\ntitle: X"
+    result = TestNoticeScaffold.new.do_prepend(body, "ko")
+
+    result.index!("<!-- TODO: Translate").should eq(0)
+    result.should contain("---\ntitle: X")
+  end
+end

--- a/spec/unit/search_spec.cr
+++ b/spec/unit/search_spec.cr
@@ -157,6 +157,45 @@ describe Hwaro::Content::Search do
       end
     end
 
+    # Regression: the exclude match must respect the path-segment boundary. The
+    # `excluded + "/"` guard in search.cr means excluding "/blog" drops pages
+    # genuinely under /blog/ (and the exact "/blog") but must NOT strip a sibling
+    # like /blogroll/ that merely shares the prefix segment. Removing the
+    # trailing-slash boundary would silently drop legitimate pages.
+    it "does not exclude pages that merely share a prefix segment" do
+      config = Hwaro::Models::Config.new
+      config.search.enabled = true
+      config.search.fields = ["title", "url"]
+      config.search.exclude = ["/blog"]
+
+      under = Hwaro::Models::Page.new("blog/post.md")
+      under.title = "Blog Post"
+      under.url = "/blog/post/"
+      under.draft = false
+      under.raw_content = "Content"
+
+      sibling = Hwaro::Models::Page.new("blogroll.md")
+      sibling.title = "Blogroll"
+      sibling.url = "/blogroll/"
+      sibling.draft = false
+      sibling.raw_content = "Content"
+
+      exact = Hwaro::Models::Page.new("blog.md")
+      exact.title = "Blog Index"
+      exact.url = "/blog"
+      exact.draft = false
+      exact.raw_content = "Content"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Search.generate([under, sibling, exact], config, output_dir)
+
+        content = File.read(File.join(output_dir, "search.json"))
+        content.should contain("/blogroll/")
+        content.should_not contain("/blog/post/")
+        content.should_not contain("\"/blog\"")
+      end
+    end
+
     it "uses custom filename" do
       config = Hwaro::Models::Config.new
       config.search.enabled = true

--- a/spec/unit/serve_command_spec.cr
+++ b/spec/unit/serve_command_spec.cr
@@ -47,6 +47,27 @@ describe Hwaro::CLI::Commands::ServeCommand do
       options.port.should eq(8080)
     end
 
+    it "raises HwaroError(HWARO_E_USAGE) when --port is out of range or non-numeric" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+
+      ["0", "-1", "99999", "abc", ""].each do |bad|
+        err = expect_raises(Hwaro::HwaroError) do
+          cmd.test_parse_options(["--port", bad])
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      end
+    end
+
+    it "accepts the inclusive --port boundary values 1 and 65535" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+
+      _, options = cmd.test_parse_options(["--port", "1"])
+      options.port.should eq(1)
+
+      _, options = cmd.test_parse_options(["--port", "65535"])
+      options.port.should eq(65535)
+    end
+
     it "parses --bind flag" do
       cmd = Hwaro::CLI::Commands::ServeCommand.new
       _, options = cmd.test_parse_options(["--bind", "127.0.0.1"])
@@ -216,6 +237,17 @@ describe Hwaro::CLI::Commands::ServeCommand do
       cmd = Hwaro::CLI::Commands::ServeCommand.new
       _, options = cmd.test_parse_options(["--header", "X-Foo = bar baz"])
       options.headers["X-Foo"].should eq("bar baz")
+    end
+
+    it "preserves a colon inside the --header value (split on first colon only)" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options([
+        "--header", "Refresh: 5; url=https://example.com",
+        "--header", "CSP: default-src https://a.com",
+      ])
+      # Value is .strip-ped, but the colon(s) after the first are kept intact.
+      options.headers["Refresh"].should eq("5; url=https://example.com")
+      options.headers["CSP"].should eq("default-src https://a.com")
     end
 
     it "raises on invalid --header (empty key)" do

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -16,6 +16,10 @@ module Hwaro
         ready_signal_line(host, port)
       end
 
+      def test_ready_signal_json(host : String, port : Int32) : String
+        ready_signal_json(host, port)
+      end
+
       def test_run_with_options(host, port, open_browser, access_log, live_reload, build_options, json_output)
         run_with_options(host, port, open_browser, access_log, live_reload, build_options, json_output)
       end
@@ -55,6 +59,25 @@ class DummyHandler
 
   def call(context)
     @called = true
+  end
+end
+
+# Downstream handler that writes a fixed Content-Type so post-processing
+# handlers (CharsetHandler, CustomHeadersHandler) can be exercised against a
+# realistic response. When @content_type is nil it sets no Content-Type at all.
+class ContentTypeHandler
+  include HTTP::Handler
+
+  property called : Bool = false
+
+  def initialize(@content_type : String?)
+  end
+
+  def call(context)
+    @called = true
+    if ct = @content_type
+      context.response.headers["Content-Type"] = ct
+    end
   end
 end
 
@@ -100,6 +123,31 @@ describe Hwaro::Services::Server do
       server = Hwaro::Services::Server.new
       line = server.test_ready_signal_line("0.0.0.0", 8080)
       line.should contain("url=http://0.0.0.0:8080")
+    end
+  end
+
+  describe "#ready_signal_json" do
+    it "emits the documented {event,url,host,port,pid} schema" do
+      server = Hwaro::Services::Server.new
+      parsed = JSON.parse(server.test_ready_signal_json("127.0.0.1", 3000))
+      parsed["event"].as_s.should eq("ready")
+      parsed["url"].as_s.should eq("http://127.0.0.1:3000")
+      parsed["host"].as_s.should eq("127.0.0.1")
+      parsed["port"].as_i.should eq(3000)
+      parsed["pid"].as_i.should eq(Process.pid)
+    end
+
+    it "emits port as a JSON integer, not a string" do
+      server = Hwaro::Services::Server.new
+      parsed = JSON.parse(server.test_ready_signal_json("0.0.0.0", 8080))
+      parsed["port"].as_i?.should eq(8080)
+      parsed["port"].as_s?.should be_nil
+    end
+
+    it "is a single line with no embedded newline" do
+      server = Hwaro::Services::Server.new
+      json = server.test_ready_signal_json("localhost", 4567)
+      json.includes?('\n').should be_false
     end
   end
 end
@@ -340,6 +388,111 @@ describe Hwaro::Services::DevCorsHandler do
     response.headers["Access-Control-Allow-Origin"]?.should be_nil
     response.headers["Access-Control-Allow-Methods"]?.should be_nil
     dummy.called.should be_false
+  end
+
+  it "reflects a bracketed loopback IPv6 Origin (strips brackets before membership check)" do
+    handler = Hwaro::Services::DevCorsHandler.new
+    dummy = DummyHandler.new
+    handler.next = dummy
+
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(cors_request("GET", "http://[::1]:3000"), response)
+
+    handler.call(context)
+
+    response.headers["Access-Control-Allow-Origin"].should eq("http://[::1]:3000")
+    response.headers["Vary"].should eq("Origin")
+    dummy.called.should be_true
+  end
+
+  it "does NOT grant CORS to a non-loopback bracketed IPv6 Origin" do
+    handler = Hwaro::Services::DevCorsHandler.new
+    dummy = DummyHandler.new
+    handler.next = dummy
+
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(cors_request("GET", "http://[2001:db8::1]:3000"), response)
+
+    handler.call(context)
+
+    response.headers["Access-Control-Allow-Origin"]?.should be_nil
+    dummy.called.should be_true
+  end
+end
+
+private def run_charset(content_type : String?)
+  handler = Hwaro::Services::CharsetHandler.new
+  handler.next = ContentTypeHandler.new(content_type)
+
+  io = IO::Memory.new
+  response = HTTP::Server::Response.new(io)
+  context = HTTP::Server::Context.new(HTTP::Request.new("GET", "/"), response)
+
+  handler.call(context)
+  response
+end
+
+describe Hwaro::Services::CharsetHandler do
+  it "appends charset to application/json" do
+    run_charset("application/json").headers["Content-Type"].should eq("application/json; charset=utf-8")
+  end
+
+  it "appends charset to feed and SVG text-shaped types" do
+    run_charset("application/rss+xml").headers["Content-Type"].should eq("application/rss+xml; charset=utf-8")
+    run_charset("image/svg+xml").headers["Content-Type"].should eq("image/svg+xml; charset=utf-8")
+  end
+
+  it "leaves binary types untouched (no charset)" do
+    run_charset("image/png").headers["Content-Type"].should eq("image/png")
+    run_charset("font/woff2").headers["Content-Type"].should eq("font/woff2")
+  end
+
+  it "is idempotent when a charset already exists (no double-append)" do
+    run_charset("text/html; charset=iso-8859-1").headers["Content-Type"].should eq("text/html; charset=iso-8859-1")
+  end
+
+  it "is a no-op when downstream sets no Content-Type" do
+    response = run_charset(nil)
+    response.headers["Content-Type"]?.should be_nil
+  end
+end
+
+describe Hwaro::Services::CustomHeadersHandler do
+  it "applies user headers and overrides built-ins set downstream" do
+    handler = Hwaro::Services::CustomHeadersHandler.new({
+      "X-Frame-Options" => "DENY",
+      "Content-Type"    => "text/custom",
+    })
+    handler.next = ContentTypeHandler.new("text/html")
+
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(HTTP::Request.new("GET", "/"), response)
+
+    handler.call(context)
+
+    response.headers["X-Frame-Options"].should eq("DENY")
+    # User value wins over the Content-Type the downstream handler set.
+    response.headers["Content-Type"].should eq("text/custom")
+  end
+
+  it "drops a header whose value contains control characters (defense-in-depth)" do
+    handler = Hwaro::Services::CustomHeadersHandler.new({
+      "X-Frame-Options" => "DENY",
+      "X-Evil"          => "a\r\nInjected: 1",
+    })
+    handler.next = ContentTypeHandler.new("text/html")
+
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(HTTP::Request.new("GET", "/"), response)
+
+    handler.call(context)
+
+    response.headers["X-Frame-Options"].should eq("DENY")
+    response.headers["X-Evil"]?.should be_nil
   end
 end
 
@@ -993,6 +1146,19 @@ describe Hwaro::Services::ChangeSet do
         config_changed: true,
       )
       cs.description.should eq("1 content, 1 template, 1 added, config file(s)")
+    end
+
+    it "describes content-asset and removed buckets" do
+      cs = Hwaro::Services::ChangeSet.new(
+        modified_content: [] of String,
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: [] of String,
+        removed_files: ["content/old.md"],
+        config_changed: false,
+        modified_content_files: ["content/a/cover.jpg"],
+      )
+      cs.description.should eq("1 content-asset, 1 removed file(s)")
     end
   end
 

--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -332,6 +332,29 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
       args["_0"].should eq("alpha")
       args["_1"].should eq("beta")
     end
+
+    # Characterization: a call that mixes a leading positional with a trailing
+    # named arg currently drops the positional. The named-arg branch fires once
+    # any `key=` is present, and the positional fallback is gated on
+    # `args.empty?`, so the quoted positional is never captured (no _0). This
+    # pins the present contract; if mixed args ever start preserving the
+    # positional, this assertion is the regression/intent guard that flips.
+    it "drops a leading positional once a named arg is present (current contract)" do
+      builder = Hwaro::Core::Build::Builder.new
+      args = builder.test_sc_parse_args(%("/img.jpg", caption="hi"))
+      args["caption"].should eq("hi")
+      args.has_key?("_0").should be_false
+    end
+
+    it "renders figure with an empty src for a mixed positional+named call (current contract)" do
+      builder = Hwaro::Core::Build::Builder.new
+      # The positional "/img.jpg" is dropped, so the figure src never fills.
+      result = builder.test_sc_process(
+        %({{ figure("/img.jpg", caption="hi") }}),
+      )
+      result.should contain(%(<img src="" ))
+      result.should contain("<figcaption>hi</figcaption>")
+    end
   end
 
   describe "placeholders" do

--- a/spec/unit/site_methods_spec.cr
+++ b/spec/unit/site_methods_spec.cr
@@ -230,6 +230,76 @@ describe Hwaro::Models::Site do
     end
   end
 
+  describe "#section_for" do
+    it "returns the language-specific section when present" do
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      site = Hwaro::Models::Site.new(config)
+
+      neutral = Hwaro::Models::Section.new("blog/_index.md")
+      neutral.section = "blog"
+      neutral.language = nil
+      neutral.title = "Neutral Blog"
+
+      ko = Hwaro::Models::Section.new("blog/_index.ko.md")
+      ko.section = "blog"
+      ko.language = "ko"
+      ko.title = "Korean Blog"
+
+      site.sections << neutral
+      site.sections << ko
+      site.build_lookup_index
+
+      site.section_for("blog", "ko").should eq(ko)
+    end
+
+    it "falls back to the language-neutral (nil) section for a missing language" do
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      site = Hwaro::Models::Site.new(config)
+
+      neutral = Hwaro::Models::Section.new("blog/_index.md")
+      neutral.section = "blog"
+      neutral.language = nil
+      neutral.title = "Neutral Blog"
+
+      site.sections << neutral
+      site.build_lookup_index
+
+      site.section_for("blog", "fr").should eq(neutral)
+    end
+
+    it "falls back to the default-language section when no neutral entry exists" do
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      site = Hwaro::Models::Site.new(config)
+
+      en = Hwaro::Models::Section.new("blog/_index.en.md")
+      en.section = "blog"
+      en.language = "en"
+      en.title = "English Blog"
+
+      site.sections << en
+      site.build_lookup_index
+
+      # No {blog, fr} and no {blog, nil}; must fall through to {blog, "en"}.
+      site.section_for("blog", "fr").should eq(en)
+    end
+
+    it "returns nil for an unknown section name" do
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      site = Hwaro::Models::Site.new(config)
+
+      blog = Hwaro::Models::Section.new("blog/_index.md")
+      blog.section = "blog"
+      site.sections << blog
+      site.build_lookup_index
+
+      site.section_for("missing", "en").should be_nil
+    end
+  end
+
   describe "#pages_for_section (with lookup index)" do
     it "returns direct pages for a section" do
       config = Hwaro::Models::Config.new
@@ -627,6 +697,25 @@ describe Hwaro::Models::Site do
       ko_pages.size.should eq(1)
       ko_pages.first.title.should eq("Korean Archived")
     end
+
+    it "terminates on a self-referencing transparent section (recursion guard)" do
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      # The index parent comes from Path[s.section].parent ("blog"), but the
+      # recursion key at line 142 comes from Path[s.path].dirname ("blog").
+      # So pages_for_section("blog") recurses back into "blog", which the
+      # `seen` guard must short-circuit instead of looping forever.
+      loopy = Hwaro::Models::Section.new("blog/_index.md")
+      loopy.section = "blog/sub"
+      loopy.transparent = true
+
+      site.sections << loopy
+      site.build_lookup_index
+
+      result = site.pages_for_section("blog", nil)
+      result.should be_a(Array(Hwaro::Models::Page))
+    end
   end
 
   describe "#pages_for_section (without lookup index)" do
@@ -707,6 +796,34 @@ describe Hwaro::Models::Site do
 
       result1.size.should eq(result2.size)
       result1.map(&.title).sort!.should eq(result2.map(&.title).sort!)
+    end
+
+    it "terminates on a transparent subsection chain via the unindexed path" do
+      config = Hwaro::Models::Config.new
+      site = Hwaro::Models::Site.new(config)
+
+      blog = Hwaro::Models::Section.new("blog/_index.md")
+      blog.section = "blog"
+
+      # Transparent child of "blog" that bubbles up; the unindexed recursion at
+      # line 175 passes the same content_items + shared `seen` set, so the guard
+      # is responsible for termination. Assert a finite array, not contents.
+      sub = Hwaro::Models::Section.new("blog/sub/_index.md")
+      sub.section = "blog/sub"
+      sub.transparent = true
+
+      post = Hwaro::Models::Page.new("blog/sub/post.md")
+      post.section = "blog/sub"
+      post.title = "Sub Post"
+
+      site.sections << blog
+      site.sections << sub
+      site.pages << post
+
+      # Do NOT call build_lookup_index - exercises the unindexed recursion site.
+      result = site.pages_for_section("blog", nil)
+      result.should be_a(Array(Hwaro::Models::Page))
+      result.should contain(post)
     end
   end
 

--- a/spec/unit/table_parser_spec.cr
+++ b/spec/unit/table_parser_spec.cr
@@ -217,6 +217,26 @@ describe Hwaro::Content::Processors::TableParser do
       result.scan(/<td/).size.should be >= 1
     end
 
+    it "keeps overflow cells when a row has more columns than headers" do
+      content = <<-MD
+        | A | B |
+        |---|---|
+        | 1 | 2 | 3 |
+        MD
+
+      result = Hwaro::Content::Processors::TableParser.process(content)
+      result.should contain("<table>")
+      # Only two headers are declared. /<th[ >]/ avoids matching the <thead>
+      # opening tag, so this counts real header cells (2).
+      result.scan(/<th[ >]/).size.should eq(2)
+      result.should contain("<th>A</th>")
+      result.should contain("<th>B</th>")
+      # The overflow third cell is KEPT (not dropped as GFM would), producing a
+      # ragged 3-<td> body row. This locks the current keep-overflow contract.
+      result.scan(/<td/).size.should eq(3)
+      result.should contain("<td>3</td>")
+    end
+
     it "handles escaped pipes within cells" do
       content = <<-MD
         | Command |

--- a/spec/unit/taxonomies_spec.cr
+++ b/spec/unit/taxonomies_spec.cr
@@ -85,6 +85,82 @@ describe Hwaro::Content::Taxonomies do
       end
     end
 
+    # A taxonomy with paginate_by set must split a term that exceeds the limit
+    # across /page/N/ directories. 5 pages with paginate_by=2 => ceil(5/2)=3
+    # pages: /tags/crystal/index.html (page 1) + page/2/ + page/3/, and NO
+    # page/4/. Exercises paginate_taxonomy + write_paginated_output + page_url.
+    it "splits a term across /page/N/ directories when paginate_by is set" do
+      config = Hwaro::Models::Config.new
+      tax = Hwaro::Models::TaxonomyConfig.new("tags")
+      tax.paginate_by = 2
+      config.taxonomies = [tax]
+
+      site = Hwaro::Models::Site.new(config)
+
+      pages = (1..5).map do |i|
+        page = Hwaro::Models::Page.new("post#{i}.md")
+        page.title = "Post #{i}"
+        page.url = "/blog/post#{i}/"
+        page.tags = ["crystal"]
+        page.draft = false
+        page.generated = false
+        page
+      end
+      site.pages = pages
+
+      Dir.mktmpdir do |output_dir|
+        templates = {
+          "taxonomy"      => "<html>{{ content }}</html>",
+          "taxonomy_term" => "<html>{{ content }}</html>",
+        }
+        Hwaro::Content::Taxonomies.generate(site, output_dir, templates)
+
+        File.exists?(File.join(output_dir, "tags", "crystal", "index.html")).should be_true
+        File.exists?(File.join(output_dir, "tags", "crystal", "page", "2", "index.html")).should be_true
+        File.exists?(File.join(output_dir, "tags", "crystal", "page", "3", "index.html")).should be_true
+        File.exists?(File.join(output_dir, "tags", "crystal", "page", "4", "index.html")).should be_false
+      end
+    end
+
+    # A term whose name slugifies to empty (all-symbol / emoji) must fall back to
+    # the safe_slugify "term-<hex>" token so it never produces a // path segment
+    # nor overwrites the /tags/ listing page itself.
+    it "uses the safe_slugify fallback for a term that slugifies to empty" do
+      config = Hwaro::Models::Config.new
+      config.taxonomies = [Hwaro::Models::TaxonomyConfig.new("tags")]
+      site = Hwaro::Models::Site.new(config)
+
+      page = Hwaro::Models::Page.new("post.md")
+      page.title = "Post"
+      page.url = "/blog/post/"
+      page.tags = ["🎉"]
+      page.draft = false
+      page.generated = false
+      site.pages = [page]
+
+      Dir.mktmpdir do |output_dir|
+        templates = {
+          "taxonomy"      => "<html>{{ content }}</html>",
+          "taxonomy_term" => "<html>{{ content }}</html>",
+        }
+        Hwaro::Content::Taxonomies.generate(site, output_dir, templates)
+
+        # Exactly one term dir, named with the non-empty term-<hex> fallback.
+        term_dirs = Dir.children(File.join(output_dir, "tags")).reject { |c| c == "index.html" }
+        term_dirs.size.should eq(1)
+        slug = term_dirs.first
+        slug.starts_with?("term-").should be_true
+
+        # The term page exists at a non-empty path segment (no /tags//).
+        File.exists?(File.join(output_dir, "tags", slug, "index.html")).should be_true
+
+        # The listing page was not overwritten by the term page; it still lists
+        # the raw term.
+        index = File.read(File.join(output_dir, "tags", "index.html"))
+        index.should contain("🎉")
+      end
+    end
+
     it "disambiguates distinct terms that slugify identically (no silent overwrite)" do
       config = Hwaro::Models::Config.new
       config.taxonomies = [Hwaro::Models::TaxonomyConfig.new("tags")]

--- a/spec/unit/template_spec.cr
+++ b/spec/unit/template_spec.cr
@@ -762,6 +762,33 @@ describe Hwaro::Content::Processors::Template do
       result = Hwaro::Content::Processors::Template.process(template, context)
       result.should eq("yes")
     end
+
+    it "returns false for matching test with an invalid regex (no raise)" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+      context.add("u", "anything")
+
+      # Unbalanced bracket "[" is an invalid regex; the rescue ArgumentError
+      # branch must return false rather than letting the error abort the build.
+      template = "{% if u is matching(\"[\") %}HIT{% else %}MISS{% endif %}"
+      result = Hwaro::Content::Processors::Template.process(template, context)
+      result.should eq("MISS")
+    end
+
+    it "matches consistently across repeated renders with a valid regex (cached)" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+      context.add("u", "photo.png")
+
+      template = "{% if u is matching(\"[.](jpg|png)$\") %}HIT{% else %}MISS{% endif %}"
+      Hwaro::Content::Processors::Template.process(template, context).should eq("HIT")
+      # Second render hits the cached compiled regex and must yield the same result.
+      Hwaro::Content::Processors::Template.process(template, context).should eq("HIT")
+    end
   end
 
   describe "Custom Functions" do
@@ -775,6 +802,19 @@ describe Hwaro::Content::Processors::Template do
       result = Hwaro::Content::Processors::Template.process(template, context)
       # Should contain a date-like string
       result.should match(/\d{4}-\d{2}-\d{2}/)
+    end
+
+    it "processes now function with explicit format argument" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+
+      template = "{{ now(format=\"%Y\") }}"
+      result = Hwaro::Content::Processors::Template.process(template, context)
+      # Explicit format branch should pass the format through to time.to_s
+      result.should match(/^\d{4}$/)
+      result.should eq(Time.local.year.to_s)
     end
 
     it "processes env function with set variable" do
@@ -835,6 +875,79 @@ describe Hwaro::Content::Processors::Template do
       template = "{{ url_for(path=\"/about/\") }}"
       result = Hwaro::Content::Processors::Template.process(template, context)
       result.should eq("https://example.com/about/")
+    end
+
+    it "load_data parses CSV cells (stripped) from a project-relative path" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data")
+          # Cells include surrounding whitespace to confirm .strip is applied.
+          File.write("data/menu.csv", "name , price\n Tea , 3 \n")
+
+          page = Hwaro::Models::Page.new("test.md")
+          config = Hwaro::Models::Config.new
+          context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+
+          template = "{% set d = load_data(path=\"data/menu.csv\") %}{{ d[1][0] }}|{{ d[1][1] }}"
+          result = Hwaro::Content::Processors::Template.process(template, context)
+          result.should eq("Tea|3")
+        end
+      end
+    end
+
+    it "load_data blocks path traversal outside the project root" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          page = Hwaro::Models::Page.new("test.md")
+          config = Hwaro::Models::Config.new
+          context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+
+          template = "[{{ load_data(path=\"../../../etc/passwd\") }}]"
+          result = Hwaro::Content::Processors::Template.process(template, context)
+          # Boundary check fails -> result stays Crinja nil. Crinja renders nil
+          # as the literal "none", so the traversal yields no file contents.
+          result.should eq("[none]")
+        end
+      end
+    end
+
+    it "load_data returns nil (empty render) for a malformed JSON data file" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data")
+          File.write("data/bad.json", "{ not valid json ")
+
+          page = Hwaro::Models::Page.new("test.md")
+          config = Hwaro::Models::Config.new
+          context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+
+          # The rescue at the parse site swallows the error into Crinja nil
+          # (no exception escapes the build); Crinja renders nil as "none".
+          template = "[{{ load_data(path=\"data/bad.json\") }}]"
+          result = Hwaro::Content::Processors::Template.process(template, context)
+          result.should eq("[none]")
+        end
+      end
+    end
+
+    it "load_data returns nil (empty render) for an unsupported extension" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("data")
+          # File must exist inside project_root to reach the else (unsupported)
+          # branch; otherwise the boundary/exists check short-circuits.
+          File.write("data/notes.txt", "hello")
+
+          page = Hwaro::Models::Page.new("test.md")
+          config = Hwaro::Models::Config.new
+          context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+
+          template = "[{{ load_data(path=\"data/notes.txt\") }}]"
+          result = Hwaro::Content::Processors::Template.process(template, context)
+          # Unsupported extension -> result stays Crinja nil -> renders "none".
+          result.should eq("[none]")
+        end
+      end
     end
   end
 

--- a/spec/unit/text_utils_spec.cr
+++ b/spec/unit/text_utils_spec.cr
@@ -296,6 +296,19 @@ describe Hwaro::Utils::TextUtils do
       input = "<STYLE>.x{}</STYLE><p>Kept</p><SCRIPT>bad()</SCRIPT>"
       Hwaro::Utils::TextUtils.strip_html(input).should eq("Kept")
     end
+
+    # Pin the documented intentional fall-through (src/utils/text_utils.cr:174-175):
+    # RAW_TEXT_ELEMENT only matches a balanced <script>/<style>...</tag> pair, so an
+    # unterminated raw-text element does NOT match and its code body leaks through the
+    # tag stripper as text. These lock that behavior so a future regex edit can't
+    # silently widen the leak or regress the balanced case.
+    it "leaks the body of an unterminated <script> (documented fall-through)" do
+      Hwaro::Utils::TextUtils.strip_html("<p>a</p><script>var x = 1;").should eq("a var x = 1;")
+    end
+
+    it "leaks the body of an unterminated <style> at EOF (documented fall-through)" do
+      Hwaro::Utils::TextUtils.strip_html("<style>.x{color:red}").should eq(".x{color:red}")
+    end
   end
 
   describe ".cjk_char?" do

--- a/src/content/processors/filters/i18n_filter.cr
+++ b/src/content/processors/filters/i18n_filter.cr
@@ -53,8 +53,11 @@ module Hwaro
 
             # Pluralize filter: {{ count | pluralize("item", "items") }}
             env.filters["pluralize"] = Crinja.filter({singular: "", plural: ""}) do
+              # Keep the count as a number (don't .to_i): truncating 1.9 → 1
+              # would wrongly pick the singular form. Grammatically only an
+              # exact count of 1 is singular.
               count = begin
-                target.as_number.to_i
+                target.as_number
               rescue Exception
                 0
               end

--- a/src/content/processors/internal_link_resolver.cr
+++ b/src/content/processors/internal_link_resolver.cr
@@ -48,7 +48,21 @@ module Hwaro
         ) : String
           return html unless html.includes?("@/")
 
-          base_path = base_url.empty? ? "" : URI.parse(base_url).path.rstrip("/")
+          # Only treat base_url as a subpath prefix when it is a real absolute
+          # URL (has a scheme). A host-only or malformed value like
+          # "example.com" parses with the whole string as `.path`, which would
+          # otherwise be prepended to every link ("example.com/a/"). Match the
+          # defensive URI::Error rescue used by the sibling absolutize methods.
+          base_path = if base_url.empty?
+                        ""
+                      else
+                        begin
+                          uri = URI.parse(base_url)
+                          uri.scheme ? uri.path.rstrip("/") : ""
+                        rescue URI::Error
+                          ""
+                        end
+                      end
 
           html.gsub(INTERNAL_LINK_REGEX) do |match|
             content_path = $1

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -873,7 +873,7 @@ module Hwaro
                   if str.includes?('+') || str.includes?('Z') || str.matches?(/T.+-\d{2}:\d{2}$/) || str.matches?(/\d{2}-\d{2}$/)
                     begin
                       return Time.parse_rfc3339(str)
-                    rescue Time::Format::Error
+                    rescue Time::Format::Error | ArgumentError
                       "%Y-%m-%dT%H:%M:%S"
                     end
                   else
@@ -887,7 +887,12 @@ module Hwaro
 
           begin
             Time.parse(str, fmt, Time::Location.local)
-          rescue Time::Format::Error
+          rescue Time::Format::Error | ArgumentError
+            # Time::Format::Error  → string doesn't match the format at all.
+            # ArgumentError        → format matches but the value is out of
+            #   range (e.g. "2024-13-45", "2024-02-30"). Both mean "no usable
+            #   date" — return nil so the rest of the front matter survives
+            #   instead of letting the exception unwind the whole parse.
             nil
           end
         end

--- a/src/content/processors/xml.cr
+++ b/src/content/processors/xml.cr
@@ -44,6 +44,11 @@ module Hwaro
           xml
             .gsub(/>\s*\n\s*</, "><") # Remove whitespace-only text between tags (cross-line only)
             .gsub(/<[^>]+>/) do |tag|
+              # Never touch comments or CDATA sections: their bytes are
+              # significant character data (RSS <content:encoded>, embedded
+              # scripts, pre-formatted code), not attribute formatting, so
+              # collapsing internal whitespace would silently corrupt them.
+              next tag if tag.starts_with?("<!--") || tag.starts_with?("<![CDATA[")
               # Collapse whitespace runs only BETWEEN attributes; leave whitespace
               # inside quoted attribute values intact (e.g. `title="a    b"`),
               # otherwise the minifier silently corrupts attribute content.

--- a/src/core/lifecycle/context.cr
+++ b/src/core/lifecycle/context.cr
@@ -125,11 +125,20 @@ module Hwaro
         end
 
         def get_bool(key : String, default : Bool = false) : Bool
-          @metadata[key]?.try(&.as?(Bool)) || default
+          # NOTE: `value || default` is wrong here — a legitimately stored
+          # `false` is falsy and would collapse to `default`, inverting the
+          # flag a previous hook set. Distinguish "absent / wrong type" (nil)
+          # from a stored `false`.
+          val = @metadata[key]?.try(&.as?(Bool))
+          val.nil? ? default : val
         end
 
         def get_int(key : String, default : Int32 = 0) : Int32
-          @metadata[key]?.try(&.as?(Int32)) || default
+          # Same nil-vs-stored-value distinction as get_bool. `0 || default`
+          # happens to work (0 is truthy in Crystal) but the explicit form
+          # keeps the two getters consistent and intent-revealing.
+          val = @metadata[key]?.try(&.as?(Int32))
+          val.nil? ? default : val
         end
       end
 

--- a/src/services/exporters/base.cr
+++ b/src/services/exporters/base.cr
@@ -104,12 +104,32 @@ module Hwaro
           Logger.debug "Exported: #{path}" if verbose
         end
 
+        # Normalize a front-matter field that may be authored as either a list
+        # (`tags: [a, b]`) or a single scalar (`tags: crystal`) into an array,
+        # so the scalar shorthand isn't silently dropped on export. Returns nil
+        # when the value is absent or empty.
+        protected def string_list_field(value : (String | Bool | Array(String))?) : Array(String)?
+          case value
+          when Array(String) then value.empty? ? nil : value
+          when String        then value.empty? ? nil : [value]
+          end
+        end
+
         # Convert @/ internal links to relative paths
         protected def rewrite_internal_links(body : String) : String
           body.gsub(/\[([^\]]*)\]\(@\/([^\)]+)\)/) do |_, match|
             text = match[1]
-            path = match[2].sub(/\.md$/, "").sub(/_index$/, "")
-            "[#{text}](/#{path})"
+            target = match[2]
+            # Peel off any #anchor or ?query suffix *before* stripping the .md /
+            # _index, otherwise `.md$` no longer anchors and links like
+            # @/guide.md#sec or @/page.md?x=1 keep their .md and 404.
+            suffix = ""
+            if idx = target.index(/[#?]/)
+              suffix = target[idx..]
+              target = target[0...idx]
+            end
+            path = target.sub(/\.md$/, "").sub(/_index$/, "")
+            "[#{text}](/#{path}#{suffix})"
           end
         end
       end

--- a/src/services/exporters/hugo_exporter.cr
+++ b/src/services/exporters/hugo_exporter.cr
@@ -102,21 +102,29 @@ module Hwaro
           lines = ["+++"]
 
           fields.each do |key, value|
+            k = toml_key(key)
             case value
             when Nil  then next
-            when Bool then lines << "#{key} = #{value}"
+            when Bool then lines << "#{k} = #{value}"
             when String
               next if value.empty?
-              lines << "#{key} = #{value.inspect}"
+              lines << "#{k} = #{value.inspect}"
             when Array(String)
               next if value.empty?
               formatted = value.map(&.inspect).join(", ")
-              lines << "#{key} = [#{formatted}]"
+              lines << "#{k} = [#{formatted}]"
             end
           end
 
           lines << "+++"
           lines.join("\n")
+        end
+
+        # Quote a front-matter key that isn't a bare TOML key. A key with a
+        # space, dot, or non-ASCII char (valid in YAML/JSON source) would emit
+        # unparseable TOML like `my key = "x"`; render it as `"my key" = "x"`.
+        private def toml_key(key : String) : String
+          key.matches?(/\A[A-Za-z0-9_-]+\z/) ? key : key.inspect
         end
       end
     end

--- a/src/services/exporters/jekyll_exporter.cr
+++ b/src/services/exporters/jekyll_exporter.cr
@@ -80,13 +80,16 @@ module Hwaro
             yaml_lines << "published: false"
           end
 
-          if tags = fields["tags"]?.as?(Array(String))
+          # Accept both list (`tags: [a, b]`) and scalar (`tags: crystal`)
+          # shorthand — a scalar would otherwise fail the Array(String) cast
+          # and silently drop the post's taxonomy membership.
+          if tags = string_list_field(fields["tags"]?)
             yaml_lines << "tags:"
             tags.each { |t| yaml_lines << "  - #{t}" }
           end
 
           # categories from taxonomies if present
-          if cats = fields["categories"]?.as?(Array(String))
+          if cats = string_list_field(fields["categories"]?)
             yaml_lines << "categories:"
             cats.each { |c| yaml_lines << "  - #{c}" }
           end

--- a/src/services/importers/html_to_markdown.cr
+++ b/src/services/importers/html_to_markdown.cr
@@ -174,9 +174,13 @@ module Hwaro
             .gsub("&#8221;", "\"")
             .gsub("&#8230;", "...")
             .gsub(/&#(\d+);/) do
-              code = $1.to_i
+              # to_i? (not to_i): a numeric entity whose digits exceed Int32
+              # (e.g. &#99999999999999999999;) must be dropped, not crash the
+              # import. The range check below already rejects it, but to_i
+              # would raise before we ever get there.
+              code = $1.to_i?
               # Validate Unicode range (exclude surrogates 0xD800..0xDFFF)
-              if code > 0 && code <= 0x10FFFF && !(0xD800 <= code <= 0xDFFF)
+              if code && code > 0 && code <= 0x10FFFF && !(0xD800 <= code <= 0xDFFF)
                 code.chr.to_s
               else
                 ""

--- a/src/utils/css_minifier.cr
+++ b/src/utils/css_minifier.cr
@@ -78,8 +78,10 @@ module Hwaro
 
         # ── Step 7: Restore preserved tokens (single-pass) ─────────────────
         result = result.gsub(/\x00PRESERVE_(\d+)\x00/) do
-          idx = $1.to_i
-          idx < preserves.size ? preserves[idx] : $0
+          # to_i? guards against a counterfeit token whose index overflows
+          # Int32 — return $0 unchanged rather than raising ArgumentError.
+          idx = $1.to_i?
+          idx && idx < preserves.size ? preserves[idx] : $0
         end
 
         result.strip

--- a/src/utils/html_minifier.cr
+++ b/src/utils/html_minifier.cr
@@ -160,8 +160,12 @@ module Hwaro
       private def restore_sensitive_blocks(html : String, preserves : Array(String)) : String
         loop do
           replaced = html.gsub(REGEX_PRESERVE_TOKEN) do
-            idx = $1.to_i
-            idx < preserves.size ? preserves[idx] : $0
+            # to_i? (not to_i) so a counterfeit token whose digits overflow
+            # Int32 (e.g. \x00HW_HTML_PB_99999999999999999999\x00 forged in
+            # author input) returns nil → emit $0 unchanged instead of raising
+            # ArgumentError and aborting minification of the whole page.
+            idx = $1.to_i?
+            idx && idx < preserves.size ? preserves[idx] : $0
           end
           break if replaced == html
           html = replaced

--- a/src/utils/js_minifier.cr
+++ b/src/utils/js_minifier.cr
@@ -138,8 +138,10 @@ module Hwaro
         # is not valid JS) can't raise IndexError — emit it unchanged instead.
         return cleaned if protected_spans.empty?
         cleaned.gsub(/\x00JSPL(\d+)\x00/) do
-          idx = $1.to_i
-          idx < protected_spans.size ? protected_spans[idx] : $0
+          # to_i? guards against a counterfeit token whose index overflows
+          # Int32 — return $0 unchanged rather than raising ArgumentError.
+          idx = $1.to_i?
+          idx && idx < protected_spans.size ? protected_spans[idx] : $0
         end
       end
 


### PR DESCRIPTION
## Summary

A stability-focused test-coverage sweep across all 19 subsystems. A discovery + adversarial-verification pass found 97 genuine gaps (edge/error/malformed-input/concurrency paths); implementing them surfaced **10 real bugs**, which are fixed here, each with a guarding test.

- Suite: **5477 → 5668 examples** (+191), 0 failures
- `crystal tool format` clean, `./bin/ameba` clean, `shards build -Dpreview_mt` green

## Bugs fixed (commit 1)

| Area | Symptom | Fix |
|---|---|---|
| `markdown` parse_time | a value-invalid date (`2024-13-45`, Feb 30) raised `ArgumentError`, escaping the parser and blanking the **entire front matter to "Untitled"** | rescue `Time::Format::Error \| ArgumentError` |
| `lifecycle/context` `get_bool` | a stored `false` collapsed to a truthy default via `\|\| default` (**flag inversion**) | distinguish nil from false |
| html/js/css minifiers | a counterfeit `\x00..._<huge>\x00` token crashed on `to_i` (Int32 overflow) | `to_i?` fallthrough |
| `html_to_markdown` | a huge numeric entity `&#999…;` crashed the import | `to_i?` + range check |
| `pluralize` filter | `1.9` rendered singular | drop `.to_i` truncation |
| `xml` minify | whitespace inside `<![CDATA[ ]]>` / `<!-- -->` was collapsed (**corrupts RSS `content:encoded`**) | skip comments/CDATA in the attribute pass |
| `internal_link_resolver` | a host-only `base_url` (`example.com`) was prefixed onto every link | use path only when scheme present + `URI::Error` rescue |
| Hugo exporter | a key with a space/dot/CJK char produced **unparseable TOML** | quote non-bare keys |
| exporter `@/` links | `@/page.md#sec` / `@/page.md?x=1` kept `.md` → **404** | split fragment/query before stripping extension |
| Jekyll exporter | scalar `tags: crystal` shorthand was **silently dropped** | accept scalar via `Base#string_list_field` |

## Tests added (commit 2)

Error-path, malformed-input, boundary, injection, and hang-guard coverage across 62 spec files — e.g. asset-pipeline path traversal, robots.txt newline injection, terminal ANSI/control sanitization, classified-error build-abort contract, **circular transparent-section recursion guard (hang)**, cache fingerprint invalidation, OG PNG render-failure → SVG fallback, CLI boundary rejection, server charset/CORS handlers.

## Pinned, not fixed (characterization tests)

Six gaps lock in current behavior because the fix is a deliberate design call: shortcode mixed positional+named args, importer slug-collision / malformed-YAML drop, JSON `>Int64` rejection (Crystal parser limit), `truncate_words(0)`, CJK word-count, unterminated raw-text `strip_html`.