### PR TITLE
feat(build): add --jobs flag to cap render concurrency

### DIFF
--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -198,6 +198,7 @@ hwaro build -i /path/to/my-site -o ./dist
 | --include-future | Include future-dated content |
 | --minify | Minify output files (see below) |
 | --no-parallel | Disable parallel processing |
+| --jobs N | Concurrent render workers (default: auto). Try `1`-`2` for template-heavy sites (see below) |
 | --cache | Enable incremental build caching (see below) |
 | --full | Force a complete rebuild, clearing the cache |
 | --skip-highlighting | Disable syntax highlighting |
@@ -253,6 +254,18 @@ hwaro build --cache --full
 
 See [Incremental Build](/features/incremental-build/) for details.
 
+**About `--jobs` (render concurrency):**
+
+By default Hwaro renders pages with an automatic, CPU-based number of concurrent workers. `--jobs N` caps that number. It never changes the generated output — only how many pages render at once.
+
+Lowering it can make **template/Crinja-heavy** sites build faster: those pages allocate many small objects, and beyond ~2 workers the garbage collector's allocation lock contends more than the extra cores help. **Markdown-heavy** sites (large page bodies) keep scaling, so the default stays automatic.
+
+```bash
+hwaro build --jobs 2   # try this if your build is template/shortcode heavy
+```
+
+Leave it unset for the automatic default. `--jobs` has no effect together with `--no-parallel`.
+
 **About `-i, --input`:**
 
 When specified, Hwaro changes its working directory to the given path before building. This lets you build a site located in another directory without `cd`-ing into it first.
@@ -286,6 +299,7 @@ hwaro serve -i /path/to/my-site -p 8080
 | --base-url URL | Temporarily override `base_url` from `config.toml` |
 | -e, --env ENV | Environment name (loads `config.<env>.toml` override) |
 | --minify | Serve minified output |
+| --jobs N | Concurrent render workers (default: auto). Try `1`-`2` for template-heavy sites |
 | --open | Open browser after starting |
 | -d, --drafts | Include draft content |
 | --include-expired | Include expired content |

--- a/spec/unit/build_command_spec.cr
+++ b/spec/unit/build_command_spec.cr
@@ -15,6 +15,7 @@ describe Hwaro::CLI::Commands::BuildCommand do
       options.drafts.should be_false
       options.minify.should be_false
       options.parallel.should be_true
+      options.workers.should eq(0)
       options.cache.should be_false
       options.highlight.should be_true
       options.verbose.should be_false
@@ -97,6 +98,24 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
       options.parallel.should be_false
       options.highlight.should be_false
+    end
+
+    it "parses --jobs into the worker count" do
+      cmd = Hwaro::CLI::Commands::BuildCommand.new
+      result, _ = cmd.parse_options(["--jobs", "2"])
+      options, _ = result
+      options.workers.should eq(2)
+    end
+
+    it "raises HwaroError(HWARO_E_USAGE) when --jobs is not a positive integer" do
+      cmd = Hwaro::CLI::Commands::BuildCommand.new
+
+      ["0", "-1", "abc", ""].each do |bad|
+        err = expect_raises(Hwaro::HwaroError) do
+          cmd.parse_options(["--jobs", bad])
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      end
     end
 
     it "defaults skip_og_image to false" do

--- a/spec/unit/build_options_spec.cr
+++ b/spec/unit/build_options_spec.cr
@@ -12,6 +12,7 @@ describe Hwaro::Config::Options::BuildOptions do
       opts.include_future.should be_false
       opts.minify.should be_false
       opts.parallel.should be_true
+      opts.workers.should eq(0)
       opts.cache.should be_false
       opts.full.should be_false
       opts.highlight.should be_true

--- a/spec/unit/serve_command_spec.cr
+++ b/spec/unit/serve_command_spec.cr
@@ -225,6 +225,35 @@ describe Hwaro::CLI::Commands::ServeCommand do
       build_options.fast_start_count.should eq(5)
     end
 
