### PR TITLE
feat(cli): make hwaro init immediate by default, add --wizard flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## Unreleased
 
 ### Added
-- `hwaro init` with no flags opens an interactive wizard in a terminal: directory, a scaffold picker with one-line descriptions, site title (written into the generated `config.toml`), a dark-theme toggle for families that ship a dark preset, and a confirm receipt. `-y`/`--yes`, any other flag, pipes/CI, and `--quiet` keep the flag path byte-identical
+- `hwaro init --wizard` opens an interactive wizard in a terminal: directory, a scaffold picker with one-line descriptions, site title (written into the generated `config.toml`), a dark-theme toggle for families that ship a dark preset, and a confirm receipt
 - Scaffold design tokens: all init scaffolds share one "Hwaro Ember" `:root` vocabulary (`src/services/scaffolds/design_tokens.cr`) — every color is a `light-dark()` pair, plus fluid `--step-*` type scale, `--space-*` rhythm, `--measure`, radii, shadows, and motion tokens. Every scaffold (including `simple`) now adapts to the OS color scheme automatically; a `@supports` fallback pins the light palette on pre-2024 browsers
 - `just scaffold-previews`: regenerate the docs' scaffold screenshots headlessly (`DARK=1` adds forced-dark self-review shots)
 
 ### Changed
