### PR TITLE
feat(cli): hearth palette refresh for terminal output

### DIFF
--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -1133,7 +1133,7 @@ describe Hwaro::Services::ChangeSet do
         removed_files: [] of String,
         config_changed: false,
       )
-      cs.description.should eq("2 content file(s)")
+      cs.description.should eq("2 content files")
     end
 
     it "describes mixed changes" do
@@ -1145,7 +1145,7 @@ describe Hwaro::Services::ChangeSet do
         removed_files: [] of String,
         config_changed: true,
       )
-      cs.description.should eq("1 content, 1 template, 1 added, config file(s)")
+      cs.description.should eq("1 content, 1 template, 1 added files, config")
     end
 
     it "describes content-asset and removed buckets" do
@@ -1158,7 +1158,7 @@ describe Hwaro::Services::ChangeSet do
         config_changed: false,
         modified_content_files: ["content/a/cover.jpg"],
       )
-      cs.description.should eq("1 content-asset, 1 removed file(s)")
+      cs.description.should eq("1 content-asset, 1 removed files")
     end
   end
 

--- a/spec/unit/terminal_style_spec.cr
+++ b/spec/unit/terminal_style_spec.cr
@@ -35,10 +35,15 @@ describe "terminal style lint" do
   end
 
   it "uses only GLYPHS-registry status glyphs in terminal output" do
-    banned = ["✔", "✘", "[DEAD]", "└─"]
+    banned = ["✔", "✘", "[DEAD]"]
+    # Tree connectors are registry glyphs (:tree_mid / :tree_last); a literal
+    # anywhere but the registry itself bypasses the ASCII fallback and the
+    # Dim paint, so it stays banned outside logger.cr.
+    connectors = ["├─", "└─"]
     offenders = output_surface_files.select do |path|
       content = File.read(path)
-      banned.any? { |glyph| content.includes?(glyph) }
+      next true if banned.any? { |glyph| content.includes?(glyph) }
+      path != "src/utils/logger.cr" && connectors.any? { |glyph| content.includes?(glyph) }
     end
     offenders.should be_empty
   end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1054,7 +1054,7 @@ module Hwaro
           # "content pages" rather than just "pages" — taxonomy/archive/section
           # index files are also written to disk, so a bare "N pages" count
           # misleads users who diff this number against `find public -name '*.html'`.
-          emit_build_receipt(ctx, raw_msg, elapsed.total_milliseconds)
+          emit_build_receipt(ctx, raw_msg, elapsed.total_milliseconds, profiler)
           # Only warn about an empty site when nothing was built at all. Under
           # `--cache`, unchanged pages are skipped (counted as `cache_hits`)
           # rather than re-rendered, so `pages_rendered` is 0 on a no-op rebuild
@@ -1160,24 +1160,36 @@ module Hwaro
         # Emit the calm closing receipt: an aligned per-phase summary plus the
         # one ember "built" outcome line. Rows are skipped when their value is
         # empty, so cached/no-op rebuilds stay terse. Falls back to plain
-        # "label: value" lines (no color, no rule) when color is off.
-        private def emit_build_receipt(ctx : Lifecycle::BuildContext, raw_msg : String, elapsed_ms : Float64)
+        # "label: value" lines (no color, no rule) when color is off. Each row
+        # carries its phase timing as a TTY-only dim detail so slow phases are
+        # visible at a glance without `--profile`.
+        private def emit_build_receipt(ctx : Lifecycle::BuildContext, raw_msg : String, elapsed_ms : Float64, profiler : Profiler)
           stats = ctx.stats
           receipt = Logger::Receipt.new("build")
-          receipt.row("read", stats.pages_read > 0 ? "#{stats.pages_read} content files" : "")
+          receipt.row("read", stats.pages_read > 0 ? "#{stats.pages_read} content files" : "",
+            detail: phase_detail(profiler, "ReadContent"))
           parsed = stats.pages_read - stats.pages_skipped
           receipt.row("parse", parsed > 0 ? "#{parsed} pages" : "",
-            emphasis: stats.pages_skipped > 0 ? "#{stats.pages_skipped} skipped" : nil)
+            emphasis: stats.pages_skipped > 0 ? "#{stats.pages_skipped} skipped" : nil,
+            detail: phase_detail(profiler, "ParseContent"))
           render_val =
             if stats.cache_hits > 0
               "#{stats.pages_rendered} pages · #{stats.cache_hits} cached"
             else
               "#{stats.pages_rendered} pages"
             end
