### PR TITLE
refactor: remove structural duplication across build, content, services & CLI

### DIFF
--- a/spec/unit/section_methods_spec.cr
+++ b/spec/unit/section_methods_spec.cr
@@ -26,25 +26,6 @@ describe Hwaro::Models::Section do
     end
   end
 
-  describe "#effective_page_template" do
-    it "returns nil when page_template is not set" do
-      section = Hwaro::Models::Section.new("blog/_index.md")
-      section.effective_page_template.should be_nil
-    end
-
-    it "returns the page_template when set" do
-      section = Hwaro::Models::Section.new("blog/_index.md")
-      section.page_template = "blog_post"
-      section.effective_page_template.should eq("blog_post")
-    end
-
-    it "returns correct template for different values" do
-      section = Hwaro::Models::Section.new("docs/_index.md")
-      section.page_template = "documentation"
-      section.effective_page_template.should eq("documentation")
-    end
-  end
-
   describe "#add_subsection" do
     it "adds a subsection to the section" do
       parent = Hwaro::Models::Section.new("blog/_index.md")
@@ -78,59 +59,6 @@ describe Hwaro::Models::Section do
 
       parent.subsections.size.should eq(3)
       parent.subsections.map(&.title).should eq(["Guide", "API", "FAQ"])
-    end
-  end
-
-  describe "#find_subsection" do
-    it "finds subsection by section name" do
-      parent = Hwaro::Models::Section.new("blog/_index.md")
-
-      archive = Hwaro::Models::Section.new("blog/archive/_index.md")
-      archive.section = "archive"
-      archive.title = "Archive"
-
-      recent = Hwaro::Models::Section.new("blog/recent/_index.md")
-      recent.section = "recent"
-      recent.title = "Recent"
-
-      parent.add_subsection(archive)
-      parent.add_subsection(recent)
-
-      found = parent.find_subsection("archive")
-      found.should_not be_nil
-      found.not_nil!.title.should eq("Archive")
-    end
-
-    it "finds subsection by title (case-insensitive)" do
-      parent = Hwaro::Models::Section.new("blog/_index.md")
-
-      archive = Hwaro::Models::Section.new("blog/archive/_index.md")
-      archive.section = "blog/archive"
-      archive.title = "Archive Section"
-
-      parent.add_subsection(archive)
-
-      found = parent.find_subsection("archive section")
-      found.should_not be_nil
-      found.not_nil!.title.should eq("Archive Section")
-    end
-
-    it "returns nil when subsection is not found" do
-      parent = Hwaro::Models::Section.new("blog/_index.md")
-
-      archive = Hwaro::Models::Section.new("blog/archive/_index.md")
-      archive.section = "archive"
-      archive.title = "Archive"
-      parent.add_subsection(archive)
-
-      found = parent.find_subsection("nonexistent")
-      found.should be_nil
-    end
-
-    it "returns nil when no subsections exist" do
-      parent = Hwaro::Models::Section.new("blog/_index.md")
-      found = parent.find_subsection("anything")
-      found.should be_nil
     end
   end
 

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -69,8 +69,7 @@ module Hwaro
           options, output_dir_explicit = result
 
           # --json implies quiet so only the final JSON document reaches stdout.
-          Logger.quiet = true if json_output
-          Runner.json_mode = true if json_output
+          Runner.enable_json_mode! if json_output
 
           if dir = input_dir
             unless Dir.exists?(dir)
@@ -190,18 +189,7 @@ module Hwaro
             # Path & URL
             CLI.register_flag(parser, INPUT_DIR_FLAG) { |v| input_dir = v }
             parser.on("-o DIR", "--output DIR", "Output directory (default: public)") { |dir| output_dir = dir; output_dir_explicit = true }
-            CLI.register_flag(parser, BASE_URL_FLAG) do |v|
-              begin
-                Models::Config.validate_base_url!(v)
-              rescue ex : ArgumentError
-                raise Hwaro::HwaroError.new(
-                  code: Hwaro::Errors::HWARO_E_USAGE,
-                  message: ex.message || "Invalid --base-url",
-                  hint: "Examples: https://example.com, https://example.com/subpath, http://localhost:3000.",
-                )
-              end
-              base_url = v
-            end
+            CLI.register_base_url(parser) { |v| base_url = v }
             CLI.register_flag(parser, ENV_FLAG) { |v| env_name = v }
 
             # Content filtering
@@ -212,17 +200,7 @@ module Hwaro
             # Build behavior
             CLI.register_flag(parser, MINIFY_FLAG) { |_| minify = true }
             parser.on("--no-parallel", "Disable parallel file processing") { parallel = false }
-            CLI.register_flag(parser, JOBS_FLAG) do |v|
-              n = v.to_i?
-              if n.nil? || n < 1
-                raise Hwaro::HwaroError.new(
-                  code: Hwaro::Errors::HWARO_E_USAGE,
-                  message: "Invalid --jobs value: #{v}",
-                  hint: "Pass a positive integer, e.g. --jobs 2. Omit it for automatic (CPU-based) parallelism.",
-                )
-              end
-              workers = n
-            end
+            CLI.register_jobs(parser) { |n| workers = n }
             parser.on("--cache", "Enable build caching (skip unchanged files)") { cache = true }
             parser.on("--full", "Force a complete rebuild (ignore cache)") { full = true }
             parser.on("--stream", "Enable streaming build to reduce memory usage") { stream = true }

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -46,8 +46,7 @@ module Hwaro
 
           # Quiet logger so --json emits only the final JSON document. Human
           # --list-targets and --dry-run output is routed around Logger below.
-          Logger.quiet = true if json_output
-          Runner.json_mode = true if json_output
+          Runner.enable_json_mode! if json_output
 
           if list_targets
             print_targets(options.env, json: json_output)

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -62,10 +62,7 @@ module Hwaro
           # rendered as the structured payload on stdout instead of the
           # human "Error [CODE]: …" line on stderr. Also silence the
           # `Created new content: …` info line so stdout stays pure JSON.
-          if json_output
-            Runner.json_mode = true
-            Logger.quiet = true
-          end
+          Runner.enable_json_mode! if json_output
 
           # Refuse to run outside a Hwaro project. Previously `hwaro new` would
           # happily create `content/drafts/foo.md` in any directory, so a typo

--- a/src/cli/commands/serve_command.cr
+++ b/src/cli/commands/serve_command.cr
@@ -78,8 +78,7 @@ module Hwaro
 
           # --json suppresses banners/action lines so the ready event is the
           # first line on stdout. Errors still go to stderr via Logger.error.
-          Logger.quiet = true if options.json
-          Runner.json_mode = true if options.json
+          Runner.enable_json_mode! if options.json
 
           if input_dir
             unless Dir.exists?(input_dir)
@@ -166,18 +165,7 @@ module Hwaro
 
             # Path & URL
             CLI.register_flag(parser, INPUT_DIR_FLAG) { |v| input_dir = v }
-            CLI.register_flag(parser, BASE_URL_FLAG) do |v|
-              begin
-                Models::Config.validate_base_url!(v)
-              rescue ex : ArgumentError
-                raise Hwaro::HwaroError.new(
-                  code: Hwaro::Errors::HWARO_E_USAGE,
-                  message: ex.message || "Invalid --base-url",
-                  hint: "Examples: https://example.com, https://example.com/subpath, http://localhost:3000.",
-                )
-              end
-              base_url = v
-            end
+            CLI.register_base_url(parser) { |v| base_url = v }
             CLI.register_flag(parser, ENV_FLAG) { |v| env_name = v }
 
             # Content filtering
@@ -187,17 +175,7 @@ module Hwaro
 
             # Build behavior
             CLI.register_flag(parser, MINIFY_FLAG) { |_| minify = true }
-            CLI.register_flag(parser, JOBS_FLAG) do |v|
-              n = v.to_i?
-              if n.nil? || n < 1
-                raise Hwaro::HwaroError.new(
-                  code: Hwaro::Errors::HWARO_E_USAGE,
-                  message: "Invalid --jobs value: #{v}",
-                  hint: "Pass a positive integer, e.g. --jobs 2. Omit it for automatic (CPU-based) parallelism.",
-                )
-              end
-              workers = n
-            end
+            CLI.register_jobs(parser) { |n| workers = n }
             parser.on("--cache", "Enable build caching (skip unchanged files)") { cache = true }
             parser.on("--stream", "Enable streaming build to reduce memory usage") { stream = true }
             parser.on("--memory-limit SIZE", "Memory limit for streaming build (e.g. 2G, 512M)") { |size| memory_limit = size }

--- a/src/cli/commands/tool/convert_command.cr
+++ b/src/cli/commands/tool/convert_command.cr
@@ -56,8 +56,7 @@ module Hwaro
               end
             end
 
-            Logger.quiet = true if json_output
-            Runner.json_mode = true if json_output
+            Runner.enable_json_mode! if json_output
 
             unless format
               raise Hwaro::HwaroError.new(

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -106,8 +106,7 @@ module Hwaro
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
 
-            Logger.quiet = true if json_output
-            Runner.json_mode = true if json_output
+            Runner.enable_json_mode! if json_output
 
             if external_only && internal_only
               Logger.warn "--external-only and --internal-only cancel each other out; checking all links"

--- a/src/cli/commands/tool/list_command.cr
+++ b/src/cli/commands/tool/list_command.cr
@@ -56,8 +56,7 @@ module Hwaro
               end
             end
 
-            Logger.quiet = true if json_output
-            Runner.json_mode = true if json_output
+            Runner.enable_json_mode! if json_output
 
             supported = POSITIONAL_CHOICES.join(", ")
 

--- a/src/cli/commands/tool/stats_command.cr
+++ b/src/cli/commands/tool/stats_command.cr
@@ -49,8 +49,7 @@ module Hwaro
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
 
-            Logger.quiet = true if json_output
-            Runner.json_mode = true if json_output
+            Runner.enable_json_mode! if json_output
 
             stats = Services::ContentStats.new(content_dir: content_dir)
             begin

--- a/src/cli/commands/tool/unused_assets_command.cr
+++ b/src/cli/commands/tool/unused_assets_command.cr
@@ -62,8 +62,7 @@ module Hwaro
             # lines included) the same way the sibling tool commands do.
             # `Logger.warn`/`.error` still reach stderr, so the no-force notice
             # below survives.
-            Logger.quiet = true if json_output
-            Runner.json_mode = true if json_output
+            Runner.enable_json_mode! if json_output
 
             service = Services::UnusedAssets.new(
               content_dir: content_dir,

--- a/src/cli/commands/tool/validate_command.cr
+++ b/src/cli/commands/tool/validate_command.cr
@@ -50,8 +50,7 @@ module Hwaro
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
 
-            Logger.quiet = true if json_output
-            Runner.json_mode = true if json_output
+            Runner.enable_json_mode! if json_output
 
             validator = Services::ContentValidator.new(content_dir: content_dir)
             begin

--- a/src/cli/metadata.cr
+++ b/src/cli/metadata.cr
@@ -79,5 +79,38 @@ module Hwaro
         end
       end
     end
+
+    # Register the shared --base-url flag, validating the value and raising a
+    # usage error on a malformed URL. Yields the validated value to `block`.
+    def self.register_base_url(parser : OptionParser, &block : String ->)
+      register_flag(parser, BASE_URL_FLAG) do |v|
+        begin
+          Models::Config.validate_base_url!(v)
+        rescue ex : ArgumentError
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: ex.message || "Invalid --base-url",
+            hint: "Examples: https://example.com, https://example.com/subpath, http://localhost:3000.",
+          )
+        end
+        block.call(v)
+      end
+    end
+
+    # Register the shared --jobs flag, parsing a positive worker count and
+    # raising a usage error otherwise. Yields the parsed Int32 to `block`.
+    def self.register_jobs(parser : OptionParser, &block : Int32 ->)
+      register_flag(parser, JOBS_FLAG) do |v|
+        n = v.to_i?
+        if n.nil? || n < 1
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "Invalid --jobs value: #{v}",
+            hint: "Pass a positive integer, e.g. --jobs 2. Omit it for automatic (CPU-based) parallelism.",
+          )
+        end
+        block.call(n)
+      end
+    end
   end
 end

--- a/src/cli/runner.cr
+++ b/src/cli/runner.cr
@@ -143,6 +143,14 @@ module Hwaro
         @@json_mode = value
       end
 
+      # Enable JSON output mode: silence human log lines and flag json_mode so
+      # error/output payloads emit machine JSON. Call when a command parses
+      # `--json`.
+      def self.enable_json_mode!
+        Logger.quiet = true
+        @@json_mode = true
+      end
+
       # Emit a classified error in either the quiet/JSON machine shape or the
       # human-friendly `Error [CODE]: message` form. JSON mode is detected
       # from `Runner.json_mode?` (set by commands that saw `--json`) or from

