### PR TITLE
fix: make serve rebuilds snapshot-consistent and self-healing on template rewrites

### DIFF
--- a/spec/unit/builder_orchestration_run_spec.cr
+++ b/spec/unit/builder_orchestration_run_spec.cr
@@ -155,5 +155,106 @@ describe Hwaro::Core::Build::Builder do
         File.exists?("public/about/index.html").should be_true
       end
     end
+
+    it "refreshes the search index after a combined content+template change" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", <<-TOML)
+            title = "T"
+            base_url = "http://localhost"
+
+            [search]
+            enabled = true
+            TOML
+          FileUtils.mkdir_p("content")
+          File.write("content/about.md", "---\ntitle: About\n---\nbody")
+          FileUtils.mkdir_p("templates")
+          File.write("templates/page.html", "<p>{{ content }}</p>")
+
+          builder = Hwaro::Core::Build::Builder.new
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          builder.run(options)
+          File.read("public/search.json").should contain("About")
+
+          # Save content and template together — the watcher's
+          # :content_and_template strategy. The SEO surfaces read page
+          # content/metadata, so they must refresh here just like the
+          # pure content-incremental path does.
+          File.write("content/about.md", "---\ntitle: Refreshed\n---\nbody")
+          File.write("templates/page.html", "<div>{{ content }}</div>")
+          builder.run_incremental_then_rerender(["content/about.md"], options)
+
+          File.read("public/search.json").should contain("Refreshed")
+        end
+      end
+    end
+  end
+
+  describe "#run_rerender output formats" do
+    it "re-renders sibling format outputs when only the format template changed" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", <<-TOML)
+            title = "T"
+            base_url = "http://localhost"
+
+            [outputs]
+            page = ["json"]
+            TOML
+          FileUtils.mkdir_p("content")
+          File.write("content/about.md", "---\ntitle: About\n---\nbody")
+          FileUtils.mkdir_p("templates")
+          File.write("templates/page.html", "<p>{{ content }}</p>")
+          File.write("templates/page.json.jinja", %({"v": 1}))
+
+          builder = Hwaro::Core::Build::Builder.new
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          builder.run(options)
+          File.read("public/about/index.json").should contain(%("v": 1))
+
+          # Edit ONLY the format template. Its pages' HTML entry template is
+          # untouched, so the selective re-render must pick them up through
+          # the format-template check or index.json stays stale.
+          File.write("templates/page.json.jinja", %({"v": 2}))
+          builder.run_rerender(options)
+
+          File.read("public/about/index.json").should contain(%("v": 2))
+        end
+      end
+    end
+  end
+
+  describe "template snapshot consistency" do
+    it "renders with the loaded template snapshot even when a partial changed on disk" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = "http://localhost"))
+          FileUtils.mkdir_p("content")
+          File.write("content/about.md", "---\ntitle: About\n---\nbody")
+          FileUtils.mkdir_p("templates/partials")
+          File.write("templates/partials/nav.html", "NAV-OLD")
+          File.write("templates/page.html", %({% include "partials/nav.html" %}|{{ content }}))
+
+          builder = Hwaro::Core::Build::Builder.new
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          builder.run(options)
+          File.read("public/about/index.html").should contain("NAV-OLD")
+
+          # An editor rewrites the partial while no template reload has
+          # happened (mid-rebuild in serve terms). A content-only
+          # incremental pass must keep rendering the snapshot the build
+          # loaded — half-written disk state must not leak into output.
+          File.write("templates/partials/nav.html", "NAV-DISK")
+          File.write("content/about.md", "---\ntitle: About\n---\nbody v2")
+          builder.run_incremental(["content/about.md"], options)
+          File.read("public/about/index.html").should contain("NAV-OLD")
+
+          # The template edit's own rebuild (run_rerender reloads the
+          # snapshot from disk) then converges on the new partial.
+          builder.run_rerender(options)
+          File.read("public/about/index.html").should contain("NAV-DISK")
+        end
+      end
+    end
   end
 end

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -2524,6 +2524,12 @@ describe "watcher ignore patterns" do
     "emacs lock file"       => ".#note.md",
     "emacs autosave"        => "#note.md#",
     ".DS_Store"             => ".DS_Store",
