### PR TITLE
fix: harden hwaro deploy against error-swallowing, stale deletes, and command corruption

### DIFF
--- a/docs/content/deploy/config.md
+++ b/docs/content/deploy/config.md
@@ -16,7 +16,6 @@ source_dir = "public"
 confirm = false
 dry_run = false
 max_deletes = 256
-workers = 10
 ```
 
 | Key | Type | Default | Description |
@@ -26,8 +25,7 @@ workers = 10
 | confirm | bool | false | Prompt for confirmation before deploying |
 | dry_run | bool | false | Show what would be deployed without making changes |
 | force | bool | false | Force deployment even if no changes detected |
-| max_deletes | int | 256 | Safety limit on file deletions (-1 disables the limit) |
-| workers | int | 10 | Number of concurrent workers |
+| max_deletes | int | 256 | Safety limit on file deletions (any negative value disables the limit) |
 
 ## Targets
 
@@ -57,7 +55,9 @@ command = "aws s3 sync {source}/ {url} --delete --exclude '.git/*'"
 | `file://` | Built-in directory sync | — |
 | `s3://` | `aws s3 sync {source}/ {url} --delete` | AWS CLI |
 | `gs://` | `gsutil -m rsync -r -d {source}/ {url}` | Google Cloud SDK |
-| `az://` | `az storage blob sync --source {source} --container {url}` | Azure CLI |
+| `az://` | `az storage blob sync --source {source} --container <container> [--destination <path>]` | Azure CLI |
+
+For `az://container/sub/dir` URLs the path becomes the `--destination` prefix inside the container.
 
 If a `command` field is set, it always takes priority over auto-generation.
 
