### PR TITLE
fix: 50+ hwaro tool bugs across convert/export/import, analysis tools, and platform generators

### DIFF
--- a/spec/unit/agents_md_command_spec.cr
+++ b/spec/unit/agents_md_command_spec.cr
@@ -67,5 +67,21 @@ describe Hwaro::CLI::Commands::Tool::AgentsMdCommand do
         end
       end
     end
+
+    it "logs 'updated' when overwriting an existing AGENTS.md with --force" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("AGENTS.md", "stale content")
+
+          output = with_captured_log do
+            cmd = Hwaro::CLI::Commands::Tool::AgentsMdCommand.new
+            cmd.run(["--write", "--force"])
+          end
+
+          output.should contain("updated")
+          output.should_not contain("created")
+        end
+      end
+    end
   end
 end

--- a/spec/unit/ci_config_spec.cr
+++ b/spec/unit/ci_config_spec.cr
@@ -48,7 +48,7 @@ describe Hwaro::Services::CIConfig do
         result.should contain("deploy:")
         result.should contain("Build and Deploy")
         result.should contain("token: ${{ secrets.GITHUB_TOKEN }}")
-        result.should contain("github.event_name == 'push'")
+        result.should contain("(github.event_name == 'push' || github.event_name == 'workflow_dispatch')")
         result.should contain("github.ref == 'refs/heads/main'")
       end
 

--- a/spec/unit/content_lister_spec.cr
+++ b/spec/unit/content_lister_spec.cr
@@ -535,4 +535,42 @@ describe Hwaro::Services::ContentInfo do
       parsed.date.should be_nil
     end
   end
+
+  describe "date parsing and sorting regression tests" do
+    it "preserves timezone offset in parse_time (regression)" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "post.md"), "---\ntitle: Offset Post\ndate: 2024-06-15T10:30:00+09:00\n---\n\nBody")
+
+        lister = Hwaro::Services::ContentLister.new(content_dir)
+        result = lister.list_all
+
+        result.size.should eq(1)
+        result.first.date.should_not be_nil
+        result.first.date.not_nil!.to_utc.hour.should eq(1)
+        result.first.date.not_nil!.to_utc.minute.should eq(30)
+      end
+    end
+
+    it "sorts tie-breaker paths ascending (A-Z) (regression)" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "c.md"), "---\ntitle: C\ndate: 2024-01-01\n---\n\nC")
+        File.write(File.join(content_dir, "a.md"), "---\ntitle: A\ndate: 2024-01-01\n---\n\nA")
+        File.write(File.join(content_dir, "b.md"), "---\ntitle: B\ndate: 2024-01-01\n---\n\nB")
+
+        lister = Hwaro::Services::ContentLister.new(content_dir)
+        result = lister.list_all
+
+        result.size.should eq(3)
+        File.basename(result[0].path).should eq("a.md")
+        File.basename(result[1].path).should eq("b.md")
+        File.basename(result[2].path).should eq("c.md")
+      end
+    end
+  end
 end

--- a/spec/unit/content_stats_spec.cr
+++ b/spec/unit/content_stats_spec.cr
@@ -285,5 +285,19 @@ describe Hwaro::Services::ContentStats do
         result.tags.should be_empty
       end
     end
+
+    it "excludes JSON frontmatter from word count (regression)" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "json-words.md"), %({"title": "Post", "description": "This is a very long description with many words"}\n\nOnlyOneWord\n))
+
+        stats = Hwaro::Services::ContentStats.new(content_dir)
+        result = stats.run
+
+        result.words_total.should eq(1)
+      end
+    end
   end
 end

--- a/spec/unit/content_validator_spec.cr
+++ b/spec/unit/content_validator_spec.cr
@@ -465,5 +465,58 @@ describe Hwaro::Services::ContentValidator do
         issues.any? { |i| i.id == "content-internal-link-broken" }.should be_false
       end
     end
+
+    it "handles out-of-range dates raising ArgumentError as content-date-invalid (regression)" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "bad-date.md"), "---\ntitle: Post\ndescription: Desc\ndate: 2024-02-30\n---\n\n# Content\n")
+
+        validator = Hwaro::Services::ContentValidator.new(content_dir)
+        issues = validator.run
+        issues.any? { |i| i.id == "content-date-invalid" }.should be_true
+      end
+    end
+
+    it "flags dates with trailing garbage suffix (regression)" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "garbage-date.md"), "---\ntitle: Post\ndescription: Desc\ndate: 2024-06-15 lol\n---\n\n# Content\n")
+
+        validator = Hwaro::Services::ContentValidator.new(content_dir)
+        issues = validator.run
+        issues.any? { |i| i.id == "content-date-invalid" }.should be_true
+      end
+    end
+
+    it "runs alt-text and internal link checks on no-frontmatter files (regression)" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "no-frontmatter.md"), "# Heading\n\n![](missing-alt.png)\n\n[Link](@/nonexistent-link.md)\n")
+
+        validator = Hwaro::Services::ContentValidator.new(content_dir)
+        issues = validator.run
+        issues.any? { |i| i.id == "content-alt-text-missing" }.should be_true
+        issues.any? { |i| i.id == "content-internal-link-broken" }.should be_true
+      end
+    end
+
+    it "excludes JSON frontmatter from body scans (regression)" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "json-fm.md"), %({"title": "Post", "description": "Desc", "some_field": "![](image.png)"}\n\n# Body\n))
+
+        validator = Hwaro::Services::ContentValidator.new(content_dir)
+        issues = validator.run
+        issues.any? { |i| i.id == "content-alt-text-missing" }.should be_false
+      end
+    end
   end
 end

--- a/spec/unit/deadlink_command_spec.cr
+++ b/spec/unit/deadlink_command_spec.cr
@@ -519,6 +519,36 @@ end
 
 # Test helper to expose private methods
 class Hwaro::CLI::Commands::Tool::DeadlinkCommand
+  @@disable_private_host_check = false
+
+  def self.disable_private_host_check=(val : Bool)
+    @@disable_private_host_check = val
+  end
+
+  private def private_host?(host : String) : Bool
+    return false if @@disable_private_host_check
+    return true if host == "localhost" || host.ends_with?(".local") || host.ends_with?(".internal")
+
+    begin
+      addrs = Socket::Addrinfo.resolve(host, 80, type: Socket::Type::STREAM)
+      addrs.any? do |addr|
+        ip = addr.ip_address.address
+        ip.starts_with?("127.") ||
+          ip.starts_with?("10.") ||
+          ip.starts_with?("192.168.") ||
+          ip.starts_with?("169.254.") ||
+          ip == "0.0.0.0" ||
+          ip == "::1" ||
+          ip == "::" ||
+          ip.starts_with?("fc") || ip.starts_with?("fd") ||
+          ip.starts_with?("fe80") ||
+          private_172?(ip)
+      end
+    rescue Socket::Error
+      false
+    end
+  end
+
   def find_links_for_test(dir : String) : Array(Link)
     find_external_links(dir)
   end
@@ -527,8 +557,12 @@ class Hwaro::CLI::Commands::Tool::DeadlinkCommand
     find_internal_links(dir)
   end
 
-  def check_internal_links_for_test(links : Array(Link), content_dir : String, taxonomy_names : Array(String) = [] of String) : Array(Result)
-    check_internal_links(links, content_dir, taxonomy_names)
+  def check_internal_links_for_test(links : Array(Link), content_dir : String, taxonomy_names : Array(String) = [] of String, base_path : String = "") : Array(Result)
+    check_internal_links(links, content_dir, taxonomy_names, base_path)
+  end
+
+  def check_links_concurrently_for_test(links : Array(Link), timeout_seconds : Int32, max_concurrency : Int32) : Array(Result)
+    check_links_concurrently(links, timeout_seconds, max_concurrency)
   end
 
   def private_host_for_test?(host : String) : Bool
@@ -572,6 +606,123 @@ describe "check-links ember output" do
       end
 
       output.should contain("checked: no links found")
+    end
+  end
+
+  it "allows one level of balanced parens in Wikipedia-style URLs" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "test.md"), "[Wiki](https://en.wikipedia.org/wiki/Array_(data_structure))")
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      links = cmd.find_links_for_test(dir)
+      links.size.should eq(1)
+      links[0].url.should eq("https://en.wikipedia.org/wiki/Array_(data_structure)")
+    end
+  end
+
+  it "skips tel: and protocol-relative links" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "test.md"), "[Tel](tel:123456) [Relative](//example.com/foo) [Valid](/internal)")
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      links = cmd.find_internal_links_for_test(dir)
+      links.size.should eq(1)
+      links[0].url.should eq("/internal")
+    end
+  end
+
+  it "decodes percent-encoded internal paths" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "user guide.pdf"), "content")
+      link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+        file: File.join(dir, "test.md"), url: "/user%20guide.pdf", kind: :internal
+      )
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      results = cmd.check_internal_links_for_test([link], dir)
+      results.should be_empty
+    end
+  end
+
+  it "strips base path prefix from root-relative URLs" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "posts"))
+      File.write(File.join(dir, "posts", "hello.md"), "hello")
+      link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+        file: File.join(dir, "test.md"), url: "/repo/posts/hello/", kind: :internal
+      )
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      results = cmd.check_internal_links_for_test([link], dir, base_path: "/repo")
+      results.should be_empty
+    end
+  end
+
+  it "follows redirects, retries on 405 with GET, and sends User-Agent header" do
+    Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = true
+
+    begin
+      user_agent = ""
+      requests = [] of String
+
+      server = HTTP::Server.new do |context|
+        user_agent = context.request.headers["User-Agent"]? || ""
+        requests << context.request.method
+
+        case context.request.path
+        when "/redirect"
+          context.response.status_code = 301
+          context.response.headers["Location"] = "/target"
+        when "/target"
+          context.response.status_code = 200
+        when "/method-retry"
+          if context.request.method == "HEAD"
+            context.response.status_code = 405
+          else
+            context.response.status_code = 200
+          end
+        else
+          context.response.status_code = 404
+        end
+      end
+
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      port = address.port
+
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+
+      link1 = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+        file: "test.md", url: "http://127.0.0.1:#{port}/redirect", kind: :external
+      )
+      results = cmd.check_links_concurrently_for_test([link1], 5, 1)
+      results.size.should eq(1)
+      results[0].status.should eq(200)
+      user_agent.should eq("hwaro-link-checker/1.0")
+
+      requests.clear
+      link2 = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+        file: "test.md", url: "http://127.0.0.1:#{port}/method-retry", kind: :external
+      )
+      results2 = cmd.check_links_concurrently_for_test([link2], 5, 1)
+      results2.size.should eq(1)
+      results2[0].status.should eq(200)
+      requests.should eq(["HEAD", "GET"])
+    ensure
+      server.try(&.close)
+      Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = false
+    end
+  end
+
+  it "skips private hosts, reporting status -1 and info logs" do
+    cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "test.md"), "[Private](http://127.0.0.1/foo)")
+
+      output = with_captured_log do
+        cmd.run(["-c", dir, "--external-only"])
+      end
+
+      output.should contain("Skipped: private/internal address")
+      output.should_not contain("✗")
     end
   end
 end

--- a/spec/unit/defaults_agents_md_spec.cr
+++ b/spec/unit/defaults_agents_md_spec.cr
@@ -44,6 +44,12 @@ describe Hwaro::Services::Defaults::AgentsMd do
       content = Hwaro::Services::Defaults::AgentsMd.content
       content.should contain "Site-Specific Instructions"
     end
+
+    it "lists correct Crinja join filter syntax" do
+      content = Hwaro::Services::Defaults::AgentsMd.content
+      content.should contain "join(\", \")"
+      content.should_not contain "join(sep="
+    end
   end
 
   describe ".remote_content" do

--- a/spec/unit/exporters/base_spec.cr
+++ b/spec/unit/exporters/base_spec.cr
@@ -84,26 +84,42 @@ describe Hwaro::Services::Exporters::Base do
   end
 
   describe "#parse_content" do
-    it "parses TOML frontmatter into a string fields hash" do
+    it "parses TOML frontmatter into a YAML::Any fields hash preserving types" do
       raw = "+++\ntitle = \"Hello\"\ndraft = false\ntags = [\"a\", \"b\"]\nweight = 5\n+++\n\nbody text"
       fields, body = TestExporter.new.test_parse_content(raw)
 
       fields["title"].should eq("Hello")
       fields["draft"].should be_false
-      fields["tags"].as(Array(String)).sort.should eq(["a", "b"])
-      fields["weight"].should eq("5")
+      fields["tags"].as_a.map(&.as_s).sort!.should eq(["a", "b"])
+      fields["weight"].should eq(5)
       body.should eq("body text")
     end
 
-    it "parses YAML frontmatter into a string fields hash" do
+    it "parses YAML frontmatter into a YAML::Any fields hash preserving types" do
       raw = "---\ntitle: Hello\ndraft: true\ntags:\n  - a\n  - b\nweight: 7\n---\n\nbody text"
       fields, body = TestExporter.new.test_parse_content(raw)
 
       fields["title"].should eq("Hello")
       fields["draft"].should be_true
-      fields["tags"].as(Array(String)).sort.should eq(["a", "b"])
-      fields["weight"].should eq("7")
+      fields["tags"].as_a.map(&.as_s).sort!.should eq(["a", "b"])
+      fields["weight"].should eq(7)
       body.should eq("body text")
+    end
+
+    it "preserves nested tables and non-string arrays" do
+      raw = "+++\ntitle = \"X\"\nnumbers = [1, 2, 3]\n[extra]\nsubtitle = \"hi\"\n[taxonomies]\ncategories = [\"tech\"]\n+++\n\nbody"
+      fields, _ = TestExporter.new.test_parse_content(raw)
+
+      fields["numbers"].as_a.map(&.as_i64).should eq([1, 2, 3])
+      fields["extra"].as_h.size.should eq(1)
+      fields["extra"]["subtitle"].should eq("hi")
+      fields["taxonomies"]["categories"].as_a.first.should eq("tech")
+    end
+
+    it "does not overflow on integers beyond Int32 range" do
+      raw = "---\ntitle: X\nid: 99999999999\n---\n\nbody"
+      fields, _ = TestExporter.new.test_parse_content(raw)
+      fields["id"].should eq(99999999999_i64)
     end
 
     it "returns the raw content unchanged when there is no frontmatter" do
@@ -113,37 +129,41 @@ describe Hwaro::Services::Exporters::Base do
       body.should eq(raw)
     end
 
-    it "returns empty fields when TOML frontmatter is malformed" do
+    it "raises on malformed TOML frontmatter instead of exporting stripped metadata" do
       raw = "+++\nnot valid toml = =\n+++\n\nbody"
-      fields, body = TestExporter.new.test_parse_content(raw)
-      fields.should be_empty
-      body.should eq("body")
+      expect_raises(TOML::ParseException) do
+        TestExporter.new.test_parse_content(raw)
+      end
     end
 
-    it "skips empty arrays in frontmatter" do
+    it "treats a leading --- pair around non-mapping text as body, not frontmatter" do
+      raw = "---\nIntro paragraph between two rules.\n---\n\nRest of document."
+      fields, body = TestExporter.new.test_parse_content(raw)
+      fields.should be_empty
+      body.should eq(raw)
+    end
+
+    it "preserves empty arrays in frontmatter" do
       raw = "+++\ntitle = \"X\"\ntags = []\n+++\n\nbody"
       fields, _ = TestExporter.new.test_parse_content(raw)
       fields["title"].should eq("X")
-      fields.has_key?("tags").should be_false
+      fields["tags"].as_a.should be_empty
     end
 
-    it "formats TOML Time values as ISO8601 with offset" do
-      # TOML's native datetime values land in the special Time branch in
-      # exporters/base.cr — the value should be re-emitted as
-      # "%Y-%m-%dT%H:%M:%S%:z".
+    it "formats TOML Time values as frontmatter date strings" do
+      # toml.cr normalizes offset datetimes to UTC at parse time; the value
+      # should be re-emitted as an RFC 3339 string.
       raw = "+++\ntitle = \"X\"\ndate = 2026-04-17T09:30:45+09:00\n+++\n\nbody"
       fields, _ = TestExporter.new.test_parse_content(raw)
       fields["title"].should eq("X")
-      fields["date"].as(String).should match(/^2026-04-17T\d{2}:\d{2}:\d{2}[+\-]\d{2}:\d{2}$/)
+      fields["date"].as_s.should match(/^2026-04-1[67]T\d{2}:\d{2}:\d{2}(?:Z|[+\-]\d{2}:\d{2})$/)
     end
 
-    it "formats YAML Time values as ISO8601 with offset" do
-      # YAML's native ISO 8601 datetime triggers value.as_time? in the
-      # YAML branch; should also be re-emitted via the same format.
-      raw = "---\ntitle: X\ndate: 2026-04-17T09:30:45Z\n---\n\nbody"
+    it "formats YAML Time values preserving the authored offset" do
+      raw = "---\ntitle: X\ndate: 2026-04-17T09:30:45+09:00\n---\n\nbody"
       fields, _ = TestExporter.new.test_parse_content(raw)
       fields["title"].should eq("X")
-      fields["date"].as(String).should match(/^2026-04-17T\d{2}:\d{2}:\d{2}[+\-]\d{2}:\d{2}$/)
+      fields["date"].as_s.should eq("2026-04-17T09:30:45+09:00")
     end
   end
 

--- a/spec/unit/exporters/hugo_exporter_spec.cr
+++ b/spec/unit/exporters/hugo_exporter_spec.cr
@@ -313,5 +313,77 @@ describe Hwaro::Services::Exporters::HugoExporter do
         fm.should contain(%("my key" = "value"))
       end
     end
+
+    it "preserves nested tables, typed scalars, and non-string arrays" do
+      # `[extra]`/`[taxonomies]` and typed values used to be flattened
+      # through a String|Bool|Array(String) union and silently dropped.
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "post.md"), <<-MD)
+          +++
+          title = "Post"
+          weight = 10
+          rating = 4.5
+          numbers = [1, 2, 3]
+          [taxonomies]
+          categories = ["tech"]
+          [extra]
+          subtitle = "hello"
+          [extra.nested]
+          key = "value"
+          +++
+
+          Body
+          MD
+
+        exporter = Hwaro::Services::Exporters::HugoExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(
+          target_type: "hugo",
+          content_dir: content_dir,
+          output_dir: output_dir,
+        )
+        result = exporter.run(options)
+        result.success.should be_true
+        result.error_count.should eq(0)
+
+        content = File.read(File.join(output_dir, "content", "post.md"))
+        fm = content.match!(/\A\+\+\+\n(.*?)\+\+\+/m)[1]
+        parsed = TOML.parse(fm)
+        parsed["weight"].raw.should eq(10)
+        parsed["rating"].raw.should eq(4.5)
+        parsed["numbers"].raw.as(Array).map(&.as(TOML::Any).raw).should eq([1, 2, 3])
+        parsed["taxonomies"]["categories"].raw.as(Array).first.as(TOML::Any).raw.should eq("tech")
+        parsed["extra"]["subtitle"].raw.should eq("hello")
+        parsed["extra"]["nested"]["key"].raw.should eq("value")
+      end
+    end
+
+    it "counts files with malformed frontmatter as errors instead of stripping metadata" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(content_dir)
+
+        # The +++ inside the multiline string truncates the frontmatter
+        # regex match; the leftover used to be exported as a corrupted body
+        # with ALL metadata silently dropped.
+        File.write(File.join(content_dir, "tricky.md"), "+++\ntitle = \"M\"\ndescription = \"\"\"\nfoo\n+++\nbar\n\"\"\"\n+++\n\nActual body\n")
+
+        exporter = Hwaro::Services::Exporters::HugoExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(
+          target_type: "hugo",
+          content_dir: content_dir,
+          output_dir: output_dir,
+        )
+        result = exporter.run(options)
+
+        result.error_count.should eq(1)
+        result.exported_count.should eq(0)
+        File.exists?(File.join(output_dir, "content", "tricky.md")).should be_false
+      end
+    end
   end
 end

--- a/spec/unit/exporters/jekyll_exporter_spec.cr
+++ b/spec/unit/exporters/jekyll_exporter_spec.cr
@@ -394,5 +394,106 @@ describe Hwaro::Services::Exporters::JekyllExporter do
         File.exists?(File.join(output_dir, "_drafts", "wip.md")).should be_true
       end
     end