+    ".tmp atomic-save file" => "page.html.tmp",
+    "VS Code crswap"        => "page.html.crswap",
+    "JetBrains safe write"  => "page.html___jb_tmp___",
+    "JetBrains old backup"  => "page.html___jb_old___",
+    "gedit atomic save"     => ".goutputstream-4XQ2K1",
+    "vim write probe"       => "4913",
   }.each do |label, name|
     it "ignores #{label} (#{name})" do
       Hwaro::Services::Server.test_watcher_ignored?(name).should be_true
@@ -2549,6 +2555,16 @@ describe "watcher ignore patterns" do
     # leading .#) should be dropped.
     Hwaro::Services::Server.test_watcher_ignored?("notes-for-~user.md").should be_false
     Hwaro::Services::Server.test_watcher_ignored?("tag-#python.md").should be_false
+  end
+
+  it "does NOT ignore files that merely resemble atomic-save byproducts" do
+    # "tmp" inside a name (or as a stem) is fine — only the trailing
+    # `.tmp` extension is a save byproduct. Same for a numeric name that
+    # isn't exactly vim's `4913` probe.
+    Hwaro::Services::Server.test_watcher_ignored?("tmp.html").should be_false
+    Hwaro::Services::Server.test_watcher_ignored?("templates/tmpl.html").should be_false
+    Hwaro::Services::Server.test_watcher_ignored?("content/posts/14913.md").should be_false
+    Hwaro::Services::Server.test_watcher_ignored?("static/img/4913.png").should be_false
   end
 
   it "excludes matched files from scan_mtimes" do

--- a/spec/unit/snapshot_template_loader_spec.cr
+++ b/spec/unit/snapshot_template_loader_spec.cr
@@ -1,0 +1,102 @@
+require "../spec_helper"
+require "../../src/core/build/builder"
+
+# SnapshotTemplateLoader serves {% include %}/{% extends %} references from
+# the in-memory template snapshot so a serve rebuild can't observe files an
+# editor is rewriting mid-render. References the snapshot can't answer fall
+# back to the filesystem loader, matching the old behavior exactly.
+
+private def with_templates_dir(&)
+  Dir.mktmpdir do |dir|
+    Dir.cd(dir) do
+      FileUtils.mkdir_p("templates/partials")
+      yield dir
+    end
+  end
+end
+
+private def build_loader(
+  templates : Hash(String, String),
+  paths : Hash(String, String),
+) : Hwaro::Core::Build::SnapshotTemplateLoader
+  Hwaro::Core::Build::SnapshotTemplateLoader.new(
+    templates, paths, Crinja::Loader::FileSystemLoader.new("templates/")
+  )
+end
+
+describe Hwaro::Core::Build::SnapshotTemplateLoader do
+  it "serves a referenced partial from the snapshot, not from disk" do
+    with_templates_dir do
+      File.write("templates/partials/nav.html", "DISK")
+      loader = build_loader(
+        {"partials/nav" => "SNAPSHOT"},
+        {"partials/nav" => "templates/partials/nav.html"},
+      )
+
+      source, file_name = loader.get_source(Crinja.new, "partials/nav.html")
+      source.should eq("SNAPSHOT")
+      file_name.should eq("templates/partials/nav.html")
+    end
+  end
+
+  it "keeps serving the snapshot when the file on disk was rewritten mid-build" do
+    with_templates_dir do
+      File.write("templates/partials/nav.html", "OLD")
+      loader = build_loader(
+        {"partials/nav" => "OLD"},
+        {"partials/nav" => "templates/partials/nav.html"},
+      )
+
+      # Editor rewrites the partial while a render is in flight — even a
+      # half-written file must not leak into this build's output.
+      File.write("templates/partials/nav.html", "HALF-WRIT")
+
+      source, _ = loader.get_source(Crinja.new, "partials/nav.html")
+      source.should eq("OLD")
+    end
+  end
+
+  it "falls back to disk for names outside the snapshot" do
+    with_templates_dir do
+      File.write("templates/partials/foot.html", "DISK-ONLY")
+      loader = build_loader(
+        {"partials/nav" => "SNAPSHOT"},
+        {"partials/nav" => "templates/partials/nav.html"},
+      )
+
+      source, _ = loader.get_source(Crinja.new, "partials/foot.html")
+      source.should eq("DISK-ONLY")
+    end
+  end
+
+  it "falls back to disk for an extension variant the snapshot didn't load" do
+    with_templates_dir do
+      # foo.html won the snapshot slot (extension priority), but the
+      # reference names foo.j2 explicitly — read its own file, like the
+      # filesystem loader would.
+      File.write("templates/foo.j2", "J2-DISK")
+      loader = build_loader(
+        {"foo" => "HTML-SNAPSHOT"},
+        {"foo" => "templates/foo.html"},
+      )
+
+      source, _ = loader.get_source(Crinja.new, "foo.j2")
+      source.should eq("J2-DISK")
+    end
+  end
+
+  it "does not claim extension-less references (filesystem semantics preserved)" do
+    with_templates_dir do
+      loader = build_loader(
+        {"partials/nav" => "SNAPSHOT"},
+        {"partials/nav" => "templates/partials/nav.html"},
+      )
+
+      # `{% include "partials/nav" %}` never resolved via the stripped-name
+      # hash before; the literal file doesn't exist, so this stays an error.
+      expect_raises(Crinja::TemplateNotFoundError) do
+        loader.get_source(Crinja.new, "partials/nav")
+      end
+    end
+  end
+end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -24,6 +24,7 @@ require "./cache"
 require "./cache_manager"
 require "./parallel"
 require "./template_deps"