@@ -84,23 +84,22 @@ Configure per-file deployment settings using pattern matchers:
 
 ```toml
 [[deployment.matchers]]
-pattern = "^.+\\.css$"
-cache_control = "max-age=31536000"
-gzip = true
-
-[[deployment.matchers]]
 pattern = "^.+\\.html$"
-cache_control = "max-age=3600"
-gzip = true
+force = true
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | pattern | string | — | Regex pattern to match file paths |
-| cache_control | string | — | Cache-Control header value |
-| content_type | string | — | Override Content-Type header |
-| gzip | bool | false | Gzip compress matched files |
-| force | bool | false | Always upload matched files |
+| force | bool | false | Always copy matched files, even when identical at the destination |
+| cache_control | string | — | Reserved — not applied by the built-in sync (see below) |
+| content_type | string | — | Reserved — not applied by the built-in sync (see below) |
+| gzip | bool | false | Reserved — not applied by the built-in sync (see below) |
+
+The built-in sync copies files and runs external CLIs; it does not talk to
+an object-store API, so it can only honor `force`. Setting `cache_control`,
+`content_type`, or `gzip` prints a warning — configure headers and
+compression at your host or CDN instead.
 
 ## See Also
 

--- a/spec/unit/deployer_service_spec.cr
+++ b/spec/unit/deployer_service_spec.cr
@@ -357,6 +357,237 @@ describe Hwaro::Services::Deployer do
       end
     end
 
+    # `hwaro deploy --dry-run --json` used to print `[]` with exit 0 for the
+    # exact configs where a real deploy raises — CI read "nothing to deploy"
+    # where the deploy itself would have failed.
+    describe "#plan parity with #run" do
+      it "raises HwaroError(HWARO_E_USAGE) for an unknown target" do
+        Dir.mktmpdir do |dir|
+          config = Hwaro::Models::Config.new
+          target = Hwaro::Models::DeploymentTarget.new
+          target.name = "production"
+          target.url = "file:///tmp/prod"
+          config.deployment.targets << target
+
+          options = Hwaro::Config::Options::DeployOptions.new(source_dir: dir, targets: ["staging"])
+          err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.plan(options, config) }
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+          (err.message || "").should contain("Unknown deploy target: staging")
+        end
+      end
+
+      it "raises HwaroError(HWARO_E_CONFIG) when the source directory is missing" do
+        Dir.mktmpdir do |dir|
+          config = Hwaro::Models::Config.new
+          target = Hwaro::Models::DeploymentTarget.new
+          target.name = "local"
+          target.url = "file://#{dir}/dest"
+          config.deployment.targets << target
+
+          options = Hwaro::Config::Options::DeployOptions.new(source_dir: "#{dir}/missing", targets: ["local"])
+          err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.plan(options, config) }
+          err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+          (err.message || "").should contain("Source directory not found")
+        end
+      end
+
+      it "raises HwaroError(HWARO_E_CONFIG) when no targets are configured" do
+        Dir.mktmpdir do |dir|
+          config = Hwaro::Models::Config.new
+          options = Hwaro::Config::Options::DeployOptions.new(source_dir: dir, targets: [] of String)
+          err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.plan(options, config) }
+          err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+          (err.message || "").should contain("No deployment targets")
+        end
+      end
+
+      it "raises HwaroError(HWARO_E_CONFIG) on an unsupported URL scheme" do
+        Dir.mktmpdir do |dir|
+          config = Hwaro::Models::Config.new
+          target = Hwaro::Models::DeploymentTarget.new
+          target.name = "unknown"
+          target.url = "gopher://example.com"
+          config.deployment.targets << target
+
+          options = Hwaro::Config::Options::DeployOptions.new(source_dir: dir, targets: ["unknown"])
+          err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.plan(options, config) }
+          err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+          (err.message || "").should contain("Unsupported deploy target URL scheme")
+        end
+      end
+
+      it "lists ops in deterministic sorted order" do
+        Dir.mktmpdir do |dir|
+          src_dir = File.join(dir, "src")
+          dest_dir = File.join(dir, "dest")
+          FileUtils.mkdir_p(File.join(src_dir, "c"))
+          File.write(File.join(src_dir, "b.html"), "b")
+          File.write(File.join(src_dir, "a.html"), "a")
+          File.write(File.join(src_dir, "c", "d.html"), "d")
+
+          config = Hwaro::Models::Config.new
+          target = Hwaro::Models::DeploymentTarget.new
+          target.name = "local"
+          target.url = "file://#{dest_dir}"
+          config.deployment.targets << target
+
+          options = Hwaro::Config::Options::DeployOptions.new(source_dir: src_dir, targets: ["local"])
+          ops = Hwaro::Services::Deployer.new.plan(options, config)
+          ops.map(&.path).should eq(["a.html", "b.html", "c/d.html"])
+        end
+      end
+    end
+
+    # Removed pages whose on-disk name was stripped (`blog/post/index.html` →
+    # `blog/post`) never matched source-shaped include globs like
+    # "**/*.html", so they survived every sync at the destination.
+    it "deletes stale stripped files when include globs match source paths" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(File.join(src_dir, "blog", "post1"))
+        File.write(File.join(src_dir, "blog", "post1", "index.html"), "p1")
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{dest_dir}"
+        target.include = "**/*.html"
+        target.strip_index_html = true
+        config.deployment.targets << target
+
+        deployer = Hwaro::Services::Deployer.new
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: src_dir, targets: ["local"])
+        deployer.run(options, config).should be_true
+        File.exists?(File.join(dest_dir, "blog", "post1")).should be_true
+
+        # Remove post1 from the source; the stale stripped file must go away.
+        FileUtils.rm_rf(File.join(src_dir, "blog", "post1"))
+        FileUtils.mkdir_p(File.join(src_dir, "blog", "post2"))
+        File.write(File.join(src_dir, "blog", "post2", "index.html"), "p2")
+
+        deployer.run(options, config).should be_true
+        File.exists?(File.join(dest_dir, "blog", "post1")).should be_false
+        File.exists?(File.join(dest_dir, "blog", "post2")).should be_true
+      end
+    end
+
+    # `--max-deletes -3` used to hard-refuse every deploy ("Refusing to
+    # delete 0 files") because only exactly -1 disabled the cap.
+    it "treats any negative max_deletes as disabling the delete cap" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(src_dir)
+        File.write(File.join(src_dir, "keep.html"), "x")
+        FileUtils.mkdir_p(dest_dir)
+        10.times { |i| File.write(File.join(dest_dir, "extra-#{i}.html"), "y") }
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{dest_dir}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: src_dir, targets: ["local"], max_deletes: -3,
+        )
+        Hwaro::Services::Deployer.new.run(options, config).should be_true
+        Dir.children(dest_dir).count(&.starts_with?("extra-")).should eq(0)
+      end
+    end
+
+    it "survives symlink cycles in the source tree" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(File.join(src_dir, "sub"))
+        File.write(File.join(src_dir, "index.html"), "hi")
+        # src/sub/loop → src: an unguarded walk crashes with ELOOP.
+        File.symlink("..", File.join(src_dir, "sub", "loop"))
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{dest_dir}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: src_dir, targets: ["local"])
+        Hwaro::Services::Deployer.new.run(options, config).should be_true
+        File.exists?(File.join(dest_dir, "index.html")).should be_true
+      end
+    end
+
+    it "refuses to deploy when the destination is a symlink into the source" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        FileUtils.mkdir_p(src_dir)
+        File.write(File.join(src_dir, "index.html"), "x")
+        link = File.join(dir, "alias_to_src")
+        File.symlink(src_dir, link)
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{link}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: src_dir, targets: ["local"])
+        err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Deployer.new.run(options, config) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        (err.message || "").should contain("overlap")
+      end
+    end
+
+    it "re-copies identical files matched by a force matcher" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(src_dir)
+        File.write(File.join(src_dir, "index.html"), "same")
+        File.write(File.join(src_dir, "style.css"), "same")
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{dest_dir}"
+        config.deployment.targets << target
+        matcher = Hwaro::Models::DeploymentMatcher.new
+        matcher.pattern = "^.+\\.html$"
+        matcher.force = true
+        config.deployment.matchers << matcher
+
+        deployer = Hwaro::Services::Deployer.new
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: src_dir, targets: ["local"])
+        deployer.deploy_structured(options, config).first.created.should eq(2)
+
+        # Second run with identical content: the html file matches the force
+        # matcher and is re-copied (updated), the css is skipped.
+        second = deployer.deploy_structured(options, config).first
+        second.updated.should eq(1)
+        second.created.should eq(0)
+      end
+    end
+
+    it "deduplicates repeated CLI target names" do
+      Dir.mktmpdir do |dir|
+        src_dir = File.join(dir, "src")
+        dest_dir = File.join(dir, "dest")
+        FileUtils.mkdir_p(src_dir)
+        File.write(File.join(src_dir, "index.html"), "x")
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "local"
+        target.url = "file://#{dest_dir}"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(source_dir: src_dir, targets: ["local", "local"])
+        results = Hwaro::Services::Deployer.new.deploy_structured(options, config)
+        results.size.should eq(1)
+      end
+    end
+
     it "auto-generates command for gs:// URL in dry_run" do
       Dir.mktmpdir do |dir|
         src_dir = File.join(dir, "src")
@@ -466,6 +697,32 @@ describe "Deployer private helpers" do
       result = deployer.test_expand_placeholders("echo done", "/tmp", target)
       result.should eq("echo done")
     end
+
+    # Sequential gsub used to re-expand placeholder-like text INSIDE expanded
+    # values: a source path containing a literal `{url}` had the target URL
+    # spliced into it (breaking the shell quoting along the way).
+    it "does not re-expand placeholder tokens inside expanded values" do
+      deployer = Hwaro::Services::Deployer.new
+      target = Hwaro::Models::DeploymentTarget.new
+      target.name = "prod"
+      target.url = "s3://my-bucket"
+
+      result = deployer.test_expand_placeholders("echo {source}", "/tmp/src{url}dir", target)
+      result.should eq("echo '/tmp/src{url}dir'")
+      result.should_not contain("s3://my-bucket")
+    end
+
+    it "does not reject brace tokens that only appear inside expanded values" do
+      deployer = Hwaro::Services::Deployer.new
+      target = Hwaro::Models::DeploymentTarget.new
+      target.name = "prod"
+      target.url = "s3://bucket"
+
+      # `{bucket}` lives in the VALUE, not the template — validation must not
+      # flag it as an unknown placeholder.
+      result = deployer.test_expand_placeholders("echo {source}", "/tmp/{bucket}", target)
+      result.should eq("echo '/tmp/{bucket}'")
+    end
   end
 
   describe "#auto_command_for_url" do
@@ -487,6 +744,14 @@ describe "Deployer private helpers" do
       # The container name (uri.host) is inlined+shell-escaped; {url} would
       # otherwise expand to the full az:// URL, which the az CLI rejects.
       result.should eq("az storage blob sync --source {source} --container 'my-container'")
+    end
+
+    it "appends --destination for az:// URLs with a path prefix" do
+      deployer = Hwaro::Services::Deployer.new
+      # az://container/sub/dir used to drop the prefix and deploy to the
+      # container root.
+      result = deployer.test_auto_command_for_url("az://my-container/sub/dir", "/tmp")
+      result.should eq("az storage blob sync --source {source} --container 'my-container' --destination 'sub/dir'")
     end
 
     it "returns nil for az:// URL with an empty container" do
@@ -533,6 +798,14 @@ describe "Deployer private helpers" do
       deployer = Hwaro::Services::Deployer.new
       result = deployer.test_local_directory_destination("dist/public")
       result.should eq("dist/public")
+    end
+
+    it "percent-decodes file:// destinations" do
+      deployer = Hwaro::Services::Deployer.new
+      # file:///var/www/my%20site must deploy to the real "my site" directory,
+      # not create a literal "my%20site" one.
+      result = deployer.test_local_directory_destination("file:///var/www/my%20site")
+      result.should eq("/var/www/my site")
     end
 
     it "returns nil for file:// with empty path" do

--- a/src/cli/commands/deploy_command.cr
+++ b/src/cli/commands/deploy_command.cr
@@ -53,36 +53,45 @@ module Hwaro
             return
           end
 
-          # --dry-run + --json: return the planned ops as a JSON array and
-          # exit without actually deploying. Schema per issue #356:
-          #   [{target, action: "create"|"update"|"delete"|"command", path, source, destination}]
-          if json_output && options.dry_run == true
-            begin
-              ops = Services::Deployer.new.plan(options)
-              STDOUT.puts ops.to_json
+          if json_output
+            # Config-load errors surface as a top-level error payload for
+            # both JSON shapes (unchanged from #356).
+            config = begin
+              Models::Config.load(env: options.env)
             rescue ex : Hwaro::HwaroError
               STDOUT.puts ex.to_error_payload.to_json
               exit(ex.exit_code)
-            rescue ex
-              # Any plain exception that reaches us here is no longer a
-              # config-load error (Models::Config.load raises HwaroError
-              # directly) — keep the legacy minimal envelope and exit 1.
-              STDOUT.puts({"status" => "error", "error" => {"message" => ex.message || "deploy plan failed"}}.to_json)
-              exit(1)
             end
-            return
-          end
 
-          if json_output
-            # Real deploy with --json (no --dry-run) returns a per-target
-            # summary. Schema per issue #374:
+            # Effective dry-run (the --dry-run flag OR deployment.dryRun in
+            # config) returns the planned ops as a JSON array and exits
+            # without deploying. Schema per issue #356:
+            #   [{target, action: "create"|"update"|"delete"|"command", path, source, destination}]
+            # Previously only the CLI flag was honored here, so a config-level
+            # dryRun fell through to the deploy path and reported
+            # {"status":"ok"} with zero counts as if a real deploy happened.
+            effective_dry_run = options.dry_run.nil? ? config.deployment.dry_run : options.dry_run
+            if effective_dry_run
+              begin
+                ops = Services::Deployer.new.plan(options, config)
+                STDOUT.puts ops.to_json
+              rescue ex : Hwaro::HwaroError
+                STDOUT.puts ex.to_error_payload.to_json
+                exit(ex.exit_code)
+              rescue ex
+                STDOUT.puts({"status" => "error", "error" => {"message" => ex.message || "deploy plan failed"}}.to_json)
+                exit(1)
+              end
+              return
+            end
+
+            # Real deploy with --json returns a per-target summary. Schema
+            # per issue #374:
             #   {"status": "ok"|"error",
             #    "targets": [{"name","status","created","updated",
             #                 "deleted","duration_ms","error"?}]}
-            # Config-load errors bubble up here as HwaroError and become a
-            # top-level error payload (shape unchanged from #356).
             results = begin
-              Services::Deployer.new.deploy_structured(options)
+              Services::Deployer.new.deploy_structured(options, config)
             rescue ex : Hwaro::HwaroError
               STDOUT.puts ex.to_error_payload.to_json
               exit(ex.exit_code)

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -959,9 +959,8 @@ module Hwaro
             # command = "aws s3 sync {source}/ {url} --delete"
 
             # [[deployment.matchers]]
-            # pattern = "^.+\\.css$"
-            # cacheControl = "max-age=31536000"
-            # gzip = true
+            # pattern = "^.+\\.html$"
+            # force = true          # always re-copy matches, even when identical
 
             TOML
         end

--- a/src/services/deployer.cr
+++ b/src/services/deployer.cr
@@ -67,21 +67,24 @@ module Hwaro
 
       # Build a list of planned operations across all configured (or explicitly
       # requested) targets without performing any filesystem writes or external
-      # commands. Returns an empty array when no targets resolve (caller is
-      # responsible for surfacing that as a friendly message or JSON error).
+      # commands. Raises the same classified errors as `#run` (missing source,
+      # no/unknown targets, bad target config, overlap, delete cap) so
+      # `hwaro deploy --dry-run --json` fails the same way a real deploy
+      # would instead of reporting an empty plan.
       def plan(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Array(PlannedOp)
         ops = [] of PlannedOp
         config ||= Models::Config.load(env: options.env)
         deployment = config.deployment
 
         source_dir = resolve_source_dir(options, deployment)
-        return ops unless Dir.exists?(source_dir)
+        require_source_dir!(source_dir)
 
         target_names = resolve_target_names(options, deployment)
-        return ops if target_names.empty?
+        require_target_names!(target_names)
 
-        targets = target_names.compact_map { |name| deployment.target_named(name) }
-        return ops if targets.empty?
+        targets = resolve_targets!(target_names, deployment)
+        effective = EffectiveOptions.new(deployment, options)
+        force_patterns = force_matcher_patterns(deployment)
 
         targets.each do |target|
           if command = target.command
@@ -96,27 +99,29 @@ module Hwaro
           end
 
           url = target.url
-          next if url.empty?
+          raise_missing_url!(target) if url.empty?
 
           if directory_destination = local_directory_destination(url)
             dest_dir = File.expand_path(directory_destination)
+            check_overlap!(source_dir, dest_dir)
+
             desired = build_desired_map(source_dir, target)
             existing = list_existing_files(dest_dir)
+
+            to_delete = compute_deletes(existing, desired.keys, target)
+            check_max_deletes!(to_delete.size, effective)
 
             desired.each do |dest_rel, src_path|
               dest_path = File.join(dest_dir, dest_rel)
               if File.exists?(dest_path)
-                next if same_file?(src_path, dest_path)
+                next if !effective.force && !force_match?(dest_rel, force_patterns) && same_file?(src_path, dest_path)
                 ops << PlannedOp.new(target: target.name, action: "update", path: dest_rel, source: src_path, destination: dest_path)
               else
                 ops << PlannedOp.new(target: target.name, action: "create", path: dest_rel, source: src_path, destination: dest_path)
               end
             end
 
-            desired_set = desired.keys.to_set
-            existing.each do |rel|
-              next if desired_set.includes?(rel)
-              next unless delete_candidate?(rel, target)
+            to_delete.each do |rel|
               ops << PlannedOp.new(target: target.name, action: "delete", path: rel, source: nil, destination: File.join(dest_dir, rel))
             end
           elsif auto_command = auto_command_for_url(url, source_dir)
@@ -127,6 +132,8 @@ module Hwaro
               source: source_dir,
               destination: url,
             )