+
+    it "maps the site root _index.md to index.md, not index/index.md" do
+      # `index/index.md` is served at `/index/`, leaving the site root empty.
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "_index.md"), "+++\ntitle = \"Home\"\n+++\n\nWelcome\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
+        exporter.run(options)
+
+        File.exists?(File.join(output_dir, "index.md")).should be_true
+        File.exists?(File.join(output_dir, "index", "index.md")).should be_false
+      end
+    end
+
+    it "quotes list items and images that YAML would reinterpret" do
+      # `- beta: gamma` reparses as a mapping and `- NO` as boolean false
+      # under Jekyll's YAML 1.1 loader.
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
+
+        File.write(File.join(content_dir, "posts", "post.md"), "+++\ntitle = \"Post\"\ndate = \"2024-01-01\"\ntags = [\"beta: gamma\", \"NO\", \"plain\"]\nimage = \"a: b.png\"\n+++\n\nBody\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
+        exporter.run(options)
+
+        content = File.read(Dir.glob(File.join(output_dir, "_posts", "*.md")).first)
+        content.should contain(%(- "beta: gamma"))
+        content.should contain(%(- "NO"))
+        content.should contain("- plain")
+        content.should contain(%(image: "a: b.png"))
+
+        # The emitted frontmatter must reparse to the original values.
+        fm = content.match!(/\A---\n(.*?)\n---/m)[1]
+        parsed = YAML.parse(fm)
+        parsed["tags"].as_a.map(&.as_s).should eq(["beta: gamma", "NO", "plain"])
+      end
+    end
+
+    it "passes through custom keys and nested extra instead of dropping them" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
+
+        File.write(File.join(content_dir, "posts", "post.md"), "+++\ntitle = \"Post\"\ndate = \"2024-01-01\"\nslug = \"custom-slug\"\nweight = 3\n[extra]\nsubtitle = \"hi\"\n+++\n\nBody\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
+        exporter.run(options)
+
+        content = File.read(Dir.glob(File.join(output_dir, "_posts", "*.md")).first)
+        fm = content.match!(/\A---\n(.*?)\n---/m)[1]
+        parsed = YAML.parse(fm)
+        parsed["slug"].should eq("custom-slug")
+        parsed["weight"].should eq(3)
+        parsed["extra"]["subtitle"].should eq("hi")
+      end
+    end
+
+    it "does not double the date prefix for already-prefixed sources" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(File.join(content_dir, "posts"))
+
+        File.write(File.join(content_dir, "posts", "2024-01-15-hello.md"), "+++\ntitle = \"Hello\"\ndate = \"2024-01-15\"\n+++\n\nBody\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
+        exporter.run(options)
+
+        File.exists?(File.join(output_dir, "_posts", "2024-01-15-hello.md")).should be_true
+        File.exists?(File.join(output_dir, "_posts", "2024-01-15-2024-01-15-hello.md")).should be_false
+      end
+    end
+
+    it "counts files with malformed frontmatter as errors instead of stripping metadata" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(content_dir)
+
+        File.write(File.join(content_dir, "bad.md"), "+++\nnot valid toml = =\n+++\n\nBody\n")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        options = Hwaro::Config::Options::ExportOptions.new(target_type: "jekyll", content_dir: content_dir, output_dir: output_dir)
+        result = exporter.run(options)
+
+        result.error_count.should eq(1)
+        result.exported_count.should eq(0)
+        Dir.glob(File.join(output_dir, "**", "*.md")).should be_empty
+      end
+    end
   end
 end

--- a/spec/unit/frontmatter_converter_spec.cr
+++ b/spec/unit/frontmatter_converter_spec.cr
@@ -792,5 +792,162 @@ describe Hwaro::Services::ConversionResult do
         converted.should_not contain("2026-05-19")
       end
     end
+
+    it "preserves the authored offset of a YAML timestamp when converting to TOML" do
+      # Regression: `to_rfc3339` converted `08:00+09:00` to the *previous
+      # day's* `23:00Z`, silently changing the post's calendar date.
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "post.md")
+        File.write(file_path, "---\ntitle: Post\ndate: 2026-07-01T08:00:00+09:00\n---\n\nContent")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+
+        converted = File.read(file_path)
+        converted.should contain("2026-07-01T08:00:00+09:00")
+        converted.should_not contain("2026-06-30")
+      end
+    end
+  end
+
+  describe "non-frontmatter leading blocks" do
+    # Regression: a document whose first lines form a `---` … `---` pair that
+    # is NOT a mapping (horizontal rule + prose, a list, an unclosed rule) was
+    # "converted" by replacing the block with empty frontmatter — silently
+    # deleting the author's content.
+    it "skips a horizontal-rule pair without touching the file" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "hr.md")
+        original = "---\nIntro paragraph between two rules.\n---\n\nRest of document.\n"
+        File.write(file_path, original)
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_false
+        File.read(file_path).should eq(original)
+
+        result = converter.convert_to_toml
+        result.success.should be_true
+        result.skipped_count.should eq(1)
+        result.error_count.should eq(0)
+        File.read(file_path).should eq(original)
+      end
+    end
+
+    it "skips a list-shaped leading block without destroying it" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "list.md")
+        original = "---\n- a\n- b\n---\n\nBody.\n"
+        File.write(file_path, original)
+
+        result = converter.convert_to_json
+        result.success.should be_true
+        result.error_count.should eq(0)
+        File.read(file_path).should eq(original)
+      end
+    end
+
+    it "skips a lone leading rule with no closing delimiter (no error exit)" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "lone.md")
+        original = "---\n\nJust a thematic break at the top.\n"
+        File.write(file_path, original)
+
+        result = converter.convert_to_toml
+        result.success.should be_true
+        result.error_count.should eq(0)
+        File.read(file_path).should eq(original)
+      end
+    end
+
+    it "does not mistake a leading shortcode brace block for JSON frontmatter" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "shortcode.md")
+        original = "{{< figure src=\"x.png\" >}}\n\nBody text.\n"
+        File.write(file_path, original)
+
+        converter.detect_format(original).should eq(Hwaro::Services::FrontmatterFormat::Unknown)
+
+        result = converter.convert_to_yaml
+        result.success.should be_true
+        result.error_count.should eq(0)
+        File.read(file_path).should eq(original)
+      end
+    end
+  end
+
+  describe "TOML value emission" do
+    it "emits non-finite floats as TOML inf/nan and reparses cleanly" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "floats.md")
+        File.write(file_path, "---\ntitle: F\nscore: .inf\npenalty: -.inf\nmiss: .nan\n---\n\nBody")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+
+        converted = File.read(file_path)
+        converted.should contain("score = inf")
+        converted.should contain("penalty = -inf")
+        converted.should contain("miss = nan")
+        fm = converted.match!(/\A\+\+\+\n(.*?)\+\+\+/m)[1]
+        TOML.parse(fm)["score"].raw.as(Float64).infinite?.should eq(1)
+      end
+    end
+
+    it "coerces mixed-type arrays so toml.cr can reparse the file" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "mixed.md")
+        File.write(file_path, "---\ntitle: M\nstuff:\n  - 1\n  - two\nratio:\n  - 1\n  - 2.5\n---\n\nBody")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+
+        converted = File.read(file_path)
+        fm = converted.match!(/\A\+\+\+\n(.*?)\+\+\+/m)[1]
+        parsed = TOML.parse(fm)
+        parsed["stuff"].raw.as(Array).map(&.as(TOML::Any).raw).should eq(["1", "two"])
+        parsed["ratio"].raw.as(Array).map(&.as(TOML::Any).raw).should eq([1.0, 2.5])
+      end
+    end
+
+    it "emits maps inside arrays as inline tables" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "inline.md")
+        File.write(file_path, "---\ntitle: I\nlinks:\n  - name: home\n    url: /\n  - plain\n---\n\nBody")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+
+        converted = File.read(file_path)
+        converted.should contain("{name = \"home\", url = \"/\"}")
+      end
+    end
+
+    it "keeps an empty table's key instead of dropping it" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "empty.md")
+        File.write(file_path, "---\ntitle: E\nextra: {}\n---\n\nBody")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+        File.read(file_path).should contain("[extra]")
+      end
+    end
+
+    it "escapes control characters with TOML-legal sequences" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "ctrl.md")
+        File.write(file_path, "---\ntitle: \"ding\\a dong\"\n---\n\nBody")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+
+        converted = File.read(file_path)
+        fm = converted.match!(/\A\+\+\+\n(.*?)\+\+\+/m)[1]
+        TOML.parse(fm)["title"].raw.as(String).should contain("ding")
+      end
+    end
   end
 end

--- a/spec/unit/import_command_spec.cr
+++ b/spec/unit/import_command_spec.cr
@@ -110,6 +110,7 @@ describe Hwaro::CLI::Commands::Tool::ImportCommand do
 
         output.should contain("skipped")
         output.should contain("--force")
+        output.should contain("--drafts")
       end
     end
   end

--- a/spec/unit/importers/astro_importer_spec.cr
+++ b/spec/unit/importers/astro_importer_spec.cr
@@ -146,7 +146,7 @@ describe Hwaro::Services::Importers::AstroImporter do
         importer.run(options)
 
         content = File.read(File.join(output_dir, "blog", "date-test.md"))
-        content.should contain("date = \"2024-05-20 00:00:00\"")
+        content.should contain("date = \"2024-05-20\"")
       end
     end
 
@@ -177,7 +177,7 @@ describe Hwaro::Services::Importers::AstroImporter do
         importer.run(options)
 
         content = File.read(File.join(output_dir, "blog", "updated-test.md"))
-        content.should contain("updated = \"2024-06-01 00:00:00\"")
+        content.should contain("updated = \"2024-06-01\"")
       end
     end
 

--- a/spec/unit/importers/base_spec.cr
+++ b/spec/unit/importers/base_spec.cr
@@ -147,23 +147,40 @@ describe Hwaro::Services::Importers::Base do
   end
 
   describe "#format_date" do
-    it "formats a Time as 'YYYY-MM-DD HH:MM:SS'" do
+    it "formats a UTC timestamp as RFC 3339" do
       t = Time.utc(2026, 4, 17, 9, 30, 45)
-      TestImporter.new.test_format_date(t).should eq("2026-04-17 09:30:45")
+      TestImporter.new.test_format_date(t).should eq("2026-04-17T09:30:45Z")
     end
 
-    it "round-trips with parse_date for the standard space-separated format" do
+    it "emits a bare date for midnight values" do
+      t = Time.utc(2026, 4, 17)
+      TestImporter.new.test_format_date(t).should eq("2026-04-17")
+    end
+
+    it "round-trips through parse_date without changing the instant" do
       importer = TestImporter.new
-      original = "2026-04-17 09:30:45"
-      parsed = importer.test_parse_date(original).not_nil!
-      importer.test_format_date(parsed).should eq(original)
+      parsed = importer.test_parse_date("2026-04-17 09:30:45").not_nil!
+      importer.test_format_date(parsed).should eq("2026-04-17T09:30:45Z")
     end
 
-    it "respects timezone-aware times by formatting in the same instant" do
-      # Time#to_s with the standard format renders local components — for a
-      # UTC Time the output should match the components as constructed.
-      t = Time.utc(2026, 12, 31, 23, 59, 59)
-      TestImporter.new.test_format_date(t).should eq("2026-12-31 23:59:59")
+    it "preserves the source offset instead of dropping it" do
+      # The zone-less "%Y-%m-%d %H:%M:%S" output dropped the offset, so a
+      # +09:00 post re-parsed as UTC shifted by nine hours.
+      t = Time.local(2026, 12, 31, 23, 59, 59, location: Time::Location.fixed(9 * 3600))
+      TestImporter.new.test_format_date(t).should eq("2026-12-31T23:59:59+09:00")
+    end
+
+    it "parses an offset date without silently ignoring the zone" do
+      importer = TestImporter.new
+      parsed = importer.test_parse_date("2026-07-01T10:00:00+09:00").not_nil!
+      parsed.offset.should eq(9 * 3600)
+      importer.test_format_date(parsed).should eq("2026-07-01T10:00:00+09:00")
+    end
+
+    it "parses Jekyll's space-separated offset format" do
+      importer = TestImporter.new
+      parsed = importer.test_parse_date("2024-01-15 10:00:00 +0900").not_nil!
+      parsed.offset.should eq(9 * 3600)
     end
   end
 end

--- a/spec/unit/importers/eleventy_importer_spec.cr
+++ b/spec/unit/importers/eleventy_importer_spec.cr
@@ -337,5 +337,83 @@ describe Hwaro::Services::Importers::EleventyImporter do
       result.success.should be_false
       result.message.should contain("not found")
     end
+
+    it "handles bundle-index files (index.md layout) correctly" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "posts")
+        bundle_a = File.join(posts_dir, "post-a")
+        bundle_b = File.join(posts_dir, "post-b")
+        FileUtils.mkdir_p(bundle_a)
+        FileUtils.mkdir_p(bundle_b)
+
+        # File at root of collection posts/index.md (without title) should still be skipped
+        File.write(File.join(posts_dir, "index.md"), "Content at root index.")
+
+        # Files at nested folders posts/post-a/index.md should use parent dir name as slug and fallback title
+        File.write(File.join(bundle_a, "index.md"), "Content A.")
+        # and if title is specified, it should still use the parent dir name as slug
+        File.write(File.join(bundle_b, "index.md"), "---\ntitle: \"Custom Title\"\n---\nContent B.")
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "eleventy",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::EleventyImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(2) # post-a/index.md and post-b/index.md
+        result.skipped_count.should eq(1)  # root index.md skipped
+
+        File.exists?(File.join(output_dir, "posts", "post-a.md")).should be_true
+        content_a = File.read(File.join(output_dir, "posts", "post-a.md"))
+        content_a.should contain("title = \"Post A\"")
+        content_a.should contain("Content A.")
+
+        File.exists?(File.join(output_dir, "posts", "post-b.md")).should be_true
+        content_b = File.read(File.join(output_dir, "posts", "post-b.md"))
+        content_b.should contain("title = \"Custom Title\"")
+        content_b.should contain("Content B.")
+      end
+    end
+
+    it "handles nested directory/slug collisions by appending a suffix and warning" do
+      Dir.mktmpdir do |dir|
+        blog_dir = File.join(dir, "blog")
+        dir_2023 = File.join(blog_dir, "2023")
+        dir_2024 = File.join(blog_dir, "2024")
+        FileUtils.mkdir_p(dir_2023)
+        FileUtils.mkdir_p(dir_2024)
+
+        File.write(File.join(dir_2023, "foo.md"), "---\ntitle: \"Foo 2023\"\n---\nContent 2023.")
+        File.write(File.join(dir_2024, "foo.md"), "---\ntitle: \"Foo 2024\"\n---\nContent 2024.")
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "eleventy",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::EleventyImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(2)
+        File.exists?(File.join(output_dir, "blog", "foo.md")).should be_true
+        File.exists?(File.join(output_dir, "blog", "foo-1.md")).should be_true
+
+        content_foo = File.read(File.join(output_dir, "blog", "foo.md"))
+        content_foo1 = File.read(File.join(output_dir, "blog", "foo-1.md"))
+
+        if content_foo.includes?("Content 2023.")
+          content_foo1.should contain("Content 2024.")
+        else
+          content_foo.should contain("Content 2024.")
+          content_foo1.should contain("Content 2023.")
+        end
+      end
+    end
   end
 end

--- a/spec/unit/importers/hexo_importer_spec.cr
+++ b/spec/unit/importers/hexo_importer_spec.cr
@@ -73,7 +73,7 @@ describe Hwaro::Services::Importers::HexoImporter do
         importer.run(options)
 
         content = File.read(File.join(output_dir, "posts", "date-prefix.md"))
-        content.should contain("date = \"2024-03-15 00:00:00\"")
+        content.should contain("date = \"2024-03-15\"")
       end
     end
 
@@ -218,7 +218,7 @@ describe Hwaro::Services::Importers::HexoImporter do
         importer.run(options)
 
         content = File.read(File.join(output_dir, "posts", "updated-post.md"))
-        content.should contain("updated = \"2024-06-15 00:00:00\"")
+        content.should contain("updated = \"2024-06-15\"")
       end
     end
 

--- a/spec/unit/importers/hugo_importer_spec.cr
+++ b/spec/unit/importers/hugo_importer_spec.cr
@@ -165,11 +165,11 @@ describe Hwaro::Services::Importers::HugoImporter do
 
         content = File.read(file_path)
         content.should contain("title = \"Hello from Hugo\"")
-        content.should contain("date = \"2024-06-15 10:00:00\"")
+        content.should contain("date = \"2024-06-15T10:00:00Z\"")
         content.should contain("description = \"A test post\"")
         content.should contain("\"crystal\"")
         content.should contain("\"static-site\"")
-        content.should contain("weight = \"10\"")
+        content.should contain("weight = 10")
         content.should contain("This is the body of the post.")
       end
     end
@@ -361,7 +361,7 @@ describe Hwaro::Services::Importers::HugoImporter do
 
         file_path = File.join(output_dir, "posts", "expiry.md")
         content = File.read(file_path)
-        content.should contain("expires = \"2025-06-01 00:00:00\"")
+        content.should contain("expires = \"2025-06-01\"")
       end
     end
 

--- a/spec/unit/importers/jekyll_importer_spec.cr
+++ b/spec/unit/importers/jekyll_importer_spec.cr
@@ -138,7 +138,7 @@ describe Hwaro::Services::Importers::JekyllImporter do
         importer.run(options)
 
         content = File.read(File.join(output_dir, "posts", "no-date-post.md"))
-        content.should contain("date = \"2023-12-25 00:00:00\"")
+        content.should contain("date = \"2023-12-25\"")
       end
     end
 
@@ -553,12 +553,10 @@ describe Hwaro::Services::Importers::JekyllImporter do
       end
     end
 
-    it "silently drops one of two source files that collide on the same slug" do
+    it "disambiguates two source files that collide on the same date-stripped slug" do
       # Two distinct posts whose date-stripped slug is identical ("hello")
-      # both map to posts/hello.md. Under no-force, the first (sorted) input
-      # is imported and the second is skipped — silent data loss in a one-shot
-      # migration. This pins the current behavior and would catch a regression
-      # (or motivate a de-dup / slug-suffix fix).
+      # used to both map to posts/hello.md, silently dropping the second in
+      # a one-shot migration; the later file now gets a date-suffixed slug.
       Dir.mktmpdir do |dir|
         posts_dir = File.join(dir, "_posts")
         FileUtils.mkdir_p(posts_dir)
@@ -588,16 +586,14 @@ describe Hwaro::Services::Importers::JekyllImporter do
         importer = Hwaro::Services::Importers::JekyllImporter.new
         result = importer.run(options)
 
-        # Exactly one survives; the other is silently dropped.
-        result.imported_count.should eq(1)
-        result.skipped_count.should eq(1)
+        # Both survive; the later (sorted) file gets a date-suffixed slug.
+        result.imported_count.should eq(2)
+        result.skipped_count.should eq(0)
 
-        # Dir.glob yields sorted paths, so the 2024-01-01 file wins.
-        output_file = File.join(output_dir, "posts", "hello.md")
-        File.exists?(output_file).should be_true
-        content = File.read(output_file)
-        content.should contain("First post body.")
-        content.should_not contain("Second post body.")
+        first = File.read(File.join(output_dir, "posts", "hello.md"))
+        first.should contain("First post body.")
+        second = File.read(File.join(output_dir, "posts", "hello-2024-06-02.md"))
+        second.should contain("Second post body.")
       end
     end
 

--- a/spec/unit/importers/notion_importer_spec.cr
+++ b/spec/unit/importers/notion_importer_spec.cr
@@ -156,5 +156,68 @@ describe Hwaro::Services::Importers::NotionImporter do
         result.imported_count.should eq(0)
       end
     end
+
+    it "handles slug collisions by appending suffix and logging a warning" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "Meeting Notes abc123def4567890.md"), "# Meeting Notes\nContent 1")
+        File.write(File.join(dir, "Meeting Notes def123def4567890.md"), "# Meeting Notes\nContent 2")
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "notion",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::NotionImporter.new
+        result = importer.run(options)
+
+        result.imported_count.should eq(2)
+        File.exists?(File.join(output_dir, "posts", "meeting-notes.md")).should be_true
+        File.exists?(File.join(output_dir, "posts", "meeting-notes-1.md")).should be_true
+      end
+    end
+
+    it "handles callouts correctly with FE0F and handles multiple callouts in same file" do
+      Dir.mktmpdir do |dir|
+        post_content = "# Page\n\n> 💡\u{FE0F} First callout\n\nSome text\n\n> ⚠️ Second callout"
+        File.write(File.join(dir, "page.md"), post_content)
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "notion",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::NotionImporter.new
+        importer.run(options)
+
+        content = File.read(File.join(output_dir, "posts", "page.md"))
+        content.should contain("> First callout")
+        content.should contain("> Second callout")
+      end
+    end
+
+    it "rewrites internal subpage links with 32-hex suffix to flattened posts links" do
+      Dir.mktmpdir do |dir|
+        post_content = "# Main Page\n\nLink: [Subpage](Parent%20Name%20abc123def4567890abc123def4567890/Sub%20Name%20def123def4567890def123def4567890.md)\n\nHTTP: [Google](https://google.com)"
+        File.write(File.join(dir, "main.md"), post_content)
+
+        output_dir = File.join(dir, "output")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "notion",
+          path: dir,
+          output_dir: output_dir,
+        )
+
+        importer = Hwaro::Services::Importers::NotionImporter.new
+        importer.run(options)
+
+        content = File.read(File.join(output_dir, "posts", "main.md"))
+        content.should contain("[Subpage](/posts/sub-name/)")
+        content.should contain("[Google](https://google.com)")
+      end
+    end
   end
 end