--- a/src/content/processors/filters/collection_filter.cr
+++ b/src/content/processors/filters/collection_filter.cr
@@ -8,28 +8,24 @@ module Hwaro
           def self.register(env : Crinja)
             # Array where filter
             env.filters["where"] = Crinja.filter({attribute: nil, value: nil}) do
-              result = begin
+              safe_array do
                 arr = target.as_a
                 attr_key = Crinja::Value.new(arguments["attribute"].to_s)
                 val = arguments["value"]
 
-                filtered = arr.select do |item|
+                arr.select do |item|
                   item_hash = item.as_h
                   item_val = item_hash[attr_key]?
                   item_val == val
                 rescue Exception
                   false
                 end
-                Crinja::Value.new(filtered)
-              rescue Exception
-                Crinja::Value.new([] of Crinja::Value)
               end
-              result
             end
 
             # Array sort_by filter
             env.filters["sort_by"] = Crinja.filter({attribute: nil, reverse: false}) do
-              result = begin
+              safe_array do
                 arr = target.as_a
                 attr_key = Crinja::Value.new(arguments["attribute"].to_s)
                 reverse = arguments["reverse"].truthy?
@@ -52,16 +48,13 @@ module Hwaro
                 end
 
                 sorted = sorted.reverse if reverse
-                Crinja::Value.new(sorted)
-              rescue Exception
-                Crinja::Value.new([] of Crinja::Value)
+                sorted
               end
-              result
             end
 
             # Group by filter
             env.filters["group_by"] = Crinja.filter({attribute: nil}) do
-              result = begin
+              safe_array do
                 arr = target.as_a
                 attr_key = Crinja::Value.new(arguments["attribute"].to_s)
                 groups = {} of String => Array(Crinja::Value)
@@ -82,19 +75,16 @@ module Hwaro
                   }
                 end
 
-                Crinja::Value.new(group_result.map { |h| Crinja::Value.new(h) })
-              rescue Exception
-                Crinja::Value.new([] of Crinja::Value)
+                group_result.map { |h| Crinja::Value.new(h) }
               end
-              result
             end
 
             # Unique filter — removes duplicate values from an array
             env.filters["unique"] = Crinja.filter do
-              result = begin
+              safe_array do
                 arr = target.as_a
                 seen = Set(String).new
-                unique_items = arr.select do |item|
+                arr.select do |item|
                   key = item.to_s
                   if seen.includes?(key)
                     false
@@ -103,16 +93,12 @@ module Hwaro
                     true
                   end
                 end
-                Crinja::Value.new(unique_items)
-              rescue Exception
-                Crinja::Value.new([] of Crinja::Value)
               end
-              result
             end
 
             # Flatten filter — flattens nested arrays one level
             env.filters["flatten"] = Crinja.filter do
-              result = begin
+              safe_array do
                 arr = target.as_a
                 flattened = [] of Crinja::Value
                 arr.each do |item|
@@ -121,26 +107,27 @@ module Hwaro
                 rescue Exception
                   flattened << item
                 end
-                Crinja::Value.new(flattened)
-              rescue Exception
-                Crinja::Value.new([] of Crinja::Value)
+                flattened
               end
-              result
             end
 
             # Compact filter — removes nil/empty values from an array
             env.filters["compact"] = Crinja.filter do
-              result = begin
+              safe_array do
                 arr = target.as_a
-                compacted = arr.reject do |item|
+                arr.reject do |item|
                   item.raw.nil? || item.to_s.empty?
                 end
-                Crinja::Value.new(compacted)
-              rescue Exception
-                Crinja::Value.new([] of Crinja::Value)
               end
-              result
             end
+          end
+
+          # Wrap a filter body that builds an Array(Crinja::Value): return it as
+          # a Crinja::Value, falling back to an empty array on any error.
+          private def self.safe_array(& : -> Array(Crinja::Value)) : Crinja::Value
+            Crinja::Value.new(yield)
+          rescue Exception
+            Crinja::Value.new([] of Crinja::Value)
           end
         end
       end

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -230,7 +230,6 @@ module Hwaro
           Filters::MiscFilters.register(@env)
         end
 
-        # Register custom tests
         # Shared body for the `empty`/`present` Crinja tests: a value is empty
         # when it's an empty string/array/hash or nil.
         private def value_empty?(value : Crinja::Raw) : Bool
@@ -248,6 +247,7 @@ module Hwaro
           end
         end
 
+        # Register custom tests
         private def register_custom_tests
           # Test if a string starts with a prefix
           # Usage: {% if page_url is startswith("/blog/") %}

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -231,6 +231,23 @@ module Hwaro
         end
 
         # Register custom tests
+        # Shared body for the `empty`/`present` Crinja tests: a value is empty
+        # when it's an empty string/array/hash or nil.
+        private def value_empty?(value : Crinja::Raw) : Bool
+          case value
+          when String
+            value.empty?
+          when Array
+            value.empty?
+          when Hash
+            value.empty?
+          when Nil
+            true
+          else
+            false
+          end
+        end
+
         private def register_custom_tests
           # Test if a string starts with a prefix
           # Usage: {% if page_url is startswith("/blog/") %}
@@ -255,36 +272,12 @@ module Hwaro
 
           # Test if value is empty (string, array, hash)
           @env.tests["empty"] = Crinja.test do
-            value = target.raw
-            case value
-            when String
-              value.empty?
-            when Array
-              value.empty?
-            when Hash
-              value.empty?
-            when Nil
-              true
-            else
-              false
-            end
+            value_empty?(target.raw)
           end
 
           # Test if value is present (not empty and not nil)
           @env.tests["present"] = Crinja.test do
-            value = target.raw
-            case value
-            when String
-              !value.empty?
-            when Array
-              !value.empty?
-            when Hash
-              !value.empty?
-            when Nil
-              false
-            else
-              true
-            end
+            !value_empty?(target.raw)
           end
 
           regex_cache = {} of String => Regex
@@ -312,6 +305,16 @@ module Hwaro
 
         # Register custom functions
         private def register_custom_functions
+          register_now_function
+          register_url_for_function
+          register_lookup_functions
+          register_image_function
+          register_data_function
+          register_asset_functions
+          register_env_function
+        end
+
+        private def register_now_function
           # now() function - returns current time
           @env.functions["now"] = Crinja.function({format: nil}) do
             format = arguments["format"]
@@ -323,7 +326,9 @@ module Hwaro
               Crinja::Value.new(time.to_s(format.to_s))
             end
           end
+        end
 
+        private def register_url_for_function
           # url_for() function - generate URL for a path
           @env.functions["url_for"] = Crinja.function({path: ""}) do
             path = arguments["path"].to_s
@@ -338,7 +343,9 @@ module Hwaro
 
           # get_url() function - alias for url_for to match
           @env.functions["get_url"] = @env.functions["url_for"]
+        end
 
+        private def register_lookup_functions
           # get_page() function - get page data by path
           # Usage: {% set about = get_page(path="about.md") %}
           #        {{ about.title }}
@@ -469,7 +476,9 @@ module Hwaro
             url = "/#{kind}/#{slug}/"
             Crinja::Value.new(base_url.rstrip("/") + url)
           end
+        end
 
+        private def register_image_function
           # resize_image() function - returns URL to a resized image variant
           # Usage: {{ resize_image(path="/images/photo.jpg", width=800).url }}
           # Returns object with:
@@ -514,7 +523,9 @@ module Hwaro
               "dominant_color" => Crinja::Value.new(dominant_color_value),
             })
           end
+        end
 
+        private def register_data_function
           # load_data() function - load data from JSON/TOML/YAML files
           # Usage: {% set data = load_data(path="data/menu.json") %}
           @env.functions["load_data"] = Crinja.function({path: ""}) do
@@ -569,7 +580,9 @@ module Hwaro
 
             result
           end
+        end
 
+        private def register_asset_functions
           # asset() function - resolve asset path from pipeline manifest
           # Usage: {{ asset(name="main.css") }}
           # Returns fingerprinted path if asset pipeline is enabled,
@@ -590,7 +603,9 @@ module Hwaro
 
           # asset_url is an alias for asset
           @env.functions["asset_url"] = @env.functions["asset"]
+        end
 
+        private def register_env_function
           # env() function - read environment variables in templates
           # Usage: {{ env("ANALYTICS_ID") }}
           #        {{ env("API_KEY", default="none") }}

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -27,7 +27,7 @@ module Hwaro
         # actually emit HTML; the `generated` check mirrors llms.cr so
         # navigational listing pages don't pollute search results. Both match
         # the guards sitemap.cr / feeds.cr / llms.cr already apply.
-        search_pages = pages.reject { |p| p.draft || !p.in_search_index || !p.render || p.generated }
+        search_pages = pages.reject { |p| !p.search_index_eligible? }
 
         # Deduplicate by URL (keep last occurrence, matching build behavior)
         seen_urls = Set(String).new

--- a/src/content/seo/jsonld.cr
+++ b/src/content/seo/jsonld.cr
@@ -8,16 +8,26 @@ module Hwaro
       module JsonLd
         extend self
 
+        # Join `path` onto `base` as a root-relative absolute URL.
+        private def abs_path(base : String, path : String) : String
+          "#{base}#{path.starts_with?("/") ? path : "/#{path}"}"
+        end
+
+        # Like abs_path, but leaves an already-absolute http(s) URL untouched.
+        private def abs_or_external(base : String, value : String) : String
+          value.starts_with?("http") ? value : abs_path(base, value)
+        end
+
         # Generate Article JSON-LD for a page
         def article(page : Models::Page, config : Models::Config, site : Models::Site? = nil) : String
           base = config.base_url_stripped
-          url = page.permalink || "#{base}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+          url = page.permalink || abs_path(base, page.url)
 
           date_published = page.date.try(&.to_s("%Y-%m-%dT%H:%M:%S%:z"))
           updated_str = page.updated.try(&.to_s("%Y-%m-%dT%H:%M:%S%:z"))
           desc = page.description
           image_url = if image = page.image
-                        image.starts_with?("http") ? image : "#{base}#{image.starts_with?("/") ? image : "/#{image}"}"
+                        abs_or_external(base, image)
                       end
           # Prefer the resolved display name from site.authors (data/authors
           # enrichment) so the schema.org author matches the visible author name
@@ -73,9 +83,9 @@ module Hwaro
         def collection_page(page : Models::Page, config : Models::Config, url_override : String? = nil) : String
           base = config.base_url_stripped
           url = if u = url_override
-                  "#{base}#{u.starts_with?("/") ? u : "/#{u}"}"
+                  abs_path(base, u)
                 else
-                  page.permalink || "#{base}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+                  page.permalink || abs_path(base, page.url)
                 end
 
           json = JSON.build do |j|
@@ -112,7 +122,7 @@ module Hwaro
 
           # Ancestors
           page.ancestors.each_with_index do |ancestor, idx|