+          else
+            raise_unsupported_scheme!(target, url)
           end
         end
 
@@ -151,6 +158,8 @@ module Hwaro
 
         target_names = resolve_target_names(options, deployment)
         require_target_names!(target_names)
+
+        warn_unapplied_matchers(deployment)
 
         targets = target_names.compact_map do |name|
           target = deployment.target_named(name)
@@ -275,22 +284,10 @@ module Hwaro
         end
 
         url = target.url
-        if url.empty?
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_CONFIG,
-            message: "Target '#{target.name}' is missing 'url' (or 'path' / 'command').",
-            hint: "Set one of:\n" \
-                  "  path    = \"/abs/local/dir\"   # copy to a local directory\n" \
-                  "  url     = \"file:///abs/dir\"  # same, file:// scheme\n" \
-                  "  url     = \"s3://bucket\"      # auto-runs `aws s3 sync …`\n" \
-                  "  url     = \"gs://bucket\"      # auto-runs `gsutil rsync …`\n" \
-                  "  url     = \"az://container\"   # auto-runs `az storage blob sync …`\n" \
-                  "  command = \"rsync … {source} user@host:/var/www/\"  # arbitrary shell command",
-          )
-        end
+        raise_missing_url!(target) if url.empty?
 
         if directory_destination = local_directory_destination(url)