--- a/spec/unit/importers/obsidian_importer_spec.cr
+++ b/spec/unit/importers/obsidian_importer_spec.cr
@@ -351,6 +351,135 @@ describe Hwaro::Services::Importers::ObsidianImporter do
       end
     end
 
+    it "handles non-image embeds and target note with alt/width option" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "embed-test.md"), <<-OBSIDIAN)
+          ---
+          title: "Embed Test"
+          ---
+          Image embed with width: ![[photo.png|400]]
+          Note embed: ![[other-page]]
+          Note embed with section: ![[other-page#Section]]
+          Note embed with alias: ![[other-page|Some Display]]
+          OBSIDIAN
+        File.write(File.join(dir, "other-page.md"), <<-OBSIDIAN)
+          ---
+          title: "Other Page"
+          ---
+          Body.
+          OBSIDIAN
+
+        output_dir = File.join(dir, "output")
+        importer = Hwaro::Services::Importers::ObsidianImporter.new
+        importer.run(Hwaro::Config::Options::ImportOptions.new(
+          source_type: "obsidian",
+          path: dir,
+          output_dir: output_dir,
+        ))
+
+        content = File.read(File.join(output_dir, "posts", "embed-test.md"))
+        content.should contain("Image embed with width: ![400](photo.png)")
+        content.should contain("Note embed: [other-page](/posts/other-page/)")
+        content.should contain("Note embed with section: [other-page#Section](/posts/other-page/#section)")
+        content.should contain("Note embed with alias: [Some Display](/posts/other-page/)")
+      end
+    end
+
+    it "slugifies section path segments for folders with spaces" do
+      Dir.mktmpdir do |dir|
+        subdir = File.join(dir, "Daily Notes")
+        FileUtils.mkdir_p(subdir)
+        File.write(File.join(subdir, "my-note.md"), <<-OBSIDIAN)
+          ---
+          title: "My Note"
+          ---
+          See [[Daily Notes/my-note]].
+          OBSIDIAN
+
+        output_dir = File.join(dir, "output")
+        importer = Hwaro::Services::Importers::ObsidianImporter.new
+        importer.run(Hwaro::Config::Options::ImportOptions.new(
+          source_type: "obsidian",
+          path: dir,
+          output_dir: output_dir,
+        ))
+
+        # Check file was written under slugified section
+        output_file = File.join(output_dir, "daily-notes", "my-note.md")
+        File.exists?(output_file).should be_true
+
+        # Check URL was resolved correctly via slugified section
+        content = File.read(output_file)
+        content.should contain("[Daily Notes/my-note](/daily-notes/my-note/)")
+      end
+    end
+
+    it "ignores embeds, wiki-links, and tags inside fenced code blocks and inline code" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "code-blocks.md"), <<-OBSIDIAN)
+          ---
+          title: "Code Blocks"
+          ---
+          ```
+          Keep ![[photo.png]] as is.
+          Keep [[other-page]] as is.
+          Keep #tag as is.
+          ```
+          Inline `[[other-page]]` and `![[photo.png]]` and `#tag`.
+          4-space indented code:
+              #tag
+              [[other-page]]
+          OBSIDIAN
+
+        output_dir = File.join(dir, "output")
+        importer = Hwaro::Services::Importers::ObsidianImporter.new
+        importer.run(Hwaro::Config::Options::ImportOptions.new(
+          source_type: "obsidian",
+          path: dir,
+          output_dir: output_dir,
+        ))
+
+        content = File.read(File.join(output_dir, "posts", "code-blocks.md"))
+        content.should contain("Keep ![[photo.png]] as is.")
+        content.should contain("Keep [[other-page]] as is.")
+        content.should contain("Keep #tag as is.")
+        content.should contain("Inline `[[other-page]]` and `![[photo.png]]` and `#tag`.")
+        content.should contain("    #tag")
+        content.should contain("    [[other-page]]")
+      end
+    end
+
+    it "excludes drafts from the link map when drafts: false" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "linker.md"), <<-OBSIDIAN)
+          ---
+          title: "Linker"
+          ---
+          See [[draft-note]].
+          OBSIDIAN
+        File.write(File.join(dir, "draft-note.md"), <<-OBSIDIAN)
+          ---
+          title: "Draft Note"
+          draft: true
+          ---
+          Draft.
+          OBSIDIAN
+
+        output_dir = File.join(dir, "output")
+        importer = Hwaro::Services::Importers::ObsidianImporter.new
+        importer.run(Hwaro::Config::Options::ImportOptions.new(
+          source_type: "obsidian",
+          path: dir,
+          output_dir: output_dir,
+          drafts: false,
+        ))
+
+        content = File.read(File.join(output_dir, "posts", "linker.md"))
+        # Since draft-note was skipped, resolving [[draft-note]] should fall back to relative slug, not '/posts/draft-note/'
+        content.should contain("[draft-note](draft-note)")
+      end
+    end
+
     it "returns error result for non-existent directory" do
       options = Hwaro::Config::Options::ImportOptions.new(
         source_type: "obsidian",

--- a/spec/unit/importers/wordpress_importer_spec.cr
+++ b/spec/unit/importers/wordpress_importer_spec.cr
@@ -219,7 +219,7 @@ describe Hwaro::Services::Importers::WordPressImporter do
 
         content = File.read(file_path)
         content.should contain("title = \"Hello World\"")
-        content.should contain("date = \"2024-01-15 10:30:00\"")
+        content.should contain("date = \"2024-01-15T10:30:00Z\"")
         content.should contain("description = \"A short excerpt\"")
         content.should contain(%(tags = ["Crystal", "Web"]))
         content.should contain(%(categories = ["Tutorial"]))
@@ -241,7 +241,7 @@ describe Hwaro::Services::Importers::WordPressImporter do
         # RFC 822 → canonical frontmatter date format. Some exporters
         # omit <wp:post_date> and only populate the RSS <pubDate>; we
         # don't want those posts to arrive dateless.
-        content.should contain(%(date = "2024-01-01 00:00:00"))
+        content.should contain(%(date = "2024-01-01"))
       end
     end
 

--- a/spec/unit/platform_config_spec.cr
+++ b/spec/unit/platform_config_spec.cr
@@ -164,6 +164,39 @@ describe Hwaro::Services::PlatformConfig do
             result.should contain("from = \"/another-old-url/\"")
             result.should contain("to = \"/posts/new-post/\"")
             result.should contain("status = 301")
+            result.should contain("force = true")
+          end
+        end
+      end
+
+      it "skips draft aliases" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            File.write("content/posts/draft-post.md", "---\ntitle: Draft Post\ndraft: true\naliases:\n  - /old-draft-url/\n---\nContent here\n")
+
+            config = Hwaro::Models::Config.new
+            generator = Hwaro::Services::PlatformConfig.new(config)
+            result = generator.generate("netlify")
+
+            result.should_not contain("/old-draft-url/")
+          end
+        end
+      end
+
+      it "calculates multilingual aliases correctly" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            File.write("content/posts/hello.ko.md", "---\ntitle: Hello KO\naliases:\n  - /old-ko-url/\n---\nContent here\n")
+
+            config = Hwaro::Models::Config.new
+            config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+            generator = Hwaro::Services::PlatformConfig.new(config)
+            result = generator.generate("netlify")
+
+            result.should contain("from = \"/old-ko-url/\"")
+            result.should contain("to = \"/ko/posts/hello/\"")
           end
         end
       end
@@ -322,6 +355,20 @@ describe Hwaro::Services::PlatformConfig do
             result.should_not contain("to = \"//contact/form/\"")
           end
         end
+      end
+    end
+
+    describe "gitlab-ci" do
+      it "generates a valid GitLab CI configuration with entrypoint override and correct default branch rule" do
+        config = Hwaro::Models::Config.new
+        generator = Hwaro::Services::PlatformConfig.new(config)
+        result = generator.generate("gitlab-ci")
+
+        result.should contain("image:")
+        result.should contain("name: ghcr.io/hahwul/hwaro:latest")
+        result.should contain("entrypoint: [\"\"]")
+        result.should contain("rules:")
+        result.should contain("- if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH")
       end
     end
 

--- a/spec/unit/tool_commands_spec.cr
+++ b/spec/unit/tool_commands_spec.cr
@@ -220,6 +220,14 @@ describe Hwaro::CLI::Commands::Tool::DoctorCommand do
       flag.not_nil!.takes_value.should be_true
       flag.not_nil!.value_hint.should eq("DIR")
     end
+
+    it "includes max-warnings flag which takes a value" do
+      meta = Hwaro::CLI::Commands::Tool::DoctorCommand.metadata
+      flag = meta.flags.find { |f| f.long == "--max-warnings" }
+      flag.should_not be_nil
+      flag.not_nil!.takes_value.should be_true
+      flag.not_nil!.value_hint.should eq("N")
+    end
   end
 
   # Pin the exit-code contract so CI pipelines can rely on

--- a/spec/unit/unused_assets_spec.cr
+++ b/spec/unit/unused_assets_spec.cr
@@ -345,5 +345,78 @@ describe Hwaro::Services::UnusedAssets do
         end
       end
     end
+
+    it "percent-encoded references are not flagged as unused (regression)" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          FileUtils.mkdir_p("static")
+          FileUtils.mkdir_p("templates")
+
+          File.write(File.join("static", "team photo.png"), "png data")
+          File.write(File.join("content", "post.md"), "---\ntitle: Post\n---\n\n![Team](/team%20photo.png)\n")
+
+          service = Hwaro::Services::UnusedAssets.new(
+            content_dir: "content",
+            static_dir: "static",
+            templates_dir: "templates"
+          )
+          result = service.run
+          result.unused_count.should eq(0)
+        end
+      end
+    end
+
+    it "config.toml raw references are not flagged as unused (regression)" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          FileUtils.mkdir_p("static")
+          FileUtils.mkdir_p("templates")
+
+          File.write(File.join("static", "og-main.png"), "png data")
+          File.write("config.toml", <<-TOML)
+            title = "T"
+            [og]
+            default_image = "static/og-main.png"
+            TOML
+
+          service = Hwaro::Services::UnusedAssets.new(
+            content_dir: "content",
+            static_dir: "static",
+            templates_dir: "templates"
+          )
+          result = service.run
+          result.unused_count.should eq(0)
+        end
+      end
+    end
+
+    it "CWD independence resolves config.toml and templates relative to content parent (regression)" do
+      Dir.mktmpdir do |project_dir|
+        content_dir = File.join(project_dir, "content")
+        static_dir = File.join(project_dir, "static")
+        templates_dir = File.join(project_dir, "templates")
+
+        FileUtils.mkdir_p(content_dir)
+        FileUtils.mkdir_p(static_dir)
+        FileUtils.mkdir_p(templates_dir)
+
+        File.write(File.join(project_dir, "config.toml"), <<-TOML)
+          title = "Project Title"
+          [og]
+          default_image = "static/og-image.png"
+          TOML
+
+        File.write(File.join(static_dir, "og-image.png"), "png data")
+
+        service = Hwaro::Services::UnusedAssets.new(
+          content_dir: content_dir,
+          static_dir: static_dir
+        )
+        result = service.run
+        result.unused_count.should eq(0)
+      end
+    end
   end
 end

--- a/src/cli/commands/tool/agents_md_command.cr
+++ b/src/cli/commands/tool/agents_md_command.cr
@@ -74,7 +74,8 @@ module Hwaro
 
             if write
               filename = "AGENTS.md"
-              if File.exists?(filename) && !force
+              existed = File.exists?(filename)
+              if existed && !force
                 # `confirm?` returns nil on EOF (piped/non-interactive stdin) —
                 # treat that the same as "no" and abort without writing.
                 unless Prompt.confirm?("AGENTS.md already exists. Overwrite?", default: false) == true
@@ -85,7 +86,8 @@ module Hwaro
 
               File.write(filename, content)
               mode_name = remote ? "remote" : "local"
-              Logger.outcome("created", "AGENTS.md · #{mode_name} mode")
+              outcome_verb = existed ? "updated" : "created"
+              Logger.outcome(outcome_verb, "AGENTS.md · #{mode_name} mode")
             else
               puts content
             end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -146,14 +146,18 @@ module Hwaro
 
             # Check external links
             external_results = check_links_concurrently(external_links, timeout, concurrency)
-            dead_external = external_results.select { |r| !(200..299).includes?(r.status) }
+            skipped_external = external_results.select { |r| r.error == "Skipped: private/internal address" }
+            dead_external = external_results.select { |r| !(200..299).includes?(r.status) && r.error != "Skipped: private/internal address" }
 
             # Check internal links. Load taxonomy names from config.toml so
             # URLs like `/tags/` or `/categories/foo/` that Hwaro generates
             # at build time aren't reported as dead (the source-only check
             # has no way to discover these otherwise).
             project_root = find_project_root(target_dir)
-            dead_internal = check_internal_links(internal_links, target_dir, load_taxonomy_names(project_root))
+            config = load_config(project_root)
+            taxonomy_names = config ? config.taxonomies.map(&.name) : [] of String
+            base_path = config ? config.base_path : ""
+            dead_internal = check_internal_links(internal_links, target_dir, taxonomy_names, base_path)
 
             total = external_links.size + internal_links.size
             dead_total = dead_external.size + dead_internal.size
@@ -172,13 +176,15 @@ module Hwaro
             Logger.section("scan", "#{external_links.size} external · #{internal_links.size} internal")
             links_noun = total == 1 ? "link" : "links"
 
-            if dead_total == 0
+            if dead_total == 0 && skipped_external.empty?
               Logger.outcome("checked", "#{total} #{links_noun} · all healthy")
             else
-              Logger.info ""
-              # One ✗ item per dead link, with the URL and reason as an →
-              # detail line. Every content-derived string passes through
-              # `sanitize_for_terminal` so a crafted URL can't inject ANSI.
+              Logger.info "" if dead_total > 0 || !skipped_external.empty?
+              skipped_external.each do |result|
+                Logger.item(sanitize_for_terminal(result.link.file), glyph: :info)
+                detail = "#{sanitize_for_terminal(result.link.url)} — #{sanitize_for_terminal(result.error.to_s)}"
+                Logger.item(detail, glyph: :arrow, indent: 6)
+              end
               dead_external.each do |result|
                 Logger.item(sanitize_for_terminal(result.link.file), glyph: :err)
                 detail = "#{sanitize_for_terminal(result.link.url)}  #{result.status}"
@@ -189,7 +195,11 @@ module Hwaro
                 Logger.item(sanitize_for_terminal(result.link.file), glyph: :err)
                 Logger.item("#{sanitize_for_terminal(result.link.url)}  #{sanitize_for_terminal(result.error.to_s)}", glyph: :arrow, indent: 6)
               end
-              Logger.outcome("checked", "#{total} #{links_noun} · #{dead_total} dead", :err)
+              if dead_total == 0
+                Logger.outcome("checked", "#{total} #{links_noun} · all healthy")
+              else
+                Logger.outcome("checked", "#{total} #{links_noun} · #{dead_total} dead", :err)
+              end
             end
 
             # A dead-links result must fail the process so `check-links` is
@@ -253,7 +263,7 @@ module Hwaro
 
           private def find_external_links(dir : String) : Array(Link)
             links = [] of Link
-            link_regex = /(?:!\[[^\]]*?\]|\[[^\]]*?\])\((https?:\/\/[^\s\)]+)\)/
+            link_regex = /(?:!\[[^\]]*?\]|\[[^\]]*?\])\((https?:\/\/(?:\([^\s()]*\)|[^\s()])+)\)/
 
             Dir.glob("#{dir}/**/*.md").each do |file|
               content = strip_code(File.read(file))
@@ -286,36 +296,46 @@ module Hwaro
               # Regular links (exclude images by using negative lookbehind)
               content.scan(/(?<!!)\[([^\]]*)\]\(([^\)]+)\)/) do |match|
                 url = clean_link_target(match[2])
-                next if url.empty? || url.starts_with?("http://") || url.starts_with?("https://") || url.starts_with?("mailto:") || url.starts_with?("#")
+                next if url.empty? || url.starts_with?("#") || url.starts_with?("//") || url =~ /\A[a-z][a-z0-9+.\-]*:/i
                 links << Link.new(file: file, url: url, kind: :internal)
               end
 
               # Image links
               content.scan(/!\[([^\]]*)\]\(([^\)]+)\)/) do |match|
                 url = clean_link_target(match[2])
-                next if url.empty? || url.starts_with?("http://") || url.starts_with?("https://")
+                next if url.empty? || url.starts_with?("//") || url =~ /\A[a-z][a-z0-9+.\-]*:/i
                 links << Link.new(file: file, url: url, kind: :image)
               end
             end
             links
           end
 
-          private def check_internal_links(links : Array(Link), content_dir : String, taxonomy_names : Array(String) = [] of String) : Array(Result)
+          private def check_internal_links(links : Array(Link), content_dir : String, taxonomy_names : Array(String) = [] of String, base_path : String = "") : Array(Result)
             results = [] of Result
             project_root = find_project_root(content_dir)
 
             links.each do |link|
+              decoded_url = URI.decode(link.url)
+              resolved_url = decoded_url
+              if resolved_url.starts_with?("/") && !base_path.empty?
+                if resolved_url == base_path
+                  resolved_url = "/"
+                elsif resolved_url.starts_with?(base_path + "/")
+                  resolved_url = resolved_url[base_path.size..]
+                end
+              end
+
               base_dir = File.dirname(link.file)
-              target = if link.url.starts_with?("@/")
+              target = if resolved_url.starts_with?("@/")
                          # Zola-style content-root link (`@/posts/hello.md`).
                          # The build resolves these against the content dir,
                          # so the checker must too — otherwise valid links
                          # like `@/index.md` were reported dead (dogfooding find).
-                         File.join(content_dir, link.url[2..])
-                       elsif link.url.starts_with?("/")
-                         File.join(content_dir, link.url.lstrip("/"))
+                         File.join(content_dir, resolved_url[2..])
+                       elsif resolved_url.starts_with?("/")
+                         File.join(content_dir, resolved_url.lstrip("/"))
                        else
-                         File.join(base_dir, link.url)
+                         File.join(base_dir, resolved_url)
                        end
 
               # Most internal URLs are written with a trailing slash
@@ -331,7 +351,7 @@ module Hwaro
                        File.exists?(target_no_slash + ".markdown") ||
                        File.exists?(File.join(target_no_slash, "_index.md")) ||
                        File.exists?(File.join(target_no_slash, "index.md")) ||
-                       (link.kind != :image && taxonomy_url?(link.url, taxonomy_names))
+                       (link.kind != :image && taxonomy_url?(resolved_url, taxonomy_names))
 
               # Also accept assets that live in static/ (source) or public/ (after build).
               # This prevents false positives for:
@@ -339,7 +359,7 @@ module Hwaro
               # - Resized/LQIP versions generated by the image pipeline (in public/)
               # - Any other files published via [content.files] or the asset pipeline.
               unless exists
-                asset_path = link.url.lstrip("/")
+                asset_path = resolved_url.lstrip("/")
                 static_candidate = File.join(project_root, "static", asset_path)
                 public_candidate = File.join(project_root, "public", asset_path)
                 exists = File.exists?(static_candidate) || File.exists?(public_candidate)
@@ -383,21 +403,15 @@ module Hwaro
             names.includes?(segments.first)
           end
 
-          # Load taxonomy names from config.toml when present. A missing or
-          # malformed config is not fatal here — the check falls back to
-          # behaving as if no taxonomies were declared, which preserves the
-          # old strict behavior for projects that haven't configured any.
-          private def load_taxonomy_names(project_root : String = ".") : Array(String)
+          private def load_config(project_root : String = ".") : Models::Config?
             config_path = File.join(project_root, "config.toml")
-            return [] of String unless File.exists?(config_path)
+            return unless File.exists?(config_path)
 
-            # Temporarily chdir so Models::Config.load finds the right file
             Dir.cd(project_root) do
-              config = Models::Config.load
-              return config.taxonomies.map(&.name)
+              Models::Config.load
             end
           rescue Exception
-            [] of String
+            nil
           end
 
           private def check_links_concurrently(links : Array(Link), timeout_seconds : Int32, max_concurrency : Int32) : Array(Result)
@@ -410,18 +424,63 @@ module Hwaro
                 while link = work_channel.receive?
                   error_message : String? = nil
                   status = begin
