### PR TITLE
docs: add missing Menus and Output Formats sidebar entries

### DIFF
--- a/docs/data/sidebar.yml
+++ b/docs/data/sidebar.yml
@@ -72,6 +72,10 @@
           url: /features/series/
         - title: Related Posts
           url: /features/related-posts/
+        - title: Menus
+          url: /features/menus/
+        - title: Output Formats
+          url: /features/output-formats/
     - title: Build & Performance
       items:
         - title: Incremental Build


### PR DESCRIPTION
## Summary
- `content/features/menus.md` and `content/features/output-formats.md` (both new in v0.17.0) existed but were never added to `data/sidebar.yml`, so they were unreachable from the docs sidebar despite being valid, non-draft pages.
- Found while auditing CHANGELOG links for v0.17.0 release prep (the `/templates/render-hooks/` link check surfaced the pattern).

## Test plan
- [x] Cross-checked every `content/**/*.md` URL against `data/sidebar.yml` entries — no other feature/template docs are orphaned, and no sidebar link is broken.