### PR TITLE
ci(snap): publish on workflow_dispatch for security rebuilds

### DIFF
--- a/.github/workflows/publish-snapcraft.yml
+++ b/.github/workflows/publish-snapcraft.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: canonical/action-build@v1
         id: build
-      - if: github.event_name == 'release'
+      - if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: snapcore/action-publish@master
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}


### PR DESCRIPTION
## Why

The Snap Store's automated USN scanner flags this snap when a staged deb
(e.g. `libxml2`) receives a security update; the fix is to rebuild so it
pulls the patched package.

> Note: the most recent release already rebuilt the snap, so it likely
> already carries the patched libxml2. This PR is a **CI/ops improvement**
> so future security rebuilds don't require cutting a release — not an
> urgent fix.

The publish step ran only on `release` events:

```yaml
- if: github.event_name == 'release'
```

So a manual `workflow_dispatch` run **built** the snap but never
**published** it.

## What

```diff
- - if: github.event_name == 'release'
+ - if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
```

Matches the existing `owasp-noir/noir` workflow. After merging, a
security rebuild is just: run the **Snapcraft Publish** workflow
manually → builds and republishes to `stable`.