-                    uri = URI.parse(link.url)
-                    host = uri.host
-                    if host && private_host?(host)
-                      error_message = "Skipped: private/internal address"
-                      results_channel.send(Result.new(link: link, status: -1, error: error_message))
-                      next
+                    current_uri = URI.parse(link.url)
+                    method = "HEAD"
+                    redirects_left = 5
+                    response_status = -1
+
+                    loop do
+                      host = current_uri.host
+                      if host && private_host?(host)
+                        error_message = "Skipped: private/internal address"
+                        response_status = -1
+                        break
+                      end
+
+                      client = HTTP::Client.new(current_uri)
+                      client.connect_timeout = timeout_seconds.seconds
+                      client.read_timeout = timeout_seconds.seconds
+
+                      begin
+                        headers = HTTP::Headers{"User-Agent" => "hwaro-link-checker/1.0"}
+                        response = if method == "HEAD"
+                                     client.head(current_uri.request_target, headers: headers)
+                                   else
+                                     client.get(current_uri.request_target, headers: headers)
+                                   end
+
+                        status_code = response.status_code
+
+                        if {301, 302, 307, 308}.includes?(status_code)
+                          if redirects_left > 0
+                            location = response.headers["Location"]?
+                            if location
+                              current_uri = current_uri.resolve(location)
+                              redirects_left -= 1
+                              next
+                            else
+                              error_message = "Redirect without Location header"
+                              response_status = status_code
+                              break
+                            end
+                          else
+                            error_message = "Too many redirects"
+                            response_status = status_code
+                            break
+                          end
+                        elsif method == "HEAD" && {405, 403, 501}.includes?(status_code)
+                          method = "GET"
+                          next
+                        else
+                          response_status = status_code
+                          break
+                        end
+                      ensure
+                        client.close
+                      end
                     end
-                    client = HTTP::Client.new(uri)
-                    client.connect_timeout = timeout_seconds.seconds
-                    client.read_timeout = timeout_seconds.seconds
-                    response = client.head(uri.request_target)
-                    response.status_code
+
+                    response_status
                   rescue ex : Socket::ConnectError
                     error_message = "Connection failed: #{ex.message}"
                     -1

--- a/src/cli/commands/tool/doctor_command.cr
+++ b/src/cli/commands/tool/doctor_command.cr
@@ -21,6 +21,8 @@ module Hwaro
           # that machine consumers may rely on.
           JSON_SCHEMA_VERSION = 1
 
+          MAX_WARNINGS_FLAG = FlagInfo.new(short: nil, long: "--max-warnings", description: "Exit non-zero when warning count exceeds N (default: unlimited)", takes_value: true, value_hint: "N")
+
           # Flags defined here are used both for OptionParser and completion generation
           FLAGS = [
             CONTENT_DIR_FLAG,
@@ -29,7 +31,7 @@ module Hwaro
             FlagInfo.new(short: nil, long: "--full", description: "Equivalent to --fix --approve (real fixes + all recommended sections)"),
             FlagInfo.new(short: nil, long: "--dry-run", description: "Preview changes without writing config.toml"),
             FlagInfo.new(short: nil, long: "--strict", description: "Treat warnings as errors when computing the exit code"),
-            FlagInfo.new(short: nil, long: "--max-warnings=N", description: "Exit non-zero when warning count exceeds N (default: unlimited)"),
+            MAX_WARNINGS_FLAG,
             JSON_FLAG,
             QUIET_FLAG,
             HELP_FLAG,
@@ -72,7 +74,7 @@ module Hwaro
               parser.on("--full", "Perform real fixes and approve all recommended sections (equivalent to --fix --approve)") { full_mode = true }
               parser.on("--dry-run", "Preview changes without writing config.toml") { dry_run_mode = true }
               parser.on("--strict", "Treat warnings as errors when computing the exit code") { strict_mode = true }
-              parser.on("--max-warnings=N", "Exit non-zero when warning count exceeds N") do |v|
+              CLI.register_flag(parser, MAX_WARNINGS_FLAG) do |v|
                 parsed = v.to_i?
                 unless parsed && parsed >= 0
                   Logger.error "--max-warnings expects a non-negative integer (got: #{v.inspect})"

--- a/src/cli/commands/tool/import_command.cr
+++ b/src/cli/commands/tool/import_command.cr
@@ -127,7 +127,7 @@ module Hwaro
             Logger.outcome("imported", summary, glyph: result.error_count > 0 ? :err : :result)
 
             if result.skipped_count > 0 && !options.force
-              Logger.warn "#{result.skipped_count} file(s) skipped because the destination already exists. Re-run with --force to overwrite."
+              Logger.warn "#{result.skipped_count} file(s) skipped because they may already exist (use --force to overwrite) or be drafts (use --drafts to import)."
             end
           end
 

--- a/src/services/content_lister.cr
+++ b/src/services/content_lister.cr
@@ -114,8 +114,8 @@ module Hwaro
 
         # Sort by date (newest first), then by path
         contents.sort_by! do |info|
-          {info.date.try(&.to_unix) || 0_i64, info.path}
-        end.reverse!
+          {-(info.date.try(&.to_unix) || 0_i64), info.path}
+        end
 
         contents
       end
@@ -253,25 +253,30 @@ module Hwaro
 
       private def parse_time(time_str : String?) : Time?
         return unless time_str
+        str = time_str.strip
+
+        begin
+          return Time.parse_rfc3339(str)
+        rescue Time::Format::Error
+        end
 
         formats = [
-          "%Y-%m-%d %H:%M:%S",
+          "%Y-%m-%dT%H:%M:%S%:z",
+          "%Y-%m-%dT%H:%M:%S%z",
+          "%Y-%m-%d %H:%M:%S %:z",
+          "%Y-%m-%d %H:%M:%S %z",
           "%Y-%m-%dT%H:%M:%S",
+          "%Y-%m-%d %H:%M:%S",
           "%Y-%m-%d",
         ]
 
         formats.each do |fmt|
-          return Time.parse(time_str, fmt, Time::Location::UTC)
-        rescue Time::Format::Error
+          return Time.parse(str, fmt, Time::Location::UTC)
+        rescue Time::Format::Error | ArgumentError
           next
         end
 
-        # Try ISO 8601 parsing as last resort
-        begin
-          Time.parse_rfc3339(time_str)
-        rescue Time::Format::Error
-          nil
-        end
+        nil
       end
 
       private def truncate(str : String, max_length : Int32) : String

--- a/src/services/content_stats.cr
+++ b/src/services/content_stats.cr
@@ -7,6 +7,7 @@ require "json"
 require "yaml"
 require "toml"
 require "./content_lister"
+require "../utils/frontmatter_scanner"
 require "../utils/logger"
 
 module Hwaro
@@ -118,7 +119,11 @@ module Hwaro
       end
 
       private def extract_body(content : String) : String
-        content.sub(TOML_FRONTMATTER_RE, "").sub(YAML_FRONTMATTER_RE, "")
+        if content.starts_with?('{') && (end_idx = Utils::FrontmatterScanner.find_json_end(content))
+          content.byte_slice(end_idx)
+        else
+          content.sub(TOML_FRONTMATTER_RE, "").sub(YAML_FRONTMATTER_RE, "")
+        end
       end
 
       private def count_words(body : String) : Int32

--- a/src/services/content_validator.cr
+++ b/src/services/content_validator.cr
@@ -56,8 +56,7 @@ module Hwaro
       private def validate_file(file_path : String, issues : Array(Issue))
         content = File.read(file_path)
 
-        frontmatter = parse_frontmatter(file_path, content, issues)
-        return unless frontmatter
+        frontmatter = parse_frontmatter(file_path, content, issues) || {} of String => FrontmatterValue
 
         title = frontmatter["title"]?
         description = frontmatter["description"]?
@@ -213,6 +212,12 @@ module Hwaro
       end
 
       private def check_date_format(file_path : String, date_str : String, issues : Array(Issue))
+        unless date_str.matches?(/^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:?\d{2}| [A-Z][A-Za-z]*| [+-]\d{2}:?\d{2})?)?$/)
+          issues << Issue.new(id: "content-date-invalid", level: :warning, category: "content", file: file_path,
+            message: "Date format may be invalid: \"#{date_str}\"")
+          return
+        end
+
         formats = [
           "%Y-%m-%d %H:%M:%S",
           "%Y-%m-%dT%H:%M:%S",
@@ -226,7 +231,7 @@ module Hwaro
           Time.parse(date_str, fmt, Time::Location::UTC)
           parsed = true
           break
-        rescue Time::Format::Error
+        rescue Time::Format::Error | ArgumentError
           next
         end
 
@@ -235,7 +240,7 @@ module Hwaro
           begin
             Time.parse_rfc3339(date_str)
             parsed = true
-          rescue Time::Format::Error
+          rescue Time::Format::Error | ArgumentError
           end
         end
 
@@ -288,7 +293,11 @@ module Hwaro
       end
 
       private def extract_body(content : String) : String
-        content.sub(TOML_FRONTMATTER_RE, "").sub(YAML_FRONTMATTER_RE, "")
+        if content.starts_with?('{') && (end_idx = Utils::FrontmatterScanner.find_json_end(content))
+          content.byte_slice(end_idx)
+        else
+          content.sub(TOML_FRONTMATTER_RE, "").sub(YAML_FRONTMATTER_RE, "")
+        end
       end
 
       private def strip_code_blocks(text : String) : String

--- a/src/services/defaults/agents_md.cr
+++ b/src/services/defaults/agents_md.cr
@@ -293,7 +293,7 @@ module Hwaro
             | `markdownify` | Render markdown to HTML |
             | `date(format="%Y-%m-%d")` | Format date |
             | `upper` / `lower` | Case conversion |
-            | `join(sep=", ")` | Join array |
+            | `join(", ")` | Join array |
 
             ## Configuration
 

--- a/src/services/exporters/base.cr
+++ b/src/services/exporters/base.cr
@@ -3,6 +3,7 @@ require "yaml"
 require "toml"
 require "../../config/options/export_options"
 require "../../utils/file_safe"
+require "../../utils/frontmatter_writer"
 require "../../utils/logger"
 
 module Hwaro
@@ -40,61 +41,63 @@ module Hwaro
           files.sort
         end
 
-        # Parse frontmatter from content, returns {fields_hash, body}
-        protected def parse_content(content : String) : {Hash(String, (String | Bool | Array(String))?), String}
-          fields = {} of String => (String | Bool | Array(String))?
+        # Parse frontmatter from content, returns {fields_hash, body}.
+        #
+        # The full parsed tree is preserved as `YAML::Any` values — nested
+        # tables (`[extra]`, `[taxonomies]`), typed scalars, and non-string
+        # arrays used to be flattened through a `String | Bool | Array(String)`
+        # union and silently dropped from every export. Time values are
+        # normalized to frontmatter date strings so downstream date logic can
+        # treat `date` uniformly.
+        #
+        # Malformed frontmatter RAISES (surfacing as a per-file export error)
+        # instead of exporting the file with all metadata stripped.
+        protected def parse_content(content : String) : {Hash(String, YAML::Any), String}
+          fields = {} of String => YAML::Any
 
           if match = content.match(TOML_FRONTMATTER_RE)
             body = content.sub(TOML_FRONTMATTER_RE, "").lstrip('\n')
-            begin
-              toml_data = TOML.parse(match[1])
-              toml_data.each do |key, value|
-                raw = value.raw
-                case raw
-                when String  then fields[key] = raw
-                when Bool    then fields[key] = raw
-                when Int64   then fields[key] = raw.to_s
-                when Float64 then fields[key] = raw.to_s
-                when Time    then fields[key] = raw.to_s("%Y-%m-%dT%H:%M:%S%:z")
-                when Array
-                  arr = raw.compact_map { |item| item.as(TOML::Any).raw.as?(String) }
-                  fields[key] = arr unless arr.empty?
-                end
-              end
-            rescue TOML::ParseException
-              # Malformed TOML front matter: surface no fields, keep body.
+            TOML.parse(match[1]).each do |key, value|
+              fields[key] = Hwaro::Utils::FrontmatterWriter.toml_to_yaml_any(value)
             end
             return {fields, body}
           elsif match = content.match(YAML_FRONTMATTER_RE)
-            body = content.sub(YAML_FRONTMATTER_RE, "").lstrip('\n')
-            begin
-              yaml_data = YAML.parse(match[1])
-              if h = yaml_data.as_h?
-                h.each do |key, value|
-                  k = key.as_s? || next
-                  if s = value.as_s?
-                    fields[k] = s
-                  elsif b = value.as_bool?
-                    fields[k] = b
-                  elsif i = value.as_i?
-                    fields[k] = i.to_s
-                  elsif f = value.as_f?
-                    fields[k] = f.to_s
-                  elsif t = value.as_time?
-                    fields[k] = t.to_s("%Y-%m-%dT%H:%M:%S%:z")
-                  elsif arr = value.as_a?
-                    strs = arr.compact_map(&.as_s?)
-                    fields[k] = strs unless strs.empty?
-                  end
-                end
+            yaml_data = YAML.parse(match[1])
+            if h = yaml_data.as_h?
+              body = content.sub(YAML_FRONTMATTER_RE, "").lstrip('\n')
+              h.each do |key, value|
+                k = key.as_s? || key.to_s
+                fields[k] = normalize_scalar_times(value)
               end
-            rescue YAML::ParseException
-              # Malformed YAML front matter: surface no fields, keep body.
+              return {fields, body}
+            elsif yaml_data.raw.nil?
+              # Genuinely empty frontmatter block.
+              return {fields, content.sub(YAML_FRONTMATTER_RE, "").lstrip('\n')}
+            else
+              # A leading `---` pair around non-mapping text is a horizontal
+              # rule, not frontmatter — keep the whole document as body.
+              return {fields, content}
             end
-            return {fields, body}
           end
 
           {fields, content}
+        end
+
+        # Recursively replace Time leaves with frontmatter date strings.
+        private def normalize_scalar_times(value : YAML::Any) : YAML::Any
+          raw = value.raw
+          case raw
+          when Time
+            YAML::Any.new(Hwaro::Utils::FrontmatterWriter.serialize_time(raw))
+          when Array
+            YAML::Any.new(value.as_a.map { |v| normalize_scalar_times(v) })
+          when Hash
+            hash = {} of YAML::Any => YAML::Any
+            value.as_h.each { |k, v| hash[k] = normalize_scalar_times(v) }
+            YAML::Any.new(hash)
+          else
+            value
+          end
         end
 
         # Write a file, creating parent directories as needed
@@ -105,13 +108,27 @@ module Hwaro
         end
 
         # Normalize a front-matter field that may be authored as either a list
-        # (`tags: [a, b]`) or a single scalar (`tags: crystal`) into an array,
-        # so the scalar shorthand isn't silently dropped on export. Returns nil
-        # when the value is absent or empty.
-        protected def string_list_field(value : (String | Bool | Array(String))?) : Array(String)?
-          case value
-          when Array(String) then value.empty? ? nil : value
-          when String        then value.empty? ? nil : [value]
+        # (`tags: [a, b]`) or a single scalar (`tags: crystal`, `tags: 2024`)
+        # into an array of strings, so shorthand isn't silently dropped on
+        # export. Returns nil when the value is absent or empty.
+        protected def string_list_field(value : YAML::Any?) : Array(String)?
+          return unless value
+
+          case raw = value.raw
+          when Array
+            strs = value.as_a.compact_map do |item|
+              item.as_s? || begin
+                item_raw = item.raw
+                item_raw.is_a?(Hash) || item_raw.is_a?(Array) || item_raw.nil? ? nil : item_raw.to_s
+              end
+            end
+            strs.empty? ? nil : strs
+          when String
+            raw.empty? ? nil : [raw]
+          when Nil, Hash
+            nil
+          else
+            [raw.to_s]
           end
         end
 

--- a/src/services/exporters/hugo_exporter.cr
+++ b/src/services/exporters/hugo_exporter.cr
@@ -54,7 +54,7 @@ module Hwaro
           fields, body = parse_content(raw)
 
           # Skip drafts unless requested
-          is_draft = fields["draft"]?.try { |v| v == true }
+          is_draft = fields["draft"]?.try(&.raw) == true
           if is_draft && !include_drafts
             return :skipped
           end
@@ -63,22 +63,26 @@ module Hwaro
           #
           # Strategy: walk every parsed frontmatter key and either rename
           # it to its Hugo equivalent (`updated`→`lastmod`, `image`→`images`,
-          # `expires`→`expiryDate`) or pass it through unchanged. Hugo
+          # `expires`→`expiryDate`) or pass it through unchanged — including
+          # nested tables (`[extra]`, `[taxonomies]`) and typed scalars. Hugo
           # accepts arbitrary keys as page params, so dropping them was a
           # silent data-loss bug for `categories`, `authors`, and any
           # custom field the user added (gh#527). Source-iteration order
           # is preserved so Hugo frontmatter reads similarly to the
           # original.
-          hugo_fields = {} of String => (String | Bool | Array(String))?
+          hugo_fields = {} of String => YAML::Any
           fields.each do |key, value|
+            next if value.raw.nil?
             case key
             when "updated"
               hugo_fields["lastmod"] = value
             when "expires"
               hugo_fields["expiryDate"] = value
             when "image"
-              if image = value.as?(String)
-                hugo_fields["images"] = [image] of String
+              if image = value.as_s?
+                hugo_fields["images"] = YAML::Any.new([YAML::Any.new(image)])
+              else
+                hugo_fields["images"] = value
               end
             else
               hugo_fields[key] = value
@@ -96,33 +100,9 @@ module Hwaro
           :exported
         end
 
-        private def generate_toml_frontmatter(fields : Hash(String, (String | Bool | Array(String))?)) : String
-          lines = ["+++"]
-
-          fields.each do |key, value|
-            k = toml_key(key)
-            case value
-            when Nil  then next
-            when Bool then lines << "#{k} = #{value}"
-            when String
-              next if value.empty?
-              lines << "#{k} = #{value.inspect}"
-            when Array(String)
-              next if value.empty?
-              formatted = value.map(&.inspect).join(", ")
-              lines << "#{k} = [#{formatted}]"
-            end
-          end
-
-          lines << "+++"
-          lines.join("\n")
-        end
-
-        # Quote a front-matter key that isn't a bare TOML key. A key with a
-        # space, dot, or non-ASCII char (valid in YAML/JSON source) would emit
-        # unparseable TOML like `my key = "x"`; render it as `"my key" = "x"`.
-        private def toml_key(key : String) : String
-          key.matches?(/\A[A-Za-z0-9_-]+\z/) ? key : key.inspect
+        private def generate_toml_frontmatter(fields : Hash(String, YAML::Any)) : String
+          body = Hwaro::Utils::FrontmatterWriter::TomlBuilder.new.build(fields)
+          "+++\n#{body}+++"
         end
       end
     end

--- a/src/services/exporters/jekyll_exporter.cr
+++ b/src/services/exporters/jekyll_exporter.cr
@@ -58,6 +58,12 @@ module Hwaro
           )
         end
 
+        # Keys emitted explicitly below; everything else passes through as a
+        # Jekyll page variable (Jekyll accepts arbitrary front-matter keys, so
+        # dropping `slug`, `weight`, `layout`, `extra.*`, … was silent data
+        # loss — the same bug class gh#527 fixed for the Hugo exporter).
+        HANDLED_KEYS = Set{"title", "date", "description", "draft", "tags", "categories", "authors", "image"}
+
         private def export_file(
           file_path : String,
           content_dir : String,
@@ -68,7 +74,7 @@ module Hwaro
           raw = File.read(file_path)
           fields, body = parse_content(raw)
 
-          is_draft = (fields["draft"]?.try { |v| v == true }) == true
+          is_draft = fields["draft"]?.try(&.raw) == true
           if is_draft && !include_drafts
             return :skipped
           end
@@ -76,15 +82,15 @@ module Hwaro
           # Build Jekyll YAML frontmatter
           yaml_lines = [] of String
 
-          if title = fields["title"]?.as?(String)
+          if title = fields["title"]?.try(&.as_s?)
             yaml_lines << "title: #{title.inspect}"
           end
 
-          if date = fields["date"]?.as?(String)
+          if date = fields["date"]?.try(&.as_s?)
             yaml_lines << "date: #{date}"
           end
 
-          if desc = fields["description"]?.as?(String)
+          if desc = fields["description"]?.try(&.as_s?)
             yaml_lines << "description: #{desc.inspect}"
           end
 
@@ -95,27 +101,33 @@ module Hwaro
 
           # Accept both list (`tags: [a, b]`) and scalar (`tags: crystal`)
           # shorthand — a scalar would otherwise fail the Array(String) cast
-          # and silently drop the post's taxonomy membership.
+          # and silently drop the post's taxonomy membership. Items are
+          # YAML-quoted when needed: a bare `- beta: gamma` reparses as a
+          # mapping and `- NO` as `false` under Jekyll's YAML 1.1 loader.
           if tags = string_list_field(fields["tags"]?)
             yaml_lines << "tags:"
-            tags.each { |t| yaml_lines << "  - #{t}" }
+            tags.each { |t| yaml_lines << "  - #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(t)}" }
           end
 
           # categories from taxonomies if present
           if cats = string_list_field(fields["categories"]?)
             yaml_lines << "categories:"
-            cats.each { |c| yaml_lines << "  - #{c}" }
+            cats.each { |c| yaml_lines << "  - #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(c)}" }
           end
 
           # Jekyll natively understands an `authors` front-matter list, so
           # carry it across instead of dropping author attribution.
-          if authors = fields["authors"]?.as?(Array(String))
+          if authors = string_list_field(fields["authors"]?)
             yaml_lines << "authors:"
-            authors.each { |a| yaml_lines << "  - #{a}" }
+            authors.each { |a| yaml_lines << "  - #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(a)}" }
           end
 
-          if image = fields["image"]?.as?(String)
-            yaml_lines << "image: #{image}"
+          if image = fields["image"]?.try(&.as_s?)
+            yaml_lines << "image: #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(image)}"
+          end
+
+          if passthrough = passthrough_yaml(fields)
+            yaml_lines << passthrough
           end
 
           frontmatter = "---\n#{yaml_lines.join("\n")}\n---"
@@ -126,6 +138,21 @@ module Hwaro
 
           write_file(out_path, "#{frontmatter}\n\n#{body.strip}\n", verbose)
           :exported
+        end
+
+        # Serialize the non-allowlisted fields through the YAML emitter (which
+        # handles nesting, typing, and quoting), returning frontmatter lines
+        # without the `---` fences, or nil when there is nothing to carry.
+        private def passthrough_yaml(fields : Hash(String, YAML::Any)) : String?
+          leftovers = {} of YAML::Any => YAML::Any
+          fields.each do |key, value|
+            next if HANDLED_KEYS.includes?(key)
+            next if value.raw.nil?
+            leftovers[YAML::Any.new(key)] = value
+          end
+          return if leftovers.empty?
+
+          YAML::Any.new(leftovers).to_yaml.lchop("---\n").chomp
         end
 
         # Reserve `path` for this run, appending `-1`, `-2`, … (with a
@@ -165,7 +192,7 @@ module Hwaro
           file_path : String,
           content_dir : String,
           output_dir : String,
-          fields : Hash(String, (String | Bool | Array(String))?),
+          fields : Hash(String, YAML::Any),
           is_draft : Bool,
           include_drafts : Bool,
         ) : String