-          receipt.row("render", render_val)
-          receipt.row("write", stats.raw_files_processed > 0 ? "#{stats.raw_files_processed} raw files" : "")
+          receipt.row("render", render_val, detail: phase_detail(profiler, "Render"))
+          receipt.row("write", stats.raw_files_processed > 0 ? "#{stats.raw_files_processed} raw files" : "",
+            detail: phase_detail(profiler, "Write"))
           receipt.outcome("built", "#{stats.pages_rendered} content pages#{raw_msg}", :result, elapsed_ms)
           receipt.emit
+        end
+
+        # A receipt row's dim timing note. Sub-millisecond phases return `nil`
+        # so trivial builds don't sprout four "0ms" notes.
+        private def phase_detail(profiler : Profiler, phase : String) : String?
+          ms = profiler.phase_ms(phase)
+          ms && ms >= 1.0 ? Logger.dur(ms) : nil
         end
 
         # Execute all build phases with lifecycle hooks

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -17,9 +17,18 @@ require "./config_snippets"
 module Hwaro
   module Services
     class Initializer
+      # One scaffold write, remembered instead of streamed: TTY output renders
+      # the collected entries as a grouped tree at the end (24 near-identical
+      # "create" lines collapse into one line per top-level entry), while
+      # plain/piped output replays them as the historical per-file
+      # "      create  path" lines, byte-for-byte.
+      private record ScaffoldEntry, action : Symbol, path : String, dir : Bool
+
       # Counts files/directories actually created so the closing receipt can
       # report "N files" (existing entries left in place are not counted).
       @created_count = 0
+
+      @entries = [] of ScaffoldEntry
 
       def run(options : Config::Options::InitOptions)
         scaffold = if remote = options.scaffold_remote
@@ -95,10 +104,16 @@ module Hwaro
         end
 
         # The wizard already rendered the heading and a scaffold/title receipt;
-        # printing them again here would double the header beat.
+        # printing them again here would double the header beat. The TTY form
+        # sits on the 4-space grid with the tree below it; the plain form
+        # keeps its historical 2-space indent.
         unless from_wizard
           Logger.heading("init", target_path == "." ? nil : target_path)
-          Logger.info "  #{Logger.paint("scaffold", Logger::Role::Dim)}  #{Logger.paint(scaffold.description, Logger::Role::Dim)}"
+          if Logger.color_enabled?
+            Logger.info "    #{Logger.paint("scaffold", Logger::Role::Dim)}  #{Logger.paint(scaffold.description, Logger::Role::Dim)}"
+          else
+            Logger.info "  scaffold  #{scaffold.description}"
+          end
         end
 
         is_multilingual = multilingual_languages.size > 1
@@ -205,14 +220,91 @@ module Hwaro
         end
 
         display_target = target_path == "." ? "." : "#{target_path}/"
