### PR TITLE
feat(cli): interactive wizard for `hwaro new` when no path is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `hwaro new` with no `<path>` opens an interactive wizard in a terminal: it prompts for the title, description, a recommended path (derived from the title and section), tags, date, draft flag, and archetype, previews a summary, and confirms before writing. Flags already passed pre-fill their prompts. Non-interactive contexts (pipes, CI, `--json`, `--quiet`) keep the classified `HWARO_E_USAGE` error, so scripts and agents are unchanged
+- Archetypes support a `{{ description }}` placeholder, and a `description` collected by the wizard is written into the new file's front matter instead of an empty value (the flag form still scaffolds an empty `description`)
+
 ## v0.16.0
 
 ### Added

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -120,14 +120,27 @@ Remote scaffolds fetch `config.toml`, `templates/`, `static/`, and content struc
 Create a new content file:
 
 ```bash
+hwaro new                                     # interactive wizard (TTY): prompts for everything
 hwaro new content/about.md
 hwaro new content/blog/my-post.md
-hwaro new -t "My Post Title"
 hwaro new posts/my-post.md -a posts
 hwaro new my-post.md --section blog --draft --tags "go,web" --date 2026-03-22
 ```
 
 Creates a Markdown file with front matter template. Supports **archetypes** for customizable templates.
+
+**Interactive mode:**
+
+Running `hwaro new` without a `<path>` in an interactive terminal opens a guided wizard.
+It prompts for the title, description, a **recommended path** (derived from the title and
+section), tags, date, draft flag, and archetype, then shows a summary and asks to confirm
+before writing. Any flags you already passed pre-fill the matching prompt, so
+`hwaro new -t "My Post"` only asks for the rest. Press `Ctrl-D` or answer `n` at the final
+prompt to cancel without creating anything.
+
+The wizard never runs in non-interactive contexts — pipes, CI, agents, `--json`, or
+`--quiet` — which instead print the classified `HWARO_E_USAGE` error, so scripted callers
+stay predictable. Pass a `<path>` (and any flags) to skip the prompts entirely.
 
 **Options:**
 
@@ -152,7 +165,7 @@ Archetypes are template files in `archetypes/` directory that define default fro
 - `archetypes/posts.md` - Used for `hwaro new posts/...`
 - `archetypes/tools/develop.md` - Used for `hwaro new tools/develop/...`
 
-Archetype files support placeholders: `{{ title }}`, `{{ date }}`, `{{ draft }}`, `{{ tags }}`
+Archetype files support placeholders: `{{ title }}`, `{{ date }}`, `{{ draft }}`, `{{ tags }}`, `{{ description }}`
 
 Example archetype (`archetypes/posts.md`):
 ```

--- a/docs/content/start/first-site.md
+++ b/docs/content/start/first-site.md
@@ -79,6 +79,9 @@ base_url = "https://example.com"
 hwaro new content/about.md
 ```
 
+> **Tip:** run `hwaro new` with no arguments to open an interactive wizard that
+> suggests a path and collects the title, description, tags, and more for you.
+
 Edit `content/about.md`:
 
 ```markdown

--- a/docs/content/writing/archetypes.md
+++ b/docs/content/writing/archetypes.md
@@ -37,6 +37,7 @@ An archetype is a Markdown file with front matter and optional content. Use plac
 | `{{ date }}` | Current local date as `YYYY-MM-DD`, or the `--date` value verbatim |
 | `{{ tags }}` | Tags from `--tags` as a TOML array (`[]` if none) |
 | `{{ draft }}` | `true` if `--draft` is passed, or the target path contains a `drafts` directory; `false` otherwise |
+| `{{ description }}` | Description collected by the interactive `hwaro new` wizard; empty string when none is given |
 
 ### Example Archetype
 
@@ -173,7 +174,7 @@ draft = false
 authors = []
 tags = []
 categories = []
-description = ""
+description = "{{ description }}"
 image = ""
 +++
 
@@ -208,19 +209,25 @@ Brief description of this documentation page.
 ```markdown
 +++
 title = "{{ title }}"
-date = {{ date }}
+date = "{{ date }}"
 draft = {{ draft }}
+description = "{{ description }}"
+tags = {{ tags }}
 +++
 
 # {{ title }}
 ```
+
+This mirrors the `archetypes/default.md` that `hwaro init` ships. The
+`{{ description }}` placeholder substitutes to an empty string for the flag
+form and to the value you type in the interactive `hwaro new` wizard.
 
 ## Tips
 
 - **Consistent metadata**: Define all commonly used front matter fields in archetypes
 - **Section-specific**: Create archetypes for each content section with relevant defaults
 - **Nested organization**: Use subdirectories in `archetypes/` to match your content structure
-- **Draft handling**: `{{ draft }}` is `true` when `--draft` is passed or the target path contains a `drafts` directory — including `hwaro new -t "Title"` without a path, which defaults to `content/drafts/`
+- **Draft handling**: `{{ draft }}` is `true` when `--draft` is passed, when you enable the draft toggle in the interactive wizard, or when the target path contains a `drafts/` segment
 
 ## See Also
 

--- a/skills/hwaro/SKILL.md
+++ b/skills/hwaro/SKILL.md
@@ -113,14 +113,19 @@ Remote scaffolds fetch `config.toml`, `templates/`, `static/`, and the content
 ```bash
 hwaro new content/blog/my-post.md            # path-based
 hwaro new my-post.md -s blog --draft --tags "crystal,web" --date 2026-03-22