@@ -174,12 +201,14 @@ module Hwaro
           dir_part = File.dirname(relative)
 
           # Section indices become regular pages (Jekyll has no `_index`).
+          # The site root maps to `index.md` at the export root — an
+          # `index/index.md` would be served at `/index/`, leaving `/` empty.
           if filename == "_index.md" || filename == "_index.markdown"
-            slug = (dir_part == "." || dir_part.empty?) ? "index" : dir_part
-            return File.join(output_dir, slug, "index.md")
+            return File.join(output_dir, "index.md") if dir_part == "." || dir_part.empty?
+            return File.join(output_dir, dir_part, "index.md")
           end
 
-          date_str = fields["date"]?.as?(String)
+          date_str = fields["date"]?.try(&.as_s?)
           date_prefix = date_str && date_str.size >= 10 ? date_str[0, 10] : nil
           dated = date_prefix && date_prefix.matches?(/^\d{4}-\d{2}-\d{2}$/)
           slug = filename.sub(/\.(md|markdown)$/, "")
@@ -189,6 +218,15 @@ module Hwaro
           # every same-day bundle once flattened into `_posts/`.
           if slug == "index" && dir_part != "." && !dir_part.empty?
             slug = File.basename(dir_part)
+          end
+
+          # A source already named `YYYY-MM-DD-slug` (file or bundle dir)
+          # would double up (`_posts/2024-01-15-2024-01-15-hello.md`) once the
+          # date prefix is re-applied below; Jekyll would then derive a dated
+          # slug/URL.
+          if dated
+            stripped = slug.sub(/\A\d{4}-\d{2}-\d{2}-/, "")
+            slug = stripped unless stripped.empty?
           end
 
           # Content under a posts-like top-level section is a blog post:

--- a/src/services/frontmatter_converter.cr
+++ b/src/services/frontmatter_converter.cr
@@ -7,6 +7,7 @@ require "json"
 require "yaml"
 require "toml"
 require "../utils/frontmatter_scanner"
+require "../utils/frontmatter_writer"
 require "../utils/logger"
 
 module Hwaro
@@ -87,11 +88,21 @@ module Hwaro
           FrontmatterFormat::TOML
         elsif content.starts_with?("#{YAML_DELIMITER}\n") || content.starts_with?("#{YAML_DELIMITER}\r\n")
           FrontmatterFormat::YAML
-        elsif content.starts_with?('{') && Utils::FrontmatterScanner.find_json_end(content)
+        elsif content.starts_with?('{') && json_frontmatter_object?(content)
           FrontmatterFormat::JSON
         else
           FrontmatterFormat::Unknown
         end
+      end
+
+      # A body that merely *starts* with `{` (e.g. a `{{< shortcode >}}` line)
+      # can balance braces and fool the scanner; only claim JSON when the
+      # leading block actually parses as a JSON object.
+      private def json_frontmatter_object?(content : String) : Bool
+        return false unless end_idx = Utils::FrontmatterScanner.find_json_end(content)
+        JSON.parse(content.byte_slice(0, end_idx)).as_h? ? true : false
+      rescue JSON::ParseException
+        false
       end
 
       # Convert a single file's frontmatter
@@ -115,10 +126,20 @@ module Hwaro
           return ConversionStatus::Skipped
         end
 
+        # A leading `---`/`+++` pair whose inside isn't a mapping (a horizontal
+        # rule followed by prose, a stray list, an unclosed delimiter) is body
+        # text, not frontmatter. Converting it used to REPLACE the block with
+        # empty frontmatter, silently deleting the author's content — skip
+        # such files instead of writing anything.
+        unless frontmatter_mapping?(content, current_format)
+          Logger.item("skipped (leading #{format_label(current_format)} block is not frontmatter): #{file_path}", glyph: :warn) if log_skipped
+          return ConversionStatus::Skipped
+        end
+
         converted_content = convert_content(content, current_format, target_format)
 
         if converted_content
-          File.write(file_path, converted_content)
+          write_in_place(file_path, converted_content)
           Logger.item(file_path, glyph: :ok)
           ConversionStatus::Converted
         else
@@ -199,6 +220,48 @@ module Hwaro
         when {FrontmatterFormat::JSON, FrontmatterFormat::TOML}
           json_to_toml(content)
         end
+      end
+
+      # True when the file's leading delimiter block both closes properly and
+      # parses as a key/value mapping. Parse *errors* return true so they
+      # surface as Failed (with a message) in the convert path rather than
+      # being silently skipped here.
+      private def frontmatter_mapping?(content : String, format : FrontmatterFormat) : Bool
+        case format
+        when FrontmatterFormat::YAML
+          return false unless match = content.match(YAML_FRONTMATTER_RE)
+          begin
+            YAML.parse(match[1]).as_h? ? true : false
+          rescue YAML::ParseException
+            true
+          end
+        when FrontmatterFormat::TOML
+          # TOML.parse always yields a table; just require a closing delimiter.
+          content.matches?(TOML_FRONTMATTER_RE)
+        else
+          # JSON detection already validated an object in detect_format.
+          true
+        end
+      end
+
+      # Replace a content file atomically (temp file + rename) so an
+      # interrupt or full disk mid-conversion can't truncate the original.
+      # rename(2) only needs directory permission, so check the file itself
+      # first — a read-only file must fail instead of being silently replaced
+      # — and carry its permissions onto the replacement.
+      private def write_in_place(file_path : String, content : String) : Nil
+        unless File::Info.writable?(file_path)
+          raise File::Error.new("File not writable", file: file_path)
+        end
+
+        permissions = File.info(file_path).permissions
+        tmp_path = "#{file_path}.hwaro-convert.tmp"
+        File.write(tmp_path, content)
+        File.chmod(tmp_path, permissions)
+        File.rename(tmp_path, file_path)
+      rescue ex
+        File.delete(tmp_path) if tmp_path && File.exists?(tmp_path)
+        raise ex
       end
 
       private def format_label(fmt : FrontmatterFormat) : String
@@ -309,7 +372,7 @@ module Hwaro
           json_data = JSON.parse(json_str)
           # Reuse the YAML→TOML builder by going through YAML::Any.
           yaml_any = json_to_yaml_any(json_data)
-          toml_body = TomlBuilder.new.build(yaml_any)
+          toml_body = Utils::FrontmatterWriter::TomlBuilder.new.build(yaml_any)
           "#{TOML_DELIMITER}\n#{toml_body}#{TOML_DELIMITER}\n#{body}"
         rescue ex
           Logger.debug "JSON parse error: #{ex.message}"
@@ -343,11 +406,7 @@ module Hwaro
       # round-trip. When the value carries no time-of-day we emit a bare
       # `YYYY-MM-DD` date and keep the day; genuine timestamps round-trip as RFC 3339.
       def self.serialize_time(time : Time) : String
-        if time.hour == 0 && time.minute == 0 && time.second == 0 && time.nanosecond == 0
-          time.to_s("%Y-%m-%d")
-        else
-          time.to_rfc3339
-        end
+        Utils::FrontmatterWriter.serialize_time(time)
       end
 
       private def yaml_any_to_json_any(yaml : YAML::Any) : JSON::Any
@@ -443,112 +502,7 @@ module Hwaro
       end
 
       private def convert_yaml_to_toml_string(yaml : YAML::Any, indent : Int32 = 0) : String
-        TomlBuilder.new.build(yaml)
-      end
-
-      private class TomlBuilder
-        def initialize
-          @output = String::Builder.new
-        end
-
-        def build(yaml : YAML::Any) : String
-          return "" unless yaml.as_h?
-          process_table(yaml, [] of String, true)
-          @output.to_s
-        end
-
-        private def process_table(yaml : YAML::Any, path : Array(String), print_header : Bool)
-          return unless yaml.as_h?
-
-          simple_values = {} of String => YAML::Any
-          tables = {} of String => YAML::Any
-          array_tables = {} of String => YAML::Any
-
-          yaml.as_h.each do |key, value|
-            key_str = key.as_s? || key.to_s
-
-            if value.as_h?
-              tables[key_str] = value
-            elsif array_of_tables?(value)
-              array_tables[key_str] = value
-            else
-              simple_values[key_str] = value
-            end
-          end
-
-          if !simple_values.empty? && print_header && !path.empty?
-            @output << "\n" unless @output.empty?
-            @output << "[" << format_path(path) << "]\n"
-          end
-
-          simple_values.each do |k, v|
-            @output << format_key(k) << " = " << to_toml_value(v) << "\n"
-          end
-
-          tables.each do |k, v|
-            process_table(v, path + [k], true)
-          end
-
-          array_tables.each do |k, v|
-            v.as_a.each do |item|
-              new_path = path + [k]
-              @output << "\n" unless @output.empty?
-              @output << "[[" << format_path(new_path) << "]]\n"
-              process_table(item, new_path, false)
-            end
-          end
-        end
-
-        private def array_of_tables?(value : YAML::Any) : Bool
-          return false unless value.as_a?
-          return false if value.as_a.empty?
-          value.as_a.all?(&.as_h?)
-        end
-
-        private def format_path(path : Array(String)) : String
-          path.map { |k| format_key(k) }.join(".")
-        end
-
-        private def format_key(key : String) : String
-          if key =~ /^[A-Za-z0-9_-]+$/
-            key
-          else
-            "\"#{escape_toml_string(key)}\""
-          end
-        end
-
-        private def to_toml_value(value : YAML::Any) : String
-          raw = value.raw
-
-          case raw
-          when Bool
-            raw.to_s
-          when Int32, Int64
-            raw.to_s
-          when Float32, Float64
-            raw.to_s
-          when Time
-            FrontmatterConverter.serialize_time(raw)
-          when Array
-            items = value.as_a.map { |v| to_toml_value(v) }
-            "[#{items.join(", ")}]"
-          when String
-            "\"#{escape_toml_string(raw)}\""
-          when Nil
-            "\"\""
-          else
-            "\"#{escape_toml_string(value.to_s)}\""
-          end
-        end
-
-        private def escape_toml_string(str : String) : String
-          str
-            .gsub("\\", "\\\\")
-            .gsub("\"", "\\\"")
-            .gsub("\n", "\\n")
-            .gsub("\t", "\\t")
-            .gsub("\r", "\\r")
-        end
+        Utils::FrontmatterWriter::TomlBuilder.new.build(yaml)
       end
 
       private def convert_toml_to_yaml_string(toml : TOML::Table) : String
@@ -567,41 +521,7 @@ module Hwaro
       end
 
       private def toml_value_to_yaml(value : TOML::Any) : YAML::Any
-        raw = value.raw
-
-        case raw
-        when String
-          YAML::Any.new(raw)
-        when Int64
-          YAML::Any.new(raw)
-        when Float64
-          YAML::Any.new(raw)
-        when Bool
-          YAML::Any.new(raw)
-        when Time
-          YAML::Any.new(FrontmatterConverter.serialize_time(raw))
-        when Array
-          arr = raw.map { |item|
-            if item.is_a?(TOML::Any)
-              toml_value_to_yaml(item)
-            else
-              YAML::Any.new(item.to_s)
-            end
-          }
-          YAML::Any.new(arr)
-        when Hash
-          if raw.is_a?(Hash(String, TOML::Any))
-            hash = {} of YAML::Any => YAML::Any
-            raw.each do |k, v|
-              hash[YAML::Any.new(k)] = toml_value_to_yaml(v)
-            end
-            YAML::Any.new(hash)
-          else
-            YAML::Any.new(raw.to_s)
-          end
-        else
-          YAML::Any.new(raw.to_s)
-        end
+        Utils::FrontmatterWriter.toml_to_yaml_any(value)
       end
     end
   end

--- a/src/services/github_actions_workflow.cr
+++ b/src/services/github_actions_workflow.cr
@@ -35,7 +35,7 @@ module Hwaro
         lines << ""
         lines << "  deploy:"
         lines << "    runs-on: ubuntu-latest"
-        lines << "    if: github.event_name == 'push' && github.ref == 'refs/heads/main'"
+        lines << "    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'"
         lines << "    steps:"
         lines << "      - name: Checkout"
         lines << "        uses: actions/checkout@v6"

--- a/src/services/importers/astro_importer.cr
+++ b/src/services/importers/astro_importer.cr
@@ -82,14 +82,16 @@ module Hwaro
           verbose : Bool,
           force : Bool,
         ) : Symbol
-          raw = File.read(file_path)
+          raw = read_text(file_path)
           frontmatter_yaml, body = split_yaml_frontmatter(raw)
 
-          fields = Hash(String, (String | Bool | Array(String))?).new
+          fields = Hash(String, FieldValue).new
 
-          if frontmatter_yaml
-            yaml = YAML.parse(frontmatter_yaml)
+          # Non-mapping frontmatter (comment-only, scalar) would raise on []?.
+          yaml = frontmatter_yaml ? YAML.parse(frontmatter_yaml) : nil
+          yaml = nil unless yaml.try(&.as_h?)
 
+          if yaml
             # Title
             if title = yaml["title"]?
               fields["title"] = title.as_s? || title.raw.to_s
@@ -193,7 +195,10 @@ module Hwaro
           # can emit a single summary warning.
           has_mdx_components = false
           if file_path.ends_with?(".mdx")
-            body = body.gsub(/^import\s+.+$\n?/m, "")
+            # [^\n], not `.+`: Crystal's /m makes `.` match newlines, so `.+$`
+            # swallowed everything from the first import line to EOF —
+            # deleting the entire article body of any real MDX file.
+            body = body.gsub(/^import[ \t]+[^\n]+$\n?/m, "")
             if body.matches?(/<[A-Z]/)
               Logger.warn "MDX components detected in #{file_path} — manual conversion needed."
               has_mdx_components = true
@@ -203,7 +208,15 @@ module Hwaro
           # Determine section from content collection name (e.g. "blog", "posts")
           section = top_section_from_path(file_path, content_dir, "posts")
 
-          slug = slugify(File.basename(file_path, File.extname(file_path)))
+          # Page bundles (`blog/my-post/index.md`): the slug is the bundle
+          # directory — a literal "index" slug collides across every bundle
+          # in the section, silently dropping all but the first.
+          base = File.basename(file_path, File.extname(file_path))
+          if base == "index"
+            parent = File.basename(File.dirname(file_path))
+            base = parent unless File.same?(File.dirname(file_path), content_dir)
+          end
+          slug = slugify(base)
 
           frontmatter = generate_frontmatter(fields)
           body = strip_redundant_title_h1(body, fields["title"]?.as?(String))

--- a/src/services/importers/base.cr
+++ b/src/services/importers/base.cr
@@ -1,6 +1,7 @@
 require "file_utils"
 require "../../config/options/import_options"
 require "../../utils/file_safe"
+require "../../utils/frontmatter_writer"
 require "../../utils/logger"
 require "../../utils/text_utils"
 require "../../utils/path_utils"
@@ -9,6 +10,10 @@ require "../../utils/output_guard"
 module Hwaro
   module Services
     module Importers
+      # Value union for the normalized frontmatter each importer builds before
+      # `generate_frontmatter` renders it as TOML.
+      alias FieldValue = (String | Bool | Int64 | Array(String))?
+
       struct ImportResult
         property success : Bool
         property message : String
@@ -33,11 +38,22 @@ module Hwaro
         # closing `---` on its own line (multiline mode so ^ matches line starts).
         YAML_FM_REGEX = /\A---[ \t]*\n(.*?\n?)^---[ \t]*$\n?(.*)\z/m
 
+        # Read a content file for import, normalizing CRLF line endings.
+        # Windows-authored sources (or `core.autocrlf=true` checkouts) would
+        # otherwise defeat the `\n`-anchored frontmatter regexes, silently
+        # dropping every field and leaking raw YAML into the page body.
+        protected def read_text(path : String) : String
+          File.read(path).gsub("\r\n", "\n")
+        end
+
         # Split YAML frontmatter from a document body. Returns {frontmatter, body}
-        # with both stripped, or {nil, content.strip} when no frontmatter present.
+        # with both stripped, or {nil, ...} when no frontmatter is present — an
+        # empty or whitespace-only block (`---\n---`) counts as absent, since
+        # `YAML.parse("")` yields a nil document whose `[]?` raises.
         protected def split_yaml_frontmatter(content : String) : {String?, String}
           if match = YAML_FM_REGEX.match(content)
-            return {match[1].strip, match[2].strip}
+            fm = match[1].strip
+            return {fm.empty? ? nil : fm, match[2].strip}
           end
           {nil, content.strip}
         end
@@ -84,24 +100,29 @@ module Hwaro
           parts.size > 1 ? parts[0] : default
         end
 
-        # Generate TOML frontmatter string from fields hash
-        protected def generate_frontmatter(fields : Hash(String, (String | Bool | Array(String))?)) : String
+        # Generate TOML frontmatter string from fields hash. Strings go
+        # through the shared TOML escaper — Crystal's `String#inspect` emits
+        # escapes TOML rejects (`\a`, `\e`, `\v`, and `\uXXXX` sequences that
+        # toml.cr misreads before a hex digit), which made the imported file
+        # break the user's own build.
+        protected def generate_frontmatter(fields : Hash(String, FieldValue)) : String
           lines = [] of String
           lines << "+++"
 
           fields.each do |key, value|
+            k = Hwaro::Utils::FrontmatterWriter.format_toml_key(key)
             case value
             when Nil
               next
-            when Bool
-              lines << "#{key} = #{value}"
+            when Bool, Int64
+              lines << "#{k} = #{value}"
             when String
               next if value.empty?
-              lines << "#{key} = #{value.inspect}"
+              lines << "#{k} = \"#{Hwaro::Utils::FrontmatterWriter.escape_toml_string(value)}\""
             when Array(String)
               next if value.empty?
-              formatted = value.map(&.inspect).join(", ")
-              lines << "#{key} = [#{formatted}]"
+              formatted = value.map { |v| "\"#{Hwaro::Utils::FrontmatterWriter.escape_toml_string(v)}\"" }.join(", ")
+              lines << "#{k} = [#{formatted}]"
             end
           end
 
@@ -217,13 +238,29 @@ module Hwaro
             .last? || ""
         end
 
-        # Parse a date string in common formats, returns nil on failure
+        # Parse a date string in common formats, returns nil on failure.
+        #
+        # Zone-bearing formats come FIRST: Crystal's `Time.parse` ignores
+        # trailing input, so a zone-less pattern would happily match
+        # `2026-07-01T10:00:00+09:00`, silently drop the `+09:00`, and shift
+        # the instant by the whole offset.
         protected def parse_date(date_str : String) : Time?
+          str = date_str.strip
+
+          begin
+            return Time.parse_rfc3339(str)
+          rescue Time::Format::Error
+            # Not RFC 3339; fall through to the lenient formats.
+          end
+
           formats = [
-            "%Y-%m-%d %H:%M:%S",
-            "%Y-%m-%dT%H:%M:%S",
-            "%Y-%m-%dT%H:%M:%S%z",
             "%Y-%m-%dT%H:%M:%S%:z",
+            "%Y-%m-%dT%H:%M:%S%z",
+            # Jekyll's conventional `2024-01-15 10:00:00 +0900`
+            "%Y-%m-%d %H:%M:%S %:z",
+            "%Y-%m-%d %H:%M:%S %z",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
             "%Y-%m-%d",
             "%B %d, %Y",
             # RFC 822 (WordPress <pubDate>, RSS feeds)
@@ -231,17 +268,20 @@ module Hwaro
           ]
 
           formats.each do |fmt|
-            return Time.parse(date_str.strip, fmt, Time::Location::UTC)
-          rescue Time::Format::Error
+            return Time.parse(str, fmt, Time::Location::UTC)
+          rescue Time::Format::Error | ArgumentError
             next
           end
 
           nil
         end
 