-        Logger.outcome("created", "#{@created_count} files · #{display_target}")
-        Logger.info "Run `hwaro build` to generate the site, then `hwaro serve` to preview."
-        Logger.info "Set `base_url` in config.toml before deploying (defaults to http://localhost:3000)."
+        emit_scaffold_log(target_path)
+        if Logger.color_enabled?
+          # Close the frame like a Receipt: dim rule, ember outcome, then
+          # hint rows whose labels align under the outcome verb.
+          Logger.info "  #{Logger.paint("─" * (Logger::RECEIPT_WIDTH - 2), Logger::Role::Dim)}"
+          Logger.outcome("created", "#{@created_count} files · #{display_target}")
+          hint_col = "created".size
+          Logger.info "    #{Logger.paint("next".ljust(hint_col), Logger::Role::Dim)}  hwaro build · hwaro serve to preview"
+          Logger.info "    #{Logger.paint("deploy".ljust(hint_col), Logger::Role::Dim)}  set base_url in config.toml first (defaults to http://localhost:3000)"
+        else
+          Logger.outcome("created", "#{@created_count} files · #{display_target}")
+          Logger.info "Run `hwaro build` to generate the site, then `hwaro serve` to preview."
+          Logger.info "Set `base_url` in config.toml before deploying (defaults to http://localhost:3000)."
+        end
+      end
+
+      # Emit the collected scaffold writes. Plain output replays the exact
+      # per-file action lines the CLI has always printed (scripts and specs
+      # match on them); a colored TTY gets the grouped tree instead.
+      private def emit_scaffold_log(target_path : String)
+        return if Logger.quiet?
+        if Logger.color_enabled?
+          emit_scaffold_tree(target_path)
+        else
+          @entries.each do |entry|
+            role = entry.action == :exist ? Logger::Role::Dim : Logger::Role::Success
+            Logger.action entry.action, entry.path, role
+          end
+        end
+      end
+
+      # Grouped tree summary of the scaffold: one row per top-level entry in
+      # creation order, with a dim per-group note (file count, notable
+      # subdirectories, kept-existing count). Dirs get a trailing slash.
+      private def emit_scaffold_tree(target_path : String)
+        group_order = [] of String
+        group_dir = {} of String => Bool
+        created = Hash(String, Int32).new(0)
+        kept = Hash(String, Int32).new(0)
+        subdirs = {} of String => Array(String)
+
+        @entries.each do |entry|
+          rel = Path[entry.path].relative_to(target_path).to_s
+          next if rel == "." || rel.empty?
+          parts = rel.split('/')
+          top = parts.first
+          unless group_dir.has_key?(top)
+            group_order << top
+            group_dir[top] = entry.dir || parts.size > 1
+          end
+          if parts.size == 1
+            kept[top] += 1 if entry.action == :exist && !entry.dir
+          elsif entry.dir
+            (subdirs[top] ||= [] of String) << parts[1] if parts.size == 2
+          else
+            entry.action == :exist ? (kept[top] += 1) : (created[top] += 1)
+          end
+        end
+        return if group_order.empty?
+
+        width = group_order.max_of { |name| name.size + (group_dir[name] ? 1 : 0) }
+        group_order.each_with_index do |name, i|
+          connector = Logger.glyph(i == group_order.size - 1 ? :tree_last : :tree_mid)
+          display = group_dir[name] ? "#{name}/" : name
+          notes = [] of String
+          if group_dir[name]
+            n = created[name]
+            notes << "#{n} #{n == 1 ? "file" : "files"}" if n > 0
+            subdirs[name]?.try(&.uniq.each { |d| notes << "#{d}/" })
+          end
+          notes << "#{kept[name]} kept" if kept[name] > 0
+          # Pad only when a note follows, so bare rows carry no trailing blanks.
+          line = "    #{connector} "
+          if notes.empty?
+            line += display
+          else
+            line += "#{display.ljust(width)}  #{Logger.paint(notes.join(" · "), Logger::Role::Dim)}"
+          end
+          Logger.info line
+        end
       end
 
       # Write each {relative_path => content} entry under base_dir, creating
       # parent directories on demand. Hash iteration order is preserved, so the
-      # @created_count tally and Logger.action sequence are unchanged.
+      # @created_count tally and the recorded entry sequence are unchanged.
       private def write_files(base_dir : String, files : Hash(String, String))
         files.each do |relative_path, content|
           full_path = File.join(base_dir, relative_path)
@@ -330,21 +422,21 @@ module Hwaro
 
       private def create_directory(path : String)
         if Dir.exists?(path)
-          Logger.action :exist, path, Logger::Role::Dim
+          @entries << ScaffoldEntry.new(:exist, path, dir: true)
         else
           Hwaro::Utils::FileSafe.mkdir_p(path)
           @created_count += 1
-          Logger.action :create, path
+          @entries << ScaffoldEntry.new(:create, path, dir: true)
         end
       end
 
       private def create_file(path : String, content : String)
         if File.exists?(path)
-          Logger.action :exist, path, Logger::Role::Dim
+          @entries << ScaffoldEntry.new(:exist, path, dir: false)
         else
           File.write(path, content)
           @created_count += 1
-          Logger.action :create, path
+          @entries << ScaffoldEntry.new(:create, path, dir: false)
         end
       end
 

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -375,17 +375,43 @@ module Hwaro
         end
       end
 
-      # Human-readable description of the change for logging.
+      # Human-readable description of the change for logging. The trailing
+      # noun is pluralized by the total file count; a config change is named
+      # separately since it is one specific file, not a category count.
       def description : String
         parts = [] of String