-hwaro new -t "My Post Title"                 # title only
+hwaro new posts/my-post.md -t "My Post Title"  # title sets front matter, not the path
 hwaro new posts/launch.md --bundle           # leaf bundle (posts/launch/index.md) for co-located assets
 hwaro new --list-archetypes --json
 ```
 
 Front matter comes from `archetypes/` (matched by `-a`, then by path, then
 `archetypes/default.md`, then a built-in). Use `--bundle` when a page owns
-images/assets; use `--no-bundle` to force a single file.
+images/assets; use `--no-bundle` to force a single file. The wizard fills the
+default archetype's `{{ description }}` placeholder; the flag form leaves it empty.
+
+Running `hwaro new` with no `<path>` opens an interactive wizard in a TTY — but
+that never triggers in agent/CI runs (no TTY), where it instead exits with
+`HWARO_E_USAGE`. **Always pass an explicit `content/<section>/<slug>.md` path.**
 
 ### C. Develop — `hwaro serve`
 

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -474,6 +474,120 @@ describe Hwaro::Services::Creator do
       end
     end
 
+    # An explicit `description` (supplied by the interactive `hwaro new` wizard)
+    # must be written as the field's value instead of the empty placeholder the
+    # flag form leaves behind, across every front-matter format.
+    it "writes the supplied description value into TOML front matter" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello", description: "A short intro")
+          Hwaro::Services::Creator.new.run(options)
+
+          File.read("content/post.md").should contain(%(description = "A short intro"))
+        end
+      end
+    end
+
+    it "writes the supplied description value into YAML front matter" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+
+          config = Hwaro::Models::Config.new
+          config.content_new.front_matter_format = "yaml"
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello", description: "A short intro")
+          Hwaro::Services::Creator.new.run(options, config)
+
+          File.read("content/post.md").should contain(%(description: "A short intro"))
+        end
+      end
+    end
+
+    it "writes the supplied description value into JSON front matter" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+
+          config = Hwaro::Models::Config.new
+          config.content_new.front_matter_format = "json"
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello", description: "A short intro")
+          Hwaro::Services::Creator.new.run(options, config)
+
+          content = File.read("content/post.md")
+          parsed = JSON.parse(content[0, content.index!("}\n") + 1])
+          parsed["description"].as_s.should eq("A short intro")
+        end
+      end
+    end
+
+    it "force-includes description even when default_fields omitted it" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+
+          config = Hwaro::Models::Config.new
+          config.content_new.default_fields = [] of String
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello", description: "Forced in")
+          Hwaro::Services::Creator.new.run(options, config)
+
+          File.read("content/post.md").should contain(%(description = "Forced in"))
+        end
+      end
+    end
+
+    it "substitutes {{ description }} in an archetype, escaping the value" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          FileUtils.mkdir_p("archetypes")
+          File.write("archetypes/default.md", %(+++\ntitle = "{{ title }}"\ndescription = "{{ description }}"\n+++\n\n))
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello", description: %(My "Quoted" intro))
+          Hwaro::Services::Creator.new.run(options)
+
+          File.read("content/post.md").should contain(%(description = "My \\"Quoted\\" intro"))
+        end
+      end
+    end
+
+    it "leaves an archetype's {{ description }} empty when none is supplied" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          FileUtils.mkdir_p("archetypes")
+          File.write("archetypes/default.md", %(+++\ntitle = "{{ title }}"\ndescription = "{{ description }}"\n+++\n\n))
+
+          options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "Hello")
+          Hwaro::Services::Creator.new.run(options)
+
+          File.read("content/post.md").should contain(%(description = ""))
+        end
+      end
+    end
+
+    describe ".slugify" do
+      it "lowercases and hyphenates a title" do
+        Hwaro::Services::Creator.slugify("My First Post!").should eq("my-first-post")
+      end
+
+      it "collapses punctuation runs and trims edge hyphens" do
+        Hwaro::Services::Creator.slugify("  Breaking News! (2024)  ").should eq("breaking-news-2024")
+      end
+
+      it "preserves CJK letters" do
+        Hwaro::Services::Creator.slugify("안녕 세계").should eq("안녕-세계")
+      end
+
+      it "returns an empty string when nothing is slug-able" do
+        Hwaro::Services::Creator.slugify("!!!").should eq("")
+      end
+    end
+
     # The default generators (no archetype) hand-roll escape_string for
     # backslash-before-quote ordering. An adversarial title (`C:\` style
     # backslash + embedded quote) must still produce front matter that

--- a/spec/unit/initializer_spec.cr
+++ b/spec/unit/initializer_spec.cr
@@ -240,7 +240,9 @@ describe Hwaro::Services::Initializer do
           content = File.read(archetype_path)
           content.should contain("+++")
           content.should contain("title = \"{{ title }}\"")
-          content.should contain("description = \"\"")
+          # `hwaro new` substitutes {{ description }} (empty when none given,
+          # or the value collected by the interactive wizard).
+          content.should contain("description = \"{{ description }}\"")
           # Regression for gh#525: archetype must not inject `# {{ title }}`
           # because every scaffold's `page.html` already renders the title
           # as `<h1>` — duplicating it produced two H1s on every new post.