-            ancestor_url = "#{base}#{ancestor.url.starts_with?("/") ? ancestor.url : "/#{ancestor.url}"}"
+            ancestor_url = abs_path(base, ancestor.url)
             items << {
               "@type"    => "ListItem",
               "position" => idx + 2,
@@ -196,7 +206,7 @@ module Hwaro
           return "" if steps.empty?
 
           base = config.base_url_stripped
-          url = "#{base}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+          url = abs_path(base, page.url)
 
           json = JSON.build do |j|
             j.object do
@@ -274,10 +284,10 @@ module Hwaro
               j.field "@type", "Person"
               j.field "name", name
               if u = url
-                j.field "url", u.starts_with?("http") ? u : "#{base}#{u.starts_with?("/") ? u : "/#{u}"}"
+                j.field "url", abs_or_external(base, u)
               end
               if img = image
-                j.field "image", img.starts_with?("http") ? img : "#{base}#{img.starts_with?("/") ? img : "/#{img}"}"
+                j.field "image", abs_or_external(base, img)
               end
             end
           end
@@ -300,7 +310,7 @@ module Hwaro
                 j.field "description", config.description
               end
               if logo_url = logo
-                j.field "logo", logo_url.starts_with?("http") ? logo_url : "#{base}#{logo_url.starts_with?("/") ? logo_url : "/#{logo_url}"}"
+                j.field "logo", abs_or_external(base, logo_url)
               end
             end
           end

--- a/src/content/seo/llms.cr
+++ b/src/content/seo/llms.cr
@@ -56,7 +56,7 @@ module Hwaro
         private def self.build_index(config : Models::Config, pages : Array(Models::Page)) : String
           base_url = config.base_url.rstrip('/')
 
-          eligible = pages.select { |p| p.render && !p.draft && p.in_search_index && !p.generated }
+          eligible = pages.select(&.search_index_eligible?)
 
           # Group by section, keyed by display heading. A section's heading
           # comes from its `_index.md`, which is the only page modeled as a

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -166,7 +166,7 @@ module Hwaro
         result = {} of String => Hash(String, Array(Models::Page))
 
         site.pages.each do |page|
-          next if page.draft || page.generated
+          next if page.excluded_from_listings?
 
           enabled_taxonomy_names.each do |tax_name|
             values = page.taxonomy_values(tax_name)
@@ -205,8 +205,7 @@ module Hwaro
         config = site.config
 
         site.pages.each do |page|
-          next if page.draft
-          next if page.generated
+          next if page.excluded_from_listings?
 
           config.taxonomies.each do |taxonomy|
             name = taxonomy.name
@@ -511,10 +510,9 @@ module Hwaro
         base.rstrip("/") + "/" + suffix.lstrip("/")
       end
 
-      private def self.write_output(page : Models::Section, output_dir : String, content : String, verbose : Bool = false)
-        url_path = Utils::PathUtils.sanitize_path(page.url.lchop("/"))
-        output_path = File.join(output_dir, url_path, "index.html")
-
+      # Guard against escaping the output dir, then mkdir + write + log a
+      # taxonomy output file. Shared by the single-page and paginated writers.
+      private def self.write_to(output_path : String, output_dir : String, content : String, verbose : Bool)
         unless Utils::OutputGuard.within_output_dir?(output_path, output_dir)
           Logger.warn "Skipping taxonomy output outside output directory: #{output_path}"
           return
@@ -525,18 +523,16 @@ module Hwaro
         Logger.action :create, output_path if verbose
       end
 
+      private def self.write_output(page : Models::Section, output_dir : String, content : String, verbose : Bool = false)
+        url_path = Utils::PathUtils.sanitize_path(page.url.lchop("/"))
+        output_path = File.join(output_dir, url_path, "index.html")
+        write_to(output_path, output_dir, content, verbose)
+      end
+
       private def self.write_paginated_output(page : Models::Section, page_number : Int32, output_dir : String, content : String, verbose : Bool = false, paginate_path : String = "page")
         url_path = Utils::PathUtils.sanitize_path(page.url.lchop("/"))
         output_path = File.join(output_dir, url_path, paginate_path, page_number.to_s, "index.html")
-
-        unless Utils::OutputGuard.within_output_dir?(output_path, output_dir)
-          Logger.warn "Skipping taxonomy output outside output directory: #{output_path}"
-          return
-        end
-
-        Hwaro::Utils::FileSafe.mkdir_p(Path[output_path].dirname)
-        File.write(output_path, content)
-        Logger.action :create, output_path if verbose
+        write_to(output_path, output_dir, content, verbose)
       end
     end
   end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1090,10 +1090,13 @@ module Hwaro
           seo_tasks = [
             -> { Content::Seo::Sitemap.generate(pages, site, output_dir, verbose); nil },
             -> { Content::Seo::Feeds.generate(pages, site.config, output_dir, verbose); nil },
-            -> { Content::Seo::Llms.generate(site.config, pages, output_dir, verbose); nil },
-            -> { Content::Search.generate(pages, site.config, output_dir, verbose); nil },
           ] of Proc(Nil)
+          # Robots slots in right after Feeds — its original position in the
+          # incremental path — so sequential (--no-parallel) output ordering is
+          # preserved, not just the generated files.
           seo_tasks << -> { Content::Seo::Robots.generate(site.config, output_dir, verbose); nil } if include_robots
+          seo_tasks << -> { Content::Seo::Llms.generate(site.config, pages, output_dir, verbose); nil }
+          seo_tasks << -> { Content::Search.generate(pages, site.config, output_dir, verbose); nil }
           ParallelHelper.execute(seo_tasks, parallel)
         end
 

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -307,11 +307,7 @@ module Hwaro
           cascade_map = @cascade_map || build_cascade_map(site.sections)
 
           changed_content_files.each do |file|
-            relative_path = begin
-              Path[file].relative_to("content").to_s
-            rescue ArgumentError
-              file.lchop("content/")
-            end
+            relative_path = path_relative_to(file, "content")
 
             page = pages_map[relative_path]?
             unless page
@@ -516,11 +512,7 @@ module Hwaro
           render_list.each do |page|
             next unless page.render
             render_page(page, site, templates, output_dir, minify, highlight, safe, verbose, global_vars, error_overlay: error_overlay, profiler: active_profiler)
-            if cache.enabled?
-              source_path = File.join("content", page.path)
-              output_path = get_output_path(page, output_dir)
-              cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
-            end
+            record_page_cache_entry(page, cache, templates, site, output_dir)
           end
 
           cache.save if options.cache
@@ -534,22 +526,11 @@ module Hwaro
           seo_pages = taxonomy_sections.empty? ? all_pages : all_pages + taxonomy_sections
 
           # --- 6. Regenerate lightweight SEO / search files in parallel ---
-          seo_tasks = [
-            -> { Content::Seo::Sitemap.generate(seo_pages, site, output_dir, verbose); nil },
-            -> { Content::Seo::Feeds.generate(seo_pages, site.config, output_dir, verbose); nil },
-            -> { Content::Seo::Robots.generate(site.config, output_dir, verbose); nil },
-            -> { Content::Seo::Llms.generate(site.config, seo_pages, output_dir, verbose); nil },
-            -> { Content::Search.generate(seo_pages, site.config, output_dir, verbose); nil },
-          ] of Proc(Nil)
-          ParallelHelper.execute(seo_tasks, options.parallel)
+          regenerate_seo_surfaces(seo_pages, site, output_dir, verbose, options.parallel, include_robots: true)
 
           elapsed = Time.instant - start_time
           Logger.outcome("rebuilt", "#{render_list.size} / #{all_pages.size} pages", :result, elapsed.total_milliseconds)
-          if options.verbose
-            @cache_manager.report_verbose
-          else
-            @cache_manager.report
-          end
+          report_cache_stats(options.verbose)
         end
 
         # Incremental parse of changed content + full re-render with reloaded templates.
@@ -576,11 +557,7 @@ module Hwaro
           cascade_map = @cascade_map || build_cascade_map(site.sections)
 
           changed_content_files.each do |file|
-            relative_path = begin
-              Path[file].relative_to("content").to_s
-            rescue ArgumentError
-              file.lchop("content/")
-            end
+            relative_path = path_relative_to(file, "content")
 
             page = pages_map[relative_path]?
             unless page
@@ -745,11 +722,7 @@ module Hwaro
 
           elapsed = Time.instant - start_time
           Logger.outcome("rebuilt", "#{count} pages · re-render", :result, elapsed.total_milliseconds)
-          if verbose
-            @cache_manager.report_verbose
-          else
-            @cache_manager.report
-          end
+          report_cache_stats(verbose)
         end
 
         # Are there any pages stashed by `--fast-start` waiting to render?
@@ -843,13 +816,7 @@ module Hwaro
           # had no effect on this deferred pass).
           taxonomy_sections = Content::Taxonomies.generate(site, output_dir, templates, verbose)
           all_pages = (site.pages + site.sections + taxonomy_sections).as(Array(Models::Page))
-          seo_tasks = [
-            -> { Content::Seo::Sitemap.generate(all_pages, site, output_dir, verbose); nil },
-            -> { Content::Seo::Feeds.generate(all_pages, site.config, output_dir, verbose); nil },
-            -> { Content::Seo::Llms.generate(site.config, all_pages, output_dir, verbose); nil },
-            -> { Content::Search.generate(all_pages, site.config, output_dir, verbose); nil },
-          ] of Proc(Nil)
-          ParallelHelper.execute(seo_tasks, options.parallel)
+          regenerate_seo_surfaces(all_pages, site, output_dir, verbose, options.parallel)
 
           # Persist cache updates from the deferred pass. The initial build
           # already saved once; without this second save, killing the server
@@ -875,11 +842,7 @@ module Hwaro
             next unless File.exists?(src_path)
             next if File.directory?(src_path)
 
-            relative = begin
-              Path[src_path].relative_to("static").to_s
-            rescue ArgumentError
-              src_path.lchop("static/")
-            end
+            relative = path_relative_to(src_path, "static")
             next if static_config.excluded?(relative)
             dest_path = File.join(output_dir, relative)
 
@@ -914,11 +877,7 @@ module Hwaro
             next unless File.exists?(src_path)
             next if File.directory?(src_path)
 
-            relative = begin
-              Path[src_path].relative_to("content").to_s
-            rescue ArgumentError
-              src_path.lchop("content/")
-            end
+            relative = path_relative_to(src_path, "content")
 
             next unless config.content_files.publish?(relative)
 
@@ -1099,11 +1058,7 @@ module Hwaro
           profiler.hook_report
 
           # Print cache stats
-          if options.verbose
-            @cache_manager.report_verbose
-          else
-            @cache_manager.report
-          end
+          report_cache_stats(options.verbose)
 
           # Run post-build hooks
           unless post_hooks.empty?
@@ -1117,6 +1072,34 @@ module Hwaro
               Utils::DebugPrinter.print(debug_site)
             end
           end
+        end
+
+        # Resolve `path` relative to `root`, falling back to a plain prefix
+        # strip when it can't be made relative (e.g. an absolute path).
+        private def path_relative_to(path : String, root : String) : String
+          Path[path].relative_to(root).to_s
+        rescue ArgumentError
+          path.lchop("#{root}/")
+        end
+
+        # Regenerate the lightweight SEO/search surfaces (sitemap, feeds, llms,
+        # search index, optionally robots) for the given page set. Each
+        # generator writes a distinct output file with no shared in-process
+        # state, so task order doesn't affect output.
+        private def regenerate_seo_surfaces(pages : Array(Models::Page), site : Models::Site, output_dir : String, verbose : Bool, parallel : Bool, include_robots : Bool = false)
+          seo_tasks = [
+            -> { Content::Seo::Sitemap.generate(pages, site, output_dir, verbose); nil },
+            -> { Content::Seo::Feeds.generate(pages, site.config, output_dir, verbose); nil },
+            -> { Content::Seo::Llms.generate(site.config, pages, output_dir, verbose); nil },
+            -> { Content::Search.generate(pages, site.config, output_dir, verbose); nil },
+          ] of Proc(Nil)
+          seo_tasks << -> { Content::Seo::Robots.generate(site.config, output_dir, verbose); nil } if include_robots
+          ParallelHelper.execute(seo_tasks, parallel)
+        end
+
+        # Emit the end-of-build cache statistics at the requested verbosity.
+        private def report_cache_stats(verbose : Bool)
+          verbose ? @cache_manager.report_verbose : @cache_manager.report
         end
 
         # Selectively invalidate Crinja caches for changed pages and affected sections.

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -261,8 +261,7 @@ module Hwaro::Core::Build::Phases::Render
     section_set_changed = cache.section_set_changed?(section_set_fp)
     listing_memo = {} of String => Tuple(Bool, Bool)
     pages.select do |page|
-      source_path = File.join("content", page.path)
-      output_path = get_output_path(page, output_dir)
+      source_path, output_path = cache_paths_for(page, output_dir)
       next true if cache.changed?(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
       # Page's own source is unchanged: only re-render it if a set it depends on
       # changed. Skip the (cheap) marker scan entirely when nothing moved.
@@ -347,6 +346,24 @@ module Hwaro::Core::Build::Phases::Render
     Utils::OutputGuard.safe_output_path(output_path, output_dir) || File.join(output_dir, "index.html")
   end
 
+  # Source + output path pair the cache keys a page by.
+  private def cache_paths_for(page : Models::Page, output_dir : String) : {String, String}
+    {File.join("content", page.path), get_output_path(page, output_dir)}
+  end
+
+  # Record this page's post-render cache entry. No-op when the cache is
+  # disabled (the default build).
+  #
+  # The `cache.enabled?` guard wraps ARGUMENT evaluation, not just the
+  # `cache.update` call: computing page_template_hash costs a shortcode-regex
+  # scan over the raw content plus an MD5 per page, so it must be skipped
+  # entirely when the cache is off.
+  private def record_page_cache_entry(page : Models::Page, cache : Cache, templates : Hash(String, String), site : Models::Site, output_dir : String)
+    return unless cache.enabled?
+    source_path, output_path = cache_paths_for(page, output_dir)
+    cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
+  end
+
   private def process_files_parallel(
     pages : Array(Models::Page),
     site : Models::Site,
@@ -423,15 +440,7 @@ module Hwaro::Core::Build::Phases::Render
               template_name = determine_template(page, templates, site)
               profiler.record_template(template_name, page.content.bytesize.to_i64, elapsed_ms)
             end
-            # Guard argument evaluation, not just the call: update is a no-op
-            # when the cache is disabled (the default build), but its
-            # arguments cost a template-hash computation — shortcode regex
-            # scans over the raw content plus an MD5 — per page.
-            if cache.enabled?
-              source_path = File.join("content", page.path)
-              output_path = get_output_path(page, output_dir)
-              cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
-            end
+            record_page_cache_entry(page, cache, templates, site, output_dir)
             ok = true
           rescue ex : Hwaro::HwaroError
             error_mutex.synchronize do
@@ -555,13 +564,7 @@ module Hwaro::Core::Build::Phases::Render
         template_name = determine_template(page, templates, site)
         profiler.record_template(template_name, page.content.bytesize.to_i64, elapsed_ms)
       end
-      # See the parallel worker: skip argument evaluation entirely when the
-      # cache is disabled — the template-hash computation is per-page work.
-      if cache.enabled?
-        source_path = File.join("content", page.path)
-        output_path = get_output_path(page, output_dir)
-        cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site))
-      end
+      record_page_cache_entry(page, cache, templates, site, output_dir)
       count += 1
     end
     count
@@ -681,10 +684,7 @@ module Hwaro::Core::Build::Phases::Render
                        crinja_env_override: crinja_env_override, template_cache_override: template_cache_override,
                        prebuilt_vars: shortcode_context, template_name: template_name)
                    else