+- `hwaro init` now initializes immediately with defaults; pass `--wizard` to open the interactive flow. Removed `-y`/`--yes` (no longer needed)
 - Terminal output: every command now speaks the ember language. `list`/`stats`/`validate`/`check-links`/`deploy`/`export`/`import`/`unused-assets`/`convert`/`platform`/`agents-md` moved from ad-hoc `info` lines onto the shared heading → context → body → outcome arc, with one glyph set (`✓ ⚠ ✗ ℹ · →`), one bar renderer, and lowercase-verb outcomes (`exported: 38 files, 4 skipped`). Raw `.colorize`, off-registry glyphs (`✔✘`, `[DEAD]`), and hand-rolled dividers are gone and lint-blocked by spec. Frozen machine surfaces — `--json` payloads, the `serve` ready line, `--version`, `Error [CODE]` shapes, plain receipt forms, exit codes — are byte-for-byte unchanged; human-readable stdout is not a stable API (use `--json`)
 - The `*-dark` scaffolds are now thin presets: the same stylesheet as their light family plus one `:root { color-scheme: dark; }` rule (~1,600 lines of duplicated dark CSS deleted). Scaffold design pass across the families: docs gains sidebar rail/overline hierarchy, hairline TOC, and real h2 section breaks; blog's hero/meta move onto the fluid scale with measure-capped prose; book keeps its serif reading character with tokenized surfaces; interactive prompts, help screens, and `--profile`/`--debug` output join the ember palette
 

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -80,9 +80,10 @@ exit code `1`, so this is a strictly additive contract.
 Create a new site:
 
 ```bash
-hwaro init                    # interactive wizard (TTY): scaffold, title, dark toggle
-hwaro init my-site            # wizard; directory prompt skipped (path taken from arg)
-hwaro init my-site -y         # skip the wizard, use defaults
+hwaro init                    # initialize immediately with defaults
+hwaro init my-site            # initialize in my-site/
+hwaro init --wizard           # interactive wizard (TTY): scaffold, title, dark toggle
+hwaro init my-site --wizard   # wizard; directory prompt skipped (path taken from arg)
 hwaro init my-site --scaffold blog
 hwaro init my-site --scaffold docs
 hwaro init my-site --scaffold book
@@ -90,16 +91,15 @@ hwaro init my-site --scaffold book
 
 **Interactive mode:**
 
-Running `hwaro init` with no option flags in an interactive terminal opens a
-guided wizard: it asks for the directory, a scaffold (picked from the base
-scaffolds, with a "Dark theme?" toggle for the ones that have a dark preset),
-and the site title, then shows a summary and asks to confirm before writing
-anything. When a path argument is given (`hwaro init my-site`), the wizard
-still runs but skips the directory prompt and uses that path directly.
+Pass `--wizard` in an interactive terminal to open a guided flow: it asks for
+the directory, a scaffold (picked from the base scaffolds, with a "Dark theme?"
+toggle for the ones that have a dark preset), and the site title, then shows a
+summary and asks to confirm before writing anything. When a path argument is
+given (`hwaro init my-site --wizard`), the wizard skips the directory prompt
+and uses that path directly.
 
-Pass `-y`/`--yes` to skip the wizard and initialize with defaults. Any other
-flag also skips it, as do non-interactive contexts (pipes, CI, `--quiet`), so
-existing scripts behave exactly as before.
+Without `--wizard`, `hwaro init` initializes immediately with defaults — the
+same behaviour scripts and CI already relied on.
 
 Every scaffold follows the reader's OS color scheme automatically (the shared
 token system uses CSS `light-dark()` pairs); the `*-dark` scaffolds are presets
@@ -124,7 +124,7 @@ Remote scaffolds fetch `config.toml`, `templates/`, `static/`, and content struc
 | Flag | Description |
 |------|-------------|
 | --scaffold TYPE | Built-in (`simple`, `bare`, `blog`, `docs`, `book`, plus `blog-dark`/`docs-dark`/`book-dark` presets that force the dark scheme) or remote source (`github:user/repo[/path]`, URL) |
-| -y, --yes | Skip the interactive wizard and initialize with defaults |
+| --wizard | Run the interactive wizard (TTY only) |
 | --agents MODE | AGENTS.md content mode: `remote` (lightweight, default) or `local` (full embedded reference) |
 | -f, --force | Force creation even if directory is not empty |
 | --skip-agents-md | Skip creating AGENTS.md file |

--- a/spec/unit/init_command_spec.cr
+++ b/spec/unit/init_command_spec.cr
@@ -154,11 +154,43 @@ describe Hwaro::CLI::Commands::InitCommand do
       options.minimal_config.should be_true
     end
 
+    it "accepts --wizard flag as a no-op for parse_options" do
+      cmd = Hwaro::CLI::Commands::InitCommand.new
+      options = cmd.parse_options(["my-site", "--wizard"])
+      options.path.should eq("my-site")
+    end
+
+    it "rejects removed -y/--yes flags" do
+      cmd = Hwaro::CLI::Commands::InitCommand.new
+      expect_raises(OptionParser::InvalidOption) do
+        cmd.parse_options(["-y"])
+      end
+      expect_raises(OptionParser::InvalidOption) do
+        cmd.parse_options(["--yes"])
+      end
+    end
+
     it "raises on unknown flags" do
       cmd = Hwaro::CLI::Commands::InitCommand.new
       expect_raises(OptionParser::InvalidOption) do
         cmd.parse_options(["--unknown-flag"])
       end
+    end
+  end
+
+  describe "wizard eligibility" do
+    it "does not run the wizard without --wizard" do
+      cmd = Hwaro::CLI::Commands::InitCommand.new
+      # Non-interactive specs fall through to parse_options; a bare invocation
+      # must not require wizard-only flags.
+      options = cmd.parse_options([] of String)
+      options.path.should eq(".")
+    end
+
+    it "registers --wizard in metadata" do
+      flag_names = Hwaro::CLI::Commands::InitCommand.metadata.flags.map(&.long)
+      flag_names.should contain("--wizard")
+      flag_names.should_not contain("--yes")
     end
   end
 

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -41,7 +41,7 @@ module Hwaro
           FlagInfo.new(short: nil, long: "--json", description: "Emit machine-readable JSON output (with --list-scaffolds)"),
 
           # Wizard control
-          FlagInfo.new(short: "-y", long: "--yes", description: "Skip the interactive wizard and initialize with defaults"),
+          FlagInfo.new(short: nil, long: "--wizard", description: "Run the interactive wizard (TTY only)"),
 
           # Debug & output
           QUIET_FLAG,
@@ -67,13 +67,12 @@ module Hwaro
             return
           end
 
-          # A bare interactive invocation (`hwaro init` or `hwaro init <path>`
-          # with no option flags on a real terminal) gets the guided wizard.
-          # A supplied path skips the directory prompt inside the wizard.
-          # Any flag — including --yes — plus non-TTY and quiet sessions keep
-          # the flag path byte-identical for scripts and CI.
+          # The guided wizard runs only when `--wizard` is passed explicitly in
+          # an interactive session. Every other invocation — bare `hwaro init`,
+          # flags, pipes/CI, and `--quiet` — initializes immediately with
+          # defaults (the former `-y`/`--yes` path).
           if wizard_eligible?(args)
-            options = InitWizard.new.run(args.first?)
+            options = InitWizard.new.run(wizard_seed_path(args))
             if options.nil?
               Logger.info "Cancelled."
               return
@@ -87,9 +86,21 @@ module Hwaro
         end
 
         private def wizard_eligible?(args : Array(String)) : Bool
+          return false unless args.any?(&.==("--wizard"))
           return false unless Prompt.interactive?
           return false if Logger.quiet?
-          args.none?(&.starts_with?("-"))
+          true
+        end
+
+        # First positional argument, ignoring flags — mirrors #parse_options'
+        # unknown_args handling so `hwaro init my-site --wizard` and
+        # `hwaro init --wizard my-site` both seed the directory prompt skip.
+        private def wizard_seed_path(args : Array(String)) : String?
+          args.each do |arg|
+            next if arg.starts_with?("-")
+            return arg
+          end
+          nil
         end
 
         # Print the list of built-in scaffolds.
@@ -200,9 +211,9 @@ module Hwaro
             parser.on("--list-scaffolds", "List available built-in scaffolds and exit") { }
             parser.on("--json", "Emit machine-readable JSON output (with --list-scaffolds)") { }
 
-            # Wizard control (its mere presence in args disables the wizard in
-            # #run; registered so OptionParser accepts it and --help shows it).
-            parser.on("-y", "--yes", "Skip the interactive wizard and initialize with defaults") { }
+            # Wizard control (handled in #run before full init; registered here
+            # so OptionParser accepts it and --help shows it).
+            parser.on("--wizard", "Run the interactive wizard (TTY only)") { }
 
             # Debug & output
             CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }

--- a/src/cli/commands/init_wizard.cr
+++ b/src/cli/commands/init_wizard.cr
@@ -6,8 +6,8 @@ require "../../utils/logger"
 module Hwaro
   module CLI
     module Commands
-      # Guided, line-based wizard for `hwaro init` when invoked bare (no
-      # option flags) in an interactive session. Mirrors `NewWizard`: it asks
+      # Guided, line-based wizard for `hwaro init --wizard` in an interactive
+      # session. Mirrors `NewWizard`: it asks
       # one styled question at a time, shows a `Receipt` summary, and confirms
       # before anything touches the filesystem. It only *collects* input — the
       # resulting `InitOptions` flows through the exact same


### PR DESCRIPTION
## Summary

- `hwaro init` now scaffolds immediately with defaults (former `-y`/`--yes` behavior)
- Add `--wizard` to explicitly run the interactive flow in a TTY
- Remove `-y`/`--yes` (no longer needed)

## Test plan

- [x] `crystal spec spec/unit/init_command_spec.cr spec/unit/init_wizard_spec.cr` — 34 examples, 0 failures