### PR TITLE
fix: 3 dogfood bugs in new features (render-hook attributes, tojson JSON)

### DIFF
--- a/spec/functional/render_hooks_spec.cr
+++ b/spec/functional/render_hooks_spec.cr
@@ -258,6 +258,40 @@ describe "Render hooks: generalized {#id .class} attribute blocks" do
       html.should_not contain("HATTR")
     end
   end
+
+  # A plain (marker-less) image must NOT reach forward across a block boundary
+  # and absorb a *later* element's attribute marker. This can happen when a
+  # non-conformant render-heading hook emits non-`<hN>` markup, leaving the
+  # heading's HATTR marker unconsumed by the heading pass — the image's gap
+  # must stop at the closing `</p>` rather than swallow the whole heading.
+  it "does not let a plain image absorb a following heading's attribute block" do
+    content = <<-MD
+      +++
+      title = "Home"
+      +++
+      ![plain image](a.png)
+
+      ## Heading Title {#hid .cls}
+      MD
+
+    build_site(
+      ATTR_CONFIG,
+      content_files: {"index.md" => content},
+      template_files: {
+        "page.html" => "<body>{{ content }}</body>",
+        # Deliberately non-conformant: emits a <div>, not an <hN>, so the
+        # heading pass can't consume the marker.
+        "hooks/render-heading.html" => %(<div class="h{{ level }}">{{ text }}</div>),
+      },
+    ) do
+      html = File.read("public/index.html")
+      # The image stays clean — the heading's id/class did not leak onto it.
+      html.should contain(%(<img src="a.png" alt="plain image" />))
+      html.should_not contain(%(id="hid"))
+      html.should_not contain(%(class="cls"))
+      html.should_not contain("HATTR")
+    end
+  end
 end
 
 MERMAID_CONTENT = <<-MD

--- a/spec/functional/render_hooks_spec.cr
+++ b/spec/functional/render_hooks_spec.cr
@@ -191,6 +191,75 @@ describe "Render hooks: heading ids, TOC, and anchors" do
   end
 end
 