+require "./template_loader"
 require "./shortcode_processor"
 require "./phases/initialize"
 require "./phases/read_content"
@@ -737,7 +738,8 @@ module Hwaro
                               selected = renderable_pages.select do |page|
                                 entry = determine_template(page, templates, site)
                                 affected_templates.includes?(entry) ||
-                                  deps.shortcodes_used_in(page.raw_content).any? { |sc| affected_templates.includes?(sc) }
+                                  deps.shortcodes_used_in(page.raw_content).any? { |sc| affected_templates.includes?(sc) } ||
+                                  format_templates_affected?(page, templates, site, affected_templates)
                               end
                               if forced = force_pages
                                 seen = selected.map(&.path).to_set
@@ -776,10 +778,22 @@ module Hwaro
           # resolution falls back taxonomy_term -> taxonomy -> page, so any
           # of those being affected triggers the regeneration. Forced content
           # pages may have changed taxonomy membership — regenerate then too.
-          if affected_templates.nil? ||
-             (force_pages && !force_pages.empty?) ||
-             ["taxonomy", "taxonomy_term", "page"].any? { |name| affected_templates.includes?(name) }
-            Content::Taxonomies.generate(site, output_dir, templates, verbose, builder: self)
+          taxonomy_sections = if affected_templates.nil? ||
+                                 (force_pages && !force_pages.empty?) ||
+                                 ["taxonomy", "taxonomy_term", "page"].any? { |name| affected_templates.includes?(name) }
+                                Content::Taxonomies.generate(site, output_dir, templates, verbose, builder: self)
+                              else
+                                [] of Models::Section
+                              end
+
+          # Content changed in this pass (run_incremental_then_rerender):
+          # sitemap/feeds/search/llms read page content and metadata, so
+          # refresh them like run_incremental does. Pure template edits skip
+          # this — template output doesn't feed the SEO surfaces.
+          if (forced = force_pages) && !forced.empty?
+            seo_pages = (site.pages + site.sections).as(Array(Models::Page))
+            seo_pages += taxonomy_sections unless taxonomy_sections.empty?
+            regenerate_seo_surfaces(seo_pages, site, output_dir, verbose, options.parallel, include_robots: true)
           end
 
           cache.save if options.cache

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -254,7 +254,9 @@ module Hwaro::Core::Build::Phases::Initialize
     end
 
     templates = {} of String => String