-        parts << "#{@modified_content.size} content" unless @modified_content.empty?
-        parts << "#{@modified_content_files.size} content-asset" unless @modified_content_files.empty?
-        parts << "#{@modified_templates.size} template" unless @modified_templates.empty?
-        parts << "#{@modified_static.size} static" unless @modified_static.empty?
-        parts << "#{@added_files.size} added" unless @added_files.empty?
-        parts << "#{@removed_files.size} removed" unless @removed_files.empty?
-        parts << "config" if @config_changed
-        parts.join(", ") + " file(s)"
+        total = 0
+        {
+          "content"       => @modified_content,
+          "content-asset" => @modified_content_files,
+          "template"      => @modified_templates,
+          "static"        => @modified_static,
+          "added"         => @added_files,
+          "removed"       => @removed_files,
+        }.each do |label, list|
+          next if list.empty?
+          parts << "#{list.size} #{label}"
+          total += list.size
+        end
+        desc = parts.empty? ? "" : "#{parts.join(", ")} #{total == 1 ? "file" : "files"}"
+        if @config_changed
+          desc = desc.empty? ? "config" : "#{desc}, config"
+        end
+        desc
+      end
+
+      # What the watch timeline prints: the path itself when exactly one file
+      # changed (the common save-one-file loop), the category summary above
+      # otherwise.
+      def display : String
+        return "config.toml" if @config_changed && all_changed_files.empty?
+        files = all_changed_files
+        files.size == 1 && !@config_changed ? files.first : description
+      end
+
+      private def all_changed_files : Array(String)
+        @modified_content + @modified_content_files + @modified_templates +
+          @modified_static + @added_files + @removed_files
       end
     end
 
@@ -603,9 +629,9 @@ module Hwaro
       #
       # Emitted AFTER `bind_tcp` succeeds (so the OS-level listening socket
       # already accepts connections) and BEFORE `listen` starts the blocking
-      # accept loop. Written directly to STDOUT (no color, no log prefix) and
-      # flushed immediately so subprocess consumers see it without buffering
-      # delay.
+      # accept loop. Written directly to STDOUT (no log prefix; dimmed on an
+      # interactive TTY, raw bytes everywhere else) and flushed immediately so
+      # subprocess consumers see it without buffering delay.
       #
       # Coexists with the pretty "Serving site at …" banner logged earlier —
       # this is an additional single line, not a replacement.
@@ -616,7 +642,13 @@ module Hwaro
       # Otherwise the human-readable `hwaro serve: ready url=... pid=...`
       # line from issue #360 is emitted.
       private def emit_ready_signal(host : String, port : Int32, json : Bool = false)
-        STDOUT.puts(json ? ready_signal_json(host, port) : ready_signal_line(host, port))
+        line = json ? ready_signal_json(host, port) : ready_signal_line(host, port)
+        # On an interactive colored TTY the machine line is dimmed so it reads
+        # as a footnote under the serve receipt; the bytes inside the escapes
+        # are unchanged. Pipes and CI (non-TTY) get the raw line exactly as
+        # documented — that is where machine consumers live.
+        line = Logger.paint(line, Logger::Role::Dim) if !json && Logger.color_enabled?
+        STDOUT.puts(line)
         STDOUT.flush
       end
 
@@ -797,11 +829,17 @@ module Hwaro
       # Choose the cheapest rebuild strategy for a given ChangeSet and execute it.
       private def apply_changeset(changeset : ChangeSet, build_options : Config::Options::BuildOptions)
         strategy = changeset.rebuild_strategy
-        # Calm watch timeline: one ember "↻ time  changed  <what>" event, then
-        # the rebuild's own "▴ rebuilt …" outcome line below it. The strategy is
+        # Calm watch timeline: one "↻ changed <what> · time" event, then the
+        # rebuild's own "▴ rebuilt …" outcome line below it, both on the same
+        # 2-space grid so the verbs and values column-align. The strategy is
         # implied by that outcome (incremental N/M, re-render, full).
         timestamp = Time.local.to_s("%H:%M:%S")
-        Logger.info "\n#{Logger.glyph(:watch)} #{Logger.paint(timestamp, Logger::Role::Dim)}  changed  #{Logger.paint(changeset.description, Logger::Role::Dim)}"
+        if Logger.color_enabled?
+          Logger.info "\n  #{Logger.glyph(:watch)} #{Logger.paint("changed", Logger::Role::Dim, bold: true)}  " \
+                      "#{changeset.display}#{Logger.paint("  ·  ", Logger::Role::Dim)}#{Logger.paint(timestamp, Logger::Role::Dim)}"
+        else
+          Logger.info "\n~ #{timestamp}  changed  #{changeset.display}"
+        end
 
         # Resolve removed sources to their output files BEFORE the rebuild
         # swaps in a site that no longer knows the deleted page's URL.