-        # Format a Time to the standard frontmatter date format
+        # Format a Time to the standard frontmatter date format, keeping the
+        # source's zone offset — the previous zone-less `%Y-%m-%d %H:%M:%S`
+        # dropped the offset, so a `+09:00` post re-parsed as UTC shifted by
+        # nine hours in feeds and sort order.
         protected def format_date(time : Time) : String
-          time.to_s("%Y-%m-%d %H:%M:%S")
+          Hwaro::Utils::FrontmatterWriter.serialize_time(time)
         end
       end
     end

--- a/src/services/importers/eleventy_importer.cr
+++ b/src/services/importers/eleventy_importer.cr
@@ -1,5 +1,6 @@
 require "yaml"
 require "json"
+require "set"
 require "./base"
 
 module Hwaro
@@ -11,6 +12,9 @@ module Hwaro
         # Nunjucks/Liquid tag patterns
         TEMPLATE_TAG_PATTERN = /\{[%{].*?[%}]\}/
 
+        # Paths (section/slug) written this run, to disambiguate collisions.
+        @used_paths = Set(String).new
+
         def run(options : Config::Options::ImportOptions) : ImportResult
           path = options.path
           output_dir = options.output_dir
@@ -18,6 +22,8 @@ module Hwaro
           skipped = 0
           errors = 0
           wrapped = 0
+
+          @used_paths.clear
 
           unless Dir.exists?(path)
             return ImportResult.new(
@@ -157,90 +163,97 @@ module Hwaro
           verbose : Bool,
           force : Bool,
         ) : Symbol
-          raw = File.read(file_path)
+          raw = read_text(file_path)
           frontmatter_yaml, body = split_yaml_frontmatter(raw)
 
-          fields = Hash(String, (String | Bool | Array(String))?).new
+          fields = Hash(String, FieldValue).new
 
           # Merge directory data as defaults
           relative_dir = File.dirname(file_path).sub(base_path, "").lstrip('/')
+          is_collection_root = relative_dir.empty? || !relative_dir.includes?('/')
           merged_yaml = merge_directory_data(dir_data, relative_dir, frontmatter_yaml)
 
           if merged_yaml
-            yaml = YAML.parse(merged_yaml)
+            if yaml_hash = YAML.parse(merged_yaml).as_h?
+              # Title
+              if title = yaml_hash["title"]?
+                fields["title"] = title.as_s? || title.raw.to_s
+              end
 
-            # Title
-            if title = yaml["title"]?
-              fields["title"] = title.as_s? || title.raw.to_s
-            end
-
-            # Date
-            if date_val = yaml["date"]?
-              case date_val.raw
-              when Time
-                fields["date"] = format_date(date_val.raw.as(Time))
-              when String
-                date_str = date_val.as_s
-                # 11ty special date values
-                unless date_str == "Last Modified" || date_str == "Created" || date_str == "git Last Modified" || date_str == "git Created"
-                  parsed = parse_date(date_str)
-                  fields["date"] = format_date(parsed) if parsed
+              # Date
+              if date_val = yaml_hash["date"]?
+                case date_val.raw
+                when Time
+                  fields["date"] = format_date(date_val.raw.as(Time))
+                when String
+                  date_str = date_val.as_s
+                  # 11ty special date values
+                  unless date_str == "Last Modified" || date_str == "Created" || date_str == "git Last Modified" || date_str == "git Created"
+                    parsed = parse_date(date_str)
+                    fields["date"] = format_date(parsed) if parsed
+                  end
                 end
               end
-            end
 
-            # Draft or excluded from collections
-            draft_val = yaml["draft"]?
-            exclude_val = yaml["eleventyExcludeFromCollections"]?
-            is_draft = !draft_val.nil? && draft_val.raw == true
-            is_excluded = !exclude_val.nil? && exclude_val.raw == true
-            if is_draft || is_excluded
-              unless include_drafts
-                return :skipped
-              end
-              fields["draft"] = true
-            end
-
-            # Tags (11ty uses tags for collection membership)
-            if tags_val = yaml["tags"]?
-              tags = [] of String
-              case tags_val.raw
-              when Array
-                tags_val.as_a.each do |t|
-                  tag_str = t.as_s? || t.raw.to_s
-                  # Skip 11ty collection tags like "post", "posts", "all"
-                  next if tag_str == "post" || tag_str == "posts" || tag_str == "all"
-                  tags << tag_str
+              # Draft or excluded from collections
+              draft_val = yaml_hash["draft"]?
+              exclude_val = yaml_hash["eleventyExcludeFromCollections"]?
+              is_draft = !draft_val.nil? && draft_val.raw == true
+              is_excluded = !exclude_val.nil? && exclude_val.raw == true
+              if is_draft || is_excluded
+                unless include_drafts
+                  return :skipped
                 end
-              when String
-                tag_str = tags_val.as_s
-                unless tag_str == "post" || tag_str == "posts" || tag_str == "all"
-                  tags << tag_str
-                end
+                fields["draft"] = true
               end
-              fields["tags"] = tags unless tags.empty?
-            end
 
-            # Description
-            if desc = yaml["description"]? || yaml["excerpt"]? || yaml["summary"]?
-              fields["description"] = desc.as_s? || desc.raw.to_s
-            end
+              # Tags (11ty uses tags for collection membership)
+              if tags_val = yaml_hash["tags"]?
+                tags = [] of String
+                case tags_val.raw
+                when Array
+                  tags_val.as_a.each do |t|
+                    tag_str = t.as_s? || t.raw.to_s
+                    # Skip 11ty collection tags like "post", "posts", "all"
+                    next if tag_str == "post" || tag_str == "posts" || tag_str == "all"
+                    tags << tag_str
+                  end
+                when String
+                  tag_str = tags_val.as_s
+                  unless tag_str == "post" || tag_str == "posts" || tag_str == "all"
+                    tags << tag_str
+                  end
+                end
+                fields["tags"] = tags unless tags.empty?
+              end
 
-            # Image
-            if image = yaml["image"]? || yaml["featuredImage"]? || yaml["cover"]?
-              fields["image"] = image.as_s? || image.raw.to_s
-            end
+              # Description
+              if desc = yaml_hash["description"]? || yaml_hash["excerpt"]? || yaml_hash["summary"]?
+                fields["description"] = desc.as_s? || desc.raw.to_s
+              end
 
-            # Template / layout
-            if layout = yaml["layout"]?
-              fields["template"] = layout.as_s? || layout.raw.to_s
+              # Image
+              if image = yaml_hash["image"]? || yaml_hash["featuredImage"]? || yaml_hash["cover"]?
+                fields["image"] = image.as_s? || image.raw.to_s
+              end
+
+              # Template / layout
+              if layout = yaml_hash["layout"]?
+                fields["template"] = layout.as_s? || layout.raw.to_s
+              end
             end
           end
 
           # Fallback title from filename
           unless fields.has_key?("title")
             name = File.basename(file_path, File.extname(file_path))
-            return :skipped if name == "index" # Skip index files without title
+            if name == "index"
+              if is_collection_root
+                return :skipped
+              else
+                name = File.basename(File.dirname(file_path))
+              end
+            end
             fields["title"] = name.gsub(/[-_]/, " ").split.map(&.capitalize).join(" ")
           end
 
@@ -267,7 +280,29 @@ module Hwaro
           # Determine section
           section = top_section_from_path(file_path, base_path, "posts")
 
-          slug = slugify(File.basename(file_path, File.extname(file_path)))
+          basename = File.basename(file_path, File.extname(file_path))
+          slug = if basename == "index" && !is_collection_root
+                   slugify(File.basename(File.dirname(file_path)))
+                 else
+                   slugify(basename)
+                 end
+
+          # Avoid collision on section/slug path
+          path_key = "#{section}/#{slug}"
+          unless @used_paths.add?(path_key)
+            base_slug = slug
+            n = 1
+            loop do
+              candidate = "#{base_slug}-#{n}"
+              path_key = "#{section}/#{candidate}"
+              if @used_paths.add?(path_key)
+                slug = candidate
+                break
+              end
+              n += 1
+            end
+            Logger.warn "Slug collision: #{section}/#{base_slug} already used, renamed to #{section}/#{slug}"
+          end
 
           frontmatter = generate_frontmatter(fields)
           body = strip_redundant_title_h1(body, fields["title"]?.as?(String))

--- a/src/services/importers/hexo_importer.cr
+++ b/src/services/importers/hexo_importer.cr
@@ -97,18 +97,21 @@ module Hwaro
           verbose : Bool,
           force : Bool,
         ) : Symbol
-          raw = File.read(file_info[:path])
+          raw = read_text(file_info[:path])
           frontmatter_yaml, body = split_yaml_frontmatter(raw)
           filename = File.basename(file_info[:path])
 
-          fields = Hash(String, (String | Bool | Array(String))?).new
+          fields = Hash(String, FieldValue).new
 
           slug = extract_slug(filename)
           filename_date = extract_date_from_filename(filename)
 
-          if frontmatter_yaml
-            yaml = YAML.parse(frontmatter_yaml)
+          # Comment-only or scalar frontmatter parses to a non-hash document
+          # whose `[]?` raises — treat anything but a mapping as no frontmatter.
+          yaml = frontmatter_yaml ? YAML.parse(frontmatter_yaml) : nil
+          yaml = nil unless yaml.try(&.as_h?)
 
+          if yaml
             # Title
             if title = yaml["title"]?
               fields["title"] = title.as_s? || title.raw.to_s
@@ -123,8 +126,6 @@ module Hwaro
                 parsed = parse_date(date_val.as_s)
                 fields["date"] = format_date(parsed) if parsed
               end
-            elsif filename_date
-              fields["date"] = format_date(filename_date)
             end
 
             # Updated
@@ -203,10 +204,12 @@ module Hwaro
                 end
               end
             end
-          else
-            if filename_date
-              fields["date"] = format_date(filename_date)
-            end
+          end
+
+          # Fall back to the filename date when frontmatter had none (or an
+          # unparseable one).
+          if !fields.has_key?("date") && filename_date
+            fields["date"] = format_date(filename_date)
           end
 
           # Mark drafts

--- a/src/services/importers/html_to_markdown.cr
+++ b/src/services/importers/html_to_markdown.cr
@@ -36,14 +36,21 @@ module Hwaro
             result = result.gsub(/<h#{level}[^>]*>(.*?)<\/h#{level}>/mi) { "#{prefix} #{$1.strip}\n\n" }
           end
 
-          # Code blocks: <pre><code>...</code></pre> or <pre>...</pre>
+          # Code blocks: <pre><code>...</code></pre> or <pre>...</pre>.
+          # Stash the finished fences behind placeholders until the very end:
+          # every later pass (lists, <p>, <a>, strip_tags, the final entity
+          # decode) would otherwise run INSIDE the code sample, converting or
+          # stripping the HTML it demonstrates and double-decoding entities.
+          code_stash = [] of String
           result = result.gsub(/<pre[^>]*>\s*<code[^>]*>(.*?)<\/code>\s*<\/pre>/mi) do
             code = decode_html_entities($1)
-            "```\n#{code.strip}\n```\n\n"
+            code_stash << "```\n#{code.strip}\n```\n\n"
+            code_placeholder(code_stash.size - 1)
           end
           result = result.gsub(/<pre[^>]*>(.*?)<\/pre>/mi) do
             code = decode_html_entities($1)
-            "```\n#{code.strip}\n```\n\n"
+            code_stash << "```\n#{code.strip}\n```\n\n"
+            code_placeholder(code_stash.size - 1)
           end
 
           # Blockquotes
@@ -55,16 +62,20 @@ module Hwaro
             lines.join("\n") + "\n\n"
           end
 
-          # Ordered lists
-          result = result.gsub(/<ol[^>]*>(.*?)<\/ol>/mi) do
-            items = $1.scan(/<li[^>]*>(.*?)<\/li>/mi)
-            items.map_with_index { |m, i| "#{i + 1}. #{strip_tags(m[1]).strip}" }.join("\n") + "\n\n"
-          end
-
-          # Unordered lists
-          result = result.gsub(/<ul[^>]*>(.*?)<\/ul>/mi) do
-            items = $1.scan(/<li[^>]*>(.*?)<\/li>/mi)
-            items.map { |m| "- #{strip_tags(m[1]).strip}" }.join("\n") + "\n\n"
+          # Lists — innermost first, so a nested <ul> inside an <li> is
+          # converted before its parent. The old single outer pass stopped at
+          # the INNER </ul>, garbling nested lists and dropping trailing items.
+          innermost_list = /<(ul|ol)[^>]*>((?:(?!<[uo]l[^>]*>).)*?)<\/\1>/mi
+          while result.matches?(innermost_list)
+            result = result.gsub(innermost_list) do
+              kind = $1.downcase
+              items = $2.scan(/<li[^>]*>(.*?)<\/li>/mi)
+              if kind == "ol"
+                items.map_with_index { |m, i| "#{i + 1}. #{strip_tags(m[1]).strip}" }.join("\n") + "\n\n"
+              else
+                items.map { |m| "- #{strip_tags(m[1]).strip}" }.join("\n") + "\n\n"
+              end
+            end
           end
 
           # Tables — convert <table> into Markdown pipe-tables. Uses the
@@ -98,14 +109,15 @@ module Hwaro
             end
           end
 
-          # Horizontal rules
-          result = result.gsub(/<hr\s*\/?>/, "\n---\n\n")
+          # Horizontal rules (attribute-bearing and uppercase forms included —
+          # Gutenberg emits `<hr class="wp-block-separator …"/>`)
+          result = result.gsub(/<hr\b[^>]*>/i, "\n---\n\n")
 
           # Paragraphs
           result = result.gsub(/<p[^>]*>(.*?)<\/p>/mi) { "#{$1.strip}\n\n" }
 
           # Line breaks
-          result = result.gsub(/<br\s*\/?>/, "  \n")
+          result = result.gsub(/<br\b[^>]*>/i, "  \n")
 
           # Inline elements
 
@@ -139,9 +151,20 @@ module Hwaro
           # Decode HTML entities
           result = decode_html_entities(result)
 
+          # Restore stashed code fences (already entity-decoded exactly once).
+          code_stash.each_with_index do |block, i|
+            result = result.sub(code_placeholder(i), block)
+          end
+
           # Clean up whitespace
           result = result.gsub(/\n{3,}/, "\n\n") # Max 2 consecutive newlines
           result.strip
+        end
+
+        # NUL-delimited placeholder: survives every regex pass (no `<>`, no
+        # `&…;`) and can't occur in real exported content (XML forbids NUL).
+        private def self.code_placeholder(index : Int32) : String
+          "\u0000hwaro-code-#{index}\u0000"
         end
 
         private def self.strip_tags(html : String) : String
@@ -159,7 +182,6 @@ module Hwaro
 
         private def self.decode_html_entities(text : String) : String
           text
-            .gsub("&amp;", "&")
             .gsub("&lt;", "<")
             .gsub("&gt;", ">")
             .gsub("&quot;", "\"")
@@ -186,6 +208,18 @@ module Hwaro
                 ""
               end
             end
+            .gsub(/&#[xX]([0-9a-fA-F]+);/) do
+              code = $1.to_i?(16)
+              if code && code > 0 && code <= 0x10FFFF && !(0xD800 <= code <= 0xDFFF)
+                code.chr.to_s
+              else
+                ""
+              end
+            end
+            .gsub("&amp;", "&")
+          # `&amp;` LAST: decoding it first turned `&amp;lt;` (a literal
+          # "&lt;" in the source text) into a real `<` — the classic
+          # double-unescape.
         end
       end
     end

--- a/src/services/importers/hugo_importer.cr
+++ b/src/services/importers/hugo_importer.cr
@@ -68,7 +68,7 @@ module Hwaro
           verbose : Bool,
           force : Bool,
         ) : Symbol
-          raw = File.read(file_path)
+          raw = read_text(file_path)
           fm_data, body = extract_frontmatter(raw)
 
           # Check draft status (only if frontmatter exists)
@@ -86,7 +86,7 @@ module Hwaro
           end
 
           # Map Hugo fields to Hwaro frontmatter
-          fields = {} of String => (String | Bool | Array(String))?
+          fields = {} of String => FieldValue
           slug_val : String? = nil
 
           if data = fm_data
@@ -95,8 +95,9 @@ module Hwaro
               fields["title"] = title
             end
 
-            # date
-            if date_str = string_value(data, "date")
+            # date (falling back to Hugo's publishDate so a page dated only
+            # via publishDate doesn't lose its date entirely)
+            if date_str = string_value(data, "date") || string_value(data, "publishDate")
               parsed = parse_date(date_str)
               fields["date"] = format_date(parsed) if parsed
             end
@@ -131,9 +132,15 @@ module Hwaro
               fields["series"] = series_arr.first? unless series_arr.empty?
             end
 
-            # weight
-            if weight = string_value(data, "weight")
-              fields["weight"] = weight
+            # weight — must stay numeric: hwaro's frontmatter reader takes
+            # `as_i?`, so a quoted `weight = "3"` silently reads as weight 0
+            # and every imported page loses its ordering.
+            if weight_val = data["weight"]?
+              case weight_raw = weight_val.raw
+              when Int64   then fields["weight"] = weight_raw
+              when Float64 then fields["weight"] = weight_raw.to_i64
+              when String  then fields["weight"] = weight_raw.to_i64?
+              end
             end
 
             # slug
@@ -203,7 +210,14 @@ module Hwaro
                     data[key_str] = yaml_any_to_toml_any(v)
                   end
                   return {data, body}
+                elsif yaml_data.raw.nil?
+                  # Empty/comment-only frontmatter: no fields, but drop the
+                  # fences — returning `raw` leaked literal `---` lines into
+                  # the imported page body.
+                  return {nil, body}
                 end
+                # Non-mapping block (a leading horizontal rule): treat the
+                # whole document as body.
               rescue ex : YAML::ParseException
                 Logger.debug "YAML front matter parse failed: #{ex.message}"
                 return {nil, raw}

--- a/src/services/importers/jekyll_importer.cr
+++ b/src/services/importers/jekyll_importer.cr
@@ -11,6 +11,9 @@ module Hwaro
         # Regex to detect Liquid tags in content
         LIQUID_TAG_PATTERN = /\{[%{].*?[%}]\}/
 
+        # Slugs written this run, to disambiguate date-prefix-strip collisions.
+        @used_slugs = Set(String).new
+
         def run(options : Config::Options::ImportOptions) : ImportResult
           path = options.path
           output_dir = options.output_dir
@@ -26,6 +29,7 @@ module Hwaro
             )
           end
 
+          @used_slugs.clear
           files = collect_files(path, options.drafts)
 
           if files.empty?
@@ -67,9 +71,12 @@ module Hwaro
         private def collect_files(path : String, include_drafts : Bool) : Array(NamedTuple(path: String, draft: Bool))
           files = [] of NamedTuple(path: String, draft: Bool)
 
+          # Recursive: Jekyll supports organizing posts in subfolders
+          # (`_posts/tech/2024-01-02-post.md` is a common category layout);
+          # a flat glob silently ignored every nested post.
           posts_dir = File.join(path, "_posts")
           if Dir.exists?(posts_dir)
-            Dir.glob(File.join(posts_dir, "*.{md,markdown}")).each do |file|
+            walk_files(posts_dir).sort.each do |file|
               files << {path: file, draft: false}
             end
           end
@@ -77,7 +84,7 @@ module Hwaro
           if include_drafts
             drafts_dir = File.join(path, "_drafts")
             if Dir.exists?(drafts_dir)
-              Dir.glob(File.join(drafts_dir, "*.{md,markdown}")).each do |file|
+              walk_files(drafts_dir).sort.each do |file|
                 files << {path: file, draft: true}
               end
             end
@@ -92,7 +99,7 @@ module Hwaro
           verbose : Bool,
           force : Bool,
         ) : Symbol
-          raw = File.read(file_info[:path])
+          raw = read_text(file_info[:path])
           frontmatter_yaml, body = split_yaml_frontmatter(raw)
           filename = File.basename(file_info[:path])
 
@@ -100,18 +107,22 @@ module Hwaro
           slug = extract_slug(filename)
           filename_date = extract_date_from_filename(filename)
 
-          # Parse YAML frontmatter
-          fields = Hash(String, (String | Bool | Array(String))?).new
+          # Parse YAML frontmatter. Comment-only or scalar frontmatter parses
+          # to a non-hash document whose `[]?` raises ("Expected Array or
+          # Hash, not Nil"), which used to drop the whole post as an error —
+          # treat anything but a mapping as no frontmatter.
+          fields = Hash(String, FieldValue).new
+          yaml = frontmatter_yaml ? YAML.parse(frontmatter_yaml) : nil
+          yaml = nil unless yaml.try(&.as_h?)
 
-          if frontmatter_yaml
-            yaml = YAML.parse(frontmatter_yaml)
-
+          if yaml
             # Title
             if title = yaml["title"]?
               fields["title"] = title.as_s? || title.raw.to_s
             end
 
-            # Date: prefer frontmatter, fall back to filename
+            # Date from frontmatter (filename fallback below also covers an
+            # unparseable frontmatter date, which used to suppress it)
             if date_val = yaml["date"]?
               case date_val.raw
               when Time