-                     msg = "No template found for #{page.path}. Using raw content."
-                     Logger.warn "#{msg}"
-                     page.build_warnings << msg unless page.build_warnings.includes?(msg)
-                     html_content
+                     no_template_fallback(page, html_content)
                    end
 
       if error_overlay && !page.build_warnings.empty?
@@ -766,10 +766,7 @@ module Hwaro::Core::Build::Phases::Render
                        crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, pagination_seo_links: pagination_seo_links,
                        template_name: template_name)
                    else
-                     msg = "No template found for #{section.path}. Using raw content."
-                     Logger.warn "#{msg}"
-                     section.build_warnings << msg unless section.build_warnings.includes?(msg)
-                     html_content
+                     no_template_fallback(section, html_content)
                    end
 
       if error_overlay && !section.build_warnings.empty?
@@ -797,6 +794,16 @@ module Hwaro::Core::Build::Phases::Render
     Logger.action :create, output_path if verbose
   end
 
+  # Render-path fallback when a page/section has no template: warn, record a
+  # dedup'd build warning, and return the raw HTML unchanged. (determine_template
+  # has its own intentionally warn-once handling and is not routed through here.)
+  private def no_template_fallback(page : Models::Page, html_content : String) : String
+    msg = "No template found for #{page.path}. Using raw content."
+    Logger.warn msg
+    page.build_warnings << msg unless page.build_warnings.includes?(msg)
+    html_content
+  end
+
   private def determine_template(page : Models::Page, templates : Hash(String, String), site : Models::Site) : String
     if custom = page.template
       return custom if templates.has_key?(custom)
@@ -822,7 +829,7 @@ module Hwaro::Core::Build::Phases::Render
     # their own "section" template (handled above), so they are excluded here.
     unless page.is_a?(Models::Section)
       if section = site.section_for(page.section, page.language)
-        if pt = section.effective_page_template
+        if pt = section.page_template
           return pt if templates.has_key?(pt)
         end
       end

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -415,19 +415,7 @@ module Hwaro::Core::Build::Phases::Transform
       end
     end
 
-    groups.each do |_name, pages|
-      sorted = pages.sort_by do |p|
-        {p.series_weight, p.date || Time::UNIX_EPOCH, p.title}
-      end
-
-      sorted.each_with_index do |page, idx|
-        page.series_index = idx + 1
-        # A single-post series has no prev/next, so leave series_pages empty
-        # to keep the template's `page.series_pages` guard from rendering an
-        # orphan series-nav box.
-        page.series_pages = sorted.size > 1 ? sorted : ([] of Models::Page)
-      end
-    end
+    assign_series_groups(groups)
 
     # Clear series data for pages whose series became empty
     affected_series.each do |series_name|
@@ -458,20 +446,7 @@ module Hwaro::Core::Build::Phases::Transform
     all_pages = site.pages.reject { |p| p.draft || p.is_index || p.generated || !p.render }
 
     # Build inverted index first (needed for both candidate discovery and scoring)
-    inverted = {} of String => Hash(String, Array(String))
-    page_lookup = {} of String => Models::Page
-
-    all_pages.each do |page|
-      page_lookup[page.path] = page
-      taxonomy_names.each do |tax_name|
-        values = page.taxonomy_values(tax_name)
-        values.each do |term|
-          inv_tax = inverted[tax_name]? || (inverted[tax_name] = {} of String => Array(String))
-          arr = inv_tax[term]? || (inv_tax[term] = [] of String)
-          arr << page.path
-        end
-      end
-    end
+    inverted, page_lookup = build_related_index(all_pages, taxonomy_names)
 
     # Collect paths of pages that need related_posts recomputed:
     # 1. Changed pages themselves
@@ -639,6 +614,22 @@ module Hwaro::Core::Build::Phases::Transform
     end
   end
 
+  # Sort each series group by weight/date/title and assign series_index and
+  # series_pages. A single-post series gets empty series_pages so the
+  # template's `page.series_pages` guard skips the orphan series-nav box.
+  private def assign_series_groups(groups : Hash(String, Array(Models::Page)))
+    groups.each do |_name, pages|
+      sorted = pages.sort_by do |p|
+        {p.series_weight, p.date || Time::UNIX_EPOCH, p.title}
+      end
+
+      sorted.each_with_index do |page, idx|
+        page.series_index = idx + 1
+        page.series_pages = sorted.size > 1 ? sorted : ([] of Models::Page)
+      end
+    end
+  end
+
   # Group pages by series name and assign series_index, series_pages.
   # Pages within a series are sorted by series_weight, then date, then title.
   private def compute_series(site : Models::Site)
@@ -651,32 +642,13 @@ module Hwaro::Core::Build::Phases::Transform
       end
     end
 
-    groups.each do |_name, pages|
-      sorted = pages.sort_by do |p|
-        {p.series_weight, p.date || Time::UNIX_EPOCH, p.title}
-      end
-
-      sorted.each_with_index do |page, idx|
-        page.series_index = idx + 1
-        # A single-post series has no prev/next, so leave series_pages empty
-        # to keep the template's `page.series_pages` guard from rendering an
-        # orphan series-nav box.
-        page.series_pages = sorted.size > 1 ? sorted : ([] of Models::Page)
-      end
-    end
+    assign_series_groups(groups)
   end
 
-  # Compute related posts for each page based on shared taxonomy terms.
-  # Pages with more shared terms are ranked higher.
-  private def compute_related_posts(site : Models::Site)
-    config = site.config.related
-    taxonomy_names = config.taxonomies
-    limit = config.limit
-    return if limit <= 0
-    pages = site.pages.reject { |p| p.draft || p.is_index || p.generated || !p.render }
-
-    # Build inverted index: {taxonomy_name => {term => Array(page_path)}}
-    # This avoids the O(N²) pairwise comparison
+  # Build the taxonomy inverted index ({tax_name => {term => [page_path]}}) and a
+  # path->page lookup for the given candidate pages. Shared by the full and
+  # incremental related-posts computations.
+  private def build_related_index(pages : Array(Models::Page), taxonomy_names : Array(String)) : {Hash(String, Hash(String, Array(String))), Hash(String, Models::Page)}
     inverted = {} of String => Hash(String, Array(String))
     page_lookup = {} of String => Models::Page
 
@@ -691,6 +663,22 @@ module Hwaro::Core::Build::Phases::Transform
         end
       end
     end
+
+    {inverted, page_lookup}
+  end
+
+  # Compute related posts for each page based on shared taxonomy terms.
+  # Pages with more shared terms are ranked higher.
+  private def compute_related_posts(site : Models::Site)
+    config = site.config.related
+    taxonomy_names = config.taxonomies
+    limit = config.limit
+    return if limit <= 0
+    pages = site.pages.reject { |p| p.draft || p.is_index || p.generated || !p.render }
+
+    # Build inverted index: {taxonomy_name => {term => Array(page_path)}}
+    # This avoids the O(N²) pairwise comparison
+    inverted, page_lookup = build_related_index(pages, taxonomy_names)
 
     pages.each do |page|
       # Count co-occurrences via inverted index: O(terms * avg_pages_per_term).

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -4,9 +4,20 @@ require "./deployment"
 require "../utils/errors"
 require "../utils/text_utils"
 require "../utils/env_substitutor"
+require "../utils/path_utils"
 
 module Hwaro
   module Models
+    # Cache-busting query suffix shared by the asset/highlight tag emitters.
+    def self.cache_bust_suffix(value : String) : String
+      value.empty? ? "" : "?v=#{HTML.escape(value)}"
+    end
+
+    # Join non-empty tag fragments with newlines.
+    def self.join_tags(*parts : String) : String
+      parts.reject(&.empty?).join("\n")
+    end
+
     class SitemapConfig
       property enabled : Bool
       property filename : String
@@ -161,12 +172,9 @@ module Hwaro
         return false unless @allow_extensions.includes?(ext)
         return false if @disallow_extensions.includes?(ext)
         @disallow_paths.each do |pattern|
-          # A malformed glob raises File::BadPatternError; skip it rather than
-          # crashing the build, so other disallow patterns still apply.
-
-          return false if File.match?(pattern, normalized_path)
-        rescue File::BadPatternError
-          next
+          # A malformed glob is treated as non-matching by glob_match?, so a
+          # config typo can't crash the build; other patterns still apply.
+          return false if Utils::PathUtils.glob_match?(pattern, normalized_path)
         end
         true
       end
@@ -279,7 +287,7 @@ module Hwaro
         return "" unless @enabled
         return "" if @dirs.empty?
 
-        suffix = cache_bust.empty? ? "" : "?v=#{HTML.escape(cache_bust)}"
+        suffix = Models.cache_bust_suffix(cache_bust)
         tags = [] of String
         @dirs.each do |dir|
           static_dir = File.join("static", dir)
@@ -297,7 +305,7 @@ module Hwaro
       def all_tags(base_url : String = "", cache_bust : String = "") : String
         css = css_tags(base_url, cache_bust)
         js = js_tags(base_url, cache_bust)
-        [css, js].reject(&.empty?).join("\n")
+        Models.join_tags(css, js)
       end
     end
 
@@ -401,6 +409,12 @@ module Hwaro
         @auto_image = AutoImageConfig.new
       end
 
+      # Append a single conditional `<meta>` line (leading newline + 2-space
+      # indent) for the OG/Twitter tag builders.
+      private def append_meta(str, attr : String, name : String, value : String)
+        str << %(\n  <meta #{attr}="#{name}" content="#{Utils::TextUtils.escape_xml(value)}">)
+      end
+
       # Generate OG meta tags.
       #
       # `og_type_override` lets the renderer force `og:type="website"` for
@@ -425,13 +439,13 @@ module Hwaro
           str << %(<meta property="og:type" content="#{Utils::TextUtils.escape_xml(og_type)}">\n  )
           str << %(<meta property="og:url" content="#{Utils::TextUtils.escape_xml(base_url)}#{Utils::TextUtils.escape_xml(url)}">)
           if desc = description
-            str << %(\n  <meta property="og:description" content="#{Utils::TextUtils.escape_xml(desc)}">)
+            append_meta(str, "property", "og:description", desc)
           end
           if img_url = resolve_image_url(image, base_url)
-            str << %(\n  <meta property="og:image" content="#{Utils::TextUtils.escape_xml(img_url)}">)
+            append_meta(str, "property", "og:image", img_url)
           end
           if fb_id = @fb_app_id
-            str << %(\n  <meta property="fb:app_id" content="#{Utils::TextUtils.escape_xml(fb_id)}">)
+            append_meta(str, "property", "fb:app_id", fb_id)
           end
         end
       end
@@ -455,16 +469,16 @@ module Hwaro
           str << %(<meta name="twitter:card" content="#{Utils::TextUtils.escape_xml(card)}">\n  )
           str << %(<meta name="twitter:title" content="#{Utils::TextUtils.escape_xml(title)}">)
           if desc = description
-            str << %(\n  <meta name="twitter:description" content="#{Utils::TextUtils.escape_xml(desc)}">)
+            append_meta(str, "name", "twitter:description", desc)
           end
           if img_url
-            str << %(\n  <meta name="twitter:image" content="#{Utils::TextUtils.escape_xml(img_url)}">)
+            append_meta(str, "name", "twitter:image", img_url)
           end
           if site = @twitter_site
-            str << %(\n  <meta name="twitter:site" content="#{Utils::TextUtils.escape_xml(site)}">)
+            append_meta(str, "name", "twitter:site", site)
           end
           if creator = @twitter_creator
-            str << %(\n  <meta name="twitter:creator" content="#{Utils::TextUtils.escape_xml(creator)}">)
+            append_meta(str, "name", "twitter:creator", creator)
           end
         end
       end
@@ -487,7 +501,7 @@ module Hwaro
       ) : String
         og = og_tags(title, description, url, image, base_url, og_type_override)
         twitter = twitter_tags(title, description, image, base_url)
-        [og, twitter].reject(&.empty?).join("\n")
+        Models.join_tags(og, twitter)
       end
     end
 