--- a/src/utils/logger.cr
+++ b/src/utils/logger.cr
@@ -29,15 +29,22 @@ module Hwaro
 
     # Semantic color roles for the unified "ember" terminal identity.
     # Each role resolves to a truecolor RGB (when COLORTERM advertises it),
-    # a 16-color named fallback, or raw text when color is disabled. This is
-    # the single source of truth for brand color — callers name a role, never
-    # a raw colorize symbol, so the palette stays consistent across commands.
+    # a 256-color approximation (when TERM advertises 256 colors), a 16-color
+    # named fallback, or raw text when color is disabled. This is the single
+    # source of truth for brand color — callers name a role, never a raw
+    # colorize symbol, so the palette stays consistent across commands.
+    #
+    # The palette is the "hearth" set: one warm ember accent plus status
+    # colors picked to sit apart from it on the hue wheel — jade for success
+    # (never olive, which reads muddy), amber for warnings, a cold crimson
+    # for errors (so errors never blur into the ember accent), and a neutral
+    # ash gray for recessive text.
     enum Role : UInt8
       Accent  # warm ember (#ec7a66 dark / #b35454 light) — headings, outcomes, URLs
-      Success # green — a check passed
-      Warn    # yellow
-      Error   # red
-      Dim     # recessive gray — labels, timings, paths, rules
+      Success # jade green — a check passed
+      Warn    # amber
+      Error   # crimson (colder than the ember accent, never confusable)
+      Dim     # recessive ash gray — labels, timings, paths, rules
       Heading # ember (alias of Accent, kept distinct for intent)
       Plain   # no color (default foreground)
     end
@@ -112,15 +119,28 @@ module Hwaro
       @@io.puts message
     end
 
+    # TTY form leads with the crimson ✗ glyph so errors scan apart from the
+    # message body; plain form stays the bare message (no escapes, no glyph)
+    # for pipes / CI.
     def self.error(message : String)
       clear_active_line
-      @@err_io.puts paint(message, Role::Error)
+      if color_enabled?
+        @@err_io.puts "#{glyph(:err)} #{paint(message, Role::Error)}"
+      else
+        @@err_io.puts message
+      end
     end
 
+    # TTY form leads with the amber ⚠ glyph; plain form keeps the historical
+    # "[WARN] " prefix so scripts that grep for it keep working.
     def self.warn(message : String)
       return if @@level > Level::Warn
       clear_active_line
-      @@err_io.puts paint("[WARN] #{message}", Role::Warn)
+      if color_enabled?
+        @@err_io.puts "#{glyph(:warn)} #{paint(message, Role::Warn)}"
+      else
+        @@err_io.puts "[WARN] #{message}"
+      end
     end
 
     def self.success(message : String)
@@ -194,15 +214,37 @@ module Hwaro
       ENV["HWARO_THEME"]? != "light"
     end
 
+    # True when the terminal advertises at least 256 colors (and color is
+    # otherwise enabled) but not truecolor — the common case for macOS
+    # Terminal.app, which never sets COLORTERM. Without this tier those
+    # terminals would fall all the way down to the raw 16-color ANSI names,
+    # which is where the palette used to look dated.
+    def self.color256? : Bool
+      return false unless color_enabled?
+      ENV["TERM"]?.try(&.includes?("256color")) || false
+    end
+
     # Truecolor RGB for a role, honoring `dark?`. `nil` for Plain.
     private def self.role_rgb(role : Role) : Tuple(UInt8, UInt8, UInt8)?
       dark = dark?
       case role
       when .accent?, .heading? then dark ? {236_u8, 122_u8, 102_u8} : {179_u8, 84_u8, 84_u8}
