### PR TITLE
fix(lint): remove redundant begin blocks

### DIFF
--- a/spec/unit/file_safe_spec.cr
+++ b/spec/unit/file_safe_spec.cr
@@ -50,12 +50,10 @@ describe Hwaro::Utils::FileSafe do
 
         worker_count.times do |i|
           spawn do
-            begin
-              Hwaro::Utils::FileSafe.mkdir_p(File.join(base, "page_#{i}"))
-              done.send(nil)
-            rescue ex
-              done.send(ex)
-            end
+            Hwaro::Utils::FileSafe.mkdir_p(File.join(base, "page_#{i}"))
+            done.send(nil)
+          rescue ex
+            done.send(ex)
           end
         end
 

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -155,15 +155,13 @@ module Hwaro
             parser.on("--minimal-config", "Generate minimal config.toml without comments and optional sections") { minimal_config = true }
             parser.on("--full-config", "Generate full config.toml with all comments and optional sections (maximum discoverability)") { full_config = true }
             parser.on("--agents MODE", "AGENTS.md content mode: remote (default) or local") do |mode|
-              begin
-                agents_mode = Config::Options::AgentsMode.from_string(mode)
-              rescue ex : ArgumentError
-                Logger.error(ex.message || "Unknown error")
-                Logger.info "Available modes:"
-                Logger.info "  remote - Lightweight with links to online docs (default)"
-                Logger.info "  local  - Full embedded reference for offline use"
-                exit(1)
-              end
+              agents_mode = Config::Options::AgentsMode.from_string(mode)
+            rescue ex : ArgumentError
+              Logger.error(ex.message || "Unknown error")
+              Logger.info "Available modes:"
+              Logger.info "  remote - Lightweight with links to online docs (default)"
+              Logger.info "  local  - Full embedded reference for offline use"
+              exit(1)
             end
 
             # Skip options

--- a/src/content/hooks/image_hooks.cr
+++ b/src/content/hooks/image_hooks.cr
@@ -189,28 +189,26 @@ module Hwaro
           # Spawn worker fibers
           CONCURRENCY.times do
             spawn do
-              begin
-                while job = work_channel.receive?
-                  begin
-                    width_map, lqip_data = resize_one(job, widths, quality, lqip_width, lqip_quality)
-                    map_mutex.synchronize do
-                      new_map[job.original_url] = width_map unless width_map.empty?
-                      new_lqip_map[job.original_url] = lqip_data if lqip_data
-                    end
-                  rescue ex
-                    # resize_one does file I/O (cp, mkdir_p, image writes) that
-                    # can raise on permissions/disk-full/vanished files. A dead
-                    # worker would stall the bounded work_channel feeder below
-                    # and hang the build, so log and move to the next job.
-                    Logger.warn "  Image resize failed for #{job.source_path}: #{ex.message}"
+              while job = work_channel.receive?
+                begin
+                  width_map, lqip_data = resize_one(job, widths, quality, lqip_width, lqip_quality)
+                  map_mutex.synchronize do
+                    new_map[job.original_url] = width_map unless width_map.empty?
+                    new_lqip_map[job.original_url] = lqip_data if lqip_data
                   end
+                rescue ex
+                  # resize_one does file I/O (cp, mkdir_p, image writes) that
+                  # can raise on permissions/disk-full/vanished files. A dead
+                  # worker would stall the bounded work_channel feeder below
+                  # and hang the build, so log and move to the next job.
+                  Logger.warn "  Image resize failed for #{job.source_path}: #{ex.message}"
                 end
-              ensure
-                # Guarantee the done signal even if the loop dies some other
-                # way; the `CONCURRENCY.times { done_channel.receive }` wait
-                # below hangs otherwise.
-                done_channel.send(nil)
               end
+            ensure
+              # Guarantee the done signal even if the loop dies some other
+              # way; the `CONCURRENCY.times { done_channel.receive }` wait
+              # below hangs otherwise.
+              done_channel.send(nil)
             end
           end
 

--- a/src/content/processors/filters/collection_filter.cr
+++ b/src/content/processors/filters/collection_filter.cr
@@ -14,13 +14,11 @@ module Hwaro
                 val = arguments["value"]
 
                 filtered = arr.select do |item|
-                  begin
-                    item_hash = item.as_h
-                    item_val = item_hash[attr_key]?
-                    item_val == val
-                  rescue Exception
-                    false
-                  end
+                  item_hash = item.as_h
+                  item_val = item_hash[attr_key]?
+                  item_val == val
+                rescue Exception
+                  false
                 end
                 Crinja::Value.new(filtered)
               rescue Exception
@@ -41,18 +39,16 @@ module Hwaro
                 # lexicographically ("1","10","2"). Strings/dates fall back to
                 # string comparison; a missing attribute sorts as "".
                 sorted = arr.sort do |a, b|
