### PR TITLE
Fix AUR PKGBUILD license install and support custom pkgrel/ref

### DIFF
--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -7,6 +7,15 @@ on:
         description: "Version to publish (e.g., 0.10.0)"
         required: true
         type: string
+      ref:
+        description: "Git ref (branch/tag/commit) to checkout (optional, defaults to v<version>)"
+        required: false
+        type: string
+      pkgrel:
+        description: "Package release version (pkgrel) (optional, defaults to 1)"
+        required: false
+        default: "1"
+        type: string
   workflow_run:
     workflows: ["Build and Release Binaries"]
     types: [completed]
@@ -21,7 +30,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.inputs.ref || (github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch) }}
 
       - name: Get Version
         id: get_version
@@ -38,7 +47,7 @@ jobs:
       - name: Update PKGBUILD version
         run: |
           sed -i "s/^pkgver=.*/pkgver=${{ env.VERSION }}/" aur/PKGBUILD
-          sed -i "s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=${{ github.event.inputs.pkgrel || '1' }}/" aur/PKGBUILD
           cat aur/PKGBUILD
 
       - name: Publish to AUR

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,15 +1,21 @@
 # Maintainer: HAHWUL <hahwul@gmail.com>
 pkgname=hwaro
 pkgver=0.16.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Lightweight and fast Static Site Generator(SSG) written in Crystal."
 arch=('x86_64')
 url="https://github.com/hahwul/hwaro"
 license=('MIT')
-source=("hwaro-${pkgver}::https://github.com/hahwul/hwaro/releases/download/v${pkgver}/hwaro-v${pkgver}-linux-x86_64")
-sha256sums=('SKIP')
+source=(
+  "hwaro-${pkgver}::https://github.com/hahwul/hwaro/releases/download/v${pkgver}/hwaro-v${pkgver}-linux-x86_64"
+  "LICENSE-hwaro-${pkgver}::https://raw.githubusercontent.com/hahwul/hwaro/refs/tags/v${pkgver}/LICENSE"
+)
+sha256sums=(
+  'SKIP'
+  'SKIP'
+)
 
 package() {
   install -Dm755 "${srcdir}/hwaro-${pkgver}" "${pkgdir}/usr/bin/hwaro"
-  install -Dm644 "${srcdir}/../LICENSE" "${pkgdir}/usr/share/licenses/hwaro/LICENSE"
+  install -Dm644 "${srcdir}/LICENSE-hwaro-${pkgver}" "${pkgdir}/usr/share/licenses/hwaro/LICENSE"
 }


### PR DESCRIPTION
## Problem
The AUR `package()` step installed the license from `${srcdir}/../LICENSE`, a path that does **not** exist on a clean AUR build. The `KSXGitHub/github-actions-deploy-aur` action only pushes `PKGBUILD` (+ generated `.SRCINFO`) to the AUR repo — not the `LICENSE` file — so `makepkg` fails when it cannot find `../LICENSE`.

Same class of bug fixed upstream in noir ([owasp-noir/noir@3f216a4](https://github.com/owasp-noir/noir/commit/3f216a42240e15e5e6195243a6b7de3c5f28e040)), reported via the AUR `noir` package.

## Fix
- Download `LICENSE` through the `source=()` array from the tagged raw URL and install it from `${srcdir}`.
- Add optional `ref` and `pkgrel` `workflow_dispatch` inputs to `release-aur.yml` so a packaging-only fix can be republished to AUR with a bumped `pkgrel` (pointing at an existing release tag) without cutting a new upstream release.