@@ -120,8 +131,6 @@ module Hwaro
                 parsed = parse_date(date_val.as_s)
                 fields["date"] = format_date(parsed) if parsed
               end
-            elsif filename_date
-              fields["date"] = format_date(filename_date)
             end
 
             # Layout -> template
@@ -199,11 +208,12 @@ module Hwaro
                 fields["image"] = (header_image.as_s? || header_image.raw.to_s) unless fields.has_key?("image")
               end
             end
-          else
-            # No frontmatter; use filename date if available
-            if filename_date
-              fields["date"] = format_date(filename_date)
-            end
+          end
+
+          # Fall back to the filename date when frontmatter had none (or an
+          # unparseable one).
+          if !fields.has_key?("date") && filename_date
+            fields["date"] = format_date(filename_date)
           end
 
           # Mark drafts
@@ -228,6 +238,20 @@ module Hwaro
             else
               slug = "untitled"
             end
+          end
+
+          # Stripping the unique `YYYY-MM-DD-` prefix can collide two posts
+          # (`2023-01-01-recap.md` + `2024-01-01-recap.md` → `recap.md`);
+          # re-attach the date to the later one instead of losing it.
+          unless @used_slugs.add?(slug)
+            candidate = filename_date ? "#{slug}-#{filename_date.to_s("%Y-%m-%d")}" : slug
+            n = 1
+            until @used_slugs.add?(candidate)
+              candidate = "#{slug}-#{n}"
+              n += 1
+            end
+            Logger.warn "Slug collision after date-prefix strip: writing #{candidate} for #{file_info[:path]}"
+            slug = candidate
           end
 
           frontmatter = generate_frontmatter(fields)

--- a/src/services/importers/notion_importer.cr
+++ b/src/services/importers/notion_importer.cr
@@ -1,4 +1,6 @@
 require "yaml"
+require "set"
+require "uri"
 require "./base"
 
 module Hwaro
@@ -8,12 +10,17 @@ module Hwaro
         # Notion exported markdown uses YAML frontmatter or embedded metadata
         # Notion export structure: folder per page, with .md files and assets
 
+        # Slugs written this run, to disambiguate collisions.
+        @used_slugs = Set(String).new
+
         def run(options : Config::Options::ImportOptions) : ImportResult
           path = options.path
           output_dir = options.output_dir
           imported = 0
           skipped = 0
           errors = 0
+
+          @used_slugs.clear
 
           unless Dir.exists?(path)
             return ImportResult.new(
@@ -64,41 +71,41 @@ module Hwaro
           verbose : Bool,
           force : Bool,
         ) : Symbol
-          raw = File.read(file_path)
+          raw = read_text(file_path)
           frontmatter_yaml, body = split_yaml_frontmatter(raw)
 
-          fields = Hash(String, (String | Bool | Array(String))?).new
+          fields = Hash(String, FieldValue).new
 
           if frontmatter_yaml
-            yaml = YAML.parse(frontmatter_yaml)
-
-            if title = yaml["title"]?
-              fields["title"] = title.as_s? || title.raw.to_s
-            end
-
-            if date_val = yaml["date"]?
-              case date_val.raw
-              when Time
-                fields["date"] = format_date(date_val.raw.as(Time))
-              when String
-                parsed = parse_date(date_val.as_s)
-                fields["date"] = format_date(parsed) if parsed
+            if yaml_hash = YAML.parse(frontmatter_yaml).as_h?
+              if title = yaml_hash["title"]?
+                fields["title"] = title.as_s? || title.raw.to_s
               end
-            end
 
-            if tags_val = yaml["tags"]?
-              tags = [] of String
-              case tags_val.raw
-              when Array
-                tags_val.as_a.each { |t| tags << (t.as_s? || t.raw.to_s) }
-              when String
-                tags_val.as_s.split(/[\s,]+/).each { |t| tags << t.strip unless t.strip.empty? }
+              if date_val = yaml_hash["date"]?
+                case date_val.raw
+                when Time
+                  fields["date"] = format_date(date_val.raw.as(Time))
+                when String
+                  parsed = parse_date(date_val.as_s)
+                  fields["date"] = format_date(parsed) if parsed
+                end
               end
-              fields["tags"] = tags unless tags.empty?
-            end
 
-            if desc = yaml["description"]?
-              fields["description"] = desc.as_s? || desc.raw.to_s
+              if tags_val = yaml_hash["tags"]?
+                tags = [] of String
+                case tags_val.raw
+                when Array
+                  tags_val.as_a.each { |t| tags << (t.as_s? || t.raw.to_s) }
+                when String
+                  tags_val.as_s.split(/[\s,]+/).each { |t| tags << t.strip unless t.strip.empty? }
+                end
+                fields["tags"] = tags unless tags.empty?
+              end
+
+              if desc = yaml_hash["description"]?
+                fields["description"] = desc.as_s? || desc.raw.to_s
+              end
             end
           end
 
@@ -127,6 +134,21 @@ module Hwaro
 
           # Determine slug
           slug = slug_from_notion_filename(file_path)
+
+          # Avoid collision on slug
+          unless @used_slugs.add?(slug)
+            base_slug = slug
+            n = 1
+            loop do
+              candidate = "#{base_slug}-#{n}"
+              if @used_slugs.add?(candidate)
+                slug = candidate
+                break
+              end
+              n += 1
+            end
+            Logger.warn "Slug collision: #{base_slug} already used, renamed to #{slug}"
+          end
 
           section = "posts"
 
@@ -160,10 +182,29 @@ module Hwaro
 
           # Convert Notion callout blocks (> emoji text) to plain blockquotes
           # Example: '> 💡 Some tip' -> '> Some tip'
-          result = result.gsub(/^> [^\w\s]\s+(.+)$/m, "> \\1")
+          result = result.gsub(/^> [^\w\s]\x{FE0F}?\s+([^\n]+)$/m, "> \\1")
 
           # Convert Notion bookmark embeds to links
           result = result.gsub(/\[bookmark\]\((.+?)\)/, "[\\1](\\1)")
+
+          # Rewrite internal subpage links (relative targets ending in .md containing a 32-hex suffix)
+          result = result.gsub(/\[([^\]]+)\]\(([^)]+)\)/) do |match|
+            text = $1
+            target = $2
+            if target.ends_with?(".md") && !target.starts_with?("http://") && !target.starts_with?("https://")
+              target_decoded = URI.decode(target)
+              if /[0-9a-fA-F]{32}/.match(target_decoded)
+                filename = File.basename(target_decoded, ".md")
+                clean_name = filename.sub(/\s+[0-9a-f]{16,}$/i, "").strip
+                slug = slugify(clean_name)
+                "[#{text}](/posts/#{slug}/)"
+              else
+                match
+              end
+            else
+              match
+            end
+          end
 
           # Convert Notion image references with captions
           # Notion exports images to subfolders; keep relative paths

--- a/src/services/importers/obsidian_importer.cr
+++ b/src/services/importers/obsidian_importer.cr
@@ -47,7 +47,7 @@ module Hwaro
           # The pass also caches each file's raw bytes so the second pass below
           # reuses them instead of re-reading every note from disk (2N → N reads).
           content_cache = {} of String => String
-          link_map = build_link_map(files, path, content_cache)
+          link_map = build_link_map(files, path, options.drafts, content_cache)
 
           files.each do |file_path|
             result = import_file(file_path, path, output_dir, options.drafts, options.verbose, options.force, link_map, content_cache)
@@ -84,22 +84,36 @@ module Hwaro
         # The lookup is case-insensitive because Obsidian itself treats
         # wiki-links that way (`[[Note]]` and `[[note]]` resolve to the same
         # file), and Hwaro authors typically lowercase slugs on publish.
-        private def build_link_map(files : Array(String), base_path : String, content_cache : Hash(String, String) = {} of String => String) : Hash(String, String)
+        private def build_link_map(
+          files : Array(String),
+          base_path : String,
+          include_drafts : Bool,
+          content_cache : Hash(String, String) = {} of String => String,
+        ) : Hash(String, String)
           map = Hash(String, String).new
           files.each do |file_path|
-            raw = File.read(file_path)
+            raw = read_text(file_path)
             content_cache[file_path] = raw
             fm_yaml, _ = split_yaml_frontmatter(raw)
 
             # Section mirrors `import_file`'s computation so the URL we
             # emit lands at the same path the file will be written to.
             section, _ = section_from_path(file_path, base_path, "posts")
+            section = section.split('/').reject(&.empty?).map { |s| slugify(s) }.join('/')
 
             basename = File.basename(file_path, File.extname(file_path))
             title = basename
             aliases = [] of String
 
-            if fm_yaml && (yaml = YAML.parse(fm_yaml))
+            if fm_yaml && (yaml = YAML.parse(fm_yaml).as_h?)
+              if draft = yaml["draft"]?
+                if draft.raw == true
+                  unless include_drafts
+                    next
+                  end
+                end
+              end
+
               if t = yaml["title"]?
                 title = t.as_s? || t.raw.to_s
               end
@@ -113,11 +127,14 @@ module Hwaro
               end
             end
 
+            relative_path = file_path.sub(base_path, "").lstrip('/')
+            relative_path_no_ext = relative_path.sub(File.extname(relative_path), "")
+
             slug = slugify(title)
             url = "/#{section}/#{slug}/"
 
             # Register every name a wiki-link could plausibly use.
-            [basename, "#{basename}.md", title, *aliases].each do |key|
+            [basename, "#{basename}.md", title, relative_path, relative_path_no_ext, *aliases].each do |key|
               next if key.empty?
               map[key.downcase.strip] = url
             end
@@ -164,75 +181,75 @@ module Hwaro
           link_map : Hash(String, String) = {} of String => String,
           content_cache : Hash(String, String) = {} of String => String,
         ) : Symbol
-          raw = content_cache[file_path]? || File.read(file_path)
+          raw = content_cache[file_path]? || read_text(file_path)
           frontmatter_yaml, body = split_yaml_frontmatter(raw)
 
-          fields = Hash(String, (String | Bool | Array(String))?).new
+          fields = Hash(String, FieldValue).new
           tags = [] of String
 
           if frontmatter_yaml
-            yaml = YAML.parse(frontmatter_yaml)
-
-            if title = yaml["title"]?
-              fields["title"] = title.as_s? || title.raw.to_s
-            end
-
-            if date_val = yaml["date"]?
-              case date_val.raw
-              when Time
-                fields["date"] = format_date(date_val.raw.as(Time))
-              when String
-                parsed = parse_date(date_val.as_s)
-                fields["date"] = format_date(parsed) if parsed
+            if yaml = YAML.parse(frontmatter_yaml).as_h?
+              if title = yaml["title"]?
+                fields["title"] = title.as_s? || title.raw.to_s
               end
-            end
 
-            if created = yaml["created"]?
-              unless fields.has_key?("date")
-                case created.raw
+              if date_val = yaml["date"]?
+                case date_val.raw
                 when Time
-                  fields["date"] = format_date(created.raw.as(Time))
+                  fields["date"] = format_date(date_val.raw.as(Time))
                 when String
-                  parsed = parse_date(created.as_s)
+                  parsed = parse_date(date_val.as_s)
                   fields["date"] = format_date(parsed) if parsed
                 end
               end
-            end
 
-            # Tags from frontmatter
-            if tags_val = yaml["tags"]?
-              case tags_val.raw
-              when Array
-                flatten_yaml_strings(tags_val).each { |t| tags << t }
-              when String
-                tags_val.as_s.split(/[\s,]+/).each { |t| tags << t.strip unless t.strip.empty? }
-              end
-            end
-
-            if desc = yaml["description"]?
-              fields["description"] = desc.as_s? || desc.raw.to_s
-            end
-
-            # Draft status
-            if draft = yaml["draft"]?
-              if draft.raw == true
-                unless include_drafts
-                  return :skipped
+              if created = yaml["created"]?
+                unless fields.has_key?("date")
+                  case created.raw
+                  when Time
+                    fields["date"] = format_date(created.raw.as(Time))
+                  when String
+                    parsed = parse_date(created.as_s)
+                    fields["date"] = format_date(parsed) if parsed
+                  end
                 end
-                fields["draft"] = true
               end
-            end
 
-            # Aliases
-            if aliases_val = yaml["aliases"]?
-              aliases = [] of String
-              case aliases_val.raw
-              when Array
-                flatten_yaml_strings(aliases_val).each { |a| aliases << a }
-              when String
-                aliases << aliases_val.as_s
+              # Tags from frontmatter
+              if tags_val = yaml["tags"]?
+                case tags_val.raw
+                when Array
+                  flatten_yaml_strings(tags_val).each { |t| tags << t }
+                when String
+                  tags_val.as_s.split(/[\s,]+/).each { |t| tags << t.strip unless t.strip.empty? }
+                end
               end
-              fields["aliases"] = aliases unless aliases.empty?
+
+              if desc = yaml["description"]?
+                fields["description"] = desc.as_s? || desc.raw.to_s
+              end
+
+              # Draft status
+              if draft = yaml["draft"]?
+                if draft.raw == true
+                  unless include_drafts
+                    return :skipped
+                  end
+                  fields["draft"] = true
+                end
+              end
+
+              # Aliases
+              if aliases_val = yaml["aliases"]?
+                aliases = [] of String
+                case aliases_val.raw
+                when Array
+                  flatten_yaml_strings(aliases_val).each { |a| aliases << a }
+                when String
+                  aliases << aliases_val.as_s
+                end
+                fields["aliases"] = aliases unless aliases.empty?
+              end
             end
           end
 
@@ -259,6 +276,7 @@ module Hwaro
 
           # Determine section from vault folder structure
           section, _ = section_from_path(file_path, base_path, "posts")
+          section = section.split('/').reject(&.empty?).map { |s| slugify(s) }.join('/')
 
           slug = slugify(fields["title"].as?(String) || File.basename(file_path, File.extname(file_path)))
 
@@ -290,6 +308,33 @@ module Hwaro
           result
         end
 
+        private def inline_code_ranges(line : String) : Array(Range(Int32, Int32))
+          ranges = [] of Range(Int32, Int32)
+          i = 0
+          len = line.size
+
+          while i < len
+            if line[i] == '`'
+              start_bt_count = 0
+              while i < len && line[i] == '`'
+                start_bt_count += 1
+                i += 1
+              end
+
+              end_idx = line.index("`" * start_bt_count, i)
+              if end_idx
+                start_pos = i - start_bt_count
+                end_pos = end_idx + start_bt_count - 1
+                ranges << (start_pos..end_pos)
+                i = end_idx + start_bt_count
+              end
+            else
+              i += 1
+            end
+          end
+          ranges
+        end
+
         private def extract_inline_tags(body : String) : Array(String)
           tags = [] of String
           # Skip code blocks when extracting tags