-          return deploy_to_directory_with_counts(target, source_dir, directory_destination, effective)
+          return deploy_to_directory_with_counts(target, source_dir, directory_destination, effective, deployment)
         end
 
         if auto_command = auto_command_for_url(url, source_dir)
@@ -299,12 +296,7 @@ module Hwaro
           return {ok, TargetCounts.new}
         end
 
-        raise Hwaro::HwaroError.new(
-          code: Hwaro::Errors::HWARO_E_CONFIG,
-          message: "Unsupported deploy target URL scheme for '#{target.name}': #{url}",
-          hint: "Set 'command' for this target to use external tools (rsync/aws/gsutil/etc). " \
-                "Example: command = \"aws s3 sync {source}/ {url} --delete\"",
-        )
+        raise_unsupported_scheme!(target, url)
       end
 
       def run(options : Config::Options::DeployOptions, config : Models::Config? = nil) : Bool
@@ -317,23 +309,8 @@ module Hwaro
         target_names = resolve_target_names(options, deployment)
         require_target_names!(target_names)
 
-        targets = target_names.map do |name|
-          target = deployment.target_named(name)
-          unless target
-            available = deployment.targets.map(&.name).join(", ")
-            hint = if available.empty?
-                     "No targets are configured. Add '[[deployment.targets]]' to config.toml."
-                   else
-                     "Configured targets: #{available}."
-                   end
-            raise Hwaro::HwaroError.new(
-              code: Hwaro::Errors::HWARO_E_USAGE,
-              message: "Unknown deploy target: #{name}",
-              hint: hint,
-            )
-          end
-          target
-        end
+        targets = resolve_targets!(target_names, deployment)
+        warn_unapplied_matchers(deployment)
 
         effective = EffectiveOptions.new(deployment, options)
 