-      when .success?           then dark ? {184_u8, 187_u8, 38_u8} : {90_u8, 130_u8, 80_u8}
-      when .warn?              then dark ? {250_u8, 189_u8, 47_u8} : {181_u8, 118_u8, 58_u8}
-      when .error?             then dark ? {251_u8, 73_u8, 52_u8} : {192_u8, 57_u8, 43_u8}
-      when .dim?               then dark ? {146_u8, 131_u8, 116_u8} : {138_u8, 128_u8, 118_u8}
+      when .success?           then dark ? {104_u8, 201_u8, 138_u8} : {23_u8, 128_u8, 74_u8}
+      when .warn?              then dark ? {245_u8, 184_u8, 74_u8} : {161_u8, 106_u8, 8_u8}
+      when .error?             then dark ? {240_u8, 72_u8, 94_u8} : {201_u8, 42_u8, 58_u8}
+      when .dim?               then dark ? {150_u8, 141_u8, 132_u8} : {130_u8, 124_u8, 118_u8}
+      end
+    end
+
+    # Nearest xterm-256 index for a role, honoring `dark?`. `nil` for Plain.
+    private def self.role_256(role : Role) : UInt8?
+      dark = dark?
+      case role
+      when .accent?, .heading? then dark ? 209_u8 : 131_u8
+      when .success?           then dark ? 78_u8 : 29_u8
+      when .warn?              then dark ? 214_u8 : 136_u8
+      when .error?             then dark ? 203_u8 : 160_u8
+      when .dim?               then dark ? 245_u8 : 243_u8
       end
     end
 
@@ -219,7 +261,7 @@ module Hwaro
 
     # Paint `text` in a semantic role. Returns raw text (no escapes) when
     # color is disabled, so scripts / CI / pipes stay clean. Prefers truecolor,
-    # falls back to the 16-color name, then to plain.
+    # then the 256-color approximation, then the 16-color name, then plain.
     def self.paint(text : String, role : Role, bold : Bool = false) : String
       unless color_enabled?
         return text
@@ -227,6 +269,8 @@ module Hwaro
       colored =
         if (rgb = role_rgb(role)) && truecolor?
           text.colorize(Colorize::ColorRGB.new(rgb[0], rgb[1], rgb[2]))
+        elsif (idx = role_256(role)) && color256?
+          text.colorize(Colorize::Color256.new(idx))
         elsif named = role_named(role)
           text.colorize(named)
         else
@@ -239,16 +283,18 @@ module Hwaro
     # used whenever color/unicode is disabled — the same gate the rest of the
     # CLI uses — so plain output never emits a stray multibyte glyph.
     GLYPHS = {
-      :ok      => {"✓", "[ok]", Role::Success},
-      :warn    => {"⚠", "[warn]", Role::Warn},
-      :err     => {"✗", "[err]", Role::Error},
-      :info    => {"ℹ", "[info]", Role::Dim},
-      :result  => {"▴", "*", Role::Accent},
-      :heading => {"●", "#", Role::Accent},
-      :ready   => {"◇", ">", Role::Accent},
-      :watch   => {"↻", "~", Role::Accent},
-      :bullet  => {"·", "-", Role::Dim},
-      :arrow   => {"→", "->", Role::Dim},
+      :ok        => {"✓", "[ok]", Role::Success},
+      :warn      => {"⚠", "[warn]", Role::Warn},
+      :err       => {"✗", "[err]", Role::Error},
+      :info      => {"ℹ", "[info]", Role::Dim},
+      :result    => {"▴", "*", Role::Accent},
+      :heading   => {"●", "#", Role::Accent},
+      :ready     => {"◇", ">", Role::Accent},
+      :watch     => {"↻", "~", Role::Accent},
+      :bullet    => {"·", "-", Role::Dim},
+      :arrow     => {"→", "->", Role::Dim},
+      :tree_mid  => {"├─", "|-", Role::Dim},
+      :tree_last => {"└─", "`-", Role::Dim},
     }
 
     # Resolve a glyph by key: colorized unicode when color is on, else the
@@ -370,7 +416,8 @@ module Hwaro
         value : String,
         role : Role,
         emphasis : String?,
-        emphasis_role : Role
+        emphasis_role : Role,
+        detail : String?
 
       @rows : Array(Row)
       @outcome : NamedTuple(verb: String, value: String, glyph: Symbol, ms: Float64?)?
@@ -382,9 +429,11 @@ module Hwaro
 
       # Append a key/value row. Skipped when empty so the summary never prints
       # noise like "0 drafts". `emphasis` is an optional differently-colored