+    it "defaults workers to 0 (auto)" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options([] of String)
+      options.workers.should eq(0)
+    end
+
+    it "parses --jobs into the worker count" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options(["--jobs", "2"])
+      options.workers.should eq(2)
+    end
+
+    it "raises HwaroError(HWARO_E_USAGE) when --jobs is not a positive integer" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+
+      ["0", "-1", "abc", ""].each do |bad|
+        err = expect_raises(Hwaro::HwaroError) do
+          cmd.test_parse_options(["--jobs", bad])
+        end
+        err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      end
+    end
+
+    it "propagates workers to build options via to_build_options" do
+      cmd = Hwaro::CLI::Commands::ServeCommand.new
+      _, options = cmd.test_parse_options(["--jobs", "3"])
+      options.to_build_options.workers.should eq(3)
+    end
+
     it "parses --header and stores in options.headers (CLI only at parse time)" do
       cmd = Hwaro::CLI::Commands::ServeCommand.new
       _, options = cmd.test_parse_options(["--header", "X-Test: hello", "--header", "Cache-Control=no-store"])

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -33,6 +33,7 @@ module Hwaro
           # Build behavior
           MINIFY_FLAG,
           FlagInfo.new(short: nil, long: "--no-parallel", description: "Disable parallel file processing"),
+          JOBS_FLAG,
           FlagInfo.new(short: nil, long: "--cache", description: "Enable build caching (skip unchanged files)"),
           FlagInfo.new(short: nil, long: "--full", description: "Force a complete rebuild (ignore cache)"),
           FlagInfo.new(short: nil, long: "--stream", description: "Enable streaming build to reduce memory usage"),
@@ -165,6 +166,7 @@ module Hwaro
           # Build behavior
           minify = false
           parallel = true
+          workers = 0
           cache = false
           full = false
           stream = false
@@ -210,6 +212,17 @@ module Hwaro
             # Build behavior
             CLI.register_flag(parser, MINIFY_FLAG) { |_| minify = true }
             parser.on("--no-parallel", "Disable parallel file processing") { parallel = false }
+            CLI.register_flag(parser, JOBS_FLAG) do |v|
+              n = v.to_i?
+              if n.nil? || n < 1
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "Invalid --jobs value: #{v}",
+                  hint: "Pass a positive integer, e.g. --jobs 2. Omit it for automatic (CPU-based) parallelism.",
+                )
+              end
+              workers = n
+            end
             parser.on("--cache", "Enable build caching (skip unchanged files)") { cache = true }
             parser.on("--full", "Force a complete rebuild (ignore cache)") { full = true }
             parser.on("--stream", "Enable streaming build to reduce memory usage") { stream = true }
@@ -240,6 +253,7 @@ module Hwaro
             include_future: include_future,
             minify: minify,
             parallel: parallel,
+            workers: workers,
             cache: cache,
             full: full,
             highlight: highlight,

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -30,6 +30,7 @@ module Hwaro
 
           # Build behavior
           MINIFY_FLAG,
+          JOBS_FLAG,
           FlagInfo.new(short: nil, long: "--cache", description: "Enable build caching (skip unchanged files)"),
           FlagInfo.new(short: nil, long: "--stream", description: "Enable streaming build to reduce memory usage"),
           FlagInfo.new(short: nil, long: "--memory-limit", description: "Memory limit for streaming build (e.g. 2G, 512M)", takes_value: true, value_hint: "SIZE"),
@@ -130,6 +131,7 @@ module Hwaro
 
           # Build behavior
           minify = false
+          workers = 0
           cache = false
           stream = false
           memory_limit = ENV["HWARO_MEMORYLIMIT"]? || nil
@@ -185,6 +187,17 @@ module Hwaro
 
             # Build behavior
             CLI.register_flag(parser, MINIFY_FLAG) { |_| minify = true }
+            CLI.register_flag(parser, JOBS_FLAG) do |v|
+              n = v.to_i?
+              if n.nil? || n < 1
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "Invalid --jobs value: #{v}",
+                  hint: "Pass a positive integer, e.g. --jobs 2. Omit it for automatic (CPU-based) parallelism.",
+                )
+              end
+              workers = n
+            end
             parser.on("--cache", "Enable build caching (skip unchanged files)") { cache = true }
             parser.on("--stream", "Enable streaming build to reduce memory usage") { stream = true }
             parser.on("--memory-limit SIZE", "Memory limit for streaming build (e.g. 2G, 512M)") { |size| memory_limit = size }