-    @template_paths.clear
+    # Built fresh and swapped in (never mutated in place) so a loader
+    # holding the previous snapshot keeps a consistent pair of hashes.
+    template_paths = {} of String => String
     if Dir.exists?("templates")
       # Single glob for all supported template extensions.
       # Priority: html > j2 > jinja2 > jinja > ecr (first loaded wins via ||=)
@@ -270,8 +272,10 @@ module Hwaro::Core::Build::Phases::Initialize
         name = relative.to_s.gsub(Builder::TEMPLATE_EXTENSION_REGEX, "")
         # Don't overwrite if already loaded (higher priority extensions loaded first)
         unless templates.has_key?(name)
-          templates[name] = File.read(path)
-          @template_paths[name] = path
+          if source = read_template_source(path)
+            templates[name] = source
+            template_paths[name] = path
+          end
         end
       end
     end
@@ -279,11 +283,12 @@ module Hwaro::Core::Build::Phases::Initialize
     unless templates.has_key?("page")
       if templates.has_key?("default")
         templates["page"] = templates["default"]
-        if default_path = @template_paths["default"]?
-          @template_paths["page"] = default_path
+        if default_path = template_paths["default"]?
+          template_paths["page"] = default_path
         end
       end
     end
+    @template_paths = template_paths
 
     # (Re)build the template dependency graph for selective invalidation
     @template_deps = TemplateDeps.new(templates)
@@ -304,10 +309,39 @@ module Hwaro::Core::Build::Phases::Initialize
 
     compute_template_var_features(templates)
 
-    # Initialize Crinja environment with file system loader
+    # Publish the snapshot BEFORE (re)building the Crinja environment so its
+    # snapshot-backed loader captures this load's template set.
+    @templates = templates
+
+    # Initialize Crinja environment with the snapshot-backed loader
     @crinja_env = setup_crinja_env
 
-    @templates = templates
+    templates
+  end
+
+  # How long `read_template_source` rides out a template file that a glob
+  # just found but a read can't open — the delete-then-recreate window of
+  # editors using "safe write" saves (vim without backupcopy, some IDEs).
+  TEMPLATE_READ_RETRIES        = 4
+  TEMPLATE_READ_RETRY_INTERVAL = 25.milliseconds
+
+  # Read a template's source, retrying briefly when the file is momentarily
+  # unreadable mid-save. A file that stays unreadable is treated as deleted
+  # (skipped with a warning) rather than aborting the whole build — during
+  # serve, the watcher's removed-file detection follows up with a full
+  # rebuild once the filesystem settles.
+  private def read_template_source(path : String) : String?
+    attempts = 0
+    loop do
+      return File.read(path)
+    rescue ex : IO::Error
+      attempts += 1
+      if attempts >= TEMPLATE_READ_RETRIES
+        Logger.warn "Could not read template #{path} (#{ex.message}); skipping it for this build."
+        return
+      end
+      sleep TEMPLATE_READ_RETRY_INTERVAL
+    end
   end
 
   # Decide, per entry template, which expensive per-page variables its static
@@ -347,9 +381,9 @@ module Hwaro::Core::Build::Phases::Initialize
   private def setup_crinja_env : Crinja
     env = Content::Processors::Template.engine.env
 
-    # Set up file system loader for template inheritance and includes
-    if Dir.exists?("templates")
-      env.loader = Crinja::Loader::FileSystemLoader.new("templates/")
+    # Set up template loader for template inheritance and includes
+    if loader = build_template_loader
+      env.loader = loader
     end
 
     env