@@ -374,22 +351,10 @@ module Hwaro
         end
 
         url = target.url
-        if url.empty?
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_CONFIG,
-            message: "Target '#{target.name}' is missing 'url' (or 'path' / 'command').",
-            hint: "Set one of:\n" \
-                  "  path    = \"/abs/local/dir\"   # copy to a local directory\n" \
-                  "  url     = \"file:///abs/dir\"  # same, file:// scheme\n" \
-                  "  url     = \"s3://bucket\"      # auto-runs `aws s3 sync …`\n" \
-                  "  url     = \"gs://bucket\"      # auto-runs `gsutil rsync …`\n" \
-                  "  url     = \"az://container\"   # auto-runs `az storage blob sync …`\n" \
-                  "  command = \"rsync … {source} user@host:/var/www/\"  # arbitrary shell command",
-          )
-        end
+        raise_missing_url!(target) if url.empty?
 
         if directory_destination = local_directory_destination(url)
-          return deploy_to_directory(target, source_dir, directory_destination, effective)
+          return deploy_to_directory(target, source_dir, directory_destination, effective, deployment)
         end
 
         if auto_command = auto_command_for_url(url, source_dir)
@@ -397,12 +362,7 @@ module Hwaro
           return deploy_via_command(target, source_dir, auto_command, effective)
         end
 
-        raise Hwaro::HwaroError.new(
-          code: Hwaro::Errors::HWARO_E_CONFIG,
-          message: "Unsupported deploy target URL scheme for '#{target.name}': #{url}",
-          hint: "Set 'command' for this target to use external tools (rsync/aws/gsutil/etc). " \
-                "Example: command = \"aws s3 sync {source}/ {url} --delete\"",
-        )
+        raise_unsupported_scheme!(target, url)
       end
 
       # Shell metacharacters that indicate potentially dangerous commands.
@@ -474,18 +434,13 @@ module Hwaro
         source_dir : String,
         dest_dir : String,
         effective : EffectiveOptions,
+        deployment : Models::DeploymentConfig,
       ) : {Bool, TargetCounts}
         Logger.heading("deploy", target.name)
         counts = TargetCounts.new
         dest_dir_expanded = File.expand_path(dest_dir)
 
-        if nested_path?(source_dir, dest_dir_expanded) || nested_path?(dest_dir_expanded, source_dir)
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_USAGE,
-            message: "Refusing to deploy: source and destination overlap.",
-            hint: "source: #{source_dir} / dest: #{dest_dir_expanded}",
-          )
-        end
+        check_overlap!(source_dir, dest_dir_expanded)
 
         Hwaro::Utils::FileSafe.mkdir_p(dest_dir_expanded)
 
@@ -496,15 +451,9 @@ module Hwaro
         validate_destination_paths(dest_dir_expanded, desired.keys)
 
         to_delete = compute_deletes(existing, desired.keys, target)
-        if effective.max_deletes != -1 && to_delete.size > effective.max_deletes
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_USAGE,
-            message: "Refusing to delete #{to_delete.size} files (max_deletes: #{effective.max_deletes}).",
-            hint: "Set deployment.maxDeletes = -1 (or pass --max-deletes -1) to disable the limit.",
-          )
-        end
+        check_max_deletes!(to_delete.size, effective)
 
-        to_copy, _skipped = compute_copies(desired, dest_dir_expanded, effective.force)
+        to_copy, _skipped = compute_copies(desired, dest_dir_expanded, effective.force, force_matcher_patterns(deployment))
 
         if effective.dry_run
           return {true, counts}
@@ -544,16 +493,11 @@ module Hwaro
         source_dir : String,
         dest_dir : String,
         effective : EffectiveOptions,
+        deployment : Models::DeploymentConfig,
       ) : Bool
         dest_dir = File.expand_path(dest_dir)
 
-        if nested_path?(source_dir, dest_dir) || nested_path?(dest_dir, source_dir)
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_USAGE,
-            message: "Refusing to deploy: source and destination overlap.",
-            hint: "source: #{source_dir} / dest: #{dest_dir}",
-          )
-        end
+        check_overlap!(source_dir, dest_dir)
 
         Hwaro::Utils::FileSafe.mkdir_p(dest_dir)
 
@@ -564,15 +508,9 @@ module Hwaro
         validate_destination_paths(dest_dir, desired.keys)
 
         to_delete = compute_deletes(existing, desired.keys, target)
-        if effective.max_deletes != -1 && to_delete.size > effective.max_deletes
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_USAGE,
-            message: "Refusing to delete #{to_delete.size} files (max_deletes: #{effective.max_deletes}).",
-            hint: "Set deployment.maxDeletes = -1 (or pass --max-deletes -1) to disable the limit.",
-          )
-        end
+        check_max_deletes!(to_delete.size, effective)
 