@@ -520,7 +534,7 @@ module Hwaro
         if @use_cdn
           %(<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/#{safe_theme}.min.css">)
         else
-          suffix = cache_bust.empty? ? "" : "?v=#{HTML.escape(cache_bust)}"
+          suffix = Models.cache_bust_suffix(cache_bust)
           %(<link rel="stylesheet" href="/assets/css/highlight/#{safe_theme}.min.css#{suffix}">)
         end
       end
@@ -533,7 +547,7 @@ module Hwaro
         if @use_cdn
           %(<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>\n<script>hljs.highlightAll();</script>)
         else
-          suffix = cache_bust.empty? ? "" : "?v=#{HTML.escape(cache_bust)}"
+          suffix = Models.cache_bust_suffix(cache_bust)
           %(<script src="/assets/js/highlight.min.js#{suffix}"></script>\n<script>hljs.highlightAll();</script>)
         end
       end
@@ -893,12 +907,8 @@ module Hwaro
           # an unclosed `[` class) makes File.match? raise File::BadPatternError;
           # treat it as non-matching rather than crashing the whole build on a
           # single config typo.
-          begin
-            File.match?(pattern, normalized) ||
-              (!pattern.includes?('/') && File.match?(pattern, basename))
-          rescue File::BadPatternError
-            false
-          end
+          Utils::PathUtils.glob_match?(pattern, normalized) ||
+            (!pattern.includes?('/') && Utils::PathUtils.glob_match?(pattern, basename))
         else
           # Literal: an exact file, or a directory subtree rooted at it.
           normalized == pattern || normalized.starts_with?("#{pattern}/")

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -177,6 +177,19 @@ module Hwaro
         !@redirect_to.nil? && !@redirect_to.try(&.empty?)
       end
 
+      # True when a page should be omitted from generated listings (taxonomy
+      # indexes, related posts, …): drafts and synthetic generated pages.
+      def excluded_from_listings? : Bool
+        draft || generated
+      end
+
+      # True when a page is eligible for the search index / llms.txt: it emits
+      # HTML, isn't a draft, opts into the search index, and isn't a synthetic
+      # generated listing page.
+      def search_index_eligible? : Bool
+        render && !draft && in_search_index && !generated
+      end
+
       # Resolve the term list for a configured taxonomy `name`. Most
       # taxonomies live in `@taxonomies`, but a few — `tags` and `authors`
       # — are stored on dedicated `Page` properties so other features

--- a/src/models/section.cr
+++ b/src/models/section.cr
@@ -38,20 +38,9 @@ module Hwaro
         @cascade = {} of String => ExtraValue
       end
 
-      # Get effective page template (for pages in this section)
-      def effective_page_template : String?
-        @page_template
-      end
-
       # Add a subsection
       def add_subsection(section : Section)
         @subsections << section
-      end
-
-      # Find subsection by name (exact section match first, then case-insensitive title)
-      def find_subsection(name : String) : Section?
-        @subsections.find { |s| s.section == name } ||
-          @subsections.find { |s| s.title.downcase == name.downcase }
       end
 
       # Get all pages including from subsections (recursive)

--- a/src/services/ci_config.cr
+++ b/src/services/ci_config.cr
@@ -1,4 +1,5 @@
 require "../utils/logger"
+require "./github_actions_workflow"
 
 module Hwaro
   module Services
@@ -22,47 +23,7 @@ module Hwaro
       end
 
       private def generate_github_actions : String
-        lines = [] of String
-        lines << "---"
-        lines << "name: Hwaro CI/CD"
-        lines << ""
-        lines << "on:"
-        lines << "  push:"
-        lines << "    branches: [main]"
-        lines << "  pull_request:"
-        lines << "    branches: [main]"
-        lines << "  workflow_dispatch:"
-        lines << ""
-        lines << "permissions:"
-        lines << "  contents: write"
-        lines << ""
-        lines << "jobs:"
-        lines << "  build:"
-        lines << "    runs-on: ubuntu-latest"
-        lines << "    if: github.event_name == 'pull_request'"
-        lines << "    steps:"
-        lines << "      - name: Checkout"
-        lines << "        uses: actions/checkout@v6"
-        lines << ""
-        lines << "      - name: Build Only"
-        lines << "        uses: hahwul/hwaro@main"
-        lines << "        with:"
-        lines << "          build_only: true"
-        lines << ""
-        lines << "  deploy:"
-        lines << "    runs-on: ubuntu-latest"
-        lines << "    if: github.event_name == 'push' && github.ref == 'refs/heads/main'"
-        lines << "    steps:"
-        lines << "      - name: Checkout"
-        lines << "        uses: actions/checkout@v6"
-        lines << ""
-        lines << "      - name: Build and Deploy"
-        lines << "        uses: hahwul/hwaro@main"
-        lines << "        with:"
-        lines << "          token: ${{ secrets.GITHUB_TOKEN }}"
-        lines << ""
-
-        lines.join("\n")
+        GithubActionsWorkflow.content
       end
     end
   end

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -73,20 +73,10 @@ module Hwaro
         config ||= Models::Config.load(env: options.env)
         deployment = config.deployment
 
-        source_dir = options.source_dir || deployment.source_dir
-        source_dir = File.expand_path(source_dir)
+        source_dir = resolve_source_dir(options, deployment)
         return ops unless Dir.exists?(source_dir)
 
-        target_names =
-          if options.targets.present?
-            options.targets
-          elsif default_target = deployment.target
-            [default_target]
-          elsif deployment.targets.size > 0
-            [deployment.targets.first.name]
-          else
-            [] of String
-          end
+        target_names = resolve_target_names(options, deployment)
         return ops if target_names.empty?
 
         targets = target_names.compact_map { |name| deployment.target_named(name) }
@@ -155,35 +145,11 @@ module Hwaro
         config ||= Models::Config.load(env: options.env)
         deployment = config.deployment
 
-        source_dir = options.source_dir || deployment.source_dir
-        source_dir = File.expand_path(source_dir)
+        source_dir = resolve_source_dir(options, deployment)
+        require_source_dir!(source_dir)
 
-        unless Dir.exists?(source_dir)
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_CONFIG,
-            message: "Source directory not found: #{source_dir}",
-            hint: "Run 'hwaro build' first, or pass '--source DIR'.",
-          )
-        end
-
-        target_names =
-          if options.targets.present?
-            options.targets
-          elsif default_target = deployment.target
-            [default_target]
-          elsif deployment.targets.size > 0
-            [deployment.targets.first.name]
-          else
-            [] of String
-          end
-
-        if target_names.empty?
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_CONFIG,
-            message: "No deployment targets configured.",
-            hint: "Add '[[deployment.targets]]' to config.toml, or pass target names: hwaro deploy <targets>",
-          )
-        end
+        target_names = resolve_target_names(options, deployment)
+        require_target_names!(target_names)
 
         targets = target_names.compact_map do |name|
           target = deployment.target_named(name)
@@ -346,35 +312,11 @@ module Hwaro
         config ||= Models::Config.load(env: options.env)
         deployment = config.deployment
 
-        source_dir = options.source_dir || deployment.source_dir
-        source_dir = File.expand_path(source_dir)
+        source_dir = resolve_source_dir(options, deployment)
+        require_source_dir!(source_dir)
 
-        unless Dir.exists?(source_dir)
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_CONFIG,
-            message: "Source directory not found: #{source_dir}",
-            hint: "Run 'hwaro build' first, or pass '--source DIR'.",
-          )
-        end
-
-        target_names =
-          if options.targets.present?
-            options.targets
-          elsif default_target = deployment.target
-            [default_target]
-          elsif deployment.targets.size > 0
-            [deployment.targets.first.name]
-          else
-            [] of String
-          end
-
-        if target_names.empty?
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_CONFIG,
-            message: "No deployment targets configured.",
-            hint: "Add '[[deployment.targets]]' to config.toml, or pass target names: hwaro deploy <targets>",
-          )
-        end
+        target_names = resolve_target_names(options, deployment)
+        require_target_names!(target_names)
 
         targets = target_names.map do |name|
           target = deployment.target_named(name)
@@ -734,26 +676,55 @@ module Hwaro
         files
       end
 
+      # Resolve the deploy source directory from options/config (expanded).
+      private def resolve_source_dir(options, deployment) : String
+        File.expand_path(options.source_dir || deployment.source_dir)
+      end
+
+      # Resolve which deploy target names to act on: explicit CLI targets, then
+      # the configured default target, then the first configured target.
+      private def resolve_target_names(options, deployment) : Array(String)
+        if options.targets.present?
+          options.targets
+        elsif default_target = deployment.target
+          [default_target]
+        elsif deployment.targets.size > 0
+          [deployment.targets.first.name]
+        else
+          [] of String
+        end
+      end
+
+      # Raise HWARO_E_CONFIG when the deploy source directory doesn't exist.
+      private def require_source_dir!(source_dir : String)
+        return if Dir.exists?(source_dir)
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          message: "Source directory not found: #{source_dir}",
+          hint: "Run 'hwaro build' first, or pass '--source DIR'.",
+        )
+      end
+
+      # Raise HWARO_E_CONFIG when no deployment targets are configured.
+      private def require_target_names!(target_names : Array(String))
+        return unless target_names.empty?
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          message: "No deployment targets configured.",
+          hint: "Add '[[deployment.targets]]' to config.toml, or pass target names: hwaro deploy <targets>",
+        )
+      end
+
       private def included_by_target?(rel : String, target : Models::DeploymentTarget) : Bool
         normalized = rel.gsub('\\', '/')
         # A malformed include/exclude glob raises File::BadPatternError. Treat a
         # bad `include` as not-matching (file excluded) and a bad `exclude` as
         # not-matching (file kept), so a config typo doesn't crash the deploy.
         if inc = target.include
-          matched = begin
-            File.match?(inc, normalized)
-          rescue File::BadPatternError
-            false
-          end
-          return false unless matched
+          return false unless Utils::PathUtils.glob_match?(inc, normalized)
         end
         if exc = target.exclude
-          excluded = begin
-            File.match?(exc, normalized)
-          rescue File::BadPatternError
-            false
-          end
-          return false if excluded
+          return false if Utils::PathUtils.glob_match?(exc, normalized)
         end
         true
       end

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -806,31 +806,29 @@ module Hwaro
       # `config-dir-missing` (directory), both suppressible via
       # `[doctor] ignore = [...]`. See
       # https://github.com/hahwul/hwaro/issues/489.
+      # Emit a "<kind> not found" config warning for `value` unless it's blank
+      # or `resolver` reports it resolves. `id`/`kind` are passed independently
+      # so route checks can keep the "config-path-missing"/"file" pairing.
+      private def emit_missing(issues : Array(Issue), label : String, value : String, *, resolver : String -> Bool, id : String, kind : String)
+        stripped = strip_query_hash(value)
+        return if stripped.empty?
+        return if resolver.call(stripped)
+        issues << Issue.new(
+          id: id,
+          level: :warning,
+          category: "config",
+          file: @config_path,
+          message: "#{label}: #{value} — #{kind} not found",
+        )
+      end
+
       private def check_referenced_paths(issues : Array(Issue), config : Models::Config)
         emit_file = ->(label : String, value : String) do
-          stripped = strip_query_hash(value)
-          return if stripped.empty?
-          return if path_resolves?(stripped)
-          issues << Issue.new(
-            id: "config-path-missing",
-            level: :warning,
-            category: "config",
-            file: @config_path,
-            message: "#{label}: #{value} — file not found",
-          )
+          emit_missing(issues, label, value, resolver: ->(s : String) { path_resolves?(s) }, id: "config-path-missing", kind: "file")
         end
 
         emit_dir = ->(label : String, value : String) do
-          stripped = strip_query_hash(value)
-          return if stripped.empty?
-          return if dir_resolves?(stripped)
-          issues << Issue.new(
-            id: "config-dir-missing",
-            level: :warning,
-            category: "config",
-            file: @config_path,
-            message: "#{label}: #{value} — directory not found",
-          )
+          emit_missing(issues, label, value, resolver: ->(s : String) { dir_resolves?(s) }, id: "config-dir-missing", kind: "directory")
         end
 
         # PWA offline_page / precache_urls are routes, not just static files:
@@ -839,16 +837,7 @@ module Hwaro
         # found" warnings. Use a route-aware check that also accepts a matching
         # content source or a built output page.
         emit_route = ->(label : String, value : String) do
-          stripped = strip_query_hash(value)
-          return if stripped.empty?
-          return if path_resolves?(stripped) || route_resolves?(stripped)
-          issues << Issue.new(
-            id: "config-path-missing",
-            level: :warning,
-            category: "config",
-            file: @config_path,
-            message: "#{label}: #{value} — file not found",
-          )
+          emit_missing(issues, label, value, resolver: ->(s : String) { path_resolves?(s) || route_resolves?(s) }, id: "config-path-missing", kind: "file")
         end
 
         config.og.default_image.try { |v| emit_file.call("[og] default_image", v) }