@@ -311,7 +356,12 @@ module Hwaro
             # Skip headings (all markdown heading levels)
             next if line.matches?(/^\s*\#{1,6}\s/)
 
+            next if line.starts_with?('\t') || line.match(/^ {4,}/)
+
+            ranges = inline_code_ranges(line)
+
             line.scan(OBSIDIAN_TAG_PATTERN) do |tag_match|
+              next if ranges.any?(&.includes?(tag_match.begin(0)))
               tag = tag_match[1]
               # Convert nested tags (tag/subtag) to just the leaf
               tags << tag.gsub("/", "-")
@@ -321,34 +371,9 @@ module Hwaro
         end
 
         private def convert_obsidian_syntax(body : String, link_map : Hash(String, String) = {} of String => String) : String
-          result = body
-
-          # Convert embeds ![[file]] to markdown image/link
-          result = result.gsub(EMBED_PATTERN) do
-            filename = $1
-            if filename.matches?(/\.(png|jpg|jpeg|gif|svg|webp|avif)$/i)
-              "![#{filename}](#{filename})"
-            else
-              "[#{filename}](#{filename})"
-            end
-          end
-
-          # Convert wiki-links [[Page|Display]] to standard markdown links.
-          # Resolve against the prebuilt link_map so the output is an absolute
-          # site URL (e.g. `/posts/note-2/`) rather than a same-page-relative
-          # slug — the old behavior wrote `[Note2](note2)` which the browser
-          # resolved as `<current-page>/note2`, producing 404s.
-          result = result.gsub(WIKILINK_PATTERN) do
-            page = $1
-            display = $~[2]? || page
-            target = resolve_wikilink(page, link_map)
-            "[#{display}](#{target})"
-          end
-
-          # Remove inline tags (already extracted to frontmatter)
           in_code_block = false
           fence_close_re : Regex? = nil
-          lines = result.split("\n").map do |line|
+          lines = body.split("\n").map do |line|
             if in_code_block
               if fence_close_re.try(&.match(line))
                 in_code_block = false
@@ -363,12 +388,54 @@ module Hwaro
               # Preserve markdown headings
               line
             else
-              # Strip inline `#tag` references (already extracted to
-              # frontmatter), but require start-of-line or whitespace before
-              # the `#` — otherwise we'd eat the `#section` anchor inside a
-              # markdown link URL like `[Note](/posts/note/#section)` that
-              # the wiki-link conversion above just emitted.
-              line.gsub(/(?:^|(?<=\s))#([a-zA-Z][\w\-\/]*)/, "").rstrip
+              if line.starts_with?('\t') || line.match(/^ {4,}/)
+                line
+              else
+                ranges = inline_code_ranges(line)
+
+                line = line.gsub(EMBED_PATTERN) do |match|
+                  if ranges.any?(&.includes?($~.begin(0)))
+                    match
+                  else
+                    full_match = $1
+                    parts = full_match.split('|', 2)
+                    target = parts[0].strip
+                    alt_or_width = parts.size > 1 ? parts[1].strip : ""
+
+                    if target.matches?(/\.(png|jpg|jpeg|gif|svg|webp|avif)$/i)
+                      alt = alt_or_width.empty? ? target : alt_or_width
+                      "![#{alt}](#{target})"
+                    else
+                      display = alt_or_width.empty? ? target : alt_or_width
+                      resolved_url = resolve_wikilink(target, link_map)
+                      "[#{display}](#{resolved_url})"
+                    end
+                  end
+                end
+
+                ranges = inline_code_ranges(line)
+
+                line = line.gsub(WIKILINK_PATTERN) do |match|
+                  if ranges.any?(&.includes?($~.begin(0)))
+                    match
+                  else
+                    page = $1
+                    display = $~[2]? || page
+                    target = resolve_wikilink(page, link_map)
+                    "[#{display}](#{target})"
+                  end
+                end
+
+                ranges = inline_code_ranges(line)
+
+                line.gsub(/(?:^|(?<=\s))#([a-zA-Z][\w\-\/]*)/) do |match|
+                  if ranges.any?(&.includes?($~.begin(0)))
+                    match
+                  else
+                    ""
+                  end
+                end.rstrip
+              end
             end
           end
           result = lines.join("\n")

--- a/src/services/importers/wordpress_importer.cr
+++ b/src/services/importers/wordpress_importer.cr
@@ -1,3 +1,4 @@
+require "uri"
 require "xml"
 require "./base"
 require "./html_to_markdown"
@@ -141,6 +142,7 @@ module Hwaro
           post_name = ""
           content_html = ""
           excerpt = ""
+          author = ""
           tags = [] of String
           categories = [] of String
 
@@ -170,6 +172,9 @@ module Hwaro
               elsif ns_href == EXCERPT_NS
                 excerpt = child.content.strip
               end
+            when "creator"
+              # <dc:creator> — carry author attribution across.
+              author = child.content.strip
             when "category"
               # WXR encodes both tags and categories as <category> elements
               # distinguished by the `domain` attribute. Keep them as
@@ -189,17 +194,23 @@ module Hwaro
             end
           end
 
-          # Only handle posts and pages
+          # Only handle posts and pages; trashed items are gone content.
           return :skipped unless post_type == "post" || post_type == "page"
+          return :skipped if status == "trash"
 
-          # Handle draft status
-          is_draft = status == "draft"
+          # Anything not published — draft, private, pending, future — must
+          # not silently become public content on the next build. An "All
+          # content" WXR export includes all of these.
+          is_draft = status != "publish"
           if is_draft && !include_drafts
             return :skipped
           end
 
-          # Determine slug
-          slug = post_name.empty? ? slugify(title) : post_name
+          # Determine slug. WordPress stores non-ASCII slugs percent-encoded
+          # (`sanitize_title`); decode so the filename matches what servers
+          # and browsers will show for the URL. Traversal is neutralized at
+          # the write_content_file sink.
+          slug = post_name.empty? ? slugify(title) : URI.decode(post_name)
           return :skipped if slug.empty?
 
           # Determine section
@@ -215,13 +226,14 @@ module Hwaro
           end
 
           # Build frontmatter fields
-          fields = {} of String => (String | Bool | Array(String))?
+          fields = {} of String => FieldValue
           fields["title"] = title unless title.empty?
           fields["date"] = date_str
           fields["description"] = excerpt unless excerpt.empty?
           fields["draft"] = true if is_draft
           fields["tags"] = tags.uniq unless tags.empty?
           fields["categories"] = categories.uniq unless categories.empty?
+          fields["authors"] = [author] unless author.empty?
 
           frontmatter = generate_frontmatter(fields)
 

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -81,6 +81,7 @@ module Hwaro
             lines << "  from = \"#{toml_escape(from)}\""
             lines << "  to = \"#{toml_escape(to)}\""
             lines << "  status = 301"
+            lines << "  force = true"
             lines << ""
           end
         end
@@ -190,7 +191,9 @@ module Hwaro
 
       private def generate_gitlab_ci : String
         lines = [] of String
-        lines << "image: ghcr.io/hahwul/hwaro:latest"
+        lines << "image:"
+        lines << "  name: ghcr.io/hahwul/hwaro:latest"
+        lines << "  entrypoint: [\"\"]"
         lines << ""
         lines << "pages:"
         lines << "  stage: deploy"
@@ -199,8 +202,8 @@ module Hwaro
         lines << "  artifacts:"
         lines << "    paths:"
         lines << "      - public"
-        lines << "  only:"
-        lines << "    - main"
+        lines << "  rules:"
+        lines << "    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
         lines << ""
 
         lines.join("\n")
@@ -288,16 +291,32 @@ module Hwaro
         end
       end
 
+      LANGUAGE_FILENAME_PATTERN = /^(.+)\.([a-z]{2,3})\.md$/
+
+      private def extract_language_from_filename(basename : String) : String?
+        return unless @config.multilingual?
+
+        if match = basename.match(LANGUAGE_FILENAME_PATTERN)
+          lang_code = match[2]
+          return lang_code if @config.languages.has_key?(lang_code) || lang_code == @config.default_language
+        end
+
+        nil
+      end
+
       private def extract_aliases_from_file(path : String, redirects : Array(Tuple(String, String)))
         raw_content = File.read(path)
         data = Processor::Markdown.parse(raw_content, path)
+        return if data[:draft]
 
         aliases = data[:aliases]
         return if aliases.empty?
 
         # Build a minimal Page to calculate its URL using the same logic as the build pipeline
         relative_path = path.lchop("content/")
-        target_url = calculate_page_url(relative_path, data[:slug], data[:custom_path])
+        basename = Path[path].basename
+        language = extract_language_from_filename(basename)
+        target_url = calculate_page_url(relative_path, data[:slug], data[:custom_path], language)
 
         aliases.each do |alias_path|
           # Carry base_path so generated redirects match the build's own
@@ -313,36 +332,50 @@ module Hwaro
       # Calculate the URL for a page, mirroring the ParseContent phase's
       # calculate_page_url (src/core/build/phases/parse_content.cr).
       # Handles slug overrides, custom_path, permalinks, and index pages.
-      private def calculate_page_url(relative_path : String, slug : String?, custom_path : String?) : String
+      private def calculate_page_url(relative_path : String, slug : String?, custom_path : String?, language : String? = nil) : String
         directory_path = Path[relative_path].dirname.to_s
 
         # Apply permalinks mapping from config
         effective_dir = @config.resolve_permalink_dir(directory_path)
 
+        lang_prefix = if language && language != @config.default_language
+                        "/#{language}"
+                      else
+                        ""
+                      end
+
         if custom_path
           custom = custom_path.lchop("/")
-          url = "/#{custom}"
+          url = "#{lang_prefix}/#{custom}"
           url += "/" unless url.ends_with?("/")
           return url
         end
 
         stem = Path[relative_path].stem
-        is_index = stem == "_index" || stem == "index"
+
+        # Remove language suffix from stem if present in language
+        clean_stem = if language
+                       stem.chomp(".#{language}")
+                     else
+                       stem
+                     end
+
+        is_index = clean_stem == "_index" || clean_stem == "index"
 
         if is_index
           if effective_dir == "." || effective_dir.empty?
-            return "/"
+            return lang_prefix.empty? ? "/" : "#{lang_prefix}/"
           else
-            return "/#{effective_dir}/"
+            return "#{lang_prefix}/#{effective_dir}/"
           end
         end
 
-        leaf = slug || stem
+        leaf = slug || clean_stem
 
         if effective_dir == "." || effective_dir.empty?
-          "/#{leaf}/"
+          "#{lang_prefix}/#{leaf}/"
         else
-          "/#{effective_dir}/#{leaf}/"
+          "#{lang_prefix}/#{effective_dir}/#{leaf}/"
         end
       end
     end

--- a/src/services/unused_assets.cr
+++ b/src/services/unused_assets.cr
@@ -5,6 +5,7 @@
 # Reports unreferenced files that may be candidates for removal.
 
 require "json"
+require "uri"
 require "../models/config"
 require "../utils/logger"
 
@@ -42,12 +43,35 @@ module Hwaro
       @content_dir : String
       @static_dir : String
       @templates_dir : String
+      @project_root : String
 
       def initialize(
         @content_dir : String = "content",
         @static_dir : String = "static",
         @templates_dir : String = "templates",
       )
+        if File.exists?("config.toml")
+          @project_root = "."
+        else
+          @project_root = find_project_root(@content_dir)
+        end
+
+        if @templates_dir == "templates"
+          @templates_dir = File.join(@project_root, "templates")
+        end
+      end
+
+      private def find_project_root(content_dir : String) : String
+        if File.basename(content_dir) == "content"
+          parent = File.dirname(content_dir)
+          return parent.empty? || parent == "." ? "." : parent
+        end
+
+        if Dir.exists?(File.join(content_dir, "content")) || Dir.exists?(File.join(content_dir, "../content"))
+          return content_dir
+        end
+
+        content_dir
       end
 
       def run : UnusedAssetsResult
@@ -73,6 +97,7 @@ module Hwaro
           # genuinely-unused `header.png` flagged when only `page-header.png` is
           # referenced (their shared suffix is preceded by `-`, inside the token).
           next if scanned_text.matches?(/(?<![\w\-.])#{Regex.escape(basename)}(?![\w\-.])/)
+          next if scanned_text.matches?(/(?<![\w\-.])#{Regex.escape(URI.encode_path(basename))}(?![\w\-.])/)
           unused << asset_path
         end
 
@@ -154,6 +179,14 @@ module Hwaro
             end
             sb << text << '\n'
           end
+
+          config_path = File.join(@project_root, "config.toml")
+          if File.exists?(config_path)
+            begin
+              sb << File.read(config_path) << '\n'
+            rescue IO::Error
+            end
+          end
         end
       end
 
@@ -162,10 +195,14 @@ module Hwaro
       # substring false positives from plain string matching.
       private def build_referenced_basenames(scanned_text : String) : Set(String)
         refs = Set(String).new
-        ext_pattern = /[\w\-\.]+\.(?:png|jpe?g|gif|svg|webp|avif|ico|bmp|tiff?|css|js|woff2?|ttf|eot|otf|mp[34]|webm|ogg|wav|pdf|zip)\b/i
+        ext_pattern = /[\w\-\.%]+\.(?:png|jpe?g|gif|svg|webp|avif|ico|bmp|tiff?|css|js|woff2?|ttf|eot|otf|mp[34]|webm|ogg|wav|pdf|zip)\b/i
 
         scanned_text.scan(ext_pattern) do |match|
-          refs << match[0]
+          token = match[0]
+          refs << token
+          if token.includes?('%')
+            refs << URI.decode(token)
+          end
         end
 
         # Files declared in `config.toml` (`[[assets.bundles]] files`,
@@ -179,8 +216,9 @@ module Hwaro
       end
 
       private def add_config_references(refs : Set(String)) : Nil
-        return unless File.exists?("config.toml")
-        config = Models::Config.load
+        config_path = File.join(@project_root, "config.toml")
+        return unless File.exists?(config_path)
+        config = Models::Config.load(config_path)
         config.assets.bundles.each do |bundle|
           bundle.files.each { |path| refs << File.basename(path) }
           # The compiled bundle name (e.g. `main.css`) is referenced

--- a/src/utils/frontmatter_writer.cr
+++ b/src/utils/frontmatter_writer.cr
@@ -1,0 +1,285 @@
+# Frontmatter Writer
+#
+# Shared serialization helpers for tools that WRITE frontmatter back to disk
+# (`tool convert`, `tool export`, importers). Centralised here so the TOML
+# emission rules — key quoting, string escaping, date formatting — stay
+# identical across every tool that produces content files.
+
+require "yaml"
+require "toml"
+require "time"
+
+module Hwaro
+  module Utils
+    module FrontmatterWriter
+      # Serialize a frontmatter date/time value without corrupting the
+      # calendar day or the author's zone.
+      #
+      # Frontmatter dates are commonly written as TOML/YAML *local dates* such
+      # as `2026-05-20`, which parse to midnight in the local time zone.
+      # Rendering those through `to_rfc3339` (always UTC) rolls the day back
+      # in any positive-offset zone — e.g. in KST `2026-05-20` becomes
+      # `2026-05-19T15:00:00Z`. When the value carries no time-of-day we emit
+      # a bare `YYYY-MM-DD`; genuine timestamps keep their own offset
+      # (`to_rfc3339` would silently convert `08:00+09:00` to the previous
+      # day's `23:00Z`).
+      def self.serialize_time(time : Time) : String
+        if time.hour == 0 && time.minute == 0 && time.second == 0 && time.nanosecond == 0
+          time.to_s("%Y-%m-%d")
+        elsif time.offset == 0
+          time.to_rfc3339
+        else
+          time.to_s("%Y-%m-%dT%H:%M:%S%:z")
+        end
+      end
+
+      # Escape a string for a double-quoted TOML basic string. Unlike Crystal's
+      # `String#inspect`, this never emits TOML-invalid escapes (`\a`, `\e`,
+      # `\v`) and leaves non-ASCII text raw — toml.cr's `\uXXXX` reader greedily
+      # consumes a following hex digit, so escaping U+200B in "Auto​build" would
+      # produce an unparseable file.
+      def self.escape_toml_string(str : String) : String
+        str
+          .gsub("\\", "\\\\")
+          .gsub("\"", "\\\"")
+          .gsub("\n", "\\n")
+          .gsub("\t", "\\t")
+          .gsub("\r", "\\r")
+          .gsub(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/) { |s| "\\u%04X" % s[0].ord }
+      end
+
+      # Convert a parsed TOML value into the YAML::Any tree the emitters
+      # consume. Time leaves become frontmatter date strings (see
+      # `serialize_time`).
+      def self.toml_to_yaml_any(value : TOML::Any) : YAML::Any
+        raw = value.raw
+
+        case raw
+        when String
+          YAML::Any.new(raw)
+        when Int64
+          YAML::Any.new(raw)
+        when Float64
+          YAML::Any.new(raw)
+        when Bool
+          YAML::Any.new(raw)
+        when Time
+          YAML::Any.new(serialize_time(raw))
+        when Array
+          arr = raw.map { |item|
+            if item.is_a?(TOML::Any)
+              toml_to_yaml_any(item)
+            else
+              YAML::Any.new(item.to_s)
+            end
+          }
+          YAML::Any.new(arr)
+        when Hash
+          if raw.is_a?(Hash(String, TOML::Any))
+            hash = {} of YAML::Any => YAML::Any
+            raw.each do |k, v|
+              hash[YAML::Any.new(k)] = toml_to_yaml_any(v)
+            end
+            YAML::Any.new(hash)
+          else
+            YAML::Any.new(raw.to_s)
+          end
+        else
+          YAML::Any.new(raw.to_s)
+        end
+      end
+
+      # YAML 1.1 words that reparse as booleans/null when left bare (Jekyll
+      # runs on Psych). `y`/`n` included defensively.
+      YAML_RESERVED_WORDS = %w[true false yes no on off null none y n ~]
+
+      # Render a string as a YAML flow scalar, leaving simple values bare and
+      # double-quoting anything YAML would reinterpret — `beta: gamma` parses
+      # as a mapping, `NO` as false, `2024-01-15` as a date, `*x` as an alias.
+      def self.yaml_scalar(str : String) : String
+        bare_safe = str.matches?(/\A[A-Za-z_](?:[A-Za-z0-9 _.\/-]*[A-Za-z0-9_.\/-])?\z/) &&
+                    !YAML_RESERVED_WORDS.includes?(str.downcase)
+        bare_safe ? str : str.inspect
+      end
+
+      # Quote a frontmatter key that isn't a bare TOML key (spaces, dots,
+      # non-ASCII — all valid in YAML/JSON source).
+      def self.format_toml_key(key : String) : String
+        if key =~ /^[A-Za-z0-9_-]+$/
+          key
+        else
+          "\"#{escape_toml_string(key)}\""
+        end
+      end
+
+      # Emits a TOML document body (no `+++` fences) from a parsed frontmatter
+      # tree: scalars first, then `[table]` sections, then `[[array-of-table]]`
+      # sections, preserving source key order within each group.
+      class TomlBuilder
+        def initialize
+          @output = String::Builder.new
+        end
+
+        def build(yaml : YAML::Any) : String
+          return "" unless yaml.as_h?
+          process_table(yaml, [] of String, true)
+          @output.to_s
+        end
+
+        # Convenience for callers holding a string-keyed field map (exporters).
+        def build(fields : Hash(String, YAML::Any)) : String
+          wrapped = {} of YAML::Any => YAML::Any
+          fields.each { |k, v| wrapped[YAML::Any.new(k)] = v }
+          build(YAML::Any.new(wrapped))
+        end
+
+        private def process_table(yaml : YAML::Any, path : Array(String), print_header : Bool)
+          return unless hash = yaml.as_h?
+
+          # An empty table (`extra: {}`) has no values to force a header out,
+          # but dropping the key entirely would silently lose it.
+          if hash.empty?
+            if print_header && !path.empty?
+              @output << "\n" unless @output.empty?
+              @output << "[" << format_path(path) << "]\n"
+            end
+            return
+          end
+
+          simple_values = {} of String => YAML::Any
+          tables = {} of String => YAML::Any
+          array_tables = {} of String => YAML::Any
+
+          hash.each do |key, value|
+            key_str = key.as_s? || key.to_s
+
+            if value.as_h?
+              tables[key_str] = value
+            elsif array_of_tables?(value)
+              array_tables[key_str] = value
+            else
+              simple_values[key_str] = value
+            end
+          end
+
+          if !simple_values.empty? && print_header && !path.empty?
+            @output << "\n" unless @output.empty?
+            @output << "[" << format_path(path) << "]\n"
+          end
+
+          simple_values.each do |k, v|
+            @output << format_key(k) << " = " << to_toml_value(v) << "\n"
+          end
+
+          tables.each do |k, v|
+            process_table(v, path + [k], true)
+          end
+
+          array_tables.each do |k, v|
+            v.as_a.each do |item|
+              new_path = path + [k]
+              @output << "\n" unless @output.empty?
+              @output << "[[" << format_path(new_path) << "]]\n"
+              process_table(item, new_path, false)
+            end
+          end
+        end
+
+        private def array_of_tables?(value : YAML::Any) : Bool
+          return false unless value.as_a?
+          return false if value.as_a.empty?
+          value.as_a.all?(&.as_h?)
+        end
+
+        private def format_path(path : Array(String)) : String
+          path.map { |k| format_key(k) }.join(".")
+        end
+
+        private def format_key(key : String) : String
+          FrontmatterWriter.format_toml_key(key)
+        end
+
+        # The TOML type family a value serializes to; toml.cr rejects arrays
+        # that mix families, so array emission needs to know them.
+        private def toml_kind(value : YAML::Any) : Symbol
+          case value.raw
+          when Bool             then :bool
+          when Int32, Int64     then :int
+          when Float32, Float64 then :float
+          when Time             then :time
+          when Array            then :array
+          when Hash             then :table
+          else                       :string
+          end
+        end
+
+        private def to_toml_value(value : YAML::Any) : String
+          raw = value.raw
+
+          case raw
+          when Bool
+            raw.to_s
+          when Int32, Int64
+            raw.to_s
+          when Float32, Float64
+            # TOML spells non-finite floats `inf`/`nan`; Crystal's `to_s`
+            # ("Infinity"/"NaN") doesn't reparse.
+            if raw.nan?
+              "nan"
+            elsif raw.infinite?
+              raw > 0 ? "inf" : "-inf"
+            else
+              raw.to_s
+            end
+          when Time
+            FrontmatterWriter.serialize_time(raw)
+          when Array
+            "[#{array_items(value).join(", ")}]"
+          when Hash
+            # A hash reached from inside an array (mixed or nested) can't be
+            # a `[table]` section; emit it as an inline table.
+            pairs = value.as_h.map do |k, v|
+              "#{format_key(k.as_s? || k.to_s)} = #{to_toml_value(v)}"
+            end
+            "{#{pairs.join(", ")}}"
+          when String
+            "\"#{FrontmatterWriter.escape_toml_string(raw)}\""
+          when Nil
+            "\"\""
+          else
+            "\"#{FrontmatterWriter.escape_toml_string(value.to_s)}\""
+          end
+        end
+
+        # Serialize array elements, keeping the array homogeneous where
+        # possible: toml.cr refuses `[1, "two"]`, so an int/float mix is
+        # promoted to floats and any other scalar mix is coerced to strings
+        # (structured members keep their shape).
+        private def array_items(value : YAML::Any) : Array(String)
+          items = value.as_a
+          kinds = items.map { |v| toml_kind(v) }.uniq!
+
+          if kinds.size <= 1
+            items.map { |v| to_toml_value(v) }
+          elsif kinds.sort == [:float, :int]
+            items.map do |v|
+              raw = v.raw
+              raw.is_a?(Int) ? "#{raw}.0" : to_toml_value(v)
+            end
+          else
+            items.map do |v|
+              case toml_kind(v)
+              when :array, :table, :string
+                to_toml_value(v)
+              when :time
+                "\"#{FrontmatterWriter.escape_toml_string(FrontmatterWriter.serialize_time(v.raw.as(Time)))}\""
+              else
+                "\"#{FrontmatterWriter.escape_toml_string(v.raw.to_s)}\""
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Deep bug-fix sweep over the \`hwaro tool\` subsystem (12 subcommands + backing services). Five parallel audits (importers ×2, exporters/convert, analysis tools, platform/ci generators) surfaced ~50 verified bugs; all are fixed here with regression specs.

### Data-destruction / data-loss (highest severity)
- **convert** replaced a leading `---` horizontal-rule pair with empty frontmatter, **deleting the author's content**; now skipped with the file untouched
- **Astro import** deleted the **entire body of every real MDX file** (`/m` DOTALL import-strip regex)
- **export** silently dropped nested tables (`[extra]`, `[taxonomies]`), non-string arrays, and typed scalars; malformed frontmatter exported as a metadata-less file
- **unused-assets --delete** removed in-use files (percent-encoded references, `og.default_image`/`pwa.icons`, CWD-dependent config resolution)
- Slug-collision data loss in Jekyll/Notion/Astro/Eleventy imports (date-strip, UUID-strip, bundle `index.md`) — now disambiguated with warnings
- CRLF sources defeated frontmatter detection in every importer (all fields dropped, raw YAML leaked into the page body)
- WordPress imported **private/pending/future posts as published**
- HtmlToMarkdown converted/stripped the HTML *inside* `<pre>` code samples and double-decoded entities — fences are now stashed (escape-before-inject)

### Correctness
- Timezone handling end-to-end: `serialize_time` UTC-normalization shifted `+09:00` posts to the previous calendar day; importer `parse_date` silently ignored trailing offsets (9-hour instant shift); `format_date` dropped the zone — a shared `Utils::FrontmatterWriter` now owns date serialization, TOML escaping, and key quoting for convert/export/import
- Jekyll export YAML injection: unquoted `- beta: gamma` reparsed as a mapping, `- NO` as `false`; root `_index.md` mapped to `/index/`; non-allowlisted keys (slug, weight, extra…) dropped; date prefixes doubled
- Hugo import quoted `weight = "3"` → hwaro read weight 0 for every imported page
- check-links false positives: redirects, HEAD-rejecting CDNs, parenthesised URLs, `tel:`/protocol-relative links, percent-encoded paths, subpath `base_path` links, and skipped private hosts all reported dead (CI exit 1)
- validate: out-of-range dates escaped as error-level "Failed to read file" via ArgumentError
- Generated GitLab CI failed at container start (image entrypoint not overridden); `workflow_dispatch` trigger was a no-op; Netlify `[[redirects]]` were shadowed by alias HTML; multilingual alias targets 404'd

### Verification
- `crystal spec`: **6095 examples, 0 failures** (≈250 new regression assertions)
- `crystal tool format --check` + `ameba`: clean
- Live round-trips on a scaffold site: TOML↔YAML↔JSON convert, hugo/jekyll export → hugo import, check-links / unused-assets / validate / list / stats smoke-tested with edge-case content (CJK, quotes-in-titles, hr-in-body, nested extra, offset datetimes)

Behavior changes to note: importer/exporter date output is now RFC 3339 with preserved offset (bare `YYYY-MM-DD` for midnights) instead of zone-less `YYYY-MM-DD HH:MM:SS`; export of malformed-frontmatter files is now a per-file **error** instead of a silent metadata-stripped export; convert skips non-mapping leading delimiter blocks.