-        to_copy, skipped = compute_copies(desired, dest_dir, effective.force)
+        to_copy, skipped = compute_copies(desired, dest_dir, effective.force, force_matcher_patterns(deployment))
 
         Logger::Receipt.new("deploy", target.name)
           .row("source", source_dir)
@@ -624,20 +562,23 @@ module Hwaro
           desired[dest_rel] = path
         end
 
-        desired
+        # Deterministic order: plan JSON, progress lines, and copy order must
+        # not depend on the OS directory-read order.
+        desired.to_a.sort_by!(&.[0]).to_h
       end
 
       private def compute_copies(
         desired : Hash(String, String),
         dest_dir : String,
         force : Bool,
+        force_patterns : Array(Regex) = [] of Regex,
       ) : {Array({String, String}), Int32}
         to_copy = [] of {String, String}
         skipped = 0
 
         desired.each do |dest_rel, src_path|
           dest_path = File.join(dest_dir, dest_rel)
-          if !force && File.exists?(dest_path) && same_file?(src_path, dest_path)
+          if !force && !force_match?(dest_rel, force_patterns) && File.exists?(dest_path) && same_file?(src_path, dest_path)
             skipped += 1
             next
           end
@@ -662,7 +603,12 @@ module Hwaro
       end
 
       private def delete_candidate?(rel : String, target : Models::DeploymentTarget) : Bool
-        included_by_target?(rel, target)
+        return true if included_by_target?(rel, target)
+        # With strip_index_html the on-disk name for `foo/index.html` is just
+        # `foo`, so include/exclude globs written against source paths (e.g.
+        # include = "**/*.html") never match the stored name and stale pages
+        # would survive every sync. Consider the un-stripped form too.
+        target.strip_index_html && included_by_target?("#{rel}/index.html", target)
       end
 
       private def list_existing_files(dest_dir : String) : Array(String)
@@ -676,7 +622,7 @@ module Hwaro
           files << rel
         end
 
-        files
+        files.sort!
       end
 
       # Resolve the deploy source directory from options/config (expanded).
@@ -686,9 +632,11 @@ module Hwaro
 
       # Resolve which deploy target names to act on: explicit CLI targets, then
       # the configured default target, then the first configured target.
+      # Duplicate CLI names are collapsed so `hwaro deploy prod prod` doesn't
+      # deploy (and report) the same target twice.
       private def resolve_target_names(options, deployment) : Array(String)
         if options.targets.present?
-          options.targets
+          options.targets.uniq
         elsif default_target = deployment.target
           [default_target]
         elsif deployment.targets.size > 0
@@ -696,6 +644,129 @@ module Hwaro
         else
           [] of String
         end
+      end
+
+      # Map target names to configured targets; unknown names raise
+      # HWARO_E_USAGE with the configured-target list in the hint. Shared by
+      # `#run` and `#plan` so dry-run and real deploys fail identically.
+      private def resolve_targets!(
+        target_names : Array(String),
+        deployment : Models::DeploymentConfig,
+      ) : Array(Models::DeploymentTarget)
+        target_names.map do |name|
+          target = deployment.target_named(name)
+          unless target
+            available = deployment.targets.map(&.name).join(", ")
+            hint = if available.empty?
+                     "No targets are configured. Add '[[deployment.targets]]' to config.toml."
+                   else
+                     "Configured targets: #{available}."
+                   end
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "Unknown deploy target: #{name}",
+              hint: hint,
+            )
+          end
+          target
+        end
+      end
+
+      private def raise_missing_url!(target : Models::DeploymentTarget) : NoReturn
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          message: "Target '#{target.name}' is missing 'url' (or 'path' / 'command').",
+          hint: "Set one of:\n" \
+                "  path    = \"/abs/local/dir\"   # copy to a local directory\n" \
+                "  url     = \"file:///abs/dir\"  # same, file:// scheme\n" \
+                "  url     = \"s3://bucket\"      # auto-runs `aws s3 sync …`\n" \
+                "  url     = \"gs://bucket\"      # auto-runs `gsutil rsync …`\n" \
+                "  url     = \"az://container\"   # auto-runs `az storage blob sync …`\n" \
+                "  command = \"rsync … {source} user@host:/var/www/\"  # arbitrary shell command",
+        )
+      end
+
+      private def raise_unsupported_scheme!(target : Models::DeploymentTarget, url : String) : NoReturn
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          message: "Unsupported deploy target URL scheme for '#{target.name}': #{url}",
+          hint: "Set 'command' for this target to use external tools (rsync/aws/gsutil/etc). " \
+                "Example: command = \"aws s3 sync {source}/ {url} --delete\"",
+        )
+      end
+
+      # Refuse overlapping source/destination. Symlinks are resolved first so
+      # a destination that is a symlink back into the source tree still trips
+      # the refusal (a lexical-only comparison would let a strip_index_html
+      # target mutate or delete the source).
+      private def check_overlap!(source_dir : String, dest_dir : String)
+        src = existing_real_path(source_dir)
+        dst = existing_real_path(dest_dir)
+        if nested_path?(src, dst) || nested_path?(dst, src)
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: "Refusing to deploy: source and destination overlap.",
+            hint: "source: #{source_dir} / dest: #{dest_dir}",
+          )
+        end
+      end
+
+      # Resolve symlinks for the deepest existing ancestor and re-append the
+      # not-yet-created remainder. Resolving only the paths that fully exist
+      # would compare a resolved source against a lexical destination (e.g.
+      # /private/var vs /var on macOS) and miss real overlaps.
+      private def existing_real_path(path : String) : String
+        suffix = [] of String
+        current = path
+        until File.exists?(current)
+          parent = File.dirname(current)
+          return path if parent == current
+          suffix << File.basename(current)
+          current = parent
+        end
+        real = File.realpath(current)
+        suffix.reverse_each { |part| real = File.join(real, part) }
+        real
+      rescue File::Error | IO::Error
+        path
+      end
+
+      # Enforce the delete safety cap. Any negative value disables the cap —
+      # previously only exactly -1 did, so `--max-deletes -3` refused every
+      # deploy with "Refusing to delete 0 files".
+      private def check_max_deletes!(count : Int32, effective : EffectiveOptions)
+        return if effective.max_deletes < 0
+        return if count <= effective.max_deletes
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_USAGE,
+          message: "Refusing to delete #{count} files (max_deletes: #{effective.max_deletes}).",
+          hint: "Set deployment.maxDeletes = -1 (or pass --max-deletes -1) to disable the limit.",
+        )
+      end
+
+      # Compile `force = true` matcher patterns (regex, per the deploy docs).
+      # An invalid pattern warns and is skipped instead of crashing the deploy.
+      private def force_matcher_patterns(deployment : Models::DeploymentConfig) : Array(Regex)
+        deployment.matchers.select(&.force).compact_map do |matcher|
+          Regex.new(matcher.pattern)
+        rescue ex : ArgumentError
+          Logger.warn "Ignoring invalid deployment matcher pattern #{matcher.pattern.inspect}: #{ex.message}"
+          nil
+        end
+      end
+
+      private def force_match?(rel : String, patterns : Array(Regex)) : Bool
+        return false if patterns.empty?
+        normalized = rel.gsub('\\', '/')
+        patterns.any?(&.matches?(normalized))
+      end
+
+      # The built-in sync only honors matcher `force`; header/compression
+      # keys need an object-store/CDN API that hwaro's copy/exec deploys
+      # don't speak. Warn instead of silently ignoring configured intent.
+      private def warn_unapplied_matchers(deployment : Models::DeploymentConfig)
+        return if deployment.matchers.none? { |m| m.cache_control || m.content_type || m.gzip }
+        Logger.warn "deployment.matchers: cache_control/content_type/gzip are not applied by hwaro's built-in sync (only 'force' is). Configure headers/compression at your host or CDN."
       end
 
       # Raise HWARO_E_CONFIG when the deploy source directory doesn't exist.