--- a/spec/unit/new_wizard_spec.cr
+++ b/spec/unit/new_wizard_spec.cr
@@ -1,0 +1,90 @@
+require "../spec_helper"
+require "../../src/cli/commands/new_wizard"
+
+private def with_prompt_input(data : String, &)
+  previous = Hwaro::CLI::Prompt.input
+  Hwaro::CLI::Prompt.input = IO::Memory.new(data)
+  begin
+    yield
+  ensure
+    Hwaro::CLI::Prompt.input = previous
+  end
+end
+
+# Run the wizard inside a throwaway project dir with a scripted answer stream.
+private def run_wizard(answers : String, options : Hwaro::Config::Options::NewOptions, archetypes = [] of Hwaro::CLI::Commands::NewWizard::Archetype) : Bool
+  result = false
+  Dir.mktmpdir do |dir|
+    Dir.cd(dir) do
+      FileUtils.mkdir_p("content")
+      with_prompt_input(answers) do
+        result = Hwaro::CLI::Commands::NewWizard.new.run(options, archetypes)
+      end
+    end
+  end
+  result
+end
+
+describe Hwaro::CLI::Commands::NewWizard do
+  it "collects fields and accepts the recommended path" do
+    options = Hwaro::Config::Options::NewOptions.new
+    # title, description, section, path(accept), tags, date(accept), draft, confirm(accept)
+    run_wizard("My First Post\nA short intro\nposts\n\ncrystal, howto\n\nn\n\n", options).should be_true
+
+    options.title.should eq("My First Post")
+    options.description.should eq("A short intro")
+    options.path.should eq("posts/my-first-post.md")
+    options.tags.should eq(["crystal", "howto"])
+    options.draft.should be_false
+    options.date.should be_nil    # today's default accepted → left unset
+    options.section.should be_nil # baked into the path, not duplicated
+  end
+
+  it "honours a custom path, explicit date, and draft" do
+    options = Hwaro::Config::Options::NewOptions.new
+    # title, description(skip), section(skip), path(custom), tags(skip), date, draft(y), confirm(accept)
+    run_wizard("Custom\n\n\nguides/custom-guide.md\n\n2024-01-02\ny\n\n", options).should be_true
+
+    options.path.should eq("guides/custom-guide.md")
+    options.description.should be_nil
+    options.section.should be_nil
+    options.tags.empty?.should be_true
+    options.date.should eq("2024-01-02")
+    options.draft.should be_true
+  end
+
+  it "uses an existing --title flag as the title default" do
+    options = Hwaro::Config::Options::NewOptions.new(title: "Seeded Title")
+    # title(accept seed), description, section(skip), path(accept), tags(skip), date(accept), draft(n), confirm(accept)
+    run_wizard("\nDesc\n\n\n\n\nn\n\n", options).should be_true
+
+    options.title.should eq("Seeded Title")
+    options.path.should eq("seeded-title.md")
+  end
+
+  it "lets the author pick an archetype from the detected list" do
+    options = Hwaro::Config::Options::NewOptions.new
+    archetypes = [
+      {name: "post", path: "archetypes/post.md"},
+      {name: "page", path: "archetypes/page.md"},
+    ]
+    # title, desc(skip), section(skip), path(accept), tags(skip), date(accept), draft(n), archetype(2), confirm(accept)
+    run_wizard("Arch\n\n\n\n\n\nn\n2\n\n", options, archetypes).should be_true
+
+    options.archetype.should eq("page")
+    options.path.should eq("arch.md")
+  end
+
+  it "returns false and leaves options unmutated when the confirmation is declined" do
+    options = Hwaro::Config::Options::NewOptions.new
+    # everything answered, but final confirm is "n"
+    run_wizard("X\n\n\n\n\n\nn\nn\n", options).should be_false
+    options.path.should be_nil
+  end
+
+  it "returns false when cancelled with EOF on the required title" do
+    options = Hwaro::Config::Options::NewOptions.new
+    run_wizard("", options).should be_false
+    options.path.should be_nil
+  end
+end