@@ -366,10 +400,25 @@ module Hwaro::Core::Build::Phases::Initialize
   private def create_fresh_crinja_env : Crinja
     engine = Content::Processors::TemplateEngine.new
     env = engine.env
-    if Dir.exists?("templates")
-      env.loader = Crinja::Loader::FileSystemLoader.new("templates/")
+    if loader = build_template_loader
+      env.loader = loader
     end
     env
+  end
+
+  # Loader for `{% include %}`/`{% extends %}` resolution. Once templates
+  # are loaded, references resolve against the in-memory snapshot (see
+  # SnapshotTemplateLoader) so a rebuild can't observe half-written files
+  # an editor is rewriting mid-render; before that (or for names outside
+  # the snapshot) the filesystem loader answers, exactly as before.
+  private def build_template_loader : Crinja::Loader?
+    return unless Dir.exists?("templates")
+    disk = Crinja::Loader::FileSystemLoader.new("templates/")
+    if (templates = @templates) && !templates.empty?
+      SnapshotTemplateLoader.new(templates, @template_paths, disk)
+    else
+      disk
+    end
   end
 
   # Tree node used while assembling `site.data` from the `data/` directory.

--- a/src/core/build/phases/output_formats.cr
+++ b/src/core/build/phases/output_formats.cr
@@ -88,6 +88,28 @@ module Hwaro::Core::Build::Phases::OutputFormats
     )
   end
 
+  # True when one of `page`'s extra output formats resolves to a template in
+  # `affected`. The serve-mode selective re-render checks this alongside the
+  # HTML entry template: editing e.g. `templates/page.json.jinja` leaves the
+  # entry template untouched, so without this check no page re-renders and
+  # the sibling `index.json` files serve stale content until a full rebuild.
+  def format_templates_affected?(page : Models::Page, templates : Hash(String, String), site : Models::Site, affected : Set(String)) : Bool
+    formats = effective_output_formats(page, site.config)
+    return false if formats.empty?
+
+    formats.any? do |fmt|
+      name = begin
+        determine_format_template(page, fmt, templates, site)
+      rescue Hwaro::HwaroError
+        # No template exists for this format — render_page will surface that
+        # for the page when something else selects it; a missing template
+        # can't be the one that changed.
+        nil
+      end
+      name ? affected.includes?(name) : false
+    end
+  end
+
   # Render and write every enabled extra format for `page`. No-op when
   # `effective_output_formats` is empty — the common case when the feature
   # isn't configured at all, so this is a cheap guard on every page.

--- a/src/core/build/template_loader.cr
+++ b/src/core/build/template_loader.cr
@@ -1,0 +1,56 @@
+# Snapshot-consistent Crinja template loader.
+#
+# Entry templates render from the in-memory hash `load_templates` built, but
+# `{% include %}` / `{% extends %}` / `{% import %}` / `{% from %}` resolve
+# through the Crinja environment's loader at render time. With a plain
+# `FileSystemLoader` that meant partials were re-read from DISK on every
+# render — so an editor (or agent) rewriting template files while a serve
+# rebuild was in flight could feed half-written or momentarily-missing
+# sources into the very rebuild that was meant to pick them up cleanly,
+# producing broken pages or spurious template errors.
+#
+# This loader serves references from the same snapshot the entry templates
+# come from, making every rebuild internally consistent: one template state
+# in, one site state out. References the snapshot can't answer fall back to
+# the filesystem loader so behavior outside the snapshot (extension-less
+# names, extension variants shadowed by load priority, exotic files) is
+# unchanged.
+
+require "crinja"
+
+module Hwaro
+  module Core
+    module Build
+      class SnapshotTemplateLoader < Crinja::Loader
+        # `templates` is keyed by extension-stripped name ("partials/nav"),
+        # `template_paths` maps that name to the source file the snapshot
+        # actually loaded ("templates/partials/nav.html"). Both hashes are
+        # treated as read-only; `load_templates` swaps in fresh hashes on
+        # reload rather than mutating these.
+        def initialize(
+          @templates : Hash(String, String),
+          @template_paths : Hash(String, String),
+          @fallback : Crinja::Loader,
+        )
+        end
+
+        def get_source(env : Crinja, template : String) : {String, String?}
+          name = template.sub(Builder::TEMPLATE_EXTENSION_REGEX, "")
+
+          # Only claim references that name the exact file the snapshot
+          # loaded (extension included). This keeps two behaviors identical
+          # to the filesystem loader: an extension-less reference still
+          # resolves (or fails) against the literal file, and a reference to
+          # a lower-priority extension variant (`foo.j2` while `foo.html`
+          # won the snapshot slot) still reads its own file.
+          if name != template && (source = @templates[name]?)
+            path = @template_paths[name]?
+            return {source, path} if path && path == File.join("templates", template)
+          end
+
+          @fallback.get_source(env, template)
+        end
+      end
+    end
+  end
+end

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -418,6 +418,13 @@ module Hwaro
     class Server
       @builder : Core::Build::Builder
       @live_reload_handler : LiveReloadHandler?