@@ -828,8 +899,11 @@ module Hwaro
             buf_a = Bytes.new(8192)
             buf_b = Bytes.new(8192)
             loop do
-              read_a = fa.read(buf_a)
-              read_b = fb.read(buf_b)
+              # IO#read may return fewer bytes than requested without being at
+              # EOF; fill each buffer fully so a short read on one side isn't
+              # mistaken for a content difference.
+              read_a = read_fully(fa, buf_a)
+              read_b = read_fully(fb, buf_b)
               return false unless read_a == read_b
               return true if read_a == 0
               return false unless buf_a[0, read_a] == buf_b[0, read_b]
@@ -844,6 +918,18 @@ module Hwaro
         false
       end
 
+      # Read until `slice` is full or EOF; returns the byte count (< slice
+      # size only at EOF).
+      private def read_fully(io : IO, slice : Bytes) : Int32
+        total = 0
+        while total < slice.size
+          read = io.read(slice[total, slice.size - total])
+          break if read == 0
+          total += read
+        end
+        total
+      end
+
       private def remove_empty_directories(root : String)
         dirs = Dir.glob(File.join(root, "**", "*")).select { |p| Dir.exists?(p) }
         dirs.sort_by! { |p| -p.count('/') }
@@ -856,19 +942,38 @@ module Hwaro
       end
 
       private def each_project_file(root : String, &block : String ->)
-        walk_project_files(root, &block)
+        visited = Set(String).new
+        visited << existing_real_path(root)
+        walk_project_files(root, visited, &block)
       end
 
-      private def walk_project_files(dir : String, &block : String ->)
+      private def walk_project_files(dir : String, visited : Set(String), &block : String ->)
         Dir.each_child(dir) do |entry|
           next if entry == ".DS_Store"
           full = File.join(dir, entry)
-          if Dir.exists?(full)
+          # info? follows symlinks; broken links and ELOOP entries are
+          # skipped instead of crashing the deploy mid-walk.
+          info = begin
+            File.info?(full)
+          rescue File::Error | IO::Error
+            nil
+          end
+          next unless info
+          if info.directory?
             if entry.starts_with?(".") && entry != ".well-known"
               next
             end
-            walk_project_files(full, &block)
-          elsif File.file?(full)
+            # Track resolved paths so symlink cycles (public/a → public) and
+            # multiple links to the same directory are walked at most once.
+            real = begin
+              File.realpath(full)
+            rescue File::Error | IO::Error
+              next
+            end
+            next if visited.includes?(real)
+            visited << real
+            walk_project_files(full, visited, &block)
+          elsif info.file?
             block.call(full)
           end
         end
@@ -933,31 +1038,38 @@ module Hwaro
       # name, etc.) instead of sending the literal to the shell.
       COMMAND_PLACEHOLDERS = {"source", "url", "target"}
 
-      # Pattern used to detect *remaining* placeholders after expansion.
-      # Anything that still matches is unknown and rejected.
+      # Pattern for `{name}` placeholder tokens in command templates.
       private COMMAND_PLACEHOLDER_RE = /\{([a-zA-Z_][\w-]*)\}/
 
       private def expand_placeholders(command : String, source_dir : String, target : Models::DeploymentTarget) : String
