### PR TITLE
fix(build): create output dir before marking it created (parallel write race)

### DIFF
--- a/spec/functional/parallel_write_race_spec.cr
+++ b/spec/functional/parallel_write_race_spec.cr
@@ -1,0 +1,47 @@
+require "./support/build_helper"
+
+# =============================================================================
+# Regression test for the parallel write-phase directory race.
+#
+# `ensure_dir` used to record a directory in `@created_dirs` BEFORE `mkdir_p`
+# actually created it. Under `-Dpreview_mt`, when two pages resolved to the
+# same output directory (a slug collision), the second worker saw the dir as
+# "already created", skipped its own mkdir, and raced ahead to `File.write`
+# on a directory that did not exist yet — a flaky
+# `Error opening file with mode 'w': ... No such file or directory` that
+# failed the whole build with HWARO_E_TEMPLATE.
+#
+# The fix records the dir only after mkdir_p returns. This test drives many
+# colliding pages through a parallel build; with the bug present it crashes
+# (probabilistically, but reliably across this many collisions), and with the
+# fix it always completes and overwrites deterministically-per-run.
+# =============================================================================
+
+describe "Parallel write race: colliding output directories" do
+  it "builds many slug-colliding pages in parallel without a missing-directory crash" do
+    # Each pair of pages collides on one shared output directory. Many pairs
+    # maximize the number of concurrent same-dir writes so the pre-fix race
+    # is hit reliably.
+    content = {} of String => String
+    50.times do |i|
+      content["a#{i}.md"] = "---\ntitle: Alpha #{i}\nslug: shared-#{i}\n---\nAlpha body #{i}"
+      content["b#{i}.md"] = "---\ntitle: Beta #{i}\nslug: shared-#{i}\n---\nBeta body #{i}"
+    end
+
+    build_site(
+      BASIC_CONFIG,
+      content_files: content,
+      template_files: {"page.html" => "TITLE={{ page_title }}|{{ content }}"},
+      parallel: true,
+    ) do
+      # Every collided directory must have been created and hold exactly one
+      # rendered page (one of the two colliding sources won the overwrite).
+      50.times do |i|
+        path = "public/shared-#{i}/index.html"
+        File.exists?(path).should be_true
+        html = File.read(path)
+        (html.includes?("Alpha #{i}") || html.includes?("Beta #{i}")).should be_true
+      end
+    end
+  end
+end

--- a/spec/functional/support/build_helper.cr
+++ b/spec/functional/support/build_helper.cr
@@ -18,6 +18,7 @@ def build_site(
   minify : Bool = false,
   highlight : Bool = false,
   cache : Bool = false,
+  parallel : Bool = false,
   &
 )
   Dir.mktmpdir do |dir|
@@ -64,7 +65,7 @@ def build_site(
         output_dir: output_dir,
         drafts: drafts,
         minify: minify,
-        parallel: false,
+        parallel: parallel,
         cache: cache,
         highlight: highlight,
         verbose: false,

--- a/src/core/build/phases/write.cr
+++ b/src/core/build/phases/write.cr
@@ -180,15 +180,18 @@ module Hwaro::Core::Build::Phases::Write
   # Avoids redundant mkdir_p syscalls (stat+mkdir) for large sites.
   # Mutex protects the Set during parallel rendering; mkdir_p is
   # itself idempotent, so the worst case without it is duplicate syscalls.
+  #
+  # The Set is recorded only AFTER mkdir_p returns, so membership truthfully
+  # implies the directory already exists on disk. Recording before creation
+  # let a second fiber writing into the same directory (two pages resolving
+  # to one output path) see it as "already created", skip its own mkdir, and
+  # race ahead to File.write on a directory that did not exist yet — a flaky
+  # "No such file or directory" under -Dpreview_mt. Two fibers may now both
+  # mkdir_p the same new directory, but mkdir_p is idempotent and MT-safe, so
+  # the worst case is one duplicate syscall, never a missing directory.
   private def ensure_dir(dir : String)
-    needs_create = @created_dirs_mutex.synchronize do
-      if @created_dirs.includes?(dir)
-        false
-      else
-        @created_dirs << dir
-        true
-      end
-    end
-    Hwaro::Utils::FileSafe.mkdir_p(dir) if needs_create
+    return if @created_dirs_mutex.synchronize { @created_dirs.includes?(dir) }
+    Hwaro::Utils::FileSafe.mkdir_p(dir)
+    @created_dirs_mutex.synchronize { @created_dirs << dir }
   end
 end


### PR DESCRIPTION
## Summary

Fixes a flaky, non-deterministic build failure under the multi-threaded runtime (`-Dpreview_mt`) when two pages resolve to the same output directory (e.g. a slug collision).

```
Render failed for dup-b.md: Error opening file with mode 'w':
'.../public/same-slug/index.html': No such file or directory
```

## Root cause

`ensure_dir` (`src/core/build/phases/write.cr`) recorded a directory in `@created_dirs` **before** `mkdir_p` actually created it on disk. A concurrent worker targeting the same directory saw it as "already created", skipped its own `mkdir`, and raced ahead to `File.write` on a directory that did not exist yet. `FileSafe.mkdir_p` itself is already MT-safe — the bug was purely the mark-before-create ordering. Single-worker builds (`CRYSTAL_WORKERS=1`) always succeeded, confirming the race.

## Fix

Record the directory in the set only **after** `mkdir_p` returns, so set membership truthfully implies the directory exists on disk. Two fibers may now both `mkdir_p` the same new directory, but `mkdir_p` is idempotent and MT-safe — the worst case is one duplicate syscall, never a missing directory.

## Testing

- New regression test `spec/functional/parallel_write_race_spec.cr` drives 50 slug-colliding page pairs (100 pages) through a parallel build. It reliably reproduces the crash on the old code (3/3 runs error with the exact "No such file or directory" symptom) and passes with the fix.
- Threads a `parallel` option through the functional `build_site` helper (defaults to `false`, preserving existing behavior).
- Full suite: **5702 examples, 0 failures**. Docs site and all 5 scaffolds rebuild cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)