@@ -252,6 +265,7 @@ module Hwaro
             include_expired: include_expired,
             include_future: include_future,
             minify: minify,
+            workers: workers,
             open_browser: open_browser,
             verbose: verbose,
             debug: debug,

--- a/src/cli/metadata.cr
+++ b/src/cli/metadata.cr
@@ -47,6 +47,7 @@ module Hwaro
     DEBUG_FLAG                 = FlagInfo.new(short: nil, long: "--debug", description: "Print debug information")
     ENV_FLAG                   = FlagInfo.new(short: "-e", long: "--env", description: "Environment name (loads config.<env>.toml override)", takes_value: true, value_hint: "ENV")
     PROFILE_FLAG               = FlagInfo.new(short: nil, long: "--profile", description: "Show build timing profile")
+    JOBS_FLAG                  = FlagInfo.new(short: nil, long: "--jobs", description: "Concurrent render workers (default: auto). Try 1-2 for template-heavy sites", takes_value: true, value_hint: "N")
     DRAFTS_FLAG                = FlagInfo.new(short: "-d", long: "--drafts", description: "Include draft content")
     INCLUDE_EXPIRED_FLAG       = FlagInfo.new(short: nil, long: "--include-expired", description: "Include expired content")
     INCLUDE_FUTURE_FLAG        = FlagInfo.new(short: nil, long: "--include-future", description: "Include future-dated content")

--- a/src/config/options/build_options.cr
+++ b/src/config/options/build_options.cr
@@ -9,6 +9,14 @@ module Hwaro
         property include_future : Bool
         property minify : Bool
         property parallel : Bool
+        # Number of concurrent render workers (fibers) for the parallel render
+        # phase. 0 = auto (CPU-based, the default). Lowering it (e.g. `--jobs 2`)
+        # reduces effective render parallelism, which on template/Crinja-heavy
+        # sites is often FASTER: those pages allocate many small objects, and
+        # past ~2 workers Boehm's global allocation lock contends harder than
+        # the extra cores help. Markdown-heavy sites keep scaling, so the
+        # default stays auto. Never changes output — only render concurrency.
+        property workers : Int32
         property cache : Bool
         property full : Bool
         property highlight : Bool
@@ -47,6 +55,7 @@ module Hwaro
           @include_future : Bool = false,
           @minify : Bool = false,
           @parallel : Bool = true,
+          @workers : Int32 = 0,
           @cache : Bool = false,
           @full : Bool = false,
           @highlight : Bool = true,

--- a/src/config/options/serve_options.cr
+++ b/src/config/options/serve_options.cr
@@ -9,6 +9,8 @@ module Hwaro
         property include_expired : Bool
         property include_future : Bool
         property minify : Bool
+        # Concurrent render workers (0 = auto). See BuildOptions#workers.
+        property workers : Int32
         property open_browser : Bool
         property verbose : Bool
         property debug : Bool
@@ -37,6 +39,7 @@ module Hwaro
           @include_expired : Bool = false,
           @include_future : Bool = false,
           @minify : Bool = false,
+          @workers : Int32 = 0,
           @open_browser : Bool = false,
           @verbose : Bool = false,
           @debug : Bool = false,
@@ -72,6 +75,7 @@ module Hwaro
             include_future: @include_future,
             minify: @minify,
             parallel: true,
+            workers: @workers,
             verbose: @verbose,
             profile: @profile,
             debug: @debug,

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -150,6 +150,10 @@ module Hwaro
         @crinja_cache_mutex : Mutex = Mutex.new(:reentrant)
         # Mutex to protect created_dirs set during parallel rendering
         @created_dirs_mutex : Mutex = Mutex.new
+        # Explicit render-worker count from `--jobs` (0 = auto/CPU-based).
+        # Set from BuildOptions at every build entry point and consumed by
+        # process_files_parallel's ParallelConfig. Does not affect output.
+        @render_workers : Int32 = 0
         # Unified cache manager for all cache layers
         @cache_manager : CacheManager = CacheManager.new
         # Pages stashed by `--fast-start` during the initial build so the