--- a/spec/unit/prompt_spec.cr
+++ b/spec/unit/prompt_spec.cr
@@ -1,0 +1,114 @@
+require "../spec_helper"
+require "../../src/cli/prompt"
+
+# Drive Prompt with a scripted input stream, restoring the previous one after.
+private def with_prompt_input(data : String, &)
+  previous = Hwaro::CLI::Prompt.input
+  Hwaro::CLI::Prompt.input = IO::Memory.new(data)
+  begin
+    yield
+  ensure
+    Hwaro::CLI::Prompt.input = previous
+  end
+end
+
+describe Hwaro::CLI::Prompt do
+  describe ".ask" do
+    it "returns the trimmed answer" do
+      with_prompt_input("  hello world  \n") do
+        Hwaro::CLI::Prompt.ask("Title").should eq("hello world")
+      end
+    end
+
+    it "returns the default on an empty line" do
+      with_prompt_input("\n") do
+        Hwaro::CLI::Prompt.ask("Title", default: "seeded").should eq("seeded")
+      end
+    end
+
+    it "lets a typed answer override the default" do
+      with_prompt_input("typed\n") do
+        Hwaro::CLI::Prompt.ask("Title", default: "seeded").should eq("typed")
+      end
+    end
+
+    it "returns nil on EOF" do
+      with_prompt_input("") do
+        Hwaro::CLI::Prompt.ask("Title").should be_nil
+      end
+    end
+
+    it "returns nil for an empty line with no default" do
+      with_prompt_input("\n") do
+        Hwaro::CLI::Prompt.ask("Description").should be_nil
+      end
+    end
+  end
+
+  describe ".ask_required" do
+    it "re-prompts until a non-empty answer arrives" do
+      with_prompt_input("\n   \nfinally\n") do
+        Hwaro::CLI::Prompt.ask_required("Title").should eq("finally")
+      end
+    end
+
+    it "returns nil on EOF" do
+      with_prompt_input("") do
+        Hwaro::CLI::Prompt.ask_required("Title").should be_nil
+      end
+    end
+  end
+
+  describe ".confirm?" do
+    it "treats y / yes as true" do
+      with_prompt_input("y\n") { Hwaro::CLI::Prompt.confirm?("ok?").should be_true }
+      with_prompt_input("YES\n") { Hwaro::CLI::Prompt.confirm?("ok?").should be_true }
+    end
+
+    it "treats other input as false" do
+      with_prompt_input("n\n") { Hwaro::CLI::Prompt.confirm?("ok?").should be_false }
+      with_prompt_input("nope\n") { Hwaro::CLI::Prompt.confirm?("ok?").should be_false }
+    end
+
+    it "uses the default on an empty line" do
+      with_prompt_input("\n") { Hwaro::CLI::Prompt.confirm?("ok?", default: true).should be_true }
+      with_prompt_input("\n") { Hwaro::CLI::Prompt.confirm?("ok?", default: false).should be_false }
+    end
+
+    it "returns nil on EOF" do
+      with_prompt_input("") { Hwaro::CLI::Prompt.confirm?("ok?").should be_nil }
+    end
+  end
+
+  describe ".select" do
+    it "returns the choice by 1-based index" do
+      with_prompt_input("2\n") do
+        Hwaro::CLI::Prompt.select("Pick", ["a", "b", "c"]).should eq("b")
+      end
+    end
+
+    it "returns the choice by exact name" do
+      with_prompt_input("c\n") do
+        Hwaro::CLI::Prompt.select("Pick", ["a", "b", "c"]).should eq("c")
+      end
+    end
+
+    it "returns nil when skipped with an empty line" do
+      with_prompt_input("\n") do
+        Hwaro::CLI::Prompt.select("Pick", ["a", "b"]).should be_nil
+      end
+    end
+
+    it "re-prompts on an unrecognised entry, then accepts a valid one" do
+      with_prompt_input("9\nzzz\n1\n") do
+        Hwaro::CLI::Prompt.select("Pick", ["a", "b"]).should eq("a")
+      end
+    end
+
+    it "returns nil immediately for an empty choice list" do
+      with_prompt_input("anything\n") do
+        Hwaro::CLI::Prompt.select("Pick", [] of String).should be_nil
+      end
+    end
+  end
+end

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -1,6 +1,8 @@
 require "option_parser"
 require "json"
 require "../metadata"
+require "../prompt"
+require "./new_wizard"
 require "../../config/options/new_options"
 require "../../models/config"
 require "../../services/creator"
@@ -77,18 +79,34 @@ module Hwaro
             )
           end
 
-          # `hwaro new` is flag-only: there is no interactive prompt, so a
-          # missing <path> always fails fast with a classified usage error.
-          # Keeping this a HwaroError lets both text and --json consumers see
-          # the same taxonomy (code/category/exit).
+          # When no <path> is given, an interactive human session (TTY + color,
+          # not --json / --quiet) gets a guided wizard that collects the title,
+          # description, recommended path, tags, date, draft, and archetype.
+          # Every non-interactive context — pipes, CI, agents, --json, --quiet —
+          # keeps the fast classified usage error so scripted callers see the
+          # same taxonomy (code/category/exit) as before and never block on a
+          # prompt that will not be answered.
           raw_path = options.path
           if raw_path.nil?
-            raise Hwaro::HwaroError.new(
-              code: Hwaro::Errors::HWARO_E_USAGE,
-              message: "missing <path> argument",
-              hint: "Usage: hwaro new <path> [options] — run 'hwaro new --help' for details.",
-            )
+            interactive = !json_output && !Logger.quiet? && Prompt.interactive?
+            if interactive
+              unless NewWizard.new.run(options, discover_archetypes)
+                Logger.info "Cancelled."
+                return
+              end
+              raw_path = options.path
+            else
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "missing <path> argument",
+                hint: "Usage: hwaro new <path> [options] — run 'hwaro new --help' for details.",
+              )
+            end
           end
+
+          # The wizard always sets a path on success; this guard is defensive
+          # and also narrows `raw_path` to String for the pipeline below.
+          return if raw_path.nil?
 
           # Canonicalize early so the rest of the pipeline (and the
           # `Created new content: …` log line) works with a path that

