### PR TITLE
fix: 13 dogfood bugs across outputs, publish-window preview, exporters, tools, and content pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- `[outputs].sections` no longer suppresses page-level output formats outside the allowlisted sections — it scopes `section` output only, as documented
+- `--include-future` / `--include-expired` are preview flags like `--drafts`: admitted pages render HTML but stay out of sitemap.xml, RSS/Atom feeds, search index, llms.txt, and generated listings (taxonomies, series, related posts, authors)
+- `hwaro tool export jekyll`: only content under `posts/`/`blog/` becomes `_posts/` entries (every Hwaro page has an auto-stamped `date`, so "dated ⇒ post" misfiled ordinary pages); other pages keep their directory tree; leaf-bundle posts slug from the bundle directory instead of `index`; destination collisions are disambiguated with a warning instead of silently overwritten
+- `hwaro tool check-links`: fenced-code stripping is now line-based CommonMark fence tracking — a 4-backtick example wrapping a 3-backtick fence no longer desyncs later fences into false-positive dead links
+- `hwaro doctor`: when config.toml fails to parse, the config sub-checks that never ran render as `(skipped)` instead of a false green `[ok]`
+- `hwaro deploy`: the non-TTY confirmation error no longer claims `--force` skips `--confirm` (it doesn't); the hint now explains the actual outs
+- Canonical URL, `og:url`, and hreflang tags percent-encode non-ASCII paths, matching the RFC 3986 URLs feeds/sitemap already emit for the same pages
+- Taxonomy terms (and tags/authors/aliases) are whitespace-trimmed at parse time — a padded term no longer leaks verbatim into term-page titles/RSS or splits into a second slug-disambiguated term page
+- Auto OG images skip codepoints the loaded font can't draw (emoji, mostly) instead of rendering blank tofu boxes
+- Heading render hook + `{#id .class}` attributes no longer leave a doubled space where the internal marker was removed
+- Fence options treat `linenostart=0` / `hl_lines="0"` as invalid (dropped) instead of silently clamping to line 1
+- Duplicate explicit `{#id}` heading ids now warn when renamed (`#dup` → `#dup-1`), matching menus' duplicate-identifier warning
+- CLI polish: singular/plural agreement for 1-item counts (`1 file`, `1 draft`, `1 unused asset`); `tool convert` notes that front-matter comments are not preserved; `unused-assets --help` names the scanned asset types
+
 ## v0.17.0
 
 ### Added

--- a/docs/content/templates/filters.md
+++ b/docs/content/templates/filters.md
@@ -200,12 +200,12 @@ Tests evaluate conditions in `{% if %}` statements.
 
 | Test | Description | Example |
 |------|-------------|---------|
-| startswith | Starts with | {% if page.url is startswith("/blog/") %} |
-| endswith | Ends with | {% if page.url is endswith("/") %} |
-| containing | Contains | {% if page.url is containing("docs") %} |
-| matching | Regex match | {% if asset is matching("[.](jpg|png)$") %} |
-| empty | Is empty | {% if page.description is empty %} |
-| present | Is not empty | {% if page.title is present %} |
+| startswith | Starts with | `{% if page.url is startswith("/blog/") %}` |
+| endswith | Ends with | `{% if page.url is endswith("/") %}` |
+| containing | Contains | `{% if page.url is containing("docs") %}` |
+| matching | Regex match | `{% if asset is matching("[.](jpg\|png)$") %}` |
+| empty | Is empty | `{% if page.description is empty %}` |
+| present | Is not empty | `{% if page.title is present %}` |
 
 ### Test Examples
 

--- a/docs/content/templates/render-hooks.md
+++ b/docs/content/templates/render-hooks.md
@@ -82,10 +82,16 @@ These four templates reproduce hwaro's stock output exactly — a useful startin
 
 ```jinja
 {# templates/hooks/render-codeblock.html #}
-<pre><code{% if lang is present %} class="language-{{ lang }}"{% endif %}>{% if highlighted is present %}{{ highlighted }}{% else %}{{ code }}{% endif %}</code></pre>
+<pre><code{% if lang is present %} class="language-{{ lang }} hljs"{% endif %}>{% if highlighted is present %}{{ highlighted }}{% else %}{{ code }}{% endif %}</code></pre>
 ```
 
 Note `{% if title is present %}`, not a bare `{% if title %}` — Crinja's truthiness only treats `false`/`0`/nil as falsy, so a bare `{% if title %}` would render `title=""` even when there's no title. The custom `is present`/`is empty` tests (also used throughout hwaro's own templates) check for that correctly.
+
+The codeblock template's ` hljs` class matches stock output under the
+default config (`[highlight] enabled = true` — most Highlight.js themes key
+their base styling off that class). If you've disabled highlighting
+entirely, stock output emits `class="language-{{ lang }}"` with no ` hljs`;
+drop it from your hook to stay byte-identical.
 
 ## Example: Figure-Wrapped Images
 

--- a/docs/content/writing/pages.md
+++ b/docs/content/writing/pages.md
@@ -298,7 +298,7 @@ console.log("Hello");
 | Cell   | Cell   |
 ```
 
-Table cells support inline Markdown: **bold**, *italic*, `code spans`, [links](url), ![images](url), and ~~strikethrough~~.
+Table cells support inline Markdown: **bold**, *italic*, `code spans`, `[links](url)`, `![images](url)`, and ~~strikethrough~~.
 
 ```markdown
 | Feature        | Example                          |

--- a/spec/content/seo/tags_spec.cr
+++ b/spec/content/seo/tags_spec.cr
@@ -49,6 +49,33 @@ describe Hwaro::Content::Seo::Tags do
       tag = Hwaro::Content::Seo::Tags.canonical_tag(page, config)
       tag.should eq %(<link rel="canonical" href="https://example.com/test/">)
     end
+
+    it "percent-encodes non-ASCII paths like feeds/sitemap do" do
+      # A Unicode taxonomy term (`/tags/日本語タグ/`) must canonicalize to the
+      # exact same RFC 3986 URL its RSS/sitemap entries advertise — raw UTF-8
+      # here and percent-encoded there is two different URLs to a crawler.
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("tags/_index.md")
+      page.url = "/tags/日本語タグ/"
+
+      tag = Hwaro::Content::Seo::Tags.canonical_tag(page, config)
+      tag.should contain("https://example.com/tags/%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%82%BF%E3%82%B0/")
+      tag.should_not contain("日本語タグ")
+    end
+
+    it "does not double-encode an already percent-encoded URL" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.url = "/tags/%E6%97%A5%E6%9C%AC/"
+
+      tag = Hwaro::Content::Seo::Tags.canonical_tag(page, config)
+      tag.should contain("/tags/%E6%97%A5%E6%9C%AC/")
+      tag.should_not contain("%25")
+    end
   end
 
   describe ".hreflang_tags" do

--- a/spec/unit/deadlink_command_spec.cr
+++ b/spec/unit/deadlink_command_spec.cr
@@ -211,6 +211,38 @@ describe Hwaro::CLI::Commands::Tool::DeadlinkCommand do
         links.map(&.url).should eq(["/page/"])
       end
     end
+
+    it "keeps fence pairing after a 4-backtick fence nesting a 3-backtick fence" do
+      # Regression (dogfooding find): the old non-greedy /```[\s\S]*?```/
+      # treated the inner ``` of a ````markdown example as a closer, so every
+      # fence after it flipped polarity and example links inside later fences
+      # were reported as dead.
+      Dir.mktmpdir do |dir|
+        content = <<-MD
+          Nested fence example:
+
+          ````markdown
+          ```mermaid
+          graph TD
+          ```
+          ````
+
+          A later documentation-only snippet:
+
+          ```markdown
+          ![Diagram](/images/does-not-exist.png)
+          ```
+
+          But [this real link](/page/) should still be found.
+          MD
+        File.write(File.join(dir, "test.md"), content)
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        links = cmd.find_internal_links_for_test(dir)
+
+        links.map(&.url).should eq(["/page/"])
+      end
+    end
   end
 
   describe "#sanitize_for_terminal (terminal-injection protection)" do

--- a/spec/unit/exporters/jekyll_exporter_spec.cr
+++ b/spec/unit/exporters/jekyll_exporter_spec.cr
@@ -17,9 +17,9 @@ describe Hwaro::Services::Exporters::JekyllExporter do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         output_dir = File.join(dir, "export")
-        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
 
-        File.write(File.join(content_dir, "post.md"), "+++\ntitle = \"My Post\"\ndate = \"2024-01-15\"\ndescription = \"A post\"\ntags = [\"crystal\"]\n+++\n\nHello world\n")
+        File.write(File.join(content_dir, "posts", "post.md"), "+++\ntitle = \"My Post\"\ndate = \"2024-01-15\"\ndescription = \"A post\"\ntags = [\"crystal\"]\n+++\n\nHello world\n")
 
         exporter = Hwaro::Services::Exporters::JekyllExporter.new
         options = Hwaro::Config::Options::ExportOptions.new(
@@ -50,9 +50,9 @@ describe Hwaro::Services::Exporters::JekyllExporter do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         output_dir = File.join(dir, "export")
-        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
 
-        File.write(File.join(content_dir, "my-post.md"), "+++\ntitle = \"My Post\"\ndate = \"2024-03-15\"\n+++\n\nContent\n")
+        File.write(File.join(content_dir, "posts", "my-post.md"), "+++\ntitle = \"My Post\"\ndate = \"2024-03-15\"\n+++\n\nContent\n")
 
         exporter = Hwaro::Services::Exporters::JekyllExporter.new
         options = Hwaro::Config::Options::ExportOptions.new(
@@ -70,9 +70,9 @@ describe Hwaro::Services::Exporters::JekyllExporter do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         output_dir = File.join(dir, "export")
-        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
 
-        File.write(File.join(content_dir, "draft.md"), "+++\ntitle = \"Draft\"\ndraft = true\ndate = \"2024-01-01\"\n+++\n\nDraft content\n")
+        File.write(File.join(content_dir, "posts", "draft.md"), "+++\ntitle = \"Draft\"\ndraft = true\ndate = \"2024-01-01\"\n+++\n\nDraft content\n")
 
         exporter = Hwaro::Services::Exporters::JekyllExporter.new
         options = Hwaro::Config::Options::ExportOptions.new(
@@ -180,9 +180,9 @@ describe Hwaro::Services::Exporters::JekyllExporter do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         output_dir = File.join(dir, "export")
-        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
 
-        File.write(File.join(content_dir, "yaml.md"), "---\ntitle: YAML Post\ndate: \"2024-05-20\"\ntags:\n  - ruby\n---\n\nContent\n")
+        File.write(File.join(content_dir, "posts", "yaml.md"), "---\ntitle: YAML Post\ndate: \"2024-05-20\"\ntags:\n  - ruby\n---\n\nContent\n")
 
         exporter = Hwaro::Services::Exporters::JekyllExporter.new
         options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
@@ -200,9 +200,9 @@ describe Hwaro::Services::Exporters::JekyllExporter do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         output_dir = File.join(dir, "export")
-        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
 
-        File.write(File.join(content_dir, "draft.md"), "+++\ntitle = \"Draft\"\ndraft = true\ndate = \"2024-06-15\"\n+++\n\nDraft\n")
+        File.write(File.join(content_dir, "posts", "draft.md"), "+++\ntitle = \"Draft\"\ndraft = true\ndate = \"2024-06-15\"\n+++\n\nDraft\n")
 
         exporter = Hwaro::Services::Exporters::JekyllExporter.new
         options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir, drafts: true)
@@ -239,9 +239,9 @@ describe Hwaro::Services::Exporters::JekyllExporter do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         output_dir = File.join(dir, "export")
-        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
 
-        File.write(File.join(content_dir, "post.md"), "+++\ntitle = \"Post\"\ndate = \"2024-01-01\"\n+++\n\n[About](@/about/_index.md)\n")
+        File.write(File.join(content_dir, "posts", "post.md"), "+++\ntitle = \"Post\"\ndate = \"2024-01-01\"\n+++\n\n[About](@/about/_index.md)\n")
 
         exporter = Hwaro::Services::Exporters::JekyllExporter.new
         options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
@@ -257,9 +257,9 @@ describe Hwaro::Services::Exporters::JekyllExporter do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         output_dir = File.join(dir, "export")
-        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
 
-        File.write(File.join(content_dir, "post.md"), "---\ntitle: Post\ndate: \"2024-01-01\"\ncategories:\n  - tech\n  - blog\n---\n\nContent\n")
+        File.write(File.join(content_dir, "posts", "post.md"), "---\ntitle: Post\ndate: \"2024-01-01\"\ncategories:\n  - tech\n  - blog\n---\n\nContent\n")
 
         exporter = Hwaro::Services::Exporters::JekyllExporter.new
         options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
@@ -276,11 +276,11 @@ describe Hwaro::Services::Exporters::JekyllExporter do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         output_dir = File.join(dir, "export")
-        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
 
         # `tags: crystal` (scalar, not a list) must not be silently dropped —
         # that would lose the post's taxonomy membership in the migration.
-        File.write(File.join(content_dir, "post.md"), "---\ntitle: Post\ndate: \"2024-01-01\"\ntags: crystal\ncategories: news\n---\n\nBody\n")
+        File.write(File.join(content_dir, "posts", "post.md"), "---\ntitle: Post\ndate: \"2024-01-01\"\ntags: crystal\ncategories: news\n---\n\nBody\n")
 
         exporter = Hwaro::Services::Exporters::JekyllExporter.new
         options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
@@ -299,9 +299,9 @@ describe Hwaro::Services::Exporters::JekyllExporter do
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         output_dir = File.join(dir, "export")
-        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
 
-        File.write(File.join(content_dir, "post.md"), "---\ntitle: Post\ndate: \"2024-01-01\"\nauthors:\n  - Jane\n  - John\n---\n\nContent\n")
+        File.write(File.join(content_dir, "posts", "post.md"), "---\ntitle: Post\ndate: \"2024-01-01\"\nauthors:\n  - Jane\n  - John\n---\n\nContent\n")
 
         exporter = Hwaro::Services::Exporters::JekyllExporter.new
         options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
@@ -311,6 +311,87 @@ describe Hwaro::Services::Exporters::JekyllExporter do
         content = File.read(files.first)
         content.should contain("authors:")
         content.should contain("- Jane")
+      end
+    end
+
+    it "keeps dated pages outside posts/blog sections as tree-preserved pages" do
+      # Hwaro auto-stamps `date` on every `hwaro new` page, so a date alone
+      # must not turn `about-us.md` or `team/engineering/deep-page.md` into
+      # a flat `_posts/` entry — that discards their section identity.
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(File.join(content_dir, "team", "engineering"))
+
+        File.write(File.join(content_dir, "about-us.md"), "+++\ntitle = \"About Us\"\ndate = \"2024-01-01\"\n+++\n\nAbout\n")
+        File.write(File.join(content_dir, "team", "engineering", "deep-page.md"), "+++\ntitle = \"Deep\"\ndate = \"2024-01-02\"\n+++\n\nDeep\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
+        exporter.run(options)
+
+        File.exists?(File.join(output_dir, "about-us.md")).should be_true
+        File.exists?(File.join(output_dir, "team", "engineering", "deep-page.md")).should be_true
+        Dir.exists?(File.join(output_dir, "_posts")).should be_false
+      end
+    end
+
+    it "uses the bundle directory as the slug for leaf-bundle posts" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(File.join(content_dir, "posts", "bundled-post"))
+
+        File.write(File.join(content_dir, "posts", "bundled-post", "index.md"), "+++\ntitle = \"Bundled\"\ndate = \"2024-04-01\"\n+++\n\nBody\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
+        exporter.run(options)
+
+        File.exists?(File.join(output_dir, "_posts", "2024-04-01-bundled-post.md")).should be_true
+        File.exists?(File.join(output_dir, "_posts", "2024-04-01-index.md")).should be_false
+      end
+    end
+
+    it "disambiguates colliding destinations instead of overwriting" do
+      # Two same-day leaf bundles with identical directory names in nested
+      # subsections both flatten to the same `_posts/<date>-<slug>.md` —
+      # the second must not silently clobber the first.
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(File.join(content_dir, "posts", "a", "launch"))
+        FileUtils.mkdir_p(File.join(content_dir, "posts", "b", "launch"))
+
+        File.write(File.join(content_dir, "posts", "a", "launch", "index.md"), "+++\ntitle = \"Launch A\"\ndate = \"2024-05-01\"\n+++\n\nA\n")
+        File.write(File.join(content_dir, "posts", "b", "launch", "index.md"), "+++\ntitle = \"Launch B\"\ndate = \"2024-05-01\"\n+++\n\nB\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
+        result = exporter.run(options)
+
+        result.exported_count.should eq(2)
+        written = Dir.glob(File.join(output_dir, "_posts", "*.md")).sort
+        written.size.should eq(2)
+        contents = written.map { |f| File.read(f) }.join
+        contents.should contain("Launch A")
+        contents.should contain("Launch B")
+      end
+    end
+
+    it "sends undated drafts in a posts section to _drafts" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
+
+        File.write(File.join(content_dir, "posts", "wip.md"), "+++\ntitle = \"WIP\"\ndraft = true\n+++\n\nWip\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir, drafts: true)
+        exporter.run(options)
+
+        File.exists?(File.join(output_dir, "_drafts", "wip.md")).should be_true
       end
     end
   end

--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -59,6 +59,26 @@ describe Hwaro::Content::Processors::Markdown do
       result[:tags].should eq(["crystal", "programming", "web"])
     end
 
+    it "strips whitespace from tags and taxonomy terms" do
+      # `"  spaced-tag  "` slugified clean but leaked verbatim into the term
+      # page <h1>/<title> and RSS <title>/<category>, and a padded duplicate
+      # of an existing term split into a second `-2` term page.
+      raw = <<-MD
+        +++
+        title = "Post"
+        tags = ["  spaced-tag  ", "clean"]
+
+        [taxonomies]
+        series = ["  My Series "]
+        +++
+        Body
+        MD
+
+      result = processor.parse(raw)
+      result[:tags].should eq(["spaced-tag", "clean"])
+      result[:taxonomies]["series"].should eq(["My Series"])
+    end
+
     it "parses aliases array" do
       raw = <<-MD
         +++

--- a/spec/unit/output_formats_spec.cr
+++ b/spec/unit/output_formats_spec.cr
@@ -120,23 +120,40 @@ describe Hwaro::Core::Build::Phases::OutputFormats do
       builder.test_effective_output_formats(page, config).should eq([] of String)
     end
 
-    it "applies the sections allowlist" do
+    it "applies the sections allowlist to section output" do
+      builder = Hwaro::Core::Build::Builder.new
+      config = Hwaro::Models::Config.new
+      config.outputs.section = ["json"]
+      config.outputs.sections = ["posts"]
+
+      in_scope = Hwaro::Models::Section.new("posts/_index.md")
+      in_scope.section = "posts"
+      builder.test_effective_output_formats(in_scope, config).should eq(["json"])
+
+      nested = Hwaro::Models::Section.new("posts/sub/_index.md")
+      nested.section = "posts/sub"
+      builder.test_effective_output_formats(nested, config).should eq(["json"])
+
+      out_of_scope = Hwaro::Models::Section.new("docs/_index.md")
+      out_of_scope.section = "docs"
+      builder.test_effective_output_formats(out_of_scope, config).should eq([] of String)
+    end
+
+    it "does not apply the sections allowlist to page output" do
       builder = Hwaro::Core::Build::Builder.new
       config = Hwaro::Models::Config.new
       config.outputs.page = ["json"]
       config.outputs.sections = ["posts"]
 
-      in_scope = Hwaro::Models::Page.new("posts/hello.md")
-      in_scope.section = "posts"
-      builder.test_effective_output_formats(in_scope, config).should eq(["json"])
+      # The allowlist restricts *section* output only — a page outside the
+      # allowlisted sections must still emit the page-level formats.
+      outside = Hwaro::Models::Page.new("about.md")
+      outside.section = ""
+      builder.test_effective_output_formats(outside, config).should eq(["json"])
 
-      nested = Hwaro::Models::Page.new("posts/sub/hello.md")
-      nested.section = "posts/sub"
-      builder.test_effective_output_formats(nested, config).should eq(["json"])
-
-      out_of_scope = Hwaro::Models::Page.new("about.md")
-      out_of_scope.section = ""
-      builder.test_effective_output_formats(out_of_scope, config).should eq([] of String)
+      inside = Hwaro::Models::Page.new("posts/hello.md")
+      inside.section = "posts"
+      builder.test_effective_output_formats(inside, config).should eq(["json"])
     end
 
     it "front matter override bypasses the sections allowlist" do

--- a/spec/unit/syntax_highlighter_spec.cr
+++ b/spec/unit/syntax_highlighter_spec.cr
@@ -246,9 +246,25 @@ describe Hwaro::Content::Processors::FenceOptions do
       opts.not_nil!.linenos.should be_true
     end
 
-    it "clamps linenostart=0 up to 1" do
-      _, opts = Hwaro::Content::Processors::FenceOptions.parse("crystal {linenostart=0}")
+    it "rejects linenostart=0 as invalid (line numbers are 1-based)" do
+      # A literal 0 used to be silently clamped up to 1 — renumbering from a
+      # line the author never asked for — while negatives were rejected.
+      # Now 0 is dropped like any other invalid value; with no other
+      # recognized option the `{...}` block doesn't activate at all.
+      lang, opts = Hwaro::Content::Processors::FenceOptions.parse("crystal {linenostart=0}")
+      lang.should eq("crystal")
+      opts.should be_nil
+    end
+
+    it "ignores linenostart=0 while honoring other options in the block" do
+      _, opts = Hwaro::Content::Processors::FenceOptions.parse("crystal {linenos=true linenostart=0}")
+      opts.not_nil!.linenos.should be_true
       opts.not_nil!.linenostart.should eq(1)
+    end
+
+    it "drops an hl_lines item containing 0" do
+      _, opts = Hwaro::Content::Processors::FenceOptions.parse(%(crystal {hl_lines="0,3"}))
+      opts.not_nil!.hl_lines.should eq([{3, 3}])
     end
 
     it "parses a bare (unquoted) hl_lines value" do

--- a/spec/unit/unpublished_content_spec.cr
+++ b/spec/unit/unpublished_content_spec.cr
@@ -1,0 +1,141 @@
+require "../spec_helper"
+require "../../src/models/page"
+require "../../src/models/site"
+require "../../src/content/seo/sitemap"
+require "../../src/content/seo/feeds"
+require "../../src/content/search"
+
+# Pages outside their publication window (future `date` / past `expires`)
+# only enter a build via --include-future / --include-expired. Those are
+# preview flags: the HTML page renders, but — exactly like drafts under
+# --drafts — the page must stay out of every public discovery surface
+# (sitemap, feeds, search index, llms.txt) and generated listings.
+describe "unpublished (future/expired) content exclusion" do
+  describe "Page#refresh_unpublished!" do
+    it "marks a future-dated page unpublished" do
+      page = Hwaro::Models::Page.new("future.md")
+      page.date = Time.utc(2099, 12, 31)
+      page.refresh_unpublished!(Time.utc)
+      page.unpublished.should be_true
+    end
+
+    it "marks an expired page unpublished" do
+      page = Hwaro::Models::Page.new("expired.md")
+      page.date = Time.utc(2020, 1, 1)
+      page.expires = Time.utc(2021, 1, 1)
+      page.refresh_unpublished!(Time.utc)
+      page.unpublished.should be_true
+    end
+
+    it "leaves a published page unmarked" do
+      page = Hwaro::Models::Page.new("live.md")
+      page.date = Time.utc(2020, 1, 1)
+      page.refresh_unpublished!(Time.utc)
+      page.unpublished.should be_false
+    end
+
+    it "clears a stale flag when the window opens (re-parse path)" do
+      page = Hwaro::Models::Page.new("was-future.md")
+      page.date = Time.utc(2020, 1, 1)
+      page.unpublished = true
+      page.refresh_unpublished!(Time.utc)
+      page.unpublished.should be_false
+    end
+  end
+
+  describe "eligibility predicates" do
+    it "excludes unpublished pages from the search index / llms.txt" do
+      page = Hwaro::Models::Page.new("future.md")
+      page.render = true
+      page.in_search_index = true
+      page.search_index_eligible?.should be_true
+      page.unpublished = true
+      page.search_index_eligible?.should be_false
+    end
+
+    it "excludes unpublished pages from generated listings" do
+      page = Hwaro::Models::Page.new("future.md")
+      page.excluded_from_listings?.should be_false
+      page.unpublished = true
+      page.excluded_from_listings?.should be_true
+    end
+  end
+
+  describe "sitemap" do
+    it "excludes unpublished pages even when they are in the build" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.sitemap.enabled = true
+        config.base_url = "https://example.com"
+        site = Hwaro::Models::Site.new(config)
+
+        live = Hwaro::Models::Page.new("live.md")
+        live.url = "/live/"
+
+        future = Hwaro::Models::Page.new("future.md")
+        future.url = "/future/"
+        future.unpublished = true
+
+        Hwaro::Content::Seo::Sitemap.generate([live, future], site, dir)
+
+        content = File.read(File.join(dir, "sitemap.xml"))
+        content.should contain("<loc>https://example.com/live/</loc>")
+        content.should_not contain("/future/")
+      end
+    end
+  end
+
+  describe "feeds" do
+    it "excludes unpublished pages from the main feed" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.base_url = "https://example.com"
+        config.feeds.enabled = true
+        config.feeds.filename = "rss.xml"
+
+        live = Hwaro::Models::Page.new("live.md")
+        live.url = "/live/"
+        live.title = "Live Post"
+        live.date = Time.utc(2024, 1, 1)
+
+        future = Hwaro::Models::Page.new("future.md")
+        future.url = "/future/"
+        future.title = "Scheduled Post"
+        future.date = Time.utc(2099, 1, 1)
+        future.unpublished = true
+
+        Hwaro::Content::Seo::Feeds.generate([live, future], config, dir)
+
+        content = File.read(File.join(dir, config.feeds.filename))
+        content.should contain("Live Post")
+        content.should_not contain("Scheduled Post")
+      end
+    end
+  end
+
+  describe "search index" do
+    it "excludes unpublished pages from search.json" do
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.search.enabled = true
+
+        live = Hwaro::Models::Page.new("live.md")
+        live.url = "/live/"
+        live.title = "Live Post"
+        live.content = "<p>hello</p>"
+
+        future = Hwaro::Models::Page.new("future.md")
+        future.url = "/future/"
+        future.title = "Scheduled Post"
+        future.content = "<p>secret</p>"
+        future.unpublished = true
+
+        Hwaro::Content::Search.generate([live, future], config, dir)
+
+        content = File.read(File.join(dir, File.basename(config.search.filename)))
+        content.should contain("Live Post")
+        content.should_not contain("Scheduled Post")
+      end
+    end
+  end
+end

--- a/spec/unit/unused_assets_command_spec.cr
+++ b/spec/unit/unused_assets_command_spec.cr
@@ -68,7 +68,7 @@ describe Hwaro::CLI::Commands::Tool::UnusedAssetsCommand do
         output.should contain("total:")
         output.should contain("unused files:")
         output.should contain("orphan.png")
-        output.should contain("found: 1 unused assets")
+        output.should contain("found: 1 unused asset")
       end
     end
   end

--- a/src/cli/commands/tool/convert_command.cr
+++ b/src/cli/commands/tool/convert_command.cr
@@ -69,7 +69,15 @@ module Hwaro
             converter = Services::FrontmatterConverter.new(content_dir)
 
             fmt = format.as(String).downcase
-            Logger.heading(NAME, fmt) if POSITIONAL_CHOICES.includes?(fmt)
+            if POSITIONAL_CHOICES.includes?(fmt)
+              Logger.heading(NAME, fmt)
+              # Conversion round-trips parsed values, so front-matter comments
+              # (and exact formatting) have no representation to survive in.
+              # Say so up front instead of silently discarding them —
+              # `doctor --fix` edits config.toml as raw text for this exact
+              # reason, but a format conversion can't.
+              Logger.item("comments in front matter are not preserved by conversion", glyph: :info) unless json_output
+            end
 
             case fmt
             when "to-yaml"

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -204,10 +204,42 @@ module Hwaro
           # before scanning so `check-links` doesn't report false-positive dead
           # links — mirrors the code-stripping the scaffold link-integrity spec
           # already performs.
+          #
+          # Fences are tracked line-by-line, CommonMark-style: a fence opens
+          # with 3+ backticks/tildes (up to 3 spaces of indent) and only
+          # closes on a fence of the same character at least as long. The old
+          # non-greedy /```[\s\S]*?```/ mispaired nested fences — a 4-backtick
+          # example wrapping a 3-backtick fence desynchronized every fence
+          # after it, resurrecting example links as false positives.
           private def strip_code(content : String) : String
-            content
-              .gsub(/```[\s\S]*?```/, "")
-              .gsub(/`[^`\n]*`/, "")
+            result = String::Builder.new
+            fence_char : Char? = nil
+            fence_len = 0
+
+            content.each_line(chomp: false) do |line|
+              if m = line.match(/\A {0,3}(`{3,}|~{3,})/)
+                marker = m[1]
+                if fence_char.nil?
+                  fence_char = marker[0]
+                  fence_len = marker.size
+                  result << '\n'
+                  next
+                elsif marker[0] == fence_char && marker.size >= fence_len
+                  fence_char = nil
+                  fence_len = 0
+                  result << '\n'
+                  next
+                end
+              end
+
+              if fence_char
+                result << '\n'
+              else
+                result << line.gsub(/`[^`\n]*`/, "")
+              end
+            end
+
+            result.to_s
           end
 
           # Link URLs/paths come from semi-trusted content (e.g. a docs/blog

--- a/src/cli/commands/tool/doctor_command.cr
+++ b/src/cli/commands/tool/doctor_command.cr
@@ -192,13 +192,20 @@ module Hwaro
           private def render_human(issues : Array(Services::Issue), config_path : String)
             plain = plain_output?
 
+            # A missing/unparseable config aborts `check_config` before any of
+            # the other config sub-checks (and `check_referenced_paths`) run.
+            # Those checks must render as skipped — a green ✓ for a check that
+            # never executed is reassuring noise on top of a broken config.
+            config_blocked = issues.any? { |i| i.id == "config-not-found" || i.id == "config-parse-error" }
+
             Logger.heading("doctor")
             Logger.info ""
             Services::CHECK_GROUPS.each do |group|
               heading = group.key == :config ? config_path : group.default_heading
               Logger.info "  #{heading}"
               group.checks.each do |spec|
-                Logger.info "    #{render_check_line(spec, issues, plain)}"
+                skipped = config_blocked && group.key == :config && !spec.issue_ids.includes?("config-parse-error")
+                Logger.info "    #{render_check_line(spec, issues, plain, skipped)}"
               end
               Logger.info ""
             end
@@ -261,7 +268,16 @@ module Hwaro
           end
 
           # Format a single named check line with an inline status glyph.
-          private def render_check_line(spec : Services::CheckSpec, issues : Array(Services::Issue), plain : Bool) : String
+          # `skipped` marks a check that never executed (e.g. the config
+          # failed to parse before it could run) — rendered as a dim dash,
+          # never as a passing ✓.
+          private def render_check_line(spec : Services::CheckSpec, issues : Array(Services::Issue), plain : Bool, skipped : Bool = false) : String
+            if skipped
+              glyph = plain ? "[--]  " : Logger.paint("–", Logger::Role::Dim)
+              label = plain ? "#{spec.label} (skipped)" : "#{spec.label} #{Logger.paint("(skipped)", Logger::Role::Dim)}"
+              return "#{glyph} #{label}"
+            end
+
             matched = issues.select { |i| spec.issue_ids.includes?(i.id) }
             level = worst_level(matched)
             "#{status_glyph(level, plain)} #{spec.label}"

--- a/src/cli/commands/tool/stats_command.cr
+++ b/src/cli/commands/tool/stats_command.cr
@@ -94,8 +94,8 @@ module Hwaro
             # Context receipt: totals, word counts (published only — matches
             # what `build` ships), then bar-chart sections and one outcome.
             receipt = Logger::Receipt.new("stats", content_dir)
-            receipt.row("total", "#{result.total.format} files",
-              emphasis: result.drafts > 0 ? "#{result.drafts.format} drafts" : nil)
+            receipt.row("total", "#{result.total.format} #{result.total == 1 ? "file" : "files"}",
+              emphasis: result.drafts > 0 ? "#{result.drafts.format} #{result.drafts == 1 ? "draft" : "drafts"}" : nil)
             receipt.row("words", "#{result.words_total.format} total · #{result.words_avg.format} avg")
             receipt.row("range", "#{result.words_min.format} min · #{result.words_max.format} max")
             receipt.emit
@@ -127,7 +127,7 @@ module Hwaro
 
             Logger.info ""
             Logger.outcome("counted",
-              "#{result.total.format} files · #{result.published.format} published · #{result.drafts.format} drafts")
+              "#{result.total.format} #{result.total == 1 ? "file" : "files"} · #{result.published.format} published · #{result.drafts.format} #{result.drafts == 1 ? "draft" : "drafts"}")
           end
 
           # Cap a bar-chart label to the column width, marking the cut with an

--- a/src/cli/commands/tool/unused_assets_command.cr
+++ b/src/cli/commands/tool/unused_assets_command.cr
@@ -18,7 +18,7 @@ module Hwaro
       module Tool
         class UnusedAssetsCommand
           NAME               = "unused-assets"
-          DESCRIPTION        = "Find unreferenced static files"
+          DESCRIPTION        = "Find unreferenced static files (images, fonts, CSS/JS, media, pdf/zip)"
           POSITIONAL_ARGS    = [] of String
           POSITIONAL_CHOICES = [] of String
 
@@ -108,7 +108,7 @@ module Hwaro
             Logger.item("dynamic references (e.g. template variables) may cause false positives", glyph: :info)
 
             unless delete_mode
-              Logger.outcome("found", "#{result.unused_count} unused assets", glyph: :warn)
+              Logger.outcome("found", "#{result.unused_count} unused #{result.unused_count == 1 ? "asset" : "assets"}", glyph: :warn)
               return
             end
 

--- a/src/content/processors/heading_ids.cr
+++ b/src/content/processors/heading_ids.cr
@@ -9,6 +9,7 @@
 
 require "html"
 require "../../utils/text_utils"
+require "../../utils/logger"
 
 module Hwaro
   module Content
@@ -45,6 +46,14 @@ module Hwaro
             while used_ids.includes?(id)
               id_counters[base_id] += 1
               id = "#{base_id}-#{id_counters[base_id]}"
+            end
+            # Renaming an auto-generated slug is routine (repeated section
+            # titles), but renaming an AUTHOR-WRITTEN `{#id}` silently moves
+            # the anchor the author explicitly asked for — warn, like menus
+            # already do for duplicate identifiers. `used_ids` is page-scoped,
+            # so this only fires for a duplicate within one page.
+            if existing_id
+              Logger.warn "Duplicate explicit heading id '##{base_id}' — this heading was renamed to '##{id}'; links to '##{base_id}' resolve to the first occurrence."
             end
           end
           used_ids << id

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -493,8 +493,13 @@ module Hwaro
         # Shared helper: extract a string array from a front matter value.
         # Uses compact_map(&.as_s?) instead of map(&.as_s) to safely skip
         # non-string elements rather than raising at runtime.
+        #
+        # Values are stripped: a tag authored as `"  crystal  "` must be the
+        # SAME term as `"crystal"` — untrimmed values leaked verbatim into
+        # term-page titles/RSS and split one term into two slug-disambiguated
+        # term pages (slugification already trimmed; identity/display didn't).
         private def fm_string_array(fm : TOML::Table | YAML::Any | JSON::Any, key : String) : Array(String)
-          fm[key]?.try(&.as_a?.try { |a| a.compact_map(&.as_s?) }) || [] of String
+          fm[key]?.try(&.as_a?.try { |a| a.compact_map(&.as_s?).map(&.strip) }) || [] of String
         end
 
         # Build the front matter result NamedTuple from any front matter source.
@@ -964,10 +969,13 @@ module Hwaro
 
           # Iterate all keys: TOML::Table yields {String, TOML::Any},
           # YAML::Any#as_h yields {YAML::Any, YAML::Any}. Unify via keys list.
+          # Terms are stripped for the same reason as `fm_string_array`:
+          # whitespace-padded terms must not become distinct taxonomy terms
+          # or leak padded strings into term-page titles and feeds.
           keys.each do |key|
             next if NON_TAXONOMY_ARRAY_KEYS.includes?(key)
             if arr = front_matter[key]?.try(&.as_a?)
-              values = arr.compact_map(&.as_s?)
+              values = arr.compact_map(&.as_s?).map(&.strip)
               taxonomies[key] = values
             end
           end
@@ -983,14 +991,14 @@ module Hwaro
             when TOML::Any, JSON::Any
               table.as_h?.try &.each do |k, v|
                 if arr = v.as_a?
-                  taxonomies[k] = arr.compact_map(&.as_s?)
+                  taxonomies[k] = arr.compact_map(&.as_s?).map(&.strip)
                 end
               end
             when YAML::Any
               table.as_h?.try &.each do |k, v|
                 next unless key_str = k.as_s?
                 if arr = v.as_a?
-                  taxonomies[key_str] = arr.compact_map(&.as_s?)
+                  taxonomies[key_str] = arr.compact_map(&.as_s?).map(&.strip)
                 end
               end
             end

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -943,7 +943,17 @@ module Hwaro
             if hattr_match = inner.match(HATTR_MARKER_RE)
               parsed = decode_and_parse_hattr(hattr_match[1])
               if parsed
-                cleaned_inner = inner.sub(hattr_match[0], "").rstrip
+                # The preprocess step glued the marker on with a leading
+                # space (`… title <!--HATTR:…-->`); remove them together.
+                # Dropping only the marker left a doubled space behind when
+                # a heading render hook appends markup after `{{ text }}`.
+                marker_with_space = " #{hattr_match[0]}"
+                cleaned_inner = if inner.includes?(marker_with_space)
+                                  inner.sub(marker_with_space, "")
+                                else
+                                  inner.sub(hattr_match[0], "")
+                                end
+                cleaned_inner = cleaned_inner.rstrip
                 new_attrs = MarkdownAttributes.apply_to_tag_attrs(attrs, parsed)
                 "<#{tag}#{new_attrs}>#{cleaned_inner}</#{tag}>"
               else

--- a/src/content/processors/syntax_highlighter.cr
+++ b/src/content/processors/syntax_highlighter.cr
@@ -271,7 +271,10 @@ module Hwaro
                 recognized += 1
               end
             when "linenostart"
-              if LINENOSTART_RE.matches?(value) && (n = value.to_i?)
+              # `0` is rejected like a negative value (the regex already
+              # blocks `-`), not silently clamped to line 1 — renumbering
+              # from a line the author never asked for.
+              if LINENOSTART_RE.matches?(value) && (n = value.to_i?) && n >= 1
                 linenostart = n.clamp(1, LINENOSTART_MAX)
                 recognized += 1
               end
@@ -327,6 +330,10 @@ module Hwaro
             start_n = m[1].to_i?
             next unless start_n
             end_n = m[2]?.try(&.to_i?) || start_n
+            # Line numbers are 1-based: a literal `0` is invalid input and is
+            # dropped like any other malformed item, not clamped up to line 1
+            # (which silently highlighted a line the author never asked for).
+            next if start_n < 1 || end_n < 1
             start_clamped = start_n.clamp(1, HL_LINE_MAX)
             end_clamped = end_n.clamp(1, HL_LINE_MAX)
             next if end_clamped < start_clamped

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -24,7 +24,7 @@ module Hwaro
 
           # 1. Generate Main Site Feed
           if config.feeds.enabled
-            site_pages = pages.reject { |p| p.draft || !p.render || p.is_a?(Models::Section) }
+            site_pages = pages.reject { |p| p.draft || p.unpublished || !p.render || p.is_a?(Models::Section) }
 
             # Deduplicate by URL (keep last occurrence, matching build behavior)
             seen_urls = Set(String).new
@@ -54,13 +54,13 @@ module Hwaro
           # 2. Generate Section Feeds — pre-group pages by section for O(1) lookup
           pages_by_section = {} of String => Array(Models::Page)
           pages.each do |p|
-            next if p.draft || !p.render || p.is_a?(Models::Section)
+            next if p.draft || p.unpublished || !p.render || p.is_a?(Models::Section)
             (pages_by_section[p.section] ||= [] of Models::Page) << p
           end
 
           pages.each do |page|
             # Check if it's a section and has feed generation enabled
-            if page.is_a?(Models::Section) && page.generate_feeds && page.render && !page.draft
+            if page.is_a?(Models::Section) && page.generate_feeds && page.render && !page.draft && !page.unpublished
               section_pages = pages_by_section[page.section]? || [] of Models::Page
 
               # Construct output path for section feed
@@ -94,7 +94,7 @@ module Hwaro
 
             # Filter pages for this language (single pass)
             lang_pages = pages.select { |p|
-              !p.draft && p.render && !p.is_a?(Models::Section) && p.language == lang_code
+              !p.draft && !p.unpublished && p.render && !p.is_a?(Models::Section) && p.language == lang_code
             }
 
             # Apply section filter if configured on the main feed

--- a/src/content/seo/og_png_renderer.cr
+++ b/src/content/seo/og_png_renderer.cr
@@ -83,6 +83,19 @@ module Hwaro
           LibStb.hwaro_font_has_glyph(info, codepoint) != 0
         end
 
+        # Drop codepoints `info` has no glyph for. stb draws missing glyphs
+        # as blank "tofu" boxes — emoji are the common case, since color
+        # emoji fonts can't be loaded here — so degrade "🔥 Title" to
+        # "Title" instead of "☐ Title". Whitespace always passes; leftover
+        # double spaces from removed runs are collapsed. Returns the
+        # original string untouched when everything is drawable.
+        def self.drop_missing_glyphs(info : LibStb::HwaroFontInfo, text : String) : String
+          return text if text.empty?
+          filtered = text.chars.select { |c| c.whitespace? || font_has_glyph?(info, c.ord) }.join
+          return text if filtered.size == text.size
+          filtered.gsub(/\s{2,}/, " ").strip
+        end
+
         # Try to find a system font, returns file path or nil
         def self.find_system_font(bold : Bool = false) : String?
           paths = bold ? BOLD_FONT_SEARCH_PATHS : FONT_SEARCH_PATHS
@@ -512,11 +525,16 @@ module Hwaro
                        else                  WIDTH - (margin_x * 2)
                        end
 
-          title_lines = word_wrap_measured(bold_info, bold_scale, page.title, wrap_width)
+          # Sanitize every string the fonts will draw: codepoints without a
+          # glyph (emoji, mostly) would render as tofu boxes otherwise.
+          title_text = drop_missing_glyphs(bold_info, page.title)
+          site_title = drop_missing_glyphs(bold_info, config.title)
+
+          title_lines = word_wrap_measured(bold_info, bold_scale, title_text, wrap_width)
           # The band style draws the title inside a fixed-height color band;
           # cap the lines so a long title can't overflow the band invisibly.
           title_lines = OgImage.cap_band_title(title_lines, font_size.to_i) if ai.style == "band"
-          desc_text = page.description || ""
+          desc_text = drop_missing_glyphs(r_info, page.description || "")
           desc_lines = desc_text.empty? ? [] of String : word_wrap_measured(r_info, r_scale, desc_text, wrap_width)
 
           # Vertical positioning — ambitious styles get very bold, confident, centered placement
@@ -572,7 +590,7 @@ module Hwaro
           # Hero: oversized "ghost" echo of the title's first word behind
           # the composition for poster-style depth.
           if ai.style == "hero"
-            if ghost = page.title.split(/\s+/).first?
+            if ghost = title_text.split(/\s+/).first?
               unless ghost.empty?
                 ghost_scale = LibStb.hwaro_font_scale_for_pixel_height(bold_info, font_size * 2.6_f32)
                 LibStb.hwaro_font_render_text(bold_info, pixels, WIDTH, HEIGHT, (margin_x - 10).to_f32, 34_f32, ghost_scale, ghost.upcase, text_color, 0.07_f32)
@@ -649,7 +667,7 @@ module Hwaro
               site_scale = LibStb.hwaro_font_scale_for_pixel_height(bold_info, 18_f32)
               site_margin = 140_f32
               site_x = (ai.logo && ai.logo_position == "bottom-left") ? (site_margin + OgImage::LOGO_SIZE + OgImage::LOGO_TEXT_GAP).to_f32 : site_margin
-              LibStb.hwaro_font_render_text(bold_info, pixels, WIDTH, HEIGHT, site_x, (HEIGHT - 55 - 18).to_f32, site_scale, config.title, accent_color, 0.6_f32)
+              LibStb.hwaro_font_render_text(bold_info, pixels, WIDTH, HEIGHT, site_x, (HEIGHT - 55 - 18).to_f32, site_scale, site_title, accent_color, 0.6_f32)
             else
               site_scale = LibStb.hwaro_font_scale_for_pixel_height(bold_info, 22_f32)
               site_margin = case ai.style
@@ -664,7 +682,7 @@ module Hwaro
               site_x = (ai.logo && ai.logo_position == "bottom-left") ? (site_margin + OgImage::LOGO_SIZE + OgImage::LOGO_TEXT_GAP).to_f32 : site_margin.to_f32
               # `split` renders the site name inside the accent block → readable color.
               site_color = ai.style == "split" ? text_color : accent_color
-              LibStb.hwaro_font_render_text(bold_info, pixels, WIDTH, HEIGHT, site_x, (HEIGHT - 65 - 22).to_f32, site_scale, config.title, site_color, 1.0_f32)
+              LibStb.hwaro_font_render_text(bold_info, pixels, WIDTH, HEIGHT, site_x, (HEIGHT - 65 - 22).to_f32, site_scale, site_title, site_color, 1.0_f32)
             end
           end
         end

--- a/src/content/seo/sitemap.cr
+++ b/src/content/seo/sitemap.cr
@@ -16,9 +16,11 @@ module Hwaro
             return
           end
 
-          # Match feeds/llms/search behavior: drafts are excluded from public
-          # discovery surfaces even when the build is run with --drafts.
-          sitemap_pages = pages.select { |p| p.in_sitemap && p.render && !p.draft }
+          # Match feeds/llms/search behavior: drafts and preview-only
+          # unpublished pages (--include-future/--include-expired) are
+          # excluded from public discovery surfaces even when the build is
+          # run with the corresponding include flag.
+          sitemap_pages = pages.select { |p| p.in_sitemap && p.render && !p.draft && !p.unpublished }
 
           # Deduplicate by URL (keep last occurrence, matching build behavior)
           seen_urls = Set(String).new

--- a/src/content/seo/tags.cr
+++ b/src/content/seo/tags.cr
@@ -1,6 +1,7 @@
 require "html"
 require "../../models/config"
 require "../../models/page"
+require "../../utils/text_utils"
 
 module Hwaro
   module Content
@@ -16,10 +17,16 @@ module Hwaro
           # self-canonicalize. `page.permalink` is the generated absolute URL
           # (base_url + page.url), i.e. the page-1/section URL — using it for a
           # paginated render would point every page at page 1.
-          if u = url_override
-            return "#{config.base_url_stripped}#{u.starts_with?("/") ? u : "/#{u}"}"
-          end
-          page.permalink || "#{config.base_url_stripped}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+          #
+          # The result is percent-encoded like feeds/sitemap URLs so a
+          # non-ASCII path (e.g. a Unicode taxonomy term) canonicalizes to
+          # the exact same RFC 3986 URL those XML surfaces advertise.
+          raw = if u = url_override
+                  "#{config.base_url_stripped}#{u.starts_with?("/") ? u : "/#{u}"}"
+                else
+                  page.permalink || "#{config.base_url_stripped}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+                end
+          Utils::TextUtils.encode_url_path(raw)
         end
 
         def canonical_tag(page : Models::Page, config : Models::Config, url_override : String? = nil) : String
@@ -36,8 +43,10 @@ module Hwaro
           base = config.base_url_stripped
 
           String.build(page.translations.size * 80) do |str|
-            # Add current page
+            # Add current page. URLs are percent-encoded to match the
+            # sitemap's xhtml:link alternates for the same pages.
             current_url = page.permalink || "#{base}#{page.url.starts_with?("/") ? page.url : "/#{page.url}"}"
+            current_url = Utils::TextUtils.encode_url_path(current_url)
             lang_code = page.language || config.default_language
             str << %(<link rel="alternate" hreflang="#{HTML.escape(lang_code)}" href="#{HTML.escape(current_url)}">)
 
@@ -45,6 +54,7 @@ module Hwaro
             page.translations.each do |t|
               next if t.is_current
               abs_url = t.url.starts_with?("http") ? t.url : "#{base}#{t.url.starts_with?("/") ? t.url : "/#{t.url}"}"
+              abs_url = Utils::TextUtils.encode_url_path(abs_url)
               str << '\n'
               str << %(<link rel="alternate" hreflang="#{HTML.escape(t.code)}" href="#{HTML.escape(abs_url)}">)
             end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -406,6 +406,10 @@ module Hwaro
           # Now identify pages that should be excluded (draft/expired/future)
           excluded_pages = [] of Models::Page
           now = Time.utc
+          # Re-stamp the publication window on re-parsed pages so pages kept
+          # via --include-future/--include-expired stay out of public
+          # artifacts and listings (same contract as the full parse phase).
+          changed_pages.each(&.refresh_unpublished!(now))
           unless include_drafts
             excluded = changed_pages.select(&.draft)
             excluded_pages.concat(excluded)

--- a/src/core/build/phases/output_formats.cr
+++ b/src/core/build/phases/output_formats.cr
@@ -42,6 +42,12 @@ module Hwaro::Core::Build::Phases::OutputFormats
 
     base = page.is_a?(Models::Section) ? config.outputs.section : config.outputs.page
     return [] of String if base.empty?
+    # The `sections` allowlist scopes *section* output only (the documented
+    # contract); page-level output is unscoped. Gating pages on it too meant
+    # `sections = ["posts"]` silently dropped `page` formats everywhere
+    # outside posts/ — scope page output per-section via `[cascade.extra]`
+    # instead.
+    return base unless page.is_a?(Models::Section)
     return base if config.outputs.sections.empty?
 
     matches_section = config.outputs.sections.any? { |s| page.section == s || page.section.starts_with?("#{s}/") }

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -81,6 +81,13 @@ module Hwaro::Core::Build::Phases::ParseContent
     expired_count = 0
     future_count = 0
 
+    # Stamp the publication window on every page before filtering: pages
+    # admitted via --include-future / --include-expired keep unpublished=true
+    # so sitemap/feeds/search/llms and generated listings can exclude them,
+    # mirroring the --drafts contract (preview renders, artifacts don't leak).
+    ctx.pages.each(&.refresh_unpublished!(now))
+    ctx.sections.each(&.refresh_unpublished!(now))
+
     filter = ->(p : Models::Page) do
       if p.parse_failed
         failed_count += 1
@@ -446,11 +453,13 @@ module Hwaro::Core::Build::Phases::ParseContent
 
   # Cascade values arrive as ExtraValue; tags/taxonomies/authors need plain
   # string arrays. Non-string elements are skipped.
+  # Values are stripped to match `fm_string_array` — cascaded taxonomy
+  # terms must not become distinct whitespace-padded terms either.
   private def cascade_string_array(value : Models::ExtraValue) : Array(String)?
     if value.is_a?(Array(String))
-      value
+      value.map(&.strip)
     elsif value.is_a?(Array(Models::ExtraValue))
-      value.compact_map(&.as?(String))
+      value.compact_map(&.as?(String)).map(&.strip)
     end
   end
 

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -456,7 +456,7 @@ module Hwaro::Core::Build::Phases::Transform
     # Rebuild groups only for affected series
     groups = {} of String => Array(Models::Page)
     site.pages.each do |page|
-      next if page.draft || !page.render
+      next if page.draft || page.unpublished || !page.render
       if name = page.series
         next unless affected_series.includes?(name)
         (groups[name] ||= [] of Models::Page) << page
@@ -491,7 +491,7 @@ module Hwaro::Core::Build::Phases::Transform
 
     taxonomy_names = config.taxonomies
     limit = config.limit
-    all_pages = site.pages.reject { |p| p.draft || p.is_index || p.generated || !p.render }
+    all_pages = site.pages.reject { |p| p.draft || p.unpublished || p.is_index || p.generated || !p.render }
 
     # Build inverted index first (needed for both candidate discovery and scoring)
     inverted, page_lookup = build_related_index(all_pages, taxonomy_names)
@@ -579,7 +579,7 @@ module Hwaro::Core::Build::Phases::Transform
     # under `--drafts` site.authors would list draft posts the generated author
     # page omits — two views of the same author disagreeing.
     site.pages.each do |page|
-      next if page.draft || page.generated
+      next if page.draft || page.unpublished || page.generated
       page.authors.each do |author_id|
         # Normalize ID: lower case, stripped
         id = author_id.strip.downcase
@@ -684,7 +684,7 @@ module Hwaro::Core::Build::Phases::Transform
     groups = {} of String => Array(Models::Page)
 
     site.pages.each do |page|
-      next if page.draft || !page.render
+      next if page.draft || page.unpublished || !page.render
       if name = page.series
         (groups[name] ||= [] of Models::Page) << page
       end
@@ -722,7 +722,7 @@ module Hwaro::Core::Build::Phases::Transform
     taxonomy_names = config.taxonomies
     limit = config.limit
     return if limit <= 0
-    pages = site.pages.reject { |p| p.draft || p.is_index || p.generated || !p.render }
+    pages = site.pages.reject { |p| p.draft || p.unpublished || p.is_index || p.generated || !p.render }
 
     # Build inverted index: {taxonomy_name => {term => Array(page_path)}}
     # This avoids the O(N²) pairwise comparison

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -437,7 +437,10 @@ module Hwaro
         String.build(256) do |str|
           str << %(<meta property="og:title" content="#{Utils::TextUtils.escape_xml(title)}">\n  )
           str << %(<meta property="og:type" content="#{Utils::TextUtils.escape_xml(og_type)}">\n  )
-          str << %(<meta property="og:url" content="#{Utils::TextUtils.escape_xml(base_url)}#{Utils::TextUtils.escape_xml(url)}">)
+          # Percent-encode the path like feeds/sitemap do, so a non-ASCII URL
+          # (e.g. a Unicode taxonomy term) yields one consistent RFC 3986
+          # URL across every surface instead of raw UTF-8 here only.
+          str << %(<meta property="og:url" content="#{Utils::TextUtils.escape_xml(base_url)}#{Utils::TextUtils.escape_xml(Utils::TextUtils.encode_url_path(url))}">)
           if desc = description
             append_meta(str, "property", "og:description", desc)
           end

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -102,6 +102,15 @@ module Hwaro
       # Whether parsing (front-matter / markdown) failed for this page
       property parse_failed : Bool
 
+      # True when the page is outside its publication window at build time
+      # (future `date` or past `expires`). Such pages only survive the parse
+      # filter under --include-future / --include-expired — preview flags —
+      # and must then behave exactly like drafts under --drafts: the HTML
+      # page renders, but the page stays out of every public discovery
+      # surface (sitemap, feeds, search index, llms.txt) and out of
+      # generated listings (taxonomies, series, related posts, authors).
+      property unpublished : Bool
+
       # Runtime / Computed Properties
       property content : String
       property raw_content : String
@@ -155,6 +164,7 @@ module Hwaro
         @content = ""
         @raw_content = ""
         @section = ""
+        @unpublished = false
         @url = ""
         @is_index = false
         @in_sitemap = true
@@ -193,16 +203,26 @@ module Hwaro
       end
 
       # True when a page should be omitted from generated listings (taxonomy
-      # indexes, related posts, …): drafts and synthetic generated pages.
+      # indexes, related posts, …): drafts, preview-only unpublished pages,
+      # and synthetic generated pages.
       def excluded_from_listings? : Bool
-        draft || generated
+        draft || unpublished || generated
       end
 
       # True when a page is eligible for the search index / llms.txt: it emits
-      # HTML, isn't a draft, opts into the search index, and isn't a synthetic
-      # generated listing page.
+      # HTML, isn't a draft or preview-only unpublished page, opts into the
+      # search index, and isn't a synthetic generated listing page.
       def search_index_eligible? : Bool
-        render && !draft && in_search_index && !generated
+        render && !draft && !unpublished && in_search_index && !generated
+      end
+
+      # Recompute `unpublished` from the publication window (`date` in the
+      # future or `expires` in the past) relative to the build's single `now`.
+      # Called by the parse-phase filter and the incremental (--cache)
+      # re-parse path so every downstream consumer sees a consistent value.
+      def refresh_unpublished!(now : Time)
+        @unpublished = (expires.try { |e| e <= now } || false) ||
+                       (date.try { |d| d > now } || false)
       end
 
       # Resolve the term list for a configured taxonomy `name`. Most

--- a/src/services/content_lister.cr
+++ b/src/services/content_lister.cr
@@ -161,7 +161,7 @@ module Hwaro
         table.emit
 
         Logger.info ""
-        Logger.outcome("listed", "#{contents.size} files")
+        Logger.outcome("listed", "#{contents.size} #{contents.size == 1 ? "file" : "files"}")
       end
 
       private def find_content_files : Array(String)

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -913,10 +913,15 @@ module Hwaro
 
       private def confirm?(prompt : String) : Bool
         unless CLI::Prompt.interactive?
+          # Note: `--force` does NOT bypass an explicit `--confirm` — it only
+          # skips the automatic confirmation added for dangerous shell
+          # commands. The old hint claimed otherwise and sent script authors
+          # down a dead end.
           raise Hwaro::HwaroError.new(
             code: Hwaro::Errors::HWARO_E_USAGE,
             message: "Cannot prompt for confirmation: stdin is not a TTY.",
-            hint: "Pass --force to skip confirmation prompts in non-interactive environments.",
+            hint: "Drop --confirm (or confirm = true in config.toml) for non-interactive deploys. " \
+                  "If this prompt came from a deploy command with shell metacharacters, --force skips that check.",
           )
         end
         CLI::Prompt.confirm?(prompt, default: false) == true

--- a/src/services/exporters/jekyll_exporter.cr
+++ b/src/services/exporters/jekyll_exporter.cr
@@ -4,12 +4,27 @@ module Hwaro
   module Services
     module Exporters
       class JekyllExporter < Base
+        # Top-level sections whose dated content maps to Jekyll's `_posts/`
+        # collection. `posts` is what the Jekyll importer itself produces
+        # (round-trip symmetric) and `blog` is the other common Hwaro layout.
+        # Membership in one of these sections — not the mere presence of a
+        # `date` — is what makes a file a blog post: Hwaro auto-stamps `date`
+        # on every `hwaro new` page, so "has a date" alone misclassified
+        # ordinary pages (`about.md`, deep section pages) as posts.
+        POST_SECTIONS = %w[posts blog]
+
+        # Destinations already written this run, used to disambiguate
+        # collisions (e.g. two same-day leaf bundles both named `index.md`)
+        # instead of silently overwriting the earlier export.
+        @written_paths = Set(String).new
+
         def run(options : Config::Options::ExportOptions) : ExportResult
           content_dir = options.content_dir
           output_dir = options.output_dir
           include_drafts = options.drafts
           verbose = options.verbose
 
+          @written_paths.clear
           files = scan_content_files(content_dir)
 
           if files.empty?
@@ -107,9 +122,28 @@ module Hwaro
           body = rewrite_internal_links(body)
 
           out_path = resolve_jekyll_path(file_path, content_dir, output_dir, fields, is_draft, include_drafts)
+          out_path = disambiguate_path(out_path)
 
           write_file(out_path, "#{frontmatter}\n\n#{body.strip}\n", verbose)
           :exported
+        end
+
+        # Reserve `path` for this run, appending `-1`, `-2`, … (with a
+        # warning) when an earlier file already claimed it. Flattening into
+        # `_posts/` makes collisions possible — two leaf bundles published
+        # the same day used to silently clobber each other.
+        private def disambiguate_path(path : String) : String
+          return path if @written_paths.add?(path)
+
+          ext = File.extname(path)
+          stem = path.chomp(ext)
+          n = 1
+          until @written_paths.add?("#{stem}-#{n}#{ext}")
+            n += 1
+          end
+          unique = "#{stem}-#{n}#{ext}"
+          Logger.warn "Export destination collision: #{path} already written this run; writing #{File.basename(unique)} instead."
+          unique
         end
 
         # Map a Hwaro content path to its Jekyll-conventional destination.
@@ -120,7 +154,10 @@ module Hwaro
         #     `_posts/posts/foo.md` would erroneously put every post in a
         #     `posts` category.
         #   - `_drafts/<slug>.md` — drafts, no date prefix.
-        #   - Root pages (`about.md`, `index.md`, ...) — anything else.
+        #   - Regular pages (`about.md`, `team/engineering/…`) — anything
+        #     else, exported with its directory layout preserved.
+        # Only dated files under a POST_SECTIONS top-level section become
+        # posts; everything else keeps its tree, whatever its `date` says.
         # `_index.md` (Hwaro's section index) maps to `<section>/index.md`,
         # the closest Jekyll equivalent (a normal page that happens to be
         # the section landing page).
@@ -147,22 +184,31 @@ module Hwaro
           dated = date_prefix && date_prefix.matches?(/^\d{4}-\d{2}-\d{2}$/)
           slug = filename.sub(/\.(md|markdown)$/, "")
 
-          # Files with a `date` are blog posts. Place them flat in `_posts/`
-          # (or `_drafts/` for drafts) — any source subdirectory like
-          # `content/posts/` or `content/blog/` is collapsed, because Jekyll
-          # treats subdirs under `_posts/` as category hints and re-applying
-          # the source folder as a category is almost never what the author
-          # meant on a Hwaro→Jekyll migration.
-          if dated
+          # Leaf bundle (`posts/my-post/index.md`): the slug is the bundle
+          # directory, not "index" — a literal "index" slug collided across
+          # every same-day bundle once flattened into `_posts/`.
+          if slug == "index" && dir_part != "." && !dir_part.empty?
+            slug = File.basename(dir_part)
+          end
+
+          # Content under a posts-like top-level section is a blog post:
+          # flat in `_posts/` when dated (or `_drafts/` for drafts — Jekyll
+          # draft filenames carry no date, so validity doesn't matter there),
+          # collapsing the source subdirectory — Jekyll treats subdirs under
+          # `_posts/` as category hints, and re-applying the source folder
+          # as a category is almost never what the author meant on a
+          # Hwaro→Jekyll migration.
+          top_section = relative.includes?('/') ? relative.split('/').first : nil
+          if top_section && POST_SECTIONS.includes?(top_section)
             if is_draft && include_drafts
               return File.join(output_dir, "_drafts", "#{slug}.md")
             end
-            return File.join(output_dir, "_posts", "#{date_prefix}-#{slug}.md")
+            return File.join(output_dir, "_posts", "#{date_prefix}-#{slug}.md") if dated
           end
 
-          # Non-dated content (about, index, archives, etc.) → keep the
-          # on-disk layout under the export root so Jekyll picks them up as
-          # regular pages (not as posts hidden under `_posts/`).
+          # Everything else (about, team/…, archives, dated or not) → keep
+          # the on-disk layout under the export root so Jekyll picks them up
+          # as regular pages and their section identity survives.
           File.join(output_dir, relative)
         end
       end


### PR DESCRIPTION
## Summary

Dogfood round against a v0.17.0 release build (3 parallel exploration passes: CLI/scaffolds, new features, core rendering + the repo docs site in a browser). 13 confirmed bugs fixed, no behavior changes for default builds on well-formed content — the repo docs site builds **byte-identical** before/after (`diff -r` of `public/` trees, OG/image steps skipped for determinism).

### Correctness

- **`[outputs].sections` gated page output too** — `sections = ["posts"]` silently dropped `page`-level JSON/XML everywhere outside `posts/`. It now scopes `section` output only, per the documented contract (`src/core/build/phases/output_formats.cr`).
- **`--include-future` / `--include-expired` leaked into public artifacts** — future/expired pages admitted by the preview flags appeared in `sitemap.xml`, RSS/Atom, `search.json`, and `llms.txt` (unlike `--drafts`). Pages now carry an `unpublished` flag stamped from the publication window in both the full parse phase and the `--cache` re-parse path; every filter that excludes drafts excludes them identically (artifacts + taxonomy/series/related/author listings).
- **Jekyll exporter** — "has a `date` ⇒ blog post" misfiled ordinary pages flat into `_posts/` (every `hwaro new` page is auto-dated); only `posts/`/`blog/` content maps to `_posts/` now (round-trip symmetric with the importer), other pages keep their tree. Leaf-bundle posts slug from the bundle dir instead of `index` (same-day bundles used to silently clobber each other); destination collisions warn and disambiguate.
- **`check-links` fence desync** — the non-greedy `/```[\s\S]*?```/` stripper mispaired a 4-backtick example wrapping a 3-backtick fence, resurrecting later documentation-only links as false-positive dead links (hit by our own docs). Replaced with line-based CommonMark fence tracking.
- **Canonical/og:url/hreflang raw UTF-8** — non-ASCII paths (Unicode taxonomy terms) now percent-encode like feeds/sitemap already did, so one page advertises one RFC 3986 URL everywhere.
- **Taxonomy term whitespace** — `"  spaced-tag  "` slugified clean but leaked verbatim into term-page `<h1>`/`<title>`/RSS, and a padded duplicate split into a second `-2` term page. Terms/tags/authors/aliases are stripped at parse time.

### UX / diagnostics

- **`doctor` false `[ok]`** — with an unparseable config, the 8 config sub-checks that never ran rendered green; they now render `(skipped)` (`--json` was already honest).
- **`deploy` wrong hint** — the non-TTY error claimed `--force` skips `--confirm`; it doesn't. Hint now explains the real outs.
- **OG images: emoji tofu** — codepoints the loaded font can't draw are skipped (`🔥🎉 Emoji Title Test 🌟` → `Emoji Title Test`) instead of blank boxes.
- **Heading hook + `{#id .class}` double space**; **`linenostart=0`/`hl_lines="0"` silently clamped to 1** (now dropped as invalid, matching negatives); **duplicate explicit `{#id}` renames now warn** (parity with menus); **pluralization** (`1 file`/`1 draft`/`1 unused asset`), `tool convert` comment-loss note, `unused-assets --help` scope note.

### Docs content

- `render-hooks.md`: the "default-equivalent" codeblock template was missing the ` hljs` class stock output emits under the default config — copying the docs' own template silently broke Highlight.js theming.
- `filters.md`: unescaped pipe split the Tests table into 4 columns mid-page; `writing/pages.md`: `[links](url)` placeholders rendered as real broken links. Both now code spans; `hwaro tool check-links` runs clean on `docs/` (`275 links, all healthy`).

## Test plan

- `crystal spec`: **6007 examples, 0 failures** (new specs: `unpublished_content_spec`, outputs page/section scoping, jekyll classification/bundle-slug/collision/undated-draft, nested-fence check-links regression, canonical encoding + double-encode guard, term trimming, fence-option zero rejection)
- `crystal tool format --check` + ameba: clean (399 files)
- Every fix re-verified end-to-end with a rebuilt release binary against scratch sites (preview-flag matrix incl. default-build regression check, jekyll export tree, broken-config doctor render, OG PNG visual check, HATTR/hook output bytes)
- Docs site output diff old-vs-new binary: **0 lines** (no unintended output changes)