-      # suffix (e.g. a yellow "2 drafts skipped").
-      def row(label : String, value : String, role : Role = Role::Plain, emphasis : String? = nil, emphasis_role : Role = Role::Warn) : self
-        @rows << Row.new(label, value, role, emphasis, emphasis_role) unless value.empty? && emphasis.nil?
+      # suffix (e.g. a yellow "2 drafts skipped"). `detail` is an optional dim
+      # trailing note (e.g. a phase timing) rendered on the TTY only — plain
+      # output stays byte-identical for scripts that parse it.
+      def row(label : String, value : String, role : Role = Role::Plain, emphasis : String? = nil, emphasis_role : Role = Role::Warn, detail : String? = nil) : self
+        @rows << Row.new(label, value, role, emphasis, emphasis_role, detail) unless value.empty? && emphasis.nil?
         self
       end
 
@@ -416,6 +465,9 @@ module Hwaro
           cell = Logger.paint(r.value, r.role)
           if e = r.emphasis
             cell = "#{cell}#{Logger.paint(" · ", Role::Dim)}#{Logger.paint(e, r.emphasis_role)}"
+          end
+          if d = r.detail
+            cell = "#{cell}#{Logger.paint(" · ", Role::Dim)}#{Logger.paint(d, Role::Dim)}"
           end
           lines << "    #{Logger.paint(r.label.ljust(width), Role::Dim)}  #{cell}"
         end
@@ -517,8 +569,8 @@ module Hwaro
     # escapes). Animation is driven by a timer fiber, decoupled from the build's
     # (possibly parallel) work so motion stays smooth regardless of phase.
     class Status
-      SPINNER  = %w[◐ ◓ ◑ ◒]
-      INTERVAL = 90.milliseconds
+      SPINNER  = %w[⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏]
+      INTERVAL = 80.milliseconds
 
       def initialize(@io : IO)
         @label = ""

--- a/src/utils/profiler.cr
+++ b/src/utils/profiler.cr
@@ -100,17 +100,17 @@ module Hwaro
       @total_start = Time.instant
     end
 
-    # Start timing a phase
+    # Start timing a phase. Phase-level timing is collected even when full
+    # profiling is disabled — it costs two clock reads per phase and feeds
+    # the per-row timings in the build receipt. The detailed per-template /
+    # per-page collectors and all reports stay gated on `--profile`.
     def start_phase(phase : String)
-      return unless @enabled
       @current_phase = phase
       @phase_start = Time.instant
     end
 
     # End timing for the current phase
     def end_phase
-      return unless @enabled
-
       phase_start = @phase_start
       current_phase = @current_phase
       return unless phase_start && current_phase
@@ -119,6 +119,19 @@ module Hwaro
       @phases << PhaseTime.new(current_phase, duration)
       @current_phase = nil
       @phase_start = nil
+    end
+
+    # Total recorded time for a named phase (summed across repeats), or `nil`
+    # when the phase never ran. Lets the build receipt show per-row timings.
+    def phase_ms(phase : String) : Float64?
+      total = 0.0
+      found = false
+      @phases.each do |entry|
+        next unless entry.phase == phase
+        total += entry.duration_ms
+        found = true
+      end
+      found ? total : nil
     end
 
     # Get total elapsed time


### PR DESCRIPTION
## Summary
- Replace the gruvbox-borrowed status palette (olive success, error hue colliding with the ember accent) with a jade/amber/crimson/ash palette; add a 256-color tier for terminals without `COLORTERM` (e.g. macOS Terminal.app) so output no longer falls back to raw 16-color ANSI
- `hwaro init`: collapse the per-file "create" wall into a grouped tree summary; align the closing next/deploy hints under the outcome column
- `hwaro build`: receipt rows now show per-phase timings (dim, TTY-only); spinner switched from quarter-circles to braille dots
- `hwaro serve`: watch timeline (`↻ changed … · time`) now column-aligns with the `▴ rebuilt` outcome line; single-file changes show the path instead of a count; the machine-readable ready line is dimmed on TTY only
- `warn`/`error` lead with `⚠`/`✗` glyphs on TTY (plain output keeps the historical `[WARN]` prefix)

Plain/piped output (scripts, CI, `NO_COLOR`, `--json`) is unchanged — verified with a before/after byte diff across `init`/`build`/`new`/`doctor`/`serve`.

## Test plan
- [x] `crystal spec` — 5750 examples, 0 failures
- [x] `crystal tool format` (clean) + `./bin/ameba` (0 offenses) on changed files
- [x] Byte-diffed plain (non-TTY) output of `init`/`build`/`new`/`doctor`/`serve` before vs. after — only intended timing/wording changes
- [x] Captured real TTY output (truecolor, 256-color, light theme, NO_COLOR) for visual review