--- a/src/cli/commands/new_wizard.cr
+++ b/src/cli/commands/new_wizard.cr
@@ -1,0 +1,125 @@
+require "../prompt"
+require "../../config/options/new_options"
+require "../../services/creator"
+require "../../utils/logger"
+
+module Hwaro
+  module CLI
+    module Commands
+      # Guided, line-based wizard for `hwaro new` when no `<path>` was given and
+      # the session is interactive. It asks one question at a time (styled with
+      # the shared ember identity), shows a `Receipt` summary, then confirms
+      # before any file is written. It only *collects* input — the resulting
+      # `NewOptions` flows back through the exact same validate/sanitize/create
+      # pipeline the flag form uses, so there is one creation path, not two.
+      class NewWizard
+        CONTENT_DIR = "content"
+
+        alias Archetype = NamedTuple(name: String, path: String)
+
+        # Mutates `options` in place and returns `true` to proceed with creation.
+        # Returns `false` on cancellation — a declined confirmation or an EOF
+        # (Ctrl-D) on a required answer — so the caller can bail out cleanly
+        # without creating anything.
+        #
+        # Any flags already supplied (`--title`, `--tags`, …) seed the matching
+        # prompt's default, so `hwaro new --title "Foo"` asks only for the rest.
+        def run(options : Config::Options::NewOptions, archetypes : Array(Archetype) = [] of Archetype) : Bool
+          Logger.heading("new")
+
+          # --- Title (required) — drives the recommended path slug.
+          title = if (seed = options.title) && !seed.empty?
+                    Prompt.ask("Title", default: seed)
+                  else
+                    Prompt.ask_required("Title")
+                  end
+          return false if title.nil?
+
+          # --- Description (optional).
+          description = Prompt.ask("Description", default: options.description)
+
+          # --- Section (optional) — only used to shape the recommended path.
+          sections = detect_sections
+          hint = sections.empty? ? "optional, e.g. posts, blog, docs" : "detected: #{sections.join(", ")}"
+          section = Prompt.ask("Section (#{hint})", default: options.section)
+
+          # --- Path (required) — default is the recommended <section>/<slug>.md.
+          slug = Hwaro::Services::Creator.slugify(title)
+          suggested = if slug.empty?
+                        nil
+                      elsif (s = section) && !s.empty?
+                        "#{s}/#{slug}.md"
+                      else
+                        "#{slug}.md"
+                      end
+          path = suggested ? Prompt.ask("Path", default: suggested) : Prompt.ask_required("Path")
+          return false if path.nil?
+
+          display_path = path.starts_with?("#{CONTENT_DIR}/") ? path : File.join(CONTENT_DIR, path)
+          if File.exists?(display_path)
+            Logger.warn "  #{display_path} already exists — creation will be rejected unless you pick another path."
+          end
+
+          # --- Tags (optional) — comma-separated, same parsing as the flag.
+          tags_default = options.tags.empty? ? nil : options.tags.join(", ")
+          tags_input = Prompt.ask("Tags (comma-separated)", default: tags_default)
+          tags = tags_input ? tags_input.split(",").map(&.strip).reject(&.empty?) : [] of String
+
+          # --- Date (optional) — defaults to today; only pinned if changed.
+          today = Time.local.to_s("%Y-%m-%d")
+          date_value = Prompt.ask("Date", default: options.date || today)
+          return false if date_value.nil?
+
+          # --- Draft toggle.
+          draft = Prompt.confirm?("Mark as draft?", default: options.draft == true)
+          return false if draft.nil?
+
+          # --- Archetype (only when the project ships any).
+          archetype = options.archetype
+          unless archetypes.empty?
+            picked = Prompt.select("Archetype", archetypes.map(&.[:name]))
+            archetype = picked unless picked.nil?
+          end
+
+          # --- Summary + confirmation.
+          Logger::Receipt.new("new")
+            .row("path", display_path)
+            .row("title", title)
+            .row("description", description || "")
+            .row("tags", tags.join(", "))
+            .row("date", date_value)
+            .row("draft", draft ? "yes" : "no")
+            .row("archetype", archetype || "")
+            .emit
+
+          return false unless Prompt.confirm?("Create #{display_path}?", default: true)
+
+          options.title = title
+          options.description = description
+          options.path = path
+          options.tags = tags
+          # Leave `date` unset when the author accepted today's default so the
+          # Creator stamps it at write time; pin it only when they changed it.
+          options.date = (date_value == today ? nil : date_value)
+          options.draft = draft
+          options.archetype = archetype
+          # The section was a path-building aid only; we baked it into `path`.
+          # Clearing it keeps `path` the single source of truth and avoids the
+          # Creator's resolve_section double-join.
+          options.section = nil
+          true
+        end
+
+        # Immediate subdirectories of content/, sorted, used purely as a hint so
+        # the author knows which sections already exist. Missing content/ (or any
+        # IO hiccup) simply yields no hint rather than failing the wizard.
+        private def detect_sections : Array(String)
+          return [] of String unless Dir.exists?(CONTENT_DIR)
+          Dir.children(CONTENT_DIR).select { |c| Dir.exists?(File.join(CONTENT_DIR, c)) }.sort!
+        rescue
+          [] of String
+        end
+      end
+    end
+  end
+end