+# Regression: with `[markdown] attributes = true`, a generalized
+# `{#id .class key=val}` block leaves a `<!--HATTR:...-->` marker resolved
+# in a post-pass AFTER the hook renders. The heading hook used to only
+# extract the narrow `<!--HID:-->` marker, so its `id` variable held the
+# auto-slug — any `#{id}` anchor the template emitted pointed at a fragment
+# the final tag didn't have. The image hook path dropped the block entirely
+# because the marker landed after the hook's `<figure>` wrapper, not glued
+# to the `<img>`.
+ATTR_CONFIG = <<-TOML
+  title = "Test Site"
+  base_url = "http://localhost"
+  [markdown]
+  attributes = true
+  TOML
+
+describe "Render hooks: generalized {#id .class} attribute blocks" do
+  it "passes the block's custom id to the heading hook so its anchors match the final id" do
+    content = <<-MD
+      +++
+      title = "Home"
+      +++
+      ## Section Title {#custom-id .highlight data-index=3}
+      MD
+
+    build_site(
+      ATTR_CONFIG,
+      content_files: {"index.md" => content},
+      template_files: {
+        "page.html"                 => "<body>{{ content }}</body>",
+        "hooks/render-heading.html" => %(<h{{ level }} id="{{ id }}"><a class="anchor" href="\#{{ id }}">#</a>{{ text }}</h{{ level }}>),
+      },
+    ) do
+      html = File.read("public/index.html")
+      # The hook's `id` is the block's custom id, so the anchor it emits
+      # matches the id postprocess_attributes applies to the tag.
+      html.should contain(%(<a class="anchor" href="#custom-id">#</a>))
+      html.should_not contain("section-title")
+      # The block's class / data-* still merge onto the hooked <h2>.
+      html.should contain(%(id="custom-id"))
+      html.should contain(%(class="highlight"))
+      html.should contain(%(data-index="3"))
+      html.should_not contain("HATTR")
+    end
+  end
+
+  it "merges an image attribute block onto an <img> a render-image hook wraps" do
+    content = <<-MD
+      +++
+      title = "Home"
+      +++
+      ![A diagram](http://example.com/d.png){.responsive width=800}
+      MD
+
+    build_site(
+      ATTR_CONFIG,
+      content_files: {"index.md" => content},
+      template_files: {
+        "page.html"               => "<body>{{ content }}</body>",
+        "hooks/render-image.html" => %(<figure><img src="{{ destination }}" alt="{{ alt }}" loading="lazy" /></figure>),
+      },
+    ) do
+      html = File.read("public/index.html")
+      # Attributes applied to the hook-wrapped <img>, not silently dropped.
+      html.should contain(%(<figure><img src="http://example.com/d.png" alt="A diagram" loading="lazy" class="responsive" width="800" /></figure>))
+      html.should_not contain("HATTR")
+    end
+  end
+end
+
 MERMAID_CONTENT = <<-MD
   +++
   title = "Home"

--- a/spec/unit/filters_spec.cr
+++ b/spec/unit/filters_spec.cr
@@ -459,6 +459,23 @@ describe "MiscFilters" do
       result.should contain("\n")
       JSON.parse(result).as_a.map(&.as_i).should eq([1, 2])
     end
+
+    # A negative indent would make `String#*` raise ArgumentError (aborting the
+    # whole build); a huge one would overflow/allocate a giant string. Both are
+    # clamped to a sane range instead of crashing.
+    it "clamps a negative indent to compact output instead of crashing" do
+      vars = {"text" => Crinja::Value.new("hi")}
+      result = render_filter("{{ text | tojson(indent=-5) }}", vars).strip
+      result.should eq(%("hi"))
+    end
+
+    it "clamps an oversized indent instead of overflowing or exhausting memory" do
+      vars = {"items" => Crinja::Value.new([Crinja::Value.new(1)])}
+      result = render_filter("{{ items | tojson(indent=999999999999) }}", vars).strip
+      JSON.parse(result).as_a.map(&.as_i).should eq([1])
+      # Clamped to <= 16 spaces per level, not billions.
+      result.should_not match(/ {17,}/)
+    end
   end
 
   describe "default" do

--- a/spec/unit/filters_spec.cr
+++ b/spec/unit/filters_spec.cr
@@ -418,6 +418,49 @@ describe "MiscFilters" do
     end
   end
 
+  # Regression: Crinja's stock `tojson` wraps its output in
+  # `SafeString.escape`, HTML-entity-escaping the JSON (`"` -> `&quot;`),
+  # which is invalid JSON in a standalone output-format file (and unusable
+  # inside a <script>). Hwaro overrides it to emit real JSON like `jsonify`.
+  describe "tojson (hwaro override)" do
+    it "produces valid, non-HTML-escaped JSON for a string" do
+      vars = {"text" => Crinja::Value.new("hello world")}
+      result = render_filter("{{ text | tojson }}", vars)
+      result.strip.should eq("\"hello world\"")
+      result.should_not contain("&quot;")
+    end
+
+    it "escapes an embedded quote as a JSON escape, not an HTML entity" do
+      vars = {"text" => Crinja::Value.new(%(say "hi"))}
+      result = render_filter("{{ text | tojson }}", vars).strip
+      result.should eq(%("say \\"hi\\""))
+      result.should_not contain("&quot;")
+      JSON.parse(result).as_s.should eq(%(say "hi"))
+    end
+
+    it "emits raw JSON for an array (round-trips)" do
+      vars = {"items" => Crinja::Value.new([Crinja::Value.new("a"), Crinja::Value.new("b")])}
+      result = render_filter("{{ items | tojson }}", vars).strip
+      result.should eq(%(["a","b"]))
+      JSON.parse(result).as_a.map(&.as_s).should eq(["a", "b"])
+    end
+
+    it "keeps </script> script-safe while staying valid JSON" do
+      vars = {"text" => Crinja::Value.new("</script>")}
+      result = render_filter("{{ text | tojson }}", vars).strip
+      result.should_not contain("</script>")
+      result.should contain("<\\/script>")
+      JSON.parse(result).as_s.should eq("</script>")
+    end
+
+    it "supports the indent argument" do
+      vars = {"items" => Crinja::Value.new([Crinja::Value.new(1), Crinja::Value.new(2)])}
+      result = render_filter("{{ items | tojson(indent=2) }}", vars).strip
+      result.should contain("\n")
+      JSON.parse(result).as_a.map(&.as_i).should eq([1, 2])
+    end
+  end
+
   describe "default" do
     it "returns original value when not empty" do
       vars = {"text" => Crinja::Value.new("hello")}

--- a/src/content/processors/filters/misc_filter.cr
+++ b/src/content/processors/filters/misc_filter.cr
@@ -35,6 +35,20 @@ module Hwaro
               JSON.build { |b| MiscFilters.build_json(b, target) }.gsub("</", "<\\/")
             end
 
+            # Override Crinja's built-in `tojson`. Crinja wraps its output in
+            # `SafeString.escape`, which HTML-entity-escapes the JSON (`"` ->
+            # `&quot;`, `&` -> `&amp;`) — that is invalid JSON in a standalone
+            # `.json`/output-format file, and also unusable inside a <script>
+            # (browsers don't HTML-decode there). Emit real JSON like `jsonify`
+            # while keeping the documented `tojson` name and its optional
+            # `indent` argument (spaces) working; `</` stays escaped so the
+            # result is still safe to embed in an inline <script>.
+            env.filters["tojson"] = Crinja.filter({indent: nil}) do
+              raw_indent = arguments["indent"].raw
+              indent_str = raw_indent.is_a?(Int) ? " " * raw_indent.to_i : ""
+              JSON.build(indent_str) { |b| MiscFilters.build_json(b, target) }.gsub("</", "<\\/")
+            end
+
             # Default filter — returns fallback when target is nil/undefined or empty string
             env.filters["default"] = Crinja.filter({value: ""}) do
               if target.raw.nil? || target.undefined?

--- a/src/content/processors/filters/misc_filter.cr
+++ b/src/content/processors/filters/misc_filter.cr
@@ -45,7 +45,12 @@ module Hwaro
             # result is still safe to embed in an inline <script>.
             env.filters["tojson"] = Crinja.filter({indent: nil}) do
               raw_indent = arguments["indent"].raw
-              indent_str = raw_indent.is_a?(Int) ? " " * raw_indent.to_i : ""
+              # Clamp on the raw Int (Crinja stores it as Int64) BEFORE building
+              # the spaces string: a negative count makes `String#*` raise
+              # ArgumentError (aborting the whole build), and a huge one would
+              # overflow `to_i` or allocate a giant per-level indent. 0..16 is a
+              # sane range for JSON indentation.
+              indent_str = raw_indent.is_a?(Int) ? " " * raw_indent.clamp(0, 16) : ""
               JSON.build(indent_str) { |b| MiscFilters.build_json(b, target) }.gsub("</", "<\\/")
             end
 

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -919,10 +919,18 @@ module Hwaro
         # `<figure>…</figure>`): the marker lands after the *whole* hook
         # output, not glued to the `<img>`, so a naive "marker immediately
         # follows the tag" match would drop the attributes silently. The
-        # tempered `(?!<img\b|<!--HATTR:)` gap stops at the next image or
-        # marker, so back-to-back attributed images each bind their own block,
-        # and the no-hook case (marker glued to the tag) keeps an empty group 3.
-        IMG_HATTR_RE = /(<img\b(?:[^>"']|"[^"]*"|'[^']*')*?)(\s*\/?>)((?:(?!<img\b|<!--HATTR:).)*?)<!--HATTR:([0-9a-f]+)-->/m
+        # tempered gap stops at the next image or marker, so back-to-back
+        # attributed images each bind their own block, and the no-hook case
+        # (marker glued to the tag) keeps an empty group 3. It also stops at a
+        # closing block tag Markd wraps the image in (`</p>`, `</li>`, table
+        # cells, `</hN>`, …): an image's own marker is always in the same block,
+        # so the gap never legitimately crosses one — this prevents a plain
+        # (marker-less) image from reaching forward and absorbing a *later*
+        # element's marker (e.g. a heading whose non-conformant hook emitted
+        # non-`<hN>` markup, leaving its HATTR marker unconsumed by the heading
+        # pass). Hook wrappers (`</figure>`, `</span>`, `</a>`, `</picture>`, …)
+        # are deliberately NOT excluded, so they still bind normally.
+        IMG_HATTR_RE = /(<img\b(?:[^>"']|"[^"]*"|'[^']*')*?)(\s*\/?>)((?:(?!<img\b|<!--HATTR:|<\/(?:p|li|t[dh]|d[dt]|h[1-6])\b).)*?)<!--HATTR:([0-9a-f]+)-->/m
 
         def postprocess_attributes(html : String) : String
           return html unless html.includes?("<!--HATTR:")

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -913,8 +913,16 @@ module Hwaro
         # `<img ...>` opening portion (quote-aware, so a `>` inside an
         # attribute value like `alt="Home > Docs"` isn't mistaken for the
         # tag end), its closer (`>` or `/>`, with any whitespace before it),
-        # and the trailing marker comment this preprocess pass appended.
-        IMG_HATTR_RE = /(<img\b(?:[^>"']|"[^"]*"|'[^']*')*?)(\s*\/?>)\s*<!--HATTR:([0-9a-f]+)-->/
+        # an optional wrapper the image trails inside (group 3), and the
+        # marker comment this preprocess pass appended. The wrapper is what a
+        # `render-image.html` hook emits around the `<img>` (e.g. a
+        # `<figure>…</figure>`): the marker lands after the *whole* hook
+        # output, not glued to the `<img>`, so a naive "marker immediately
+        # follows the tag" match would drop the attributes silently. The
+        # tempered `(?!<img\b|<!--HATTR:)` gap stops at the next image or
+        # marker, so back-to-back attributed images each bind their own block,
+        # and the no-hook case (marker glued to the tag) keeps an empty group 3.
+        IMG_HATTR_RE = /(<img\b(?:[^>"']|"[^"]*"|'[^']*')*?)(\s*\/?>)((?:(?!<img\b|<!--HATTR:).)*?)<!--HATTR:([0-9a-f]+)-->/m
 
         def postprocess_attributes(html : String) : String
           return html unless html.includes?("<!--HATTR:")
@@ -941,9 +949,10 @@ module Hwaro
           result = result.gsub(IMG_HATTR_RE) do |match|
             img_open = $1
             closer = $2
-            parsed = decode_and_parse_hattr($3)
+            wrapper = $3
+            parsed = decode_and_parse_hattr($4)
             if parsed
-              "#{MarkdownAttributes.apply_to_img(img_open, parsed)}#{closer}"
+              "#{MarkdownAttributes.apply_to_img(img_open, parsed)}#{closer}#{wrapper}"
             else
               match
             end

--- a/src/content/processors/syntax_highlighter.cr
+++ b/src/content/processors/syntax_highlighter.cr
@@ -678,6 +678,19 @@ module Hwaro
             if hid_match = inner.match(MarkdownExtensions::HID_MARKER_RE)
               custom_id = hid_match[1]
               inner = inner.sub(hid_match[0], "").rstrip
+            elsif hattr_match = inner.match(MarkdownExtensions::HATTR_MARKER_RE)
+              # `## Heading {#id .class}` (generalized attributes extension)
+              # leaves a `<!--HATTR:...-->` marker instead. Pull just the
+              # custom `#id` out of it so the hook's `id` variable — and any
+              # `#{id}` anchors the template emits — match the id that
+              # `postprocess_attributes` will ultimately set on the tag.
+              # Leave the marker IN `inner`: postprocess still needs it to
+              # merge the block's classes/other attributes onto the heading.
+              if decoded = MarkdownAttributes.decode(hattr_match[1])
+                if parsed = MarkdownAttributes.parse(decoded)
+                  custom_id = parsed.id
+                end
+              end
             end
 
             title_text = strip_tags(inner)


### PR DESCRIPTION
Found by dogfooding the four newest features (render hooks #681, menus #679, markdown attrs/fences #678, output formats #677) with an edge-case test site. Three real bugs, all fixed with regression coverage.

## Bugs fixed

**1. Heading render-hook + `{#id .class}` attribute block → broken in-page anchors**
With `[markdown] attributes = true`, `## Title {#custom-id .highlight}` fed the render-heading hook the auto-slug (`title`) instead of `custom-id`, while a later pass set the real id on the tag. Any `href="#{{ id }}"` anchor the hook emitted pointed at a fragment that didn't exist. The hook now decodes the `<!--HATTR:-->` marker to pull the custom id (it already handled the narrower `<!--HID:-->` case), leaving the marker in place for the class/attr merge.

**2. Image render-hook + `{.class width=…}` block → attributes silently dropped**
When a `render-image.html` hook wrapped the `<img>` (e.g. in `<figure>`), the attribute marker landed after the wrapper, so `IMG_HATTR_RE` never matched and `class`/`width` vanished with no warning. Relaxed the regex to tolerate a wrapper between the tag and its marker; the no-hook path stays byte-identical.

**3. `{{ … | tojson }}` produced invalid JSON**
Crinja's stock `tojson` HTML-entity-escapes its output (`"` → `&quot;`), so the *documented* output-format example (`"title": {{ page.title | tojson }}`) emitted broken JSON — and `| safe` couldn't undo it (the escaping happens inside the filter). It's also wrong for `<script>` embedding. hwaro now overrides `tojson` to emit real JSON like its existing `jsonify` filter (only `</`→`<\/` for script safety), keeping the `indent` arg.

## Verification
- +7 regression tests (5 for `tojson`, 2 functional for the hook×attribute interactions).
- Full suite **5984 examples, 0 failures**; `crystal tool format --check` clean; ameba clean on changed files.
- No-hook markdown output verified byte-identical; all JSON output-format files validate.

Also checked (no bugs): menu `active_path` incl. base_path & file-extension URLs, `--minify` on output files, per-language/front-matter menus, fence line-number/hl_lines rendering, inline markup (ins/mark/sub/sup).