+      # True after a watch rebuild raised. A failed rebuild can leave the
+      # builder's in-memory state (reloaded templates, partially updated
+      # site relationships) ahead of what's on disk, and the pages that
+      # failed to render are not re-selected when the NEXT event touches an
+      # unrelated file — so the next changeset escalates to a full rebuild
+      # to guarantee convergence, whatever the user saves.
+      @rebuild_failed : Bool = false
 
       # Debounce interval: after detecting changes, wait this long for
       # additional changes to settle before triggering a rebuild.
@@ -598,6 +605,11 @@ module Hwaro
               @builder.render_deferred(deferred_options)
               @live_reload_handler.try(&.notify_reload)
             rescue ex
+              # Deferred pages have no HTML on disk yet and incremental
+              # strategies will never render them — flag the failure so the
+              # first watch rebuild escalates to a full one (the watcher only
+              # starts after this fiber signals done, so no race on the flag).
+              @rebuild_failed = true
               Logger.error "[Fast-start] Background render failed: #{ex.message}"
               Logger.debug "[Fast-start] Backtrace: #{ex.backtrace?.try(&.first(5).join("\n    ")) || "unavailable"}"
               @live_reload_handler.try(&.notify_build_error(ex.message || "Background render failed"))
@@ -705,11 +717,13 @@ module Hwaro
 
                 begin
                   apply_changeset(changeset, build_options)
+                  @rebuild_failed = false
                 rescue ex
                   # Surface the failure both in the terminal and the
                   # browser. Without the WS push the developer sees the
                   # stale page and keeps editing on top of a broken
                   # build until they happen to glance at the terminal.
+                  @rebuild_failed = true
                   Logger.error "[Watch] Build failed: #{ex.message}"
                   Logger.debug "[Watch] Backtrace: #{ex.backtrace?.try(&.first(5).join("\n    ")) || "unavailable"}"
                   @live_reload_handler.try(&.notify_build_error(ex.message || "Build failed"))
@@ -829,6 +843,13 @@ module Hwaro
       # Choose the cheapest rebuild strategy for a given ChangeSet and execute it.
       private def apply_changeset(changeset : ChangeSet, build_options : Config::Options::BuildOptions)
         strategy = changeset.rebuild_strategy
+        # After a failed rebuild the cheap strategies can't be trusted to
+        # cover the pages the failure left stale — rebuild everything once,
+        # then return to incremental strategies (see @rebuild_failed).
+        if @rebuild_failed && strategy != :full
+          Logger.info "  Previous rebuild failed — running a full rebuild to recover."
+          strategy = :full
+        end
         # Calm watch timeline: one "↻ changed <what> · time" event, then the
         # rebuild's own "▴ rebuilt …" outcome line below it, both on the same
         # 2-space grid so the verbs and values column-align. The strategy is