@@ -226,6 +230,7 @@ module Hwaro
         end
 
         def run(options : Config::Options::BuildOptions)
+          @render_workers = options.workers
           run(
             output_dir: options.output_dir,
             base_url: options.base_url,
@@ -263,6 +268,7 @@ module Hwaro
         # - Recomputes series/related posts only for affected pages
         # - Selectively invalidates Crinja caches
         def run_incremental(changed_content_files : Array(String), options : Config::Options::BuildOptions)
+          @render_workers = options.workers
           config = @config
           site = @site
           templates = @templates
@@ -549,6 +555,7 @@ module Hwaro
         # Incremental parse of changed content + full re-render with reloaded templates.
         # Used when both content and templates changed simultaneously.
         def run_incremental_then_rerender(changed_content_files : Array(String), options : Config::Options::BuildOptions)
+          @render_workers = options.workers
           config = @config
           site = @site
 
@@ -635,6 +642,7 @@ module Hwaro
         # membership may have changed too, so taxonomy pages regenerate
         # whenever force_pages are present.
         def run_rerender(options : Config::Options::BuildOptions, force_pages : Array(Models::Page)? = nil)
+          @render_workers = options.workers
           config = @config
           site = @site
 
@@ -767,6 +775,7 @@ module Hwaro
         # page assets. Without this step those images never get produced
         # in a fast-start serve session until the user saves a file.
         def render_deferred(options : Config::Options::BuildOptions) : Int32
+          @render_workers = options.workers
           pages = @deferred_pages
           return 0 if pages.nil? || pages.empty?
 

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -362,7 +362,11 @@ module Hwaro::Core::Build::Phases::Render
   ) : Int32
     return 0 if pages.empty?
 
-    config = ParallelConfig.new(enabled: true)
+    # @render_workers (from `--jobs`, 0 = auto) caps the concurrent render
+    # fibers. Fewer fibers means fewer of the runtime's worker threads render
+    # at once, which on allocation-heavy template sites reduces GC-allocator
+    # lock contention. Output is identical regardless of the count.
+    config = ParallelConfig.new(enabled: true, max_workers: @render_workers)
     worker_count = config.calculate_workers(pages.size)
     safe = site.config.markdown.safe
 


### PR DESCRIPTION
## Summary

Adds an opt-in `--jobs N` flag to `build` and `serve` to cap the number of concurrent render fibers (`0` = auto = today's default, unchanged).

## Why

Profiling large builds showed the parallel render phase is bound by **Boehm GC's global allocation lock** under `-Dpreview_mt`, not by hwaro code. Template/Crinja-heavy pages allocate many small objects, and past ~2 render workers the alloc-lock contention (system time climbs sharply: W=1 sys≈0.3s → W=8 sys≈4.5s on a 14-core box) outweighs the extra cores. Those sites build **~20% faster with fewer workers**, while markdown/prose-heavy sites keep scaling to ~4.

The optimum is therefore **workload-dependent**, so the default cannot be safely changed (it would regress one class of site). `--jobs` hands the knob to the user without touching the default.

```
realistic 2000-page site (template-heavy):
  default (auto):  ~1.10s
  --jobs 2:        ~0.85s   (~20% faster, byte-identical output)
markdown-heavy site:
  default (auto):  ~0.87s   (keeps the auto default; fewer workers would be slower)
```

## Changes

- `BuildOptions.workers` / `ServeOptions.workers` (`0` = auto)
- `--jobs N` flag on `build` + `serve` (rejects non-positive / non-numeric values)
- Builder `@render_workers` → `ParallelConfig.max_workers` in `process_files_parallel`

## Verification

- ✅ Output **byte-identical** across `--jobs 1/2/3` vs default — benchmark corpora + real `blog`/`docs` scaffolds
- ✅ **No default regression** — unset `--jobs` takes the same code path; perf within noise of `main`
- ✅ `crystal spec`: 5672 examples, 0 failures · `ameba`: 0 failures · format clean
- ✅ Flag appears in `--help` and shell completions (driven by `FLAGS` metadata)

Never affects output — only how many fibers render concurrently.