--- a/src/cli/prompt.cr
+++ b/src/cli/prompt.cr
@@ -1,0 +1,109 @@
+require "../utils/logger"
+
+module Hwaro
+  module CLI
+    # Small, reusable line-prompt toolkit for interactive commands.
+    #
+    # Output goes through `Logger.io` (the same redirectable IO the rest of the
+    # CLI prints to) and reads from an injectable input IO that defaults to
+    # `STDIN`. Tests drive both ends without a real terminal:
+    #
+    #     Logger.io = IO::Memory.new
+    #     Prompt.input = IO::Memory.new("My Title\n\n")
+    #
+    # Every prompt is styled with the shared "ember" identity (the `◇` ready
+    # glyph + a dim default hint) and degrades to plain text under
+    # `NO_COLOR` / non-TTY, so piped or captured output stays clean.
+    #
+    # A bare EOF (Ctrl-D) on any prompt returns `nil` — callers treat that as
+    # "cancelled" rather than looping forever on a closed stream.
+    module Prompt
+      @@input : IO = STDIN
+
+      # Inject the input stream (specs). Pass `STDIN` to restore the default.
+      def self.input=(io : IO) : Nil
+        @@input = io
+      end
+
+      def self.input : IO
+        @@input
+      end
+
+      # True only when both ends are a real terminal. Commands gate interactive
+      # flows on this so pipes, CI, and agents fall back to non-interactive
+      # behaviour instead of blocking on a `gets` that will never arrive.
+      def self.interactive? : Bool
+        STDIN.tty? && STDOUT.tty?
+      end
+
+      # Ask a free-text question. Returns the trimmed answer, `default` when the
+      # user just presses Enter, or `nil` on EOF (Ctrl-D).
+      def self.ask(label : String, default : String? = nil) : String?
+        emit_label(label, default)
+        line = @@input.gets
+        return if line.nil?
+        answer = line.strip
+        answer.empty? ? default : answer
+      end
+
+      # Ask until a non-empty answer is given. Returns `nil` on EOF so the caller
+      # can cancel cleanly instead of spinning on a closed stream.
+      def self.ask_required(label : String) : String?
+        loop do
+          emit_label(label, nil)
+          line = @@input.gets
+          return if line.nil?
+          answer = line.strip
+          return answer unless answer.empty?
+          Logger.warn "  required — please enter a value."
+        end
+      end
+
+      # Yes/no question. `default` decides the Enter behaviour and which letter
+      # is capitalised in the `[Y/n]` / `[y/N]` hint. Returns `nil` on EOF.
+      def self.confirm?(label : String, default : Bool = false) : Bool?
+        suffix = default ? "[Y/n]" : "[y/N]"
+        Logger.io.print "  #{Logger.glyph(:ready)} #{Logger.paint(label, Logger::Role::Plain, bold: true)} #{Logger.paint(suffix, Logger::Role::Dim)} "
+        Logger.io.flush
+        line = @@input.gets
+        return if line.nil?
+        answer = line.strip.downcase
+        return default if answer.empty?
+        answer == "y" || answer == "yes"
+      end
+
+      # Numbered single-choice picker. Enter (or an out-of-the-way blank line)
+      # returns `nil`, meaning "no selection" — callers use that for the
+      # auto/default branch. Accepts either the 1-based index or an exact choice
+      # string. Returns `nil` on EOF. Re-asks on an unrecognised entry.
+      def self.select(label : String, choices : Array(String), skip_hint : String = "Enter to skip") : String?
+        return if choices.empty?
+        loop do
+          Logger.io.puts "  #{Logger.glyph(:ready)} #{Logger.paint(label, Logger::Role::Plain, bold: true)} #{Logger.paint("(#{skip_hint})", Logger::Role::Dim)}"
+          choices.each_with_index do |choice, i|
+            Logger.io.puts "      #{Logger.paint("#{i + 1})", Logger::Role::Dim)} #{choice}"
+          end
+          Logger.io.print "  #{Logger.paint("choice", Logger::Role::Dim)} "
+          Logger.io.flush
+          line = @@input.gets
+          return if line.nil?
+          answer = line.strip
+          return if answer.empty?
+          if (idx = answer.to_i?) && idx >= 1 && idx <= choices.size
+            return choices[idx - 1]
+          end
+          if choices.includes?(answer)
+            return answer
+          end
+          Logger.warn "  '#{answer}' is not one of the choices — enter a number 1-#{choices.size}, a name, or press Enter to skip."
+        end
+      end
+
+      private def self.emit_label(label : String, default : String?) : Nil
+        hint = (default && !default.empty?) ? " #{Logger.paint("[#{default}]", Logger::Role::Dim)}" : ""
+        Logger.io.print "  #{Logger.glyph(:ready)} #{Logger.paint(label, Logger::Role::Plain, bold: true)}#{hint} "
+        Logger.io.flush
+      end
+    end
+  end
+end

--- a/src/config/options/new_options.cr
+++ b/src/config/options/new_options.cr
@@ -4,6 +4,10 @@ module Hwaro
       class NewOptions
         property path : String?
         property title : String?
+        # Free-text description written into the front matter. `nil` (the flag
+        # default) leaves the scaffolded `description` field empty, matching the
+        # prior behaviour; the interactive wizard sets it to an actual value.
+        property description : String?
         property archetype : String?
         property date : String?
         property draft : Bool?
@@ -17,6 +21,7 @@ module Hwaro
         def initialize(
           @path : String? = nil,
           @title : String? = nil,
+          @description : String? = nil,
           @archetype : String? = nil,
           @date : String? = nil,
           @draft : Bool? = nil,

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -111,6 +111,17 @@ module Hwaro
         sanitized_segments.join(PATH_SEP)
       end
 
+      # Derive a filename-safe slug from a free-text title: lowercase, then
+      # collapse every run of non-letter/non-digit Unicode characters to a
+      # single hyphen and trim hyphens off the ends. Returns "" when the title
+      # has no slug-able characters (the caller decides how to handle that).
+      # Single source of truth for the title→filename mapping, shared by the
+      # Creator's title-only fallback and the interactive `new` wizard's
+      # recommended-path suggestion.
+      def self.slugify(title : String) : String
+        title.downcase.gsub(/[^\p{L}\p{N}]+/, "-").strip("-")
+      end
+
       private def self.sanitize_url_segment(segment : String) : String
         return segment if segment.empty?
         String.build(segment.bytesize) do |io|
@@ -266,7 +277,7 @@ module Hwaro
               hint: "Pass a non-empty --title.",
             )
           end
-          slug = title.downcase.gsub(/[^\p{L}\p{N}]+/, "-").strip("-")
+          slug = Creator.slugify(title)
           if slug.empty?
             raise Hwaro::HwaroError.new(
               code: Hwaro::Errors::HWARO_E_USAGE,
@@ -295,6 +306,7 @@ module Hwaro
         # Full ISO with offset is still accepted if provided via --date.
         date = options.date || Time.local.to_s("%Y-%m-%d")
         tags = options.tags
+        description = options.description
 
         # Find archetype, extracting any hwaro directives (e.g. bundle=true)
         # before substitution so they don't end up in generated content.
@@ -360,9 +372,9 @@ module Hwaro
         end
 
         content = if archetype_content
-                    process_archetype(archetype_content, title, date, is_draft, tags)
+                    process_archetype(archetype_content, title, date, is_draft, tags, description)
                   else
-                    generate_default_content(title, date, is_draft, tags, content_new)
+                    generate_default_content(title, date, is_draft, tags, content_new, description)
                   end
 
         if File.exists?(full_path)
@@ -535,7 +547,7 @@ module Hwaro
         nil
       end
 
-      private def process_archetype(archetype_content : String, title : String, date : String, is_draft : Bool, tags : Array(String)) : String
+      private def process_archetype(archetype_content : String, title : String, date : String, is_draft : Bool, tags : Array(String), description : String? = nil) : String
         # Archetypes wrap these placeholders in quoted TOML fields
         # (`title = "{{ title }}"`), so the substituted values must be escaped
         # the same way `tags` already is — otherwise a title/date containing a
@@ -543,12 +555,17 @@ module Hwaro
         # generated file fails to build.
         safe_title = escape_string(title)
         safe_date = escape_string(date)
+        # An unset description substitutes to "" so an archetype that ships a
+        # `description = "{{ description }}"` line still produces valid output.
+        safe_description = escape_string(description || "")
         tags_str = tags.empty? ? "[]" : "[#{tags.map { |t| "\"#{escape_string(t)}\"" }.join(", ")}]"
         content = archetype_content
           .gsub("{{ title }}", safe_title)
           .gsub("{{title}}", safe_title)
           .gsub("{{ date }}", safe_date)
           .gsub("{{date}}", safe_date)
