### PR TITLE
Update landing page showcase with new example themes

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -253,110 +253,110 @@
                 </div>
                 <div class="showcase-grid">
                     <a
-                        href="https://hahwul.github.io/hwaro-examples/neon-tokyo/"
+                        href="https://hahwul.github.io/hwaro-examples/burin/"
                         class="showcase-card"
                         target="_blank"
                         rel="noopener"
                     >
                         <div class="showcase-preview">
                             <img
-                                src="https://examples.hwaro.hahwul.com/screenshots/neon-tokyo.png"
-                                alt="neon-tokyo"
+                                src="https://examples.hwaro.hahwul.com/screenshots/burin.png"
+                                alt="burin"
                                 loading="lazy"
                             />
                         </div>
                         <div class="showcase-info">
-                            <span class="showcase-name">neon-tokyo</span>
-                            <span class="showcase-tag">landing</span>
+                            <span class="showcase-name">burin</span>
+                            <span class="showcase-tag">portfolio</span>
                         </div>
                     </a>
                     <a
-                        href="https://hahwul.github.io/hwaro-examples/clean-seoul/"
+                        href="https://hahwul.github.io/hwaro-examples/maru/"
                         class="showcase-card"
                         target="_blank"
                         rel="noopener"
                     >
                         <div class="showcase-preview">
                             <img
-                                src="https://examples.hwaro.hahwul.com/screenshots/clean-seoul.png"
-                                alt="clean-seoul"
+                                src="https://examples.hwaro.hahwul.com/screenshots/maru.png"
+                                alt="maru"
                                 loading="lazy"
                             />
                         </div>
                         <div class="showcase-info">
-                            <span class="showcase-name">clean-seoul</span>
-                            <span class="showcase-tag">blog</span>
-                        </div>
-                    </a>
-                    <a
-                        href="https://hahwul.github.io/hwaro-examples/dojo/"
-                        class="showcase-card"
-                        target="_blank"
-                        rel="noopener"
-                    >
-                        <div class="showcase-preview">
-                            <img
-                                src="https://examples.hwaro.hahwul.com/screenshots/dojo.png"
-                                alt="dojo"
-                                loading="lazy"
-                            />
-                        </div>
-                        <div class="showcase-info">
-                            <span class="showcase-name">dojo</span>
+                            <span class="showcase-name">maru</span>
                             <span class="showcase-tag">docs</span>
                         </div>
                     </a>
                     <a
-                        href="https://hahwul.github.io/hwaro-examples/terraform/"
+                        href="https://hahwul.github.io/hwaro-examples/virga/"
                         class="showcase-card"
                         target="_blank"
                         rel="noopener"
                     >
                         <div class="showcase-preview">
                             <img
-                                src="https://examples.hwaro.hahwul.com/screenshots/terraform.png"
-                                alt="terraform"
+                                src="https://examples.hwaro.hahwul.com/screenshots/virga.png"
+                                alt="virga"
                                 loading="lazy"
                             />
                         </div>
                         <div class="showcase-info">
-                            <span class="showcase-name">terraform</span>
-                            <span class="showcase-tag">dashboard</span>
+                            <span class="showcase-name">virga</span>
+                            <span class="showcase-tag">blog</span>
                         </div>
                     </a>
                     <a
-                        href="https://hahwul.github.io/hwaro-examples/neobrutal/"
+                        href="https://hahwul.github.io/hwaro-examples/gouache/"
                         class="showcase-card"
                         target="_blank"
                         rel="noopener"
                     >
                         <div class="showcase-preview">
                             <img
-                                src="https://examples.hwaro.hahwul.com/screenshots/neobrutal.png"
-                                alt="neobrutal"
+                                src="https://examples.hwaro.hahwul.com/screenshots/gouache.png"
+                                alt="gouache"
                                 loading="lazy"
                             />
                         </div>
                         <div class="showcase-info">
-                            <span class="showcase-name">neobrutal</span>
-                            <span class="showcase-tag">landing</span>
+                            <span class="showcase-name">gouache</span>
+                            <span class="showcase-tag">portfolio</span>
                         </div>
                     </a>
                     <a
-                        href="https://hahwul.github.io/hwaro-examples/kinetic-typography/"
+                        href="https://hahwul.github.io/hwaro-examples/dalbit/"
                         class="showcase-card"
                         target="_blank"
                         rel="noopener"
                     >
                         <div class="showcase-preview">
                             <img
-                                src="https://examples.hwaro.hahwul.com/screenshots/kinetic-typography.png"
-                                alt="kinetic-typography"
+                                src="https://examples.hwaro.hahwul.com/screenshots/dalbit.png"
+                                alt="dalbit"
                                 loading="lazy"
                             />
                         </div>
                         <div class="showcase-info">
-                            <span class="showcase-name">kinetic-typography</span>
+                            <span class="showcase-name">dalbit</span>
+                            <span class="showcase-tag">gallery</span>
+                        </div>
+                    </a>
+                    <a
+                        href="https://hahwul.github.io/hwaro-examples/hanok/"
+                        class="showcase-card"
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        <div class="showcase-preview">
+                            <img
+                                src="https://examples.hwaro.hahwul.com/screenshots/hanok.png"
+                                alt="hanok"
+                                loading="lazy"
+                            />
+                        </div>
+                        <div class="showcase-info">
+                            <span class="showcase-name">hanok</span>
                             <span class="showcase-tag">landing</span>
                         </div>
                     </a>


### PR DESCRIPTION
## Summary

Updates the "Built with Hwaro" showcase on the landing page to reflect the refreshed examples gallery at [examples.hwaro.hahwul.com](https://examples.hwaro.hahwul.com/).

## Changes

Replaces the six showcase cards:

| Before | After | Tag |
|--------|-------|-----|
| neon-tokyo | burin | portfolio |
| clean-seoul | maru | docs |
| dojo | virga | blog |
| terraform | gouache | portfolio |
| neobrutal | dalbit | gallery |
| kinetic-typography | hanok | landing |

## Test plan

- [x] `bin/hwaro build -i docs` completes successfully
- [x] Built `docs/public/index.html` contains all six new showcase entries