--- a/src/services/github_actions_workflow.cr
+++ b/src/services/github_actions_workflow.cr
@@ -1,0 +1,53 @@
+module Hwaro
+  module Services
+    # The GitHub Actions deploy workflow YAML. Shared by `hwaro tool ci`
+    # (CIConfig) and `hwaro tool platform github-pages` (PlatformConfig) so the
+    # two generators stay byte-for-byte in lockstep — both write the same
+    # `.github/workflows/deploy.yml`.
+    module GithubActionsWorkflow
+      def self.content : String
+        lines = [] of String
+        lines << "---"
+        lines << "name: Hwaro CI/CD"
+        lines << ""
+        lines << "on:"
+        lines << "  push:"
+        lines << "    branches: [main]"
+        lines << "  pull_request:"
+        lines << "    branches: [main]"
+        lines << "  workflow_dispatch:"
+        lines << ""
+        lines << "permissions:"
+        lines << "  contents: write"
+        lines << ""
+        lines << "jobs:"
+        lines << "  build:"
+        lines << "    runs-on: ubuntu-latest"
+        lines << "    if: github.event_name == 'pull_request'"
+        lines << "    steps:"
+        lines << "      - name: Checkout"
+        lines << "        uses: actions/checkout@v6"
+        lines << ""
+        lines << "      - name: Build Only"
+        lines << "        uses: hahwul/hwaro@main"
+        lines << "        with:"
+        lines << "          build_only: true"
+        lines << ""
+        lines << "  deploy:"
+        lines << "    runs-on: ubuntu-latest"
+        lines << "    if: github.event_name == 'push' && github.ref == 'refs/heads/main'"
+        lines << "    steps:"
+        lines << "      - name: Checkout"
+        lines << "        uses: actions/checkout@v6"
+        lines << ""
+        lines << "      - name: Build and Deploy"
+        lines << "        uses: hahwul/hwaro@main"
+        lines << "        with:"
+        lines << "          token: ${{ secrets.GITHUB_TOKEN }}"
+        lines << ""
+
+        lines.join("\n")
+      end
+    end
+  end
+end

--- a/src/services/importers/astro_importer.cr
+++ b/src/services/importers/astro_importer.cr
@@ -71,20 +71,7 @@ module Hwaro
         end
 
         private def collect_markdown_files(dir : String) : Array(String)
-          files = [] of String
-          scan_dir(dir, files)
-          files
-        end
-
-        private def scan_dir(dir : String, files : Array(String))
-          Dir.each_child(dir) do |entry|
-            full_path = File.join(dir, entry)
-            if File.directory?(full_path)
-              scan_dir(full_path, files)
-            elsif entry.ends_with?(".md") || entry.ends_with?(".mdx")
-              files << full_path
-            end
-          end
+          walk_files(dir, [".md", ".mdx"])
         end
 
         private def import_file(
@@ -96,7 +83,7 @@ module Hwaro
           force : Bool,
         ) : Symbol
           raw = File.read(file_path)
-          frontmatter_yaml, body = parse_astro_file(raw)
+          frontmatter_yaml, body = split_yaml_frontmatter(raw)
 
           fields = Hash(String, (String | Bool | Array(String))?).new
 
@@ -213,14 +200,8 @@ module Hwaro
             end
           end
 
-          # Determine section from content collection name
-          relative = file_path.sub(content_dir, "").lstrip('/')
-          parts = relative.split("/")
-          section = if parts.size > 1
-                      parts[0] # Collection name (e.g., "blog", "posts")
-                    else
-                      "posts"
-                    end
+          # Determine section from content collection name (e.g. "blog", "posts")
+          section = top_section_from_path(file_path, content_dir, "posts")
 
           slug = slugify(File.basename(file_path, File.extname(file_path)))
 
@@ -229,17 +210,6 @@ module Hwaro
           written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
           return :skipped unless written
           has_mdx_components ? :imported_wrapped : :imported
-        end
-
-        YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m
-
-        private def parse_astro_file(content : String) : Tuple(String?, String)
-          if match = YAML_FM_REGEX.match(content)
-            yaml_str = match[1].strip
-            body = match[2].strip
-            return {yaml_str, body}
-          end
-          {nil, content.strip}
         end
       end
     end

--- a/src/services/importers/base.cr
+++ b/src/services/importers/base.cr
@@ -29,6 +29,61 @@ module Hwaro
       abstract class Base
         abstract def run(options : Config::Options::ImportOptions) : ImportResult
 
+        # Regex matching YAML frontmatter: opening `---` on the first line and a
+        # closing `---` on its own line (multiline mode so ^ matches line starts).
+        YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m
+
+        # Split YAML frontmatter from a document body. Returns {frontmatter, body}
+        # with both stripped, or {nil, content.strip} when no frontmatter present.
+        protected def split_yaml_frontmatter(content : String) : {String?, String}
+          if match = YAML_FM_REGEX.match(content)
+            return {match[1].strip, match[2].strip}
+          end
+          {nil, content.strip}
+        end
+
+        # Recursively collect files under `dir` whose name ends with one of
+        # `extensions`. `skip_dir`, when given, receives each subdirectory's
+        # basename and skips recursion into it when it returns true.
+        protected def walk_files(dir : String, extensions : Array(String) = [".md", ".markdown"], skip_dir : Proc(String, Bool)? = nil) : Array(String)
+          files = [] of String
+          walk_files_into(dir, files, extensions, skip_dir)
+          files
+        end
+
+        private def walk_files_into(dir : String, files : Array(String), extensions : Array(String), skip_dir : Proc(String, Bool)?)
+          Dir.each_child(dir) do |entry|
+            full_path = File.join(dir, entry)
+            if File.directory?(full_path)
+              next if skip_dir && skip_dir.call(entry)
+              walk_files_into(full_path, files, extensions, skip_dir)
+            elsif extensions.any? { |ext| entry.ends_with?(ext) }
+              files << full_path
+            end
+          end
+        end
+
+        # Split a file's path (relative to base_path) into {section, filename},
+        # where section is the parent-directory chain joined with "/" (or
+        # `default` for a top-level file) and filename is the last path segment.
+        protected def section_from_path(file_path : String, base_path : String, default : String) : {String, String}
+          relative = file_path.sub(base_path, "").lstrip('/')
+          parts = relative.split("/")
+          if parts.size > 1
+            {parts[0..-2].join("/"), parts.last}
+          else
+            {default, parts.first}
+          end
+        end
+
+        # The top-level section (first path segment) for a file relative to
+        # base_path, or `default` for a top-level file.
+        protected def top_section_from_path(file_path : String, base_path : String, default : String = "posts") : String
+          relative = file_path.sub(base_path, "").lstrip('/')
+          parts = relative.split("/")
+          parts.size > 1 ? parts[0] : default
+        end
+
         # Generate TOML frontmatter string from fields hash
         protected def generate_frontmatter(fields : Hash(String, (String | Bool | Array(String))?)) : String
           lines = [] of String

--- a/src/services/importers/eleventy_importer.cr
+++ b/src/services/importers/eleventy_importer.cr
@@ -70,27 +70,10 @@ module Hwaro
         end
 
         private def collect_content_files(path : String) : Array(String)
-          files = [] of String
-          scan_dir(path, files)
-          files
-        end
-
-        private def scan_dir(dir : String, files : Array(String))
-          Dir.each_child(dir) do |entry|
-            full_path = File.join(dir, entry)
-            if File.directory?(full_path)
-              # Skip common non-content directories
-              next if entry.starts_with?(".")
-              next if entry == "node_modules"
-              next if entry == "_site"
-              next if entry == "_includes"
-              next if entry == "_layouts"
-              next if entry == "_data"
-              scan_dir(full_path, files)
-            elsif entry.ends_with?(".md") || entry.ends_with?(".markdown")
-              files << full_path
-            end
-          end
+          # Skip common non-content directories
+          walk_files(path, skip_dir: ->(entry : String) {
+            entry.starts_with?(".") || {"node_modules", "_site", "_includes", "_layouts", "_data"}.includes?(entry)
+          })
         end
 
         # Load 11ty directory data files (dirname.json or dirname.11tydata.json)
@@ -175,7 +158,7 @@ module Hwaro
           force : Bool,
         ) : Symbol
           raw = File.read(file_path)
-          frontmatter_yaml, body = parse_eleventy_file(raw)
+          frontmatter_yaml, body = split_yaml_frontmatter(raw)
 
           fields = Hash(String, (String | Bool | Array(String))?).new
 
@@ -282,13 +265,7 @@ module Hwaro
           end
 
           # Determine section
-          relative = file_path.sub(base_path, "").lstrip('/')
-          parts = relative.split("/")
-          section = if parts.size > 1
-                      parts[0]
-                    else
-                      "posts"
-                    end
+          section = top_section_from_path(file_path, base_path, "posts")
 
           slug = slugify(File.basename(file_path, File.extname(file_path)))
 
@@ -297,17 +274,6 @@ module Hwaro
           written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
           return :skipped unless written
           has_template_tags ? :imported_wrapped : :imported
-        end
-
-        YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m
-
-        private def parse_eleventy_file(content : String) : Tuple(String?, String)
-          if match = YAML_FM_REGEX.match(content)
-            yaml_str = match[1].strip
-            body = match[2].strip
-            return {yaml_str, body}
-          end
-          {nil, content.strip}
         end
 
         # Merge directory data with per-file frontmatter (file data takes precedence)

--- a/src/services/importers/hexo_importer.cr
+++ b/src/services/importers/hexo_importer.cr
@@ -88,16 +88,7 @@ module Hwaro
         end
 
         private def scan_markdown(dir : String) : Array(String)
-          files = [] of String
-          Dir.each_child(dir) do |entry|
-            full_path = File.join(dir, entry)
-            if File.directory?(full_path)
-              scan_markdown(full_path).each { |f| files << f }
-            elsif entry.ends_with?(".md") || entry.ends_with?(".markdown")
-              files << full_path
-            end
-          end
-          files
+          walk_files(dir)
         end
 
         private def import_file(
@@ -107,7 +98,7 @@ module Hwaro
           force : Bool,
         ) : Symbol
           raw = File.read(file_info[:path])
-          frontmatter_yaml, body = parse_hexo_file(raw)
+          frontmatter_yaml, body = split_yaml_frontmatter(raw)
           filename = File.basename(file_info[:path])
 
           fields = Hash(String, (String | Bool | Array(String))?).new
@@ -247,17 +238,6 @@ module Hwaro
           written = write_content_file(output_dir, "posts", slug, frontmatter, body.strip, verbose, force)
           return :skipped unless written
           has_hexo_tags ? :imported_wrapped : :imported
-        end
-
-        YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m
-
-        private def parse_hexo_file(content : String) : Tuple(String?, String)
-          if match = YAML_FM_REGEX.match(content)
-            yaml_str = match[1].strip
-            body = match[2].strip
-            return {yaml_str, body}
-          end
-          {nil, content.strip}
         end
 
         private def extract_slug(filename : String) : String

--- a/src/services/importers/hugo_importer.cr
+++ b/src/services/importers/hugo_importer.cr
@@ -174,11 +174,9 @@ module Hwaro
           has_shortcodes ? :imported_wrapped : :imported
         end
 
-        # Regex for TOML frontmatter: +++ on first line, +++ on its own line
+        # Regex for TOML frontmatter: +++ on first line, +++ on its own line.
+        # (YAML frontmatter reuses the inherited Base::YAML_FM_REGEX.)
         TOML_FM_REGEX = /\A\+\+\+[ \t]*\n(.*?\n?)^\+\+\+[ \t]*$\n?(.*)\z/m
-
-        # Regex for YAML frontmatter: --- on first line, --- on its own line
-        YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m
 
         private def extract_frontmatter(raw : String) : {Hash(String, TOML::Any)?, String} | {Hash(String, YAML::Any)?, String}
           if raw.starts_with?("+++")

--- a/src/services/importers/hugo_importer.cr
+++ b/src/services/importers/hugo_importer.cr
@@ -57,20 +57,7 @@ module Hwaro
         end
 
         private def scan_markdown_files(content_dir : String) : Array(String)
-          files = [] of String
-          scan_dir(content_dir, files)
-          files
-        end
-
-        private def scan_dir(dir : String, files : Array(String))
-          Dir.each_child(dir) do |entry|
-            path = File.join(dir, entry)
-            if File.directory?(path)
-              scan_dir(path, files)
-            elsif entry.ends_with?(".md") || entry.ends_with?(".markdown")
-              files << path
-            end
-          end
+          walk_files(content_dir)
         end
 
         private def process_file(
@@ -169,18 +156,8 @@ module Hwaro
 
           frontmatter = generate_frontmatter(fields)
 
-          # Determine relative path for output structure
-          relative_path = file_path.sub(content_dir, "").lstrip('/')
-
           # Determine section and filename
-          parts = relative_path.split("/")
-          if parts.size > 1
-            section = parts[0..-2].join("/")
-            filename = parts.last
-          else
-            section = ""
-            filename = parts.first
-          end
+          section, filename = section_from_path(file_path, content_dir, "")
 
           # Determine slug for the file
           if filename == "_index.md" || filename == "_index.markdown"

--- a/src/services/importers/jekyll_importer.cr
+++ b/src/services/importers/jekyll_importer.cr
@@ -93,7 +93,7 @@ module Hwaro
           force : Bool,
         ) : Symbol
           raw = File.read(file_info[:path])