+          .gsub("{{ description }}", safe_description)
+          .gsub("{{description}}", safe_description)
           .gsub("{{ draft }}", is_draft.to_s)
           .gsub("{{draft}}", is_draft.to_s)
           .gsub("{{ tags }}", tags_str)
@@ -567,13 +584,26 @@ module Hwaro
         is_draft : Bool,
         tags : Array(String),
         content_new : Models::ContentNewConfig,
+        description : String? = nil,
       ) : String
+        # Map of extra-field name → value. Today only `description` carries a
+        # value (supplied by the interactive `new` wizard); every other extra
+        # field still scaffolds an empty placeholder. A provided description is
+        # force-included even when the project's `default_fields` omitted it, so
+        # the entered value is never silently dropped.
+        field_values = {} of String => String
+        extra_fields = content_new.extra_fields
+        if d = description
+          field_values["description"] = d
+          extra_fields = ["description"] + extra_fields unless extra_fields.includes?("description")
+        end
+
         if content_new.json?
-          build_json_front_matter(title, date, is_draft, tags, content_new.extra_fields)
+          build_json_front_matter(title, date, is_draft, tags, extra_fields, field_values)
         elsif content_new.yaml?
-          build_yaml_front_matter(title, date, is_draft, tags, content_new.extra_fields)
+          build_yaml_front_matter(title, date, is_draft, tags, extra_fields, field_values)
         else
-          build_toml_front_matter(title, date, is_draft, tags, content_new.extra_fields)
+          build_toml_front_matter(title, date, is_draft, tags, extra_fields, field_values)
         end
       end
 
@@ -588,14 +618,14 @@ module Hwaro
       # `<h1>{{ page.title | e }}</h1>`, so injecting a markdown `# title`
       # here would produce two H1s on every page created via `hwaro new`
       # (gh#525).
-      private def build_toml_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String)) : String
+      private def build_toml_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String), field_values : Hash(String, String) = {} of String => String) : String
         safe_title = escape_string(title)
         date_literal = date.matches?(TOML_DATETIME_RE) ? date : "\"#{escape_string(date)}\""
         String.build do |str|
           str << "+++\n"
           str << "title = \"#{safe_title}\"\n"
           str << "date = #{date_literal}\n"
-          extra_fields.each { |f| str << "#{f} = \"\"\n" }
+          extra_fields.each { |f| str << "#{f} = \"#{escape_string(field_values[f]? || "")}\"\n" }
           str << "draft = true\n" if is_draft
           unless tags.empty?
             rendered = tags.map { |t| "\"#{escape_string(t)}\"" }.join(", ")
@@ -605,7 +635,7 @@ module Hwaro
         end
       end
 
-      private def build_yaml_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String)) : String
+      private def build_yaml_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String), field_values : Hash(String, String) = {} of String => String) : String
         safe_title = escape_string(title)
         String.build do |str|
           str << "---\n"
@@ -614,7 +644,7 @@ module Hwaro
           # valid YAML, and a normal date parses back as a String scalar (an
           # unquoted YYYY-MM-DD parses as a Time node and is silently dropped).
           str << "date: \"#{escape_string(date)}\"\n"
-          extra_fields.each { |f| str << "#{f}: \"\"\n" }
+          extra_fields.each { |f| str << "#{f}: \"#{escape_string(field_values[f]? || "")}\"\n" }
           str << "draft: true\n" if is_draft
           unless tags.empty?
             str << "tags:\n"
@@ -624,11 +654,11 @@ module Hwaro
         end
       end
 