-        expanded = command
-          .gsub("{source}", shell_escape(source_dir))
-          .gsub("{url}", shell_escape(target.url))
-          .gsub("{target}", shell_escape(target.name))
+        # Validate the ORIGINAL template, then substitute in a single pass:
+        # expanded values (paths, urls) may legitimately contain `{...}` text
+        # and must be neither re-validated nor re-expanded. The previous
+        # sequential gsub let a source path containing a literal `{url}` get
+        # substituted a second time, corrupting the command and splicing the
+        # shell quoting.
+        validate_no_unexpanded_placeholders!(command, target)
 
-        validate_no_unexpanded_placeholders!(command, expanded, target)
-        expanded
+        command.gsub(COMMAND_PLACEHOLDER_RE) do |token|
+          case $~[1]
+          when "source" then shell_escape(source_dir)
+          when "url"    then shell_escape(target.url)
+          when "target" then shell_escape(target.name)
+          else               token
+          end
+        end
       end
 
-      # Raise HWARO_E_CONFIG if the expanded command still contains any
+      # Raise HWARO_E_CONFIG if the command template contains any unknown
       # `{name}` tokens — catches typos like `{srouce}` and forward-
       # looking placeholders (`{bucket}`, `{region}`) before the literal
       # reaches the underlying deploy tool and produces a confusing
       # downstream error.
       private def validate_no_unexpanded_placeholders!(
-        original : String,
-        expanded : String,
+        command : String,
         target : Models::DeploymentTarget,
       ) : Nil
-        unresolved = expanded.scan(COMMAND_PLACEHOLDER_RE)
+        unresolved = command.scan(COMMAND_PLACEHOLDER_RE)
           .map { |m| m[1] }
           .uniq!
           .reject { |name| COMMAND_PLACEHOLDERS.includes?(name) }
@@ -999,7 +1111,12 @@ module Hwaro
           # `az://container` URL, which the az CLI rejects as a container name.
           container = uri.host
           return if container.nil? || container.empty?
-          "az storage blob sync --source {source} --container #{shell_escape(container)}"
+          command = "az storage blob sync --source {source} --container #{shell_escape(container)}"
+          # az://container/sub/dir → sync under the sub/dir prefix; dropping
+          # the path silently deployed to the container root.
+          prefix = uri.path.lchop('/')
+          command += " --destination #{shell_escape(URI.decode(prefix))}" unless prefix.empty?
+          command
         end
       end
 
@@ -1016,7 +1133,10 @@ module Hwaro
             path = host + path unless host.empty?
           end
           return if path.empty?
-          return path
+          # URI components stay percent-encoded (a space is `%20`); decode so
+          # `file:///var/www/my%20site` deploys to the real directory instead
+          # of creating a literal `my%20site` one.
+          return URI.decode(path)
         end
 
         # No scheme: treat as local path


### PR DESCRIPTION
## Summary

Bug-fix pass over the `hwaro deploy` subsystem, each item reproduced against the built binary before and after the fix:

- **`plan()`/`run()` parity**: `hwaro deploy --dry-run --json` used to return `[]` with exit 0 for configs that a real deploy would refuse (missing source dir, unknown target, unsupported URL scheme, delete-cap exceeded, etc.) — CI would read "nothing to deploy" instead of a failure. `plan()` now raises the same classified `HwaroError`s as `run()`. Config-level `dryRun = true` combined with `--json` (no CLI flag) also now correctly returns the plan array instead of reporting a fake `{"status":"ok"}` deploy.
- **Stale deletes with `strip_index_html`**: when `strip_index_html` is on, the on-disk name for `blog/post/index.html` is `blog/post`, but `include`/`exclude` globs are written against source-shaped paths (e.g. `include = "**/*.html"`). Deleted pages never matched the glob against their stripped name and stuck around at the destination forever.
- **Placeholder double-expansion**: sequential `gsub` calls let literal `{url}`/`{target}` text *inside* an already-expanded value (e.g. a source path containing `{url}`) get re-expanded, corrupting the command and splicing shell quoting. Placeholder validation now runs against the original template and expansion is single-pass.
- **`--max-deletes` negative values**: only exactly `-1` disabled the delete cap; any other negative value (e.g. `-3`) hard-refused every deploy with "Refusing to delete 0 files". Any negative value now disables the cap.
- **Symlink cycles crash the deploy walk**: a symlink loop in the source tree (or destination) crashed with an unclassified "Too many levels of symbolic links" error. The walker now tracks visited real paths and skips broken/looping entries.
- **`file://` percent-encoding**: `file:///var/www/my%20site` created a literal `my%20site` directory instead of deploying into the real `my site` directory.
- **`az://container/sub/dir` dropped the subpath**: deployed to the container root instead of under `sub/dir`; the auto-generated command now appends `--destination`.
- **`[[deployment.matchers]]` was dead config**: parsed from `config.toml` but never consulted anywhere. `force` is now honored by the built-in directory sync (always re-copies matches); `cache_control`/`content_type`/`gzip` (which the built-in copy/exec deploy can't apply) now print a warning instead of silently doing nothing. Docs updated to match reality.
- Also fixed while in the area: source/destination overlap check now resolves symlinks (an aliased destination could overlap the source undetected), plan/copy/delete ordering is now sorted for determinism, and duplicate CLI target names are deduped.

## Test plan

- [x] `crystal spec` — 6056 examples, 0 failures
- [x] `crystal tool format` + `lib/ameba/bin/ameba.cr` — clean
- [x] Each bug manually reproduced against the built binary before the fix and re-verified after (dry-run/json parity, strip+include stale delete, brace-in-path placeholder corruption, negative max-deletes, symlink cycle, percent-encoded file://, az subpath, matcher force/warn, symlinked-destination overlap)
- [x] 15 new regression specs added in `deployer_service_spec.cr`