@@ -948,6 +969,17 @@ module Hwaro
         # emacs autosave:    #filename#
         /(?:\A|\/)\.#[^\/]+$/,
         /(?:\A|\/)#[^\/]+#$/,
+        # Atomic-save temp files: write-to-temp-then-rename editors create
+        # these next to the target for a moment. Watching them turned every
+        # such save into an add+remove pair — a needless FULL rebuild — and,
+        # worse, could trigger a rebuild while the real file was still being
+        # swapped in.
+        /\.tmp$/,
+        /\.crswap$/,                        # VS Code safe-write swap
+        /___jb_tmp___$/,                    # JetBrains safe write
+        /___jb_old___$/,                    # JetBrains safe-write backup
+        /(?:\A|\/)\.goutputstream-[^\/]+$/, # GNOME (gedit) atomic save
+        /(?:\A|\/)4913$/,                   # vim's write-permission probe
       ]
 
       protected def self.watcher_ignored?(path : String) : Bool


### PR DESCRIPTION
## Problem

Rewriting template files during `hwaro serve` intermittently broke the served site — torn layouts, stale sibling outputs, and pages that never recovered until an unrelated full rebuild.

## Root causes & fixes

1. **Render-time disk reads for partials.** Entry templates render from the in-memory snapshot, but `{% include %}`/`{% extends %}`/`{% import %}` resolved through Crinja's `FileSystemLoader` — re-read from disk on every render. An editor or agent rewriting files mid-rebuild leaked half-written partials into the very rebuild meant to pick them up. → New `SnapshotTemplateLoader` serves references from the same snapshot the entry templates use, so every rebuild is internally consistent: one template state in, one site state out. References outside the snapshot (extension-less names, extension variants shadowed by load priority) fall back to the filesystem loader, preserving existing semantics exactly.

2. **Output-format template edits re-rendered nothing.** Editing `templates/page.json.jinja` selected 0 pages in the selective rerender (only the HTML entry template + shortcodes were checked), leaving `index.json` stale until a full rebuild. → Page selection now also checks each page's effective format templates (`format_templates_affected?`).

3. **Combined content+template saves skipped the SEO surfaces.** `run_incremental_then_rerender` never refreshed sitemap/feeds/search/llms (the pure content-incremental path does). → `run_rerender` regenerates them when `force_pages` are present; pure template edits still skip the work.

4. **Failed rebuilds never converged.** A failed rebuild leaves the builder's in-memory state (reloaded templates, partially updated relationships) ahead of the on-disk output, and the failed pages were never re-selected when the next event touched an unrelated file. → The watcher escalates the next rebuild to `:full` after any failure, including a failed fast-start background render.

5. **Atomic-save byproducts triggered mid-save rebuilds.** `.tmp`, VS Code `.crswap`, JetBrains `___jb_tmp___`/`___jb_old___`, gedit `.goutputstream-*`, and vim's `4913` probe are now ignored by the watcher, and `load_templates` retries briefly when a globbed template file momentarily vanishes during a delete-then-recreate save instead of aborting the whole rebuild.

## Verification

- Full spec suite: 6032 examples, 0 failures; `crystal tool format --check` + ameba clean
- 14 new specs: loader resolution/fallback semantics, new watcher ignore patterns, and regression tests for format-template rerender, SEO-surface refresh, and snapshot render consistency
- **Byte-identical cold-build output vs `main`** (`diff -r` on a site exercising extends/includes/shortcodes/outputs/search/taxonomies, plus a branch-vs-branch determinism check)
- Live `hwaro serve` scenarios: format-template edit → `index.json` updates; broken partial → old pages stay intact, unrelated static save escalates to a full rebuild, fix converges every page; combined content+template save → search.json/rss.xml/HTML all refresh; a torn slow write (half the file, 1.2s pause, rest) fails transiently and converges automatically