-          frontmatter_yaml, body = parse_jekyll_file(raw)
+          frontmatter_yaml, body = split_yaml_frontmatter(raw)
           filename = File.basename(file_info[:path])
 
           # Extract slug and date from filename
@@ -236,20 +236,6 @@ module Hwaro
 
           return :skipped unless written
           has_liquid ? :imported_wrapped : :imported
-        end
-
-        # Regex to match YAML frontmatter: opening --- on first line,
-        # closing --- on its own line. Uses multiline mode so ^ matches line starts.
-        YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m
-
-        private def parse_jekyll_file(content : String) : Tuple(String?, String)
-          if match = YAML_FM_REGEX.match(content)
-            yaml_str = match[1].strip
-            body = match[2].strip
-            return {yaml_str, body}
-          end
-
-          {nil, content.strip}
         end
 
         private def extract_slug(filename : String) : String

--- a/src/services/importers/notion_importer.cr
+++ b/src/services/importers/notion_importer.cr
@@ -54,20 +54,7 @@ module Hwaro
         end
 
         private def collect_markdown_files(path : String) : Array(String)
-          files = [] of String
-          scan_dir(path, files)
-          files
-        end
-
-        private def scan_dir(dir : String, files : Array(String))
-          Dir.each_child(dir) do |entry|
-            full_path = File.join(dir, entry)
-            if File.directory?(full_path)
-              scan_dir(full_path, files)
-            elsif entry.ends_with?(".md") || entry.ends_with?(".markdown")
-              files << full_path
-            end
-          end
+          walk_files(path)
         end
 
         private def import_file(
@@ -78,7 +65,7 @@ module Hwaro
           force : Bool,
         ) : Symbol
           raw = File.read(file_path)
-          frontmatter_yaml, body = parse_markdown_file(raw)
+          frontmatter_yaml, body = split_yaml_frontmatter(raw)
 
           fields = Hash(String, (String | Bool | Array(String))?).new
 
@@ -147,18 +134,6 @@ module Hwaro
           body = strip_redundant_title_h1(body, fields["title"]?.as?(String))
           written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
           written ? :imported : :skipped
-        end
-
-        # Regex to match YAML frontmatter
-        YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m
-
-        private def parse_markdown_file(content : String) : Tuple(String?, String)
-          if match = YAML_FM_REGEX.match(content)
-            yaml_str = match[1].strip
-            body = match[2].strip
-            return {yaml_str, body}
-          end
-          {nil, content.strip}
         end
 
         private def extract_title_from_body(body : String) : String?

--- a/src/services/importers/obsidian_importer.cr
+++ b/src/services/importers/obsidian_importer.cr
@@ -72,9 +72,7 @@ module Hwaro
         end
 
         private def collect_markdown_files(path : String) : Array(String)
-          files = [] of String
-          scan_dir(path, files)
-          files
+          walk_files(path, skip_dir: ->(entry : String) { entry.starts_with?(".") })
         end
 
         # Build a name → URL map covering every note in the vault. Keys are
@@ -91,13 +89,11 @@ module Hwaro
           files.each do |file_path|
             raw = File.read(file_path)
             content_cache[file_path] = raw
-            fm_yaml, _ = parse_markdown_file(raw)
+            fm_yaml, _ = split_yaml_frontmatter(raw)
 
             # Section mirrors `import_file`'s computation so the URL we
             # emit lands at the same path the file will be written to.
-            relative = file_path.sub(base_path, "").lstrip('/')
-            parts = relative.split("/")
-            section = parts.size > 1 ? parts[0..-2].join("/") : "posts"
+            section, _ = section_from_path(file_path, base_path, "posts")
 
             basename = File.basename(file_path, File.extname(file_path))
             title = basename
@@ -158,18 +154,6 @@ module Hwaro
           anchor.empty? ? slug : "#{slug}##{slugify(anchor.lchop('#').lchop('^'))}"
         end
 
-        private def scan_dir(dir : String, files : Array(String))
-          Dir.each_child(dir) do |entry|
-            full_path = File.join(dir, entry)
-            # Skip hidden directories (like .obsidian, .trash)
-            if File.directory?(full_path)
-              scan_dir(full_path, files) unless entry.starts_with?(".")
-            elsif entry.ends_with?(".md") || entry.ends_with?(".markdown")
-              files << full_path
-            end
-          end
-        end
-
         private def import_file(
           file_path : String,
           base_path : String,
@@ -181,7 +165,7 @@ module Hwaro
           content_cache : Hash(String, String) = {} of String => String,
         ) : Symbol
           raw = content_cache[file_path]? || File.read(file_path)
-          frontmatter_yaml, body = parse_markdown_file(raw)
+          frontmatter_yaml, body = split_yaml_frontmatter(raw)
 
           fields = Hash(String, (String | Bool | Array(String))?).new
           tags = [] of String
@@ -274,13 +258,7 @@ module Hwaro
           body = convert_obsidian_syntax(body, link_map)
 
           # Determine section from vault folder structure
-          relative = file_path.sub(base_path, "").lstrip('/')
-          parts = relative.split("/")
-          if parts.size > 1
-            section = parts[0..-2].join("/")
-          else
-            section = "posts"
-          end
+          section, _ = section_from_path(file_path, base_path, "posts")
 
           slug = slugify(fields["title"].as?(String) || File.basename(file_path, File.extname(file_path)))
 
@@ -288,17 +266,6 @@ module Hwaro
           body = strip_redundant_title_h1(body, fields["title"]?.as?(String))
           written = write_content_file(output_dir, section, slug, frontmatter, body.strip, verbose, force)
           written ? :imported : :skipped
-        end
-
-        YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m
-
-        private def parse_markdown_file(content : String) : Tuple(String?, String)
-          if match = YAML_FM_REGEX.match(content)
-            yaml_str = match[1].strip
-            body = match[2].strip
-            return {yaml_str, body}
-          end
-          {nil, content.strip}
         end
 
         # Recursively flatten a YAML array value into a flat list of strings.

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -194,20 +194,21 @@ module Hwaro
         Logger.info "Set `base_url` in config.toml before deploying (defaults to http://localhost:3000)."
       end
 
-      private def create_scaffold_content(target_path : String, scaffold : Scaffolds::Base, skip_taxonomies : Bool)
-        content_files = scaffold.content_files(skip_taxonomies)
-
-        content_files.each do |relative_path, content|
-          full_path = File.join(target_path, "content", relative_path)
+      # Write each {relative_path => content} entry under base_dir, creating
+      # parent directories on demand. Hash iteration order is preserved, so the
+      # @created_count tally and Logger.action sequence are unchanged.
+      private def write_files(base_dir : String, files : Hash(String, String))
+        files.each do |relative_path, content|
+          full_path = File.join(base_dir, relative_path)
           dir_path = File.dirname(full_path)
-
-          # Create directory if it doesn't exist
-          unless Dir.exists?(dir_path)
-            create_directory(dir_path)
-          end
-
+          create_directory(dir_path) unless Dir.exists?(dir_path)
           create_file(full_path, content)
         end
+      end
+
+      private def create_scaffold_content(target_path : String, scaffold : Scaffolds::Base, skip_taxonomies : Bool)
+        content_files = scaffold.content_files(skip_taxonomies)
+        write_files(File.join(target_path, "content"), content_files)
       end
 
       private def create_scaffold_templates(target_path : String, scaffold : Scaffolds::Base, skip_taxonomies : Bool)
@@ -218,14 +219,7 @@ module Hwaro
         # (e.g. `partials/nav.html`) so the parent directory is
         # created on demand instead of relying on a flat layout.
         template_files = scaffold.template_files(skip_taxonomies)
-        template_files.each do |relative_path, content|
-          full_path = File.join(templates_dir, relative_path)
-          dir_path = File.dirname(full_path)
-          unless Dir.exists?(dir_path)
-            create_directory(dir_path)
-          end
-          create_file(full_path, content)
-        end
+        write_files(templates_dir, template_files)
 
         # Create shortcodes directory and files only if the scaffold ships any.
         # (Bare scaffold returns empty to stay truly minimal.)
@@ -254,31 +248,12 @@ module Hwaro
         archetypes_dir = File.join(target_path, "archetypes")
         create_directory(archetypes_dir)
 
-        archetype_files.each do |relative_path, content|
-          full_path = File.join(archetypes_dir, relative_path)
-          dir_path = File.dirname(full_path)
-
-          unless Dir.exists?(dir_path)
-            create_directory(dir_path)
-          end
-
-          create_file(full_path, content)
-        end
+        write_files(archetypes_dir, archetype_files)
       end
 
       private def create_scaffold_static_files(target_path : String, scaffold : Scaffolds::Base)
         static_dir = File.join(target_path, "static")
-
-        scaffold.static_files.each do |relative_path, content|
-          full_path = File.join(static_dir, relative_path)
-          dir_path = File.dirname(full_path)
-
-          unless Dir.exists?(dir_path)
-            create_directory(dir_path)
-          end
-
-          create_file(full_path, content)
-        end
+        write_files(static_dir, scaffold.static_files)
       end
 
       private def create_multilingual_content(
@@ -288,12 +263,7 @@ module Hwaro
         scaffold : Scaffolds::Base,
       )
         content_dir = File.join(target_path, "content")
-        scaffold.multilingual_content_files(languages, skip_taxonomies).each do |relative_path, content|
-          full_path = File.join(content_dir, relative_path)
-          dir_path = File.dirname(full_path)
-          create_directory(dir_path) unless Dir.exists?(dir_path)
-          create_file(full_path, content)
-        end
+        write_files(content_dir, scaffold.multilingual_content_files(languages, skip_taxonomies))
       end
 
       private def language_display_name(code : String) : String

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -4,6 +4,7 @@ require "../models/config"
 require "../models/page"
 require "../content/processors/markdown"
 require "../utils/logger"
+require "./github_actions_workflow"
 
 module Hwaro
   module Services
@@ -184,47 +185,7 @@ module Hwaro
       end
 
       private def generate_github_pages : String
-        lines = [] of String
-        lines << "---"
-        lines << "name: Hwaro CI/CD"
-        lines << ""
-        lines << "on:"
-        lines << "  push:"
-        lines << "    branches: [main]"
-        lines << "  pull_request:"
-        lines << "    branches: [main]"
-        lines << "  workflow_dispatch:"
-        lines << ""
-        lines << "permissions:"
-        lines << "  contents: write"
-        lines << ""
-        lines << "jobs:"
-        lines << "  build:"
-        lines << "    runs-on: ubuntu-latest"
-        lines << "    if: github.event_name == 'pull_request'"
-        lines << "    steps:"
-        lines << "      - name: Checkout"
-        lines << "        uses: actions/checkout@v6"
-        lines << ""
-        lines << "      - name: Build Only"
-        lines << "        uses: hahwul/hwaro@main"
-        lines << "        with:"
-        lines << "          build_only: true"
-        lines << ""
-        lines << "  deploy:"
-        lines << "    runs-on: ubuntu-latest"
-        lines << "    if: github.event_name == 'push' && github.ref == 'refs/heads/main'"
-        lines << "    steps:"
-        lines << "      - name: Checkout"
-        lines << "        uses: actions/checkout@v6"
-        lines << ""
-        lines << "      - name: Build and Deploy"
-        lines << "        uses: hahwul/hwaro@main"
-        lines << "        with:"
-        lines << "          token: ${{ secrets.GITHUB_TOKEN }}"
-        lines << ""
-
-        lines.join("\n")
+        GithubActionsWorkflow.content
       end
 
       private def generate_gitlab_ci : String

--- a/src/services/scaffolds/bare.cr
+++ b/src/services/scaffolds/bare.cr
@@ -61,7 +61,7 @@ module Hwaro
             str << plugins_config
             str << content_files_config
             str << sitemap_config
-            str << feeds_config
+            str << feeds_config(feed_sections)
           end
           config
         end

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -785,6 +785,46 @@ module Hwaro
           ConfigSnippets.highlight
         end
 
