### PR TITLE
feat(docs): add scroll-driven motion + interactive benchmark to landing

### DIFF
--- a/docs/static/assets/css/07-landing.css
+++ b/docs/static/assets/css/07-landing.css
@@ -110,38 +110,46 @@
 
 /* Toned-down fire cover as an immersive backdrop.
    Sits below the ember canvas (z-index 1) and hero content (z-index 2).
-   Centered and capped to the native width (1280px) so it never upscales and
-   stays crisp. A soft scrim keeps the centered title readable, and a radial
-   mask feathers every edge to transparent so the art dissolves into the
-   page's pure-black background instead of ending on a hard rectangle. */
+   The pseudo-element is sized to the image itself (capped at the native
+   1280px so it never upscales) and centred at 48%. Because the radial mask
+   is now measured against this image-sized box rather than the viewport, the
+   feather stays locked to the artwork's edges at every screen size: it is
+   fully transparent (88%) well before the image's rectangle (sides at 100%,
+   corners at 141%), so the art always dissolves smoothly into the page's
+   pure-black background with no visible border. A soft scrim keeps the
+   centred title readable. */
 .hero-bg::before {
     content: "";
     position: absolute;
-    inset: 0;
+    top: 48%;
+    left: 50%;
+    width: min(1240px, 94vw);
+    aspect-ratio: 16 / 9;
+    transform: translate(-50%, -50%);
     z-index: 0;
     background-image:
         radial-gradient(
-            ellipse 60% 50% at 50% 48%,
+            ellipse 68% 60% at 50% 50%,
             rgba(0, 0, 0, 0.5) 0%,
-            rgba(0, 0, 0, 0.18) 54%,
-            rgba(0, 0, 0, 0) 80%
+            rgba(0, 0, 0, 0.18) 55%,
+            rgba(0, 0, 0, 0) 82%
         ),
         url("/images/landing/cover.jpg");
     background-repeat: no-repeat;
-    background-position: center, center 48%;
-    background-size: auto, min(1240px, 94vw);
+    background-position: center;
+    background-size: cover;
     filter: saturate(0.58) brightness(0.88);
     -webkit-mask-image: radial-gradient(
-        ellipse 44% 42% at 50% 48%,
-        #000 30%,
-        rgba(0, 0, 0, 0.55) 64%,
-        transparent 100%
+        ellipse 50% 50% at 50% 50%,
+        #000 24%,
+        rgba(0, 0, 0, 0.5) 58%,
+        transparent 88%
     );
     mask-image: radial-gradient(
-        ellipse 44% 42% at 50% 48%,
-        #000 30%,
-        rgba(0, 0, 0, 0.55) 64%,
-        transparent 100%
+        ellipse 50% 50% at 50% 50%,
+        #000 24%,
+        rgba(0, 0, 0, 0.5) 58%,
+        transparent 88%
     );
 }
 
@@ -389,17 +397,136 @@
 }
 
 .bench-track {
-    height: 6px;
-    background: #111;
-    border-radius: 3px;
+    position: relative;
+    height: 12px;
+    background: #111418;
+    border-radius: 6px;
     overflow: hidden;
+    transition: box-shadow 0.25s ease;
 }
 