-                  begin
-                    av = a.as_h[attr_key]? || Crinja::Value.new("")
-                    bv = b.as_h[attr_key]? || Crinja::Value.new("")
-                    cmp = if av.number? && bv.number?
-                            av.as_number <=> bv.as_number
-                          else
-                            av.to_s <=> bv.to_s
-                          end
-                    cmp || 0
-                  rescue Exception
-                    0
-                  end
+                  av = a.as_h[attr_key]? || Crinja::Value.new("")
+                  bv = b.as_h[attr_key]? || Crinja::Value.new("")
+                  cmp = if av.number? && bv.number?
+                          av.as_number <=> bv.as_number
+                        else
+                          av.to_s <=> bv.to_s
+                        end
+                  cmp || 0
+                rescue Exception
+                  0
                 end
 
                 sorted = sorted.reverse if reverse
@@ -71,14 +67,12 @@ module Hwaro
                 groups = {} of String => Array(Crinja::Value)
 
                 arr.each do |item|
-                  begin
-                    item_hash = item.as_h
-                    key = item_hash[attr_key]?.try(&.to_s) || ""
-                    groups[key] ||= [] of Crinja::Value
-                    groups[key] << item
-                  rescue Exception
-                    # Skip non-hash items
-                  end
+                  item_hash = item.as_h
+                  key = item_hash[attr_key]?.try(&.to_s) || ""
+                  groups[key] ||= [] of Crinja::Value
+                  groups[key] << item
+                rescue Exception
+                  # Skip non-hash items
                 end
 
                 group_result = groups.map do |key, items|
@@ -122,12 +116,10 @@ module Hwaro
                 arr = target.as_a
                 flattened = [] of Crinja::Value
                 arr.each do |item|
-                  begin
-                    sub = item.as_a
-                    sub.each { |v| flattened << v }
-                  rescue Exception
-                    flattened << item
-                  end
+                  sub = item.as_a
+                  sub.each { |v| flattened << v }
+                rescue Exception
+                  flattened << item
                 end
                 Crinja::Value.new(flattened)
               rescue Exception

--- a/src/content/processors/filters/math_filter.cr
+++ b/src/content/processors/filters/math_filter.cr
@@ -8,38 +8,34 @@ module Hwaro
           def self.register(env : Crinja)
             # Ceil filter — rounds up to the nearest integer
             env.filters["ceil"] = Crinja.filter do
-              begin
-                num = target.as_number
-                if num.is_a?(Float64)
-                  if num.nan? || num.infinite? || num > Int64::MAX.to_f || num < Int64::MIN.to_f
-                    target
-                  else
-                    Crinja::Value.new(num.ceil.to_i64)
-                  end
+              num = target.as_number
+              if num.is_a?(Float64)
+                if num.nan? || num.infinite? || num > Int64::MAX.to_f || num < Int64::MIN.to_f
+                  target
                 else
-                  Crinja::Value.new(num.to_i64)
+                  Crinja::Value.new(num.ceil.to_i64)
                 end
-              rescue Exception
-                target
+              else
+                Crinja::Value.new(num.to_i64)
               end
+            rescue Exception
+              target
             end
 
             # Floor filter — rounds down to the nearest integer
             env.filters["floor"] = Crinja.filter do
-              begin
-                num = target.as_number
-                if num.is_a?(Float64)
-                  if num.nan? || num.infinite? || num > Int64::MAX.to_f || num < Int64::MIN.to_f
-                    target
-                  else
-                    Crinja::Value.new(num.floor.to_i64)
-                  end
+              num = target.as_number
+              if num.is_a?(Float64)
+                if num.nan? || num.infinite? || num > Int64::MAX.to_f || num < Int64::MIN.to_f
+                  target
                 else
-                  Crinja::Value.new(num.to_i64)
+                  Crinja::Value.new(num.floor.to_i64)
                 end
-              rescue Exception
-                target
+              else
+                Crinja::Value.new(num.to_i64)
               end
+            rescue Exception
+              target
             end
           end
         end

--- a/src/services/importers/hexo_importer.cr
+++ b/src/services/importers/hexo_importer.cr
@@ -36,21 +36,19 @@ module Hwaro
           end
 
           files.each do |file_info|
-            begin
-              result = import_file(file_info, output_dir, options.verbose, options.force)
-              case result
-              when :imported
-                imported += 1
-              when :imported_wrapped
-                imported += 1
-                wrapped += 1
-              when :skipped
-                skipped += 1
-              end
-            rescue ex
-              errors += 1
-              Logger.warn "Error importing #{file_info[:path]}: #{ex.message}"
+            result = import_file(file_info, output_dir, options.verbose, options.force)
+            case result
+            when :imported
+              imported += 1
+            when :imported_wrapped
+              imported += 1
+              wrapped += 1
+            when :skipped
+              skipped += 1
             end
+          rescue ex
+            errors += 1
+            Logger.warn "Error importing #{file_info[:path]}: #{ex.message}"
           end
 
           if wrapped > 0


### PR DESCRIPTION
Closes the lint errors in CI by removing redundant begin blocks in blocks/spawn/filter/iterator where direct rescue/ensure is supported.