+        # Dark-theme highlight block shared by the *_dark scaffolds (identical
+        # across blog/docs/book dark variants).
+        protected def highlight_dark_config : String
+          <<-TOML
+
+            # =============================================================================
+            # Syntax Highlighting
+            # =============================================================================
+            # Code blocks are highlighted in the browser by Highlight.js and themed by
+            # an inlined, ember-warm dark theme in css/style.css (so you recolor syntax
+            # by editing that CSS, not the `theme` below). `mode = "server"` can
+            # highlight at build time with no JS, but its Tartrazine backend isn't
+            # multi-thread-safe, so the scaffold default stays "client".
+
+            [highlight]
+            enabled = true
+            mode = "client"              # "client" = Highlight.js in the browser; "server" = build-time (no JS)
+            theme = "github-dark"        # Highlight.js theme name; the scaffold's inlined CSS overrides its colors
+            use_cdn = true               # true loads Highlight.js from a CDN; false expects a self-hosted build
+
+            TOML
+        end
+
+        # Shared search overlay markup; only the input placeholder varies per
+        # scaffold (e.g. "Search posts...", "Search documentation...").
+        protected def search_overlay_html(placeholder : String) : String
+          <<-HTML
+            <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
+              <div class="search-modal">
+                <div class="search-input-wrap">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                  <input type="search" id="searchInput" aria-label="Search" placeholder="#{placeholder}" autocomplete="off">
+                  <kbd onclick="closeSearch()">ESC</kbd>
+                </div>
+                <div class="search-results" id="searchResults"></div>
+              </div>
+            </div>
+            HTML
+        end
+
         protected def og_config : String
           ConfigSnippets.og
         end

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -68,7 +68,7 @@ module Hwaro
             "header.html"          => header_template,
             "footer.html"          => footer_template,
             "partials/nav.html"    => blog_nav_html,
-            "partials/search.html" => search_overlay_html,
+            "partials/search.html" => search_overlay_html("Search posts..."),
             "index.html"           => blog_home_template,
             "page.html"            => blog_page_template,
             "section.html"         => blog_section_template,
@@ -106,7 +106,7 @@ module Hwaro
             str << sitemap_config
             str << robots_config
             str << llms_config
-            str << feeds_config(["posts"])
+            str << feeds_config(feed_sections)
 
             # Optional features (commented out by default)
             str << permalinks_config
@@ -982,22 +982,6 @@ module Hwaro
               }
             })();
             JS
-        end
-
-        # Search overlay HTML
-        private def search_overlay_html : String
-          <<-HTML
-            <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
-              <div class="search-modal">
-                <div class="search-input-wrap">
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-                  <input type="search" id="searchInput" aria-label="Search" placeholder="Search posts..." autocomplete="off">
-                  <kbd onclick="closeSearch()">ESC</kbd>
-                </div>
-                <div class="search-results" id="searchResults"></div>
-              </div>
-            </div>
-            HTML
         end
 
         # Blog header navigation HTML

--- a/src/services/scaffolds/blog_dark.cr
+++ b/src/services/scaffolds/blog_dark.cr
@@ -43,7 +43,7 @@ module Hwaro
             str << sitemap_config
             str << robots_config
             str << llms_config
-            str << feeds_config(["posts"])
+            str << feeds_config(feed_sections)
 
             # Optional features (commented out by default)
             str << permalinks_config
@@ -60,27 +60,6 @@ module Hwaro
             str << deployment_config
           end
           config
-        end
-
-        private def highlight_dark_config : String
-          <<-TOML
-
-            # =============================================================================
-            # Syntax Highlighting
-            # =============================================================================
-            # Code blocks are highlighted in the browser by Highlight.js and themed by
-            # an inlined, ember-warm dark theme in css/style.css (so you recolor syntax
-            # by editing that CSS, not the `theme` below). `mode = "server"` can
-            # highlight at build time with no JS, but its Tartrazine backend isn't
-            # multi-thread-safe, so the scaffold default stays "client".
-
-            [highlight]
-            enabled = true
-            mode = "client"              # "client" = Highlight.js in the browser; "server" = build-time (no JS)
-            theme = "github-dark"        # Highlight.js theme name; the scaffold's inlined CSS overrides its colors
-            use_cdn = true               # true loads Highlight.js from a CDN; false expects a self-hosted build
-
-            TOML
         end
 
         private def css_content : String

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -65,7 +65,7 @@ module Hwaro
             "header.html"               => header_template,
             "footer.html"               => footer_template,
             "partials/nav.html"         => book_header_html,
-            "partials/search.html"      => search_overlay_html,
+            "partials/search.html"      => search_overlay_html("Search this book..."),
             "partials/page-arrows.html" => book_nav_html,
             "partials/sidebar.html"     => book_sidebar_html,
             "page.html"                 => book_page_template,
@@ -95,7 +95,7 @@ module Hwaro
             str << sitemap_config
             str << robots_config
             str << llms_config
-            str << feeds_config
+            str << feeds_config(feed_sections)
             str << permalinks_config
             str << auto_includes_config
             str << assets_config
@@ -1313,22 +1313,6 @@ module Hwaro
             {{ auto_includes_js }}
             </body>
             </html>
-            HTML
-        end
-
-        # Search overlay HTML
-        private def search_overlay_html : String
-          <<-HTML
-            <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
-              <div class="search-modal">
-                <div class="search-input-wrap">
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-                  <input type="search" id="searchInput" aria-label="Search" placeholder="Search this book..." autocomplete="off">
-                  <kbd onclick="closeSearch()">ESC</kbd>
-                </div>
-                <div class="search-results" id="searchResults"></div>
-              </div>
-            </div>
             HTML
         end
 

--- a/src/services/scaffolds/book_dark.cr
+++ b/src/services/scaffolds/book_dark.cr
@@ -36,7 +36,7 @@ module Hwaro
             str << sitemap_config
             str << robots_config
             str << llms_config
-            str << feeds_config
+            str << feeds_config(feed_sections)
             str << permalinks_config
             str << auto_includes_config
             str << assets_config
@@ -51,27 +51,6 @@ module Hwaro
             str << deployment_config
           end
           config
-        end
-
-        private def highlight_dark_config : String
-          <<-TOML
-
-            # =============================================================================
-            # Syntax Highlighting
-            # =============================================================================
-            # Code blocks are highlighted in the browser by Highlight.js and themed by
-            # an inlined, ember-warm dark theme in css/style.css (so you recolor syntax
-            # by editing that CSS, not the `theme` below). `mode = "server"` can
-            # highlight at build time with no JS, but its Tartrazine backend isn't
-            # multi-thread-safe, so the scaffold default stays "client".
-
-            [highlight]
-            enabled = true
-            mode = "client"              # "client" = Highlight.js in the browser; "server" = build-time (no JS)
-            theme = "github-dark"        # Highlight.js theme name; the scaffold's inlined CSS overrides its colors
-            use_cdn = true               # true loads Highlight.js from a CDN; false expects a self-hosted build
-
-            TOML
         end
 
         private def css_content : String

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -100,7 +100,7 @@ module Hwaro
             "header.html"           => header_template,
             "footer.html"           => footer_template,
             "partials/nav.html"     => docs_nav_html,
-            "partials/search.html"  => search_overlay_html,
+            "partials/search.html"  => search_overlay_html("Search documentation..."),
             "partials/sidebar.html" => docs_sidebar_html,
             "page.html"             => docs_page_template,
             "section.html"          => docs_section_template,
@@ -136,7 +136,7 @@ module Hwaro
             str << sitemap_config
             str << robots_config
             str << llms_config
-            str << feeds_config
+            str << feeds_config(feed_sections)
 
             # Optional features (commented out by default)
             str << permalinks_config
@@ -1068,22 +1068,6 @@ module Hwaro
             {{ auto_includes_js }}
             </body>
             </html>
-            HTML
-        end
-
-        # Search overlay HTML shared by page and section templates
-        private def search_overlay_html : String
-          <<-HTML
-            <div class="search-overlay" id="searchOverlay" onclick="if(event.target===this)closeSearch()">
-              <div class="search-modal">
-                <div class="search-input-wrap">
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-                  <input type="search" id="searchInput" aria-label="Search" placeholder="Search documentation..." autocomplete="off">
-                  <kbd onclick="closeSearch()">ESC</kbd>
-                </div>
-                <div class="search-results" id="searchResults"></div>
-              </div>
-            </div>
             HTML
         end
 

--- a/src/services/scaffolds/docs_dark.cr
+++ b/src/services/scaffolds/docs_dark.cr
@@ -42,7 +42,7 @@ module Hwaro
             str << sitemap_config
             str << robots_config
             str << llms_config
-            str << feeds_config
+            str << feeds_config(feed_sections)
 
             # Optional features (commented out by default)
             str << permalinks_config
@@ -59,27 +59,6 @@ module Hwaro
             str << deployment_config
           end
           config
-        end
-
-        private def highlight_dark_config : String
-          <<-TOML
-
-            # =============================================================================
-            # Syntax Highlighting
-            # =============================================================================
-            # Code blocks are highlighted in the browser by Highlight.js and themed by
-            # an inlined, ember-warm dark theme in css/style.css (so you recolor syntax
-            # by editing that CSS, not the `theme` below). `mode = "server"` can
-            # highlight at build time with no JS, but its Tartrazine backend isn't
-            # multi-thread-safe, so the scaffold default stays "client".
-
-            [highlight]
-            enabled = true
-            mode = "client"              # "client" = Highlight.js in the browser; "server" = build-time (no JS)
-            theme = "github-dark"        # Highlight.js theme name; the scaffold's inlined CSS overrides its colors
-            use_cdn = true               # true loads Highlight.js from a CDN; false expects a self-hosted build
-
-            TOML
         end
 
         private def css_content : String

--- a/src/services/scaffolds/simple.cr
+++ b/src/services/scaffolds/simple.cr
@@ -76,7 +76,7 @@ module Hwaro
             str << sitemap_config
             str << robots_config
             str << llms_config
-            str << feeds_config
+            str << feeds_config(feed_sections)
 
             # Optional features (commented out by default)
             str << permalinks_config

--- a/src/utils/path_utils.cr
+++ b/src/utils/path_utils.cr
@@ -56,6 +56,15 @@ module Hwaro
         end
         real_path == real_root || real_path.starts_with?(real_root + File::SEPARATOR)
       end
+
+      # File.match? that treats a malformed glob as non-matching instead of
+      # raising File::BadPatternError, so a single config typo can't crash a
+      # build or deploy.
+      def glob_match?(pattern : String, path : String) : Bool
+        File.match?(pattern, path)
+      rescue File::BadPatternError
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Behavior-preserving structural refactoring driven by a multi-agent structural audit (each finding adversarially verified for *real / behavior-preserving / worthwhile* before implementation). Extracts shared helpers and collapses copy-paste across **10 subsystems**.

**Net ~420 fewer lines across 47 files**, with **zero change to generated output** (verified byte-for-byte) or public behavior.

## What changed

**Build pipeline** (`core/build/`)
- `builder.cr`: `path_relative_to`, `regenerate_seo_surfaces`, `report_cache_stats`
- `render.cr`: `cache_paths_for` + `record_page_cache_entry`, `no_template_fallback`; split the 12 Crinja functions out of the ~300-line `register_custom_functions`
- `transform.cr`: `assign_series_groups`, `build_related_index` — shared by the full and incremental series/related-posts paths

**Content**
- `collection_filter.cr`: `safe_array` wrapper replaces the 6 repeated `begin/rescue → empty array` filter bodies
- `template.cr`: `value_empty?` shared by the `empty`/`present` Crinja tests
- `jsonld.cr`: `abs_path` / `abs_or_external` collapse 9 inline URL builders
- `taxonomies.cr`: `write_to` shared by `write_output` / `write_paginated_output`
- `page.cr`: `excluded_from_listings?` / `search_index_eligible?` predicates (applied in taxonomies/search/llms)

**Models**
- `config.cr`: `cache_bust_suffix`, `join_tags`, `append_meta`; delegate glob matching to `PathUtils.glob_match?`
- `section.cr`: drop dead `find_subsection` + no-op `effective_page_template` wrapper

**Services**
- `deployer.cr`: `resolve_source_dir` / `resolve_target_names` / `require_*` helpers (plan keeps its silent returns; only the raising callers raise)
- `ci_config` + `platform_config`: share `GithubActionsWorkflow.content` (single source for `deploy.yml`)
- `initializer.cr`: `write_files`; `doctor.cr`: `emit_missing`
- importers: hoist `split_yaml_frontmatter`, `walk_files`, `section_from_path` / `top_section_from_path` into `Base` — removes the 6-way directory-walk + YAML-splitter duplication

**CLI**
- `Runner.enable_json_mode!` (replaces 9 duplicated `Logger.quiet`+`json_mode` pairs); `CLI.register_base_url` / `register_jobs` flag helpers

## Verification

- `crystal tool format --check` clean · `./bin/ameba` 374 files, 0 failures
- `crystal spec`: **5671 examples, 0 failures** (−7 vs main = the removed dead-code specs)
- **Generated-output byte diff vs `main`** (`diff -r`): identical for all 8 scaffolds × 2 config modes, a full `docs/` build, and multi-format importer runs (nested dirs, hidden-dir skip, `.mdx`, `node_modules` skip)

## Deferred (intentionally not in this PR)

Output-byte-sensitive or higher-risk items the audit flagged where the dedup would risk regressing generated output for limited gain — left as follow-ups: light/dark CSS templating, OG PNG pixel-loop extraction, the incremental re-parse loop, the front-matter generic dispatch, Any-tree walker unification, completion-command split, and the ChangeSet/handlers file move.