-.bench-bar {
+.bench-svg {
+    display: block;
+    width: 100%;
     height: 100%;
-    background: #333;
-    border-radius: 3px;
-    transition: width 0.6s ease;
+}
+
+/* Bars grow from zero when the benchmark scrolls into view. The stagger
+   delay (--d) is per row; filter has no delay so hover stays snappy. */
+.bench-fill {
+    transform-origin: left center;
+    transform-box: fill-box;
+    transition:
+        transform 1s var(--ease-out) var(--d, 0s),
+        filter 0.25s ease;
+}
+
+.js .bench-fill {
+    transform: scaleX(0);
+}
+
+.js .benchmark.is-visible .bench-fill {
+    transform: scaleX(1);
+}
+
+.benchmark-bars .bench-row:nth-child(1) {
+    --d: 0.05s;
+}
+.benchmark-bars .bench-row:nth-child(2) {
+    --d: 0.16s;
+}
+.benchmark-bars .bench-row:nth-child(3) {
+    --d: 0.27s;
+}
+.benchmark-bars .bench-row:nth-child(4) {
+    --d: 0.38s;
+}
+.benchmark-bars .bench-row:nth-child(5) {
+    --d: 0.49s;
+}
+
+/* Continuous ember sheen sweeping the Hwaro bar so it always reads as
+   "alive" against the static competitor bars. */
+.bench-sheen {
+    transform-box: fill-box;
+    opacity: 0;
+}
+
+.benchmark.is-visible .bench-sheen {
+    animation: benchSheen 3.6s ease-in-out 1.3s infinite;
+}
+
+@keyframes benchSheen {
+    0% {
+        transform: translateX(0);
+        opacity: 0;
+    }
+    8% {
+        opacity: 0.9;
+    }
+    34% {
+        opacity: 0.9;
+    }
+    42% {
+        transform: translateX(calc(var(--travel) * 1px));
+        opacity: 0;
+    }
+    100% {
+        transform: translateX(calc(var(--travel) * 1px));
+        opacity: 0;
+    }
+}
+
+/* Hover / keyboard focus: spotlight one row, dim the rest. */
+.bench-row {
+    border-radius: 8px;
+    outline: none;
+    transition: opacity 0.25s ease;
+}
+
+.bench-name,
+.bench-time {
+    transition:
+        color 0.2s ease,
+        transform 0.2s ease;
+}
+
+.bench-time {
+    display: inline-block;
+    transform-origin: left center;
+}
+
+.benchmark-bars:hover .bench-row:not(:hover),
+.benchmark-bars:focus-within .bench-row:not(:focus-within) {
+    opacity: 0.4;
+}
+
+.bench-row:hover .bench-fill,
+.bench-row:focus-within .bench-fill {
+    filter: brightness(1.3) saturate(1.15);
+}
+
+.bench-row:hover .bench-track,
+.bench-row:focus-within .bench-track {
+    box-shadow:
+        inset 0 0 0 1px var(--hair-strong),
+        0 6px 22px -8px var(--primary-glow);
+}
+
+.bench-row:hover .bench-name,
+.bench-row:focus-within .bench-name,
+.bench-row:hover .bench-time,
+.bench-row:focus-within .bench-time {
+    color: #fff;
+}
+
+.bench-row:hover .bench-time,
+.bench-row:focus-within .bench-time {
+    transform: scale(1.12);
+}
+
+.bench-row:focus-visible {
+    box-shadow: 0 0 0 2px var(--primary-glow);
 }
 
 .bench-time {
@@ -412,10 +539,6 @@
 .bench-highlight .bench-name {
     color: #fff;
     font-weight: 600;
-}
-
-.bench-highlight .bench-bar {
-    background: var(--primary);
 }
 
 .bench-highlight .bench-time {
@@ -971,5 +1094,63 @@
         border-top: 1px solid #1a1a1e;
         border-radius: 0 0 8px 8px;
         padding: 0.6rem;
+    }
+}
+
+/* =============================================================================
+   Motion — hero entrance + scroll-reveal
+   ============================================================================= */
+
+/* Hero copy rises in on load. */
+.hero-content {
+    animation: heroRise 1s var(--ease-out) 0.15s both;
+}
+
+@keyframes heroRise {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+/* Below-the-fold sections fade + rise as they enter the viewport.
+   Gated on .js so no-JS visitors still see every section. */
+.js .reveal {
+    opacity: 0;
+    transform: translateY(28px);
+    transition:
+        opacity 0.7s var(--ease-out),
+        transform 0.7s var(--ease-out);
+}
+
+.js .reveal.is-visible {
+    opacity: 1;
+    transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hero-content {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
+
+    .js .reveal {
+        opacity: 1;
+        transform: none;
+        transition: none;
+    }
+
+    .js .bench-fill {
+        transform: scaleX(1);
+        transition: none;
+    }
+
+    .bench-sheen {
+        display: none;
     }
 }

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -15,81 +15,12 @@
             rel="stylesheet"
         />
         {{ auto_includes_css }}
-
-        <style>
-            /* Shared SVG animation keyframes */
-            .fire-pulse {
-                transform-origin: center 144px;
-                animation: pulse 1.5s infinite alternate ease-in-out;
-            }
-            @keyframes pulse {
-                0% {
-                    transform: scaleY(1);
-                    opacity: 0.92;
-                }
-                100% {
-                    transform: scaleY(1.03);
-                    opacity: 1;
-                }
-            }
-            .spark {
-                animation-timing-function: ease-in;
-                animation-iteration-count: infinite;
-            }
-            .spark-1 {
-                animation-name: flyUp1;
-                animation-duration: 2s;
-            }
-            .spark-2 {
-                animation-name: flyUp2;
-                animation-duration: 2.5s;
-                animation-delay: 0.5s;
-            }
-            .spark-3 {
-                animation-name: flyUp3;
-                animation-duration: 1.8s;
-                animation-delay: 1.2s;
-            }
-            @keyframes flyUp1 {
-                0% {
-                    transform: translateY(0);
-                    opacity: 0;
-                }
-                50% {
-                    opacity: 0.8;
-                }
-                100% {
-                    transform: translateY(-40px);
-                    opacity: 0;
-                }
-            }
-            @keyframes flyUp2 {
-                0% {
-                    transform: translateY(0);
-                    opacity: 0;
-                }
-                50% {
-                    opacity: 1;
-                }
-                100% {
-                    transform: translateY(-50px);
-                    opacity: 0;
-                }
-            }
-            @keyframes flyUp3 {
-                0% {
-                    transform: translateY(0);
-                    opacity: 0;
-                }
-                50% {
-                    opacity: 0.9;
-                }
-                100% {
-                    transform: translateY(-45px);
-                    opacity: 0;
-                }
-            }
-        </style>
+        <!-- Progressive enhancement: only the JS-driven reveal/fill effects
+             below the fold start hidden, so a no-JS visitor still sees all
+             content (and the benchmark bars at full width). -->
+        <script>
+            document.documentElement.classList.add("js");
+        </script>
     </head>
     <body class="landing-body">
         <header class="landing-header">
@@ -161,7 +92,7 @@
             <!-- ============================================================
                  FEATURES
                  ============================================================ -->
-            <section class="features">
+            <section class="features reveal">
                 <div class="features-header">
                     <h2>Everything built in.</h2>
                     <p>No plugins needed. Enable in config.toml and go.</p>
@@ -217,46 +148,86 @@
             <!-- ============================================================
                  BENCHMARK
                  ============================================================ -->
-            <section class="benchmark">
+            <section class="benchmark reveal">
                 <div class="benchmark-header">
                     <h2>1,000 pages. Under 7 seconds.</h2>
                     <p>Benchmarked against popular static site generators.</p>
                 </div>
+
+                <!-- SVG gradient/sheen definitions shared by every bar. Kept
+                     out of .benchmark-bars so the row nth-child stagger is
+                     not thrown off by an extra child. -->
+                <svg
+                    class="bench-defs"
+                    width="0"
+                    height="0"
+                    aria-hidden="true"
+                    focusable="false"
+                >
+                    <defs>
+                        <linearGradient id="benchGrad" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0" stop-color="#2f2f37" />
+                            <stop offset="1" stop-color="#51515d" />
+                        </linearGradient>
+                        <linearGradient id="benchGradHot" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0" stop-color="#e7a85f" />
+                            <stop offset="0.55" stop-color="#c46262" />
+                            <stop offset="1" stop-color="#974646" />
+                        </linearGradient>
+                        <linearGradient id="benchSheen" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0" stop-color="#fff" stop-opacity="0" />
+                            <stop offset="0.5" stop-color="#ffe9cc" stop-opacity="0.9" />
+                            <stop offset="1" stop-color="#fff" stop-opacity="0" />
+                        </linearGradient>
+                    </defs>
+                </svg>
+
                 <div class="benchmark-bars">
-                    <div class="bench-row">
+                    <div class="bench-row" tabindex="0" aria-label="Zola: 5.2 seconds">
                         <span class="bench-name">Zola</span>
                         <div class="bench-track">
-                            <div class="bench-bar" style="width: 63%"></div>
+                            <svg class="bench-svg" viewBox="0 0 100 12" preserveAspectRatio="none" aria-hidden="true">
+                                <rect class="bench-fill" x="0" y="0" width="44.8" height="12" fill="url(#benchGrad)" />
+                            </svg>
                         </div>
-                        <span class="bench-time">5.2s</span>
+                        <span class="bench-time" data-time="5.2">5.2s</span>
                     </div>
-                    <div class="bench-row bench-highlight">
+                    <div class="bench-row bench-highlight" tabindex="0" aria-label="Hwaro: 6.2 seconds">
                         <span class="bench-name">Hwaro</span>
                         <div class="bench-track">
-                            <div class="bench-bar" style="width: 75%"></div>
+                            <svg class="bench-svg" viewBox="0 0 100 12" preserveAspectRatio="none" aria-hidden="true">
+                                <rect class="bench-fill" x="0" y="0" width="53.4" height="12" fill="url(#benchGradHot)" />
+                                <rect class="bench-sheen" x="0" y="0" width="15" height="12" fill="url(#benchSheen)" style="--travel: 38" />
+                            </svg>
                         </div>
-                        <span class="bench-time">6.2s</span>
+                        <span class="bench-time" data-time="6.2">6.2s</span>
                     </div>
-                    <div class="bench-row">
+                    <div class="bench-row" tabindex="0" aria-label="Hugo: 8.2 seconds">
                         <span class="bench-name">Hugo</span>
                         <div class="bench-track">
-                            <div class="bench-bar" style="width: 100%"></div>
+                            <svg class="bench-svg" viewBox="0 0 100 12" preserveAspectRatio="none" aria-hidden="true">
+                                <rect class="bench-fill" x="0" y="0" width="70.7" height="12" fill="url(#benchGrad)" />
+                            </svg>
                         </div>
-                        <span class="bench-time">8.2s</span>
+                        <span class="bench-time" data-time="8.2">8.2s</span>
                     </div>
-                    <div class="bench-row">
+                    <div class="bench-row" tabindex="0" aria-label="Eleventy: 9.0 seconds">
                         <span class="bench-name">Eleventy</span>
                         <div class="bench-track">
-                            <div class="bench-bar" style="width: 109%"></div>
+                            <svg class="bench-svg" viewBox="0 0 100 12" preserveAspectRatio="none" aria-hidden="true">
+                                <rect class="bench-fill" x="0" y="0" width="77.6" height="12" fill="url(#benchGrad)" />
+                            </svg>
                         </div>
-                        <span class="bench-time">9.0s</span>
+                        <span class="bench-time" data-time="9.0">9.0s</span>
                     </div>
-                    <div class="bench-row">
+                    <div class="bench-row" tabindex="0" aria-label="Jekyll: 11.6 seconds">
                         <span class="bench-name">Jekyll</span>
                         <div class="bench-track">
-                            <div class="bench-bar" style="width: 141%"></div>
+                            <svg class="bench-svg" viewBox="0 0 100 12" preserveAspectRatio="none" aria-hidden="true">
+                                <rect class="bench-fill" x="0" y="0" width="100" height="12" fill="url(#benchGrad)" />
+                            </svg>
                         </div>
-                        <span class="bench-time">11.6s</span>
+                        <span class="bench-time" data-time="11.6">11.6s</span>
                     </div>
                 </div>
                 <p class="benchmark-link">
@@ -272,7 +243,7 @@
             <!-- ============================================================
                  SHOWCASE
                  ============================================================ -->
-            <section class="showcase">
+            <section class="showcase reveal">
                 <div class="showcase-header">
                     <h2>Built with Hwaro</h2>
                     <p>
@@ -403,7 +374,7 @@
             <!-- ============================================================
                  CTA
                  ============================================================ -->
-            <section class="landing-cta">
+            <section class="landing-cta reveal">
                 <p class="cta-heading">Start building.</p>
                 <p class="cta-sub">
                     One command to install. Three lines to deploy.
@@ -721,6 +692,63 @@
             document.addEventListener('keydown', function(e) {
                 if (e.key === 'Escape') close();
             });
+        })();
+        </script>
+        <script>
+        // Scroll-reveal for below-the-fold sections + the interactive
+        // benchmark chart (bars grow from zero, times count up) once each
+        // section scrolls into view. Honors prefers-reduced-motion.
+        (function() {
+            var reduce = window.matchMedia &&
+                window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+            function countUp(el, target) {
+                if (reduce) { el.textContent = target.toFixed(1) + 's'; return; }
+                var dur = 1100, t0 = null;
+                el.textContent = '0.0s';
+                function step(ts) {
+                    if (t0 === null) t0 = ts;
+                    var p = Math.min((ts - t0) / dur, 1);
+                    var eased = 1 - Math.pow(1 - p, 3);
+                    el.textContent = (target * eased).toFixed(1) + 's';
+                    if (p < 1) requestAnimationFrame(step);
+                }
+                requestAnimationFrame(step);
+            }
+
+            function runBench(section) {
+                var times = section.querySelectorAll('.bench-time');
+                for (var i = 0; i < times.length; i++) {
+                    (function(el, idx) {
+                        var target = parseFloat(el.getAttribute('data-time'));
+                        if (reduce) { countUp(el, target); return; }
+                        setTimeout(function() { countUp(el, target); },
+                            120 * idx + 120);
+                    })(times[i], i);
+                }
+            }
+
+            var reveals = document.querySelectorAll('.reveal');
+
+            function show(el) {
+                el.classList.add('is-visible');
+                if (el.classList.contains('benchmark')) runBench(el);
+            }
+
+            if (reduce || !('IntersectionObserver' in window)) {
+                for (var i = 0; i < reveals.length; i++) show(reveals[i]);
+                return;
+            }
+
+            var io = new IntersectionObserver(function(entries) {
+                entries.forEach(function(e) {
+                    if (!e.isIntersecting) return;
+                    show(e.target);
+                    io.unobserve(e.target);
+                });
+            }, { threshold: 0.2, rootMargin: '0px 0px -8% 0px' });
+
+            for (var j = 0; j < reveals.length; j++) io.observe(reveals[j]);
         })();
         </script>
     </body>


### PR DESCRIPTION
Make the docs landing page feel more dynamic while keeping the minimal ember/brazier aesthetic.

## What changed
- **Interactive benchmark chart** — rebuilt as SVG bars that grow from zero and count up when scrolled into view. Competitor bars are neutral; the Hwaro bar gets an ember gradient + a continuous sheen sweep. Hover / keyboard-focus spotlights one row and dims the rest. Bars are now scaled to the slowest SSG, so every bar is visible and proportional (previously the longest were clipped at the track edge and looked identical).
- **Scroll motion** — below-the-fold sections fade + rise as they enter the viewport; hero copy rises in on load.
- **Cover image edge** — the hero backdrop pseudo-element is now sized to the image and the radial mask is feathered relative to that box, so the artwork dissolves into the black background with no visible border at any viewport size.
- **Cleanup** — removed the dead `.fire-pulse`/`.spark` keyframes.

## Accessibility / robustness
- All motion respects `prefers-reduced-motion`.
- Reveal/fill hidden states are gated behind a `.js` class, so no-JS visitors still see every section and the benchmark bars at full width.

## Verification
Previewed with `hwaro serve` and screenshotted with headless Chrome at 1100 / 1440 / 1920 and mobile (390px), plus `prefers-reduced-motion` and JS-disabled — content visible and bars full in every fallback. Docs-only change (HTML/CSS), no Crystal code touched.