-      private def build_json_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String)) : String
+      private def build_json_front_matter(title : String, date : String, is_draft : Bool, tags : Array(String), extra_fields : Array(String), field_values : Hash(String, String) = {} of String => String) : String
         fields = {} of String => JSON::Any
         fields["title"] = JSON::Any.new(title)
         fields["date"] = JSON::Any.new(date)
-        extra_fields.each { |f| fields[f] = JSON::Any.new("") }
+        extra_fields.each { |f| fields[f] = JSON::Any.new(field_values[f]? || "") }
         fields["draft"] = JSON::Any.new(true) if is_draft
         unless tags.empty?
           fields["tags"] = JSON::Any.new(tags.map { |t| JSON::Any.new(t) })

--- a/src/services/scaffolds/bare.cr
+++ b/src/services/scaffolds/bare.cr
@@ -169,7 +169,7 @@ module Hwaro
             title = "{{ title }}"
             date = "{{ date }}"
             draft = {{ draft }}
-            description = ""
+            description = "{{ description }}"
             +++
 
             MD

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -280,8 +280,9 @@ module Hwaro
 
         # Built-in default archetype content (TOML front matter).
         # `Services::Creator` substitutes `{{ title }}`, `{{ date }}`,
-        # `{{ draft }}`, and `{{ tags }}`; other fields (description) ship
-        # with empty values for users to fill in.
+        # `{{ draft }}`, `{{ tags }}`, and `{{ description }}`. An unset
+        # description substitutes to "" — identical to the prior hardcoded
+        # empty value — while the interactive `hwaro new` wizard fills it in.
         #
         # The body is intentionally empty: every scaffold's `page.html` /
         # `post.html` already renders `<h1>{{ page.title | e }}</h1>`, so
@@ -293,7 +294,7 @@ module Hwaro
             title = "{{ title }}"
             date = "{{ date }}"
             draft = {{ draft }}
-            description = ""
+            description = "{{ description }}"
             tags = {{ tags }}
             +++
 

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -207,7 +207,7 @@ module Hwaro
             title = "{{ title }}"
             date = "{{ date }}"
             draft = {{ draft }}
-            description = ""
+            description = "{{ description }}"
             authors = []
             categories = []
             tags = {{ tags }}

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -173,7 +173,7 @@ module Hwaro
             +++
             title = "{{ title }}"
             draft = {{ draft }}
-            description = ""
+            description = "{{ description }}"
             weight = 0
             toc = true
             +++

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -81,7 +81,7 @@ module Hwaro
             title = "{{ title }}"
             date = "{{ date }}"
             draft = {{ draft }}
-            description = ""
+            description = "{{ description }}"
             # weight = 10
             toc = true
             tags = {{ tags }}


### PR DESCRIPTION
## Summary

`hwaro new` with no `<path>` used to fail fast with `HWARO_E_USAGE`. In an interactive terminal it now opens a guided, ember-styled wizard that collects the title, description, a **recommended path** (derived from the title + section), tags, date, draft flag, and archetype, previews a `Receipt` summary, and confirms before writing. Flags already passed pre-fill their prompts.

Non-interactive contexts (pipes, CI, agents, `--json`, `--quiet`) keep the **exact** classified usage error, so scripted callers never block on a prompt and see the same taxonomy (code/category/exit) as before.

```
  ● new ────────────────────────────────────────
  ◇ Title My First Post
  ◇ Description A short intro
  ◇ Section (optional, e.g. posts, blog, docs) posts
  ◇ Path [posts/my-first-post.md]
  ◇ Tags (comma-separated) crystal, howto
  ◇ Date [2026-06-30]
  ◇ Mark as draft? [y/N] n
  ◇ Archetype (Enter to skip)
      1) default
  ● new ────────────────────────────────────────
    path         content/posts/my-first-post.md
    title        My First Post
    description  A short intro
    tags         crystal, howto
    date         2026-06-30
    draft        no
  ◇ Create content/posts/my-first-post.md? [Y/n] y
  ▴ created  content/posts/my-first-post.md
```

## Changes

- **New `CLI::Prompt`** — reusable line-prompt toolkit (`ask` / `ask_required` / `confirm?` / `select`) with an injectable input IO (testable) and ember styling; degrades cleanly under `NO_COLOR`/non-TTY.
- **New `NewWizard`** — orchestrates the questions, builds the recommended path via `Creator.slugify`, shows a `Logger::Receipt`, confirms, and feeds a normal `NewOptions` back through the **existing** validate/sanitize/create pipeline (one creation path, not two). Section is folded into the path, never double-joined.
- **Description threading** — `NewOptions#description` is written into the front matter as a value instead of an empty placeholder; archetypes gain a `{{ description }}` placeholder. The shipped scaffold archetypes use it — **byte-identical output when no description is given**.
- **`Creator.slugify`** extracted as the single title→filename source of truth.
- **Docs + CHANGELOG** — CLI reference (interactive mode), archetypes (`{{ description }}` placeholder, corrected a stale draft note), getting-started tip, and the agent skill (clarifies the wizard never triggers in agent/CI runs).

## Testing

- `crystal spec` — **5703 examples, 0 failures** (26 new: prompt, wizard, description threading).
- Verified end-to-end through a pseudo-TTY (file created with the typed description + tags).
- Non-interactive fallbacks confirmed: `echo | hwaro new`, `--json`, `--quiet` all emit `HWARO_E_USAGE`.
- `crystal tool format --check` clean; `./bin/ameba` clean (378 files, 0 failures).
- Docs site builds clean; new sections confirmed in rendered HTML.