### PR TITLE
fix: SSG correctness fixes — watcher coverage, summary fidelity, deterministic output, sRGB resize, config typo warnings

### DIFF
--- a/spec/functional/build_integration_spec.cr
+++ b/spec/functional/build_integration_spec.cr
@@ -1357,6 +1357,61 @@ describe "Build Integration: Summary via page_summary variable" do
       html.should contain("SUMMARY=Fallback summary")
     end
   end
+
+  # Summaries render through the same sub-pipeline as the body — shortcodes,
+  # markdown extensions, and internal links must not diverge between the
+  # article and its list-page/feed summary.
+  it "expands shortcodes in the summary instead of leaking literal syntax" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "post.md" => %(---\ntitle: Post\n---\nIntro {{ badge(label="new") }} text.\n\n<!-- more -->\n\nBody.),
+      },
+      template_files: {
+        "page.html"             => "SUMMARY={{ page_summary }}|{{ content }}",
+        "shortcodes/badge.html" => %(<span class="badge">{{ label }}</span>),
+      },
+    ) do
+      html = File.read("public/post/index.html")
+      html.should contain(%(SUMMARY=))
+      html.should contain(%(<span class="badge">new</span>))
+      html.should_not contain("{{ badge")
+    end
+  end
+
+  it "renders markdown-extension syntax (tables) in the summary like the body" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "post.md" => "---\ntitle: Post\n---\n| a | b |\n|---|---|\n| 1 | 2 |\n\n<!-- more -->\n\nBody.",
+      },
+      template_files: {
+        "page.html" => "SUMMARY[{{ page_summary }}]|{{ content }}",
+      },
+    ) do
+      html = File.read("public/post/index.html")
+      summary_part = html.split("|").first
+      summary_part.should contain("<table")
+    end
+  end
+
+  it "resolves internal @/ links inside the summary" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "post.md"  => "---\ntitle: Post\n---\nSee [other](@/other.md) first.\n\n<!-- more -->\n\nBody.",
+        "other.md" => "---\ntitle: Other\n---\nOther body.",
+      },
+      template_files: {
+        "page.html" => "SUMMARY={{ page_summary }}|{{ content }}",
+      },
+    ) do
+      html = File.read("public/post/index.html")
+      html.should contain(%(SUMMARY=))
+      html.should contain(%(href="/other/"))
+      html.should_not contain("@/other.md")
+    end
+  end
 end
 
 # ---------------------------------------------------------------------------

--- a/spec/functional/cache_spec.cr
+++ b/spec/functional/cache_spec.cr
@@ -159,6 +159,38 @@ describe "Cache: Cache with multiple files" do
   end
 end
 
+describe "Cache: i18n change invalidation" do
+  it "rebuilds pages when a translation file changes" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", BASIC_CONFIG)
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates")
+        FileUtils.mkdir_p("i18n")
+        File.write("content/page.md", "---\ntitle: Page\n---\nBody")
+        File.write("templates/page.html", %({{ "greeting" | t }}|{{ content }}))
+        File.write("i18n/en.toml", %(greeting = "Hello"))
+
+        builder1 = Hwaro::Core::Build::Builder.new
+        Hwaro::Content::Hooks.all.each { |h| builder1.register(h) }
+        builder1.run(output_dir: "public", parallel: false, cache: true, highlight: false, verbose: false, profile: false)
+        File.read("public/page/index.html").should contain("Hello")
+
+        sleep 100.milliseconds
+        File.write("i18n/en.toml", %(greeting = "Bonjour"))
+
+        builder2 = Hwaro::Core::Build::Builder.new
+        Hwaro::Content::Hooks.all.each { |h| builder2.register(h) }
+        builder2.run(output_dir: "public", parallel: false, cache: true, highlight: false, verbose: false, profile: false)
+
+        html = File.read("public/page/index.html")
+        html.should contain("Bonjour")
+        html.should_not contain("Hello")
+      end
+    end
+  end
+end
+
 describe "Cache: Template change invalidation" do
   it "rebuilds all pages when templates change" do
     Dir.mktmpdir do |dir|

--- a/spec/functional/edge_cases_spec.cr
+++ b/spec/functional/edge_cases_spec.cr
@@ -474,4 +474,66 @@ describe "Edge Cases: Duplicate output path detection" do
 
     log.should contain("Duplicate alias output path")
   end
+
+  it "writes the first page in source-path order on a slug collision (deterministic winner)" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "posts/a.md" => "---\ntitle: A\nslug: dup\n---\nAAA-WINNER",
+        "posts/b.md" => "---\ntitle: B\nslug: dup\n---\nBBB-LOSER",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+    ) do
+      html = File.read("public/posts/dup/index.html")
+      html.should contain("AAA-WINNER")
+      html.should_not contain("BBB-LOSER")
+    end
+  end
+
+  it "keeps the deterministic winner under parallel render too" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "posts/a.md" => "---\ntitle: A\nslug: dup\n---\nAAA-WINNER",
+        "posts/b.md" => "---\ntitle: B\nslug: dup\n---\nBBB-LOSER",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+      parallel: true,
+    ) do
+      html = File.read("public/posts/dup/index.html")
+      html.should contain("AAA-WINNER")
+      html.should_not contain("BBB-LOSER")
+    end
+  end
+
+  it "keeps the real page when a later page's alias collides with its URL" do
+    # zzz.md's alias points at /about/, which about.md already owns. The
+    # alias redirect must not stomp the real page's index.html.
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "about.md" => "---\ntitle: About\n---\nREAL-PAGE-BODY",
+        "zzz.md"   => "---\ntitle: Z\naliases:\n  - /about/\n---\nZ",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+    ) do
+      html = File.read("public/about/index.html")
+      html.should contain("REAL-PAGE-BODY")
+    end
+  end
+
+  it "writes the alias redirect of the first claimant on alias collisions" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "one.md" => "---\ntitle: One\naliases:\n  - /shared/\n---\nOne",
+        "two.md" => "---\ntitle: Two\naliases:\n  - /shared/\n---\nTwo",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+    ) do
+      html = File.read("public/shared/index.html")
+      html.should contain("/one/")
+      html.should_not contain("/two/")
+    end
+  end
 end

--- a/spec/functional/edge_cases_spec.cr
+++ b/spec/functional/edge_cases_spec.cr
@@ -536,6 +536,51 @@ describe "Edge Cases: Duplicate output path detection" do
       html.should_not contain("/two/")
     end
   end
+
+  it "lets the real page beat an earlier page's alias for the same URL" do
+    # a-legacy.md sorts before guide.md, but a page's own content always
+    # outranks a redirect stub — real URLs claim before aliases.
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "a-legacy.md" => "---\ntitle: Legacy\naliases:\n  - /guide/\n---\nLEGACY",
+        "guide.md"    => "---\ntitle: Guide\n---\nREAL-GUIDE-BODY",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+    ) do
+      html = File.read("public/guide/index.html")
+      html.should contain("REAL-GUIDE-BODY")
+    end
+  end
+
+  it "does not let a render:false page claim a URL from a real page" do
+    # A headless page never writes output, so it must not suppress the
+    # real page that shares its URL.
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "a-headless.md" => "---\ntitle: Headless\nrender: false\nslug: about\n---\nHIDDEN",
+        "z-about.md"    => "---\ntitle: About\nslug: about\n---\nREAL-ABOUT-BODY",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+    ) do
+      html = File.read("public/about/index.html")
+      html.should contain("REAL-ABOUT-BODY")
+    end
+  end
+
+  it "ignores an alias that duplicates the page's own URL" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "about.md" => "---\ntitle: About\naliases:\n  - /about/\n---\nOWN-BODY",
+      },
+      template_files: {"page.html" => "{{ content }}"},
+    ) do
+      html = File.read("public/about/index.html")
+      html.should contain("OWN-BODY")
+    end
+  end
 end
 
 # ---------------------------------------------------------------------------

--- a/spec/functional/edge_cases_spec.cr
+++ b/spec/functional/edge_cases_spec.cr
@@ -537,3 +537,35 @@ describe "Edge Cases: Duplicate output path detection" do
     end
   end
 end
+
+# ---------------------------------------------------------------------------
+# 14. Sequential render failure aggregation
+# ---------------------------------------------------------------------------
+describe "Edge Cases: sequential render failure aggregation" do
+  it "renders past a failing page and reports every failure once (no first-error abort)" do
+    # build_helper runs with parallel: false, so this exercises
+    # process_files_sequential. Two pages share a broken template; the loop
+    # must attempt both (grouped "Render failed for 2 pages" summary) instead
+    # of aborting on the first, and still fail loud with the classified error.
+    err = nil
+    log = with_captured_log do
+      err = expect_raises(Hwaro::HwaroError) do
+        build_site(
+          BASIC_CONFIG,
+          content_files: {
+            "bad1.md" => "---\ntitle: B1\ntemplate: broken\n---\nx",
+            "bad2.md" => "---\ntitle: B2\ntemplate: broken\n---\nx",
+            "good.md" => "---\ntitle: Good\n---\nok",
+          },
+          template_files: {
+            "page.html"   => "{{ content }}",
+            "broken.html" => "{{ page.title.nonexistent_attr }}",
+          },
+        ) { }
+      end
+    end
+
+    err.not_nil!.code.should eq(Hwaro::Errors::HWARO_E_TEMPLATE)
+    log.should contain("Render failed for 2 pages")
+  end
+end

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../src/services/defaults/config"
 
 # Helper to load a Config from a TOML string via a temp file.
 private def load_config(toml : String) : Hwaro::Models::Config
@@ -2483,6 +2484,65 @@ describe "Hwaro::Models::Config#resolve_permalink_dir" do
 
     it "clamps an oversized integer [deployment] max_deletes to Int32::MAX (int_or_nil)" do
       load_config("[deployment]\nmax_deletes = 99999999999").deployment.max_deletes.should eq(Int32::MAX)
+    end
+  end
+
+  describe "unknown top-level key warnings" do
+    it "warns with a did-you-mean suggestion for a typo'd section" do
+      log = with_captured_log do
+        load_config("[markdonw]\nemoji = true")
+      end
+      log.should contain("Unknown key 'markdonw'")
+      log.should contain("Did you mean 'markdown'?")
+    end
+
+    it "warns with a did-you-mean suggestion for a typo'd scalar" do
+      log = with_captured_log do
+        load_config(%(titel = "My Site"))
+      end
+      log.should contain("Unknown key 'titel'")
+      log.should contain("Did you mean 'title'?")
+    end
+
+    it "warns without a suggestion for a key nothing resembles" do
+      log = with_captured_log do
+        load_config("[zzqxy]\nfoo = 1")
+      end
+      log.should contain("Unknown key 'zzqxy'")
+      log.should_not contain("Did you mean")
+    end
+
+    it "does not warn for any known top-level key" do
+      toml = String.build do |io|
+        io << %(title = "t"\ndescription = "d"\nbase_url = "https://example.com"\ndefault_language = "en"\n)
+        (Hwaro::Models::Config::KNOWN_TOP_LEVEL_KEYS -
+          %w[title description base_url default_language taxonomies menus outputs languages permalinks]).each do |key|
+          io << "[" << key << "]\n"
+        end
+      end
+      log = with_captured_log { load_config(toml) }
+      log.should_not contain("Unknown key")
+    end
+
+    # Drift guard: every section doctor/config-snippets knows about must be
+    # in the loader's known-key list, or a valid section would be flagged.
+    it "covers every SECTION_REGISTRY section" do
+      Hwaro::Services::ConfigSnippets::SECTION_REGISTRY.each_key do |section|
+        Hwaro::Models::Config::KNOWN_TOP_LEVEL_KEYS.includes?(section).should be_true
+      end
+    end
+
+    # Drift guard: the scaffolded default configs must load without any
+    # unknown-key warning — they exercise the full documented key surface.
+    it "does not warn on the generated default configs" do
+      {
+        Hwaro::Services::Defaults::ConfigSamples.config,
+        Hwaro::Services::Defaults::ConfigSamples.config_without_taxonomies,
+        Hwaro::Services::Defaults::ConfigSamples.config_multilingual(["en", "ko"]),
+      }.each do |toml|
+        log = with_captured_log { load_config(toml) }
+        log.should_not contain("Unknown key")
+      end
     end
   end
 end

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -703,6 +703,20 @@ describe Hwaro::Services::ChangeSet do
       cs.needs_full_rebuild?.should be_true
     end
 
+    it "returns true when data/i18n files were modified" do
+      cs = Hwaro::Services::ChangeSet.new(
+        modified_content: [] of String,
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: [] of String,
+        removed_files: [] of String,
+        config_changed: false,
+        modified_data: ["data/authors.yml"],
+      )
+      cs.needs_full_rebuild?.should be_true
+      cs.empty?.should be_false
+    end
+
     it "returns false for content-only modification" do
       cs = Hwaro::Services::ChangeSet.new(
         modified_content: ["content/posts/hello.md"],
@@ -1079,6 +1093,31 @@ describe Hwaro::Services::ChangeSet do
       ])
       merged.content_files_only?.should be_true
     end
+
+    it "merges modified_data with deduplication" do
+      cs1 = Hwaro::Services::ChangeSet.new(
+        modified_content: [] of String,
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: [] of String,
+        removed_files: [] of String,
+        config_changed: false,
+        modified_data: ["data/authors.yml"],
+      )
+      cs2 = Hwaro::Services::ChangeSet.new(
+        modified_content: [] of String,
+        modified_templates: [] of String,
+        modified_static: [] of String,
+        added_files: [] of String,
+        removed_files: [] of String,
+        config_changed: false,
+        modified_data: ["data/authors.yml", "i18n/ko.toml"],
+      )
+
+      merged = cs1.merge(cs2)
+      merged.modified_data.should eq(["data/authors.yml", "i18n/ko.toml"])
+      merged.rebuild_strategy.should eq(:full)
+    end
   end
 
   describe "#rebuild_strategy" do
@@ -1427,6 +1466,22 @@ describe "Server#detect_changes" do
     cs = server.test_detect_changes(old, new_m)
     cs.config_changed.should be_true
     cs.needs_full_rebuild?.should be_true
+  end
+
+  it "detects modified data and i18n files and forces a full rebuild" do
+    server = Hwaro::Services::Server.new
+    t1 = Time.utc(2025, 1, 1, 0, 0, 0)
+    t2 = Time.utc(2025, 1, 1, 0, 0, 5)
+
+    old = {"data/authors.yml" => t1, "i18n/en.toml" => t1}
+    new_m = {"data/authors.yml" => t2, "i18n/en.toml" => t2}
+
+    cs = server.test_detect_changes(old, new_m)
+    cs.modified_data.sort.should eq(["data/authors.yml", "i18n/en.toml"])
+    cs.modified_content.should be_empty
+    cs.empty?.should be_false
+    cs.needs_full_rebuild?.should be_true
+    cs.rebuild_strategy.should eq(:full)
   end
 
   it "detects added files" do

--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -191,6 +191,40 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
       result.should contain("fenced2")
     end
 
+    # CommonMark fence semantics now come from the shared FenceTracker
+    # (same rules as the table/definition/math walkers and Markd itself).
+    # The three specs below pin the divergences the old ad-hoc regex had.
+    it "does not treat a 4-space-indented ``` as a fence opener (indented code is literal)" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/note" => "<span>{{ body }}</span>"}
+      # In CommonMark "    ```" is indented-code content, not a delimiter —
+      # the old scanner opened a fence here and silently stopped expanding
+      # shortcodes for the rest of the document.
+      content = "    ```\n\n{% note %}live{% end %}"
+      result = builder.test_sc_process(content, templates)
+      result.should contain("<span>live</span>")
+    end
+
+    it "closes a fence on a longer closer run (CommonMark closer-length rule)" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/note" => "<span>{{ body }}</span>"}
+      # ```` validly closes a ``` fence; the old exact-length comparison
+      # never closed it, so everything below stayed unexpanded.
+      content = "```\nfenced\n````\n{% note %}live{% end %}"
+      result = builder.test_sc_process(content, templates)
+      result.should contain("<span>live</span>")
+      result.should contain("fenced")
+    end
+
+    it "does not open a backtick fence whose info string contains a backtick" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/note" => "<span>{{ body }}</span>"}
+      # CommonMark: "``` a`b" is not a fence opener (inline code instead).
+      content = "``` a`b\n{% note %}live{% end %}"
+      result = builder.test_sc_process(content, templates)
+      result.should contain("<span>live</span>")
+    end
+
     # Regression for https://github.com/hahwul/hwaro/issues/477
     # Single-backtick inline code spans should be opaque to the shortcode
     # processor, the same way fenced code blocks already are. The bug was
@@ -472,6 +506,21 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
       builder = Hwaro::Core::Build::Builder.new
       # The token is outside any fence or inline code
       builder.test_content_may_contain_shortcodes?(%({% codeblock(lang="crystal") %} `code` {% end %})).should be_true
+    end
+
+    # Pre-filter must agree with process_shortcodes_jinja's FenceTracker:
+    # the same CommonMark rules decide fencing in both, or the skip
+    # decision and the actual expansion drift apart.
+    it "returns true when a shortcode follows a 4-space-indented ``` line" do
+      builder = Hwaro::Core::Build::Builder.new
+      content = "    ```\n\n{% note %}live{% end %}"
+      builder.test_content_may_contain_shortcodes?(content).should be_true
+    end
+
+    it "returns true when a shortcode follows a fence closed by a longer run" do
+      builder = Hwaro::Core::Build::Builder.new
+      content = "```\nfenced\n````\n{% note %}live{% end %}"
+      builder.test_content_may_contain_shortcodes?(content).should be_true
     end
   end
 end

--- a/src/content/processors/fence_tracker.cr
+++ b/src/content/processors/fence_tracker.cr
@@ -26,6 +26,14 @@ module Hwaro
         @fence_char = '`'
         @fence_len = 0
 
+        # True while inside an open fence: after the opener line was fed,
+        # until (and excluding) the line after the closer. Lets callers that
+        # need to route in-fence lines differently (e.g. the shortcode
+        # processor's chunk buffering) branch before feeding the line.
+        def in_fence? : Bool
+          @in_fence
+        end
+
         # Feed the next line (with or without its trailing newline).
         # Returns true when the line must pass through verbatim: a fence
         # delimiter or any line inside an open fence.

--- a/src/content/processors/image_processor.cr
+++ b/src/content/processors/image_processor.cr
@@ -107,7 +107,7 @@ module Hwaro
             end
 
             begin
-              result = LibStb.stbir_resize_uint8_linear(
+              result = LibStb.stbir_resize_uint8_srgb(
                 pixels, src_w, src_h, 0,
                 out_pixels, out_w, out_h, 0,
                 channels
@@ -198,7 +198,7 @@ module Hwaro
           return if thumb_pixels.null?
 
           begin
-            resized = LibStb.stbir_resize_uint8_linear(
+            resized = LibStb.stbir_resize_uint8_srgb(
               pixels, src_w, src_h, 0,
               thumb_pixels, out_w, out_h, 0,
               channels
@@ -327,7 +327,7 @@ module Hwaro
               next if out_pixels.null?
 
               begin
-                resized = LibStb.stbir_resize_uint8_linear(
+                resized = LibStb.stbir_resize_uint8_srgb(
                   pixels, src_w, src_h, 0,
                   out_pixels, out_w, out_h, 0,
                   channels

--- a/src/content/processors/image_processor.cr
+++ b/src/content/processors/image_processor.cr
@@ -110,7 +110,7 @@ module Hwaro
               result = LibStb.stbir_resize_uint8_srgb(
                 pixels, src_w, src_h, 0,
                 out_pixels, out_w, out_h, 0,
-                channels
+                stbir_layout(channels)
               )
 
               if result.null?
@@ -201,7 +201,7 @@ module Hwaro
             resized = LibStb.stbir_resize_uint8_srgb(
               pixels, src_w, src_h, 0,
               thumb_pixels, out_w, out_h, 0,
-              channels
+              stbir_layout(channels)
             )
             return if resized.null?
 
@@ -330,7 +330,7 @@ module Hwaro
                 resized = LibStb.stbir_resize_uint8_srgb(
                   pixels, src_w, src_h, 0,
                   out_pixels, out_w, out_h, 0,
-                  channels
+                  stbir_layout(channels)
                 )
                 unless resized.null?
                   if write_image(dest, ext, out_w, out_h, channels.to_i32, out_pixels, quality)
@@ -375,6 +375,16 @@ module Hwaro
 
         # Calculate output dimensions preserving aspect ratio.
         # Returns {0, 0} for invalid inputs to signal caller to skip.
+        # Map a decoded channel count to the stbir_pixel_layout the sRGB
+        # resize entry point expects. Counts map 1:1 (1→1CHANNEL, 3→RGB,
+        # 4→RGBA) EXCEPT gray+alpha: layout 2 (STBIR_2CHANNEL) declares "no
+        # transparency channel", so the sRGB codepath would gamma-decode the
+        # alpha bytes as if they were color, warping transparency gradients.
+        # STBIR_RA (9) keeps alpha linear and alpha-weights the filter.
+        private def stbir_layout(channels : Int32) : Int32
+          channels == 2 ? 9 : channels
+        end
+
         private def calculate_dimensions(src_w : Int32, src_h : Int32, target_w : Int32, target_h : Int32) : {Int32, Int32}
           # Guard against zero source dimensions (prevents division by zero)
           return {0, 0} if src_w <= 0 || src_h <= 0

--- a/src/content/seo/og_png_renderer.cr
+++ b/src/content/seo/og_png_renderer.cr
@@ -168,7 +168,7 @@ module Hwaro
             resized = LibC.malloc(buf_size).as(UInt8*)
             return if resized.null?
 
-            result = LibStb.stbir_resize_uint8_linear(
+            result = LibStb.stbir_resize_uint8_srgb(
               src_pixels, src_w, src_h, 0,
               resized, target_w, target_h, 0, 4
             )
@@ -1129,7 +1129,7 @@ module Hwaro
             return if resized.null?
 
             begin
-              result = LibStb.stbir_resize_uint8_linear(
+              result = LibStb.stbir_resize_uint8_srgb(
                 src_pixels, src_w, src_h, 0,
                 resized, dw, dh, 0, 4
               )

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -205,6 +205,12 @@ module Hwaro
         # dev server can render them in a background fiber after the
         # "ready" signal has been emitted. Nil outside of fast-start mode.
         @deferred_pages : Array(Models::Page)? = nil
+        # Output URLs each page must NOT write because an earlier page (in
+        # source-path order) already claimed them. Keyed by page.path. Under
+        # parallel render the colliding file's bytes were whichever worker
+        # finished last — run-to-run nondeterministic output. Nil when the
+        # build has no collisions (the common case).
+        @collision_suppressed : Hash(String, Set(String))? = nil
 
         def initialize
           @lifecycle = Lifecycle::Manager.new

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -405,6 +405,12 @@ module Hwaro
             return
           end
 
+          # Re-render <!-- more --> summaries for the re-parsed pages with the
+          # body pipeline (parse_single_page reset summary_html to nil); the
+          # listing pages re-rendered below read it.
+          render_page_summaries(changed_pages, site, templates, highlight,
+            link_targets: (site.pages + site.sections).as(Array(Models::Page)))
+
           # --- 2. Incrementally update relationships ---
           # Run taxonomy update on ALL re-parsed pages first (including those about
           # to be excluded), so excluded pages' old entries are properly removed.
@@ -761,6 +767,12 @@ module Hwaro
           if options.verbose && affected_templates && pages_to_render.size < renderable_pages.size
             Logger.info "  #{pages_to_render.size} of #{renderable_pages.size} pages affected."
           end
+
+          # Recompute <!-- more --> summaries for the render set with the
+          # reloaded templates: a shortcode template edit changes summary
+          # output too, and pages re-parsed by run_incremental_then_rerender
+          # arrive here with summary_html reset to nil.
+          render_page_summaries(pages_to_render, site, templates, highlight, link_targets: all_pages)
 
           global_vars = build_global_vars(site, options.cache_busting)
           @pages_by_path = build_pages_by_path(site)

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -205,12 +205,13 @@ module Hwaro
         # dev server can render them in a background fiber after the
         # "ready" signal has been emitted. Nil outside of fast-start mode.
         @deferred_pages : Array(Models::Page)? = nil
-        # Output URLs each page must NOT write because an earlier page (in
-        # source-path order) already claimed them. Keyed by page.path. Under
-        # parallel render the colliding file's bytes were whichever worker
-        # finished last — run-to-run nondeterministic output. Nil when the
-        # build has no collisions (the common case).
-        @collision_suppressed : Hash(String, Set(String))? = nil
+        # Deterministic owner (page.path) of every claimed output URL — page
+        # URLs and alias destinations. A page that is not the recorded winner
+        # for a URL must not write it; under parallel render the colliding
+        # file's bytes were whichever worker finished last. Recomputed per
+        # full build and per incremental/rerender pass (see
+        # compute_output_url_winners). Nil until the first render pass.
+        @output_url_winners : Hash(String, String)? = nil
 
         def initialize
           @lifecycle = Lifecycle::Manager.new
@@ -410,6 +411,11 @@ module Hwaro
           # listing pages re-rendered below read it.
           render_page_summaries(changed_pages, site, templates, highlight,
             link_targets: (site.pages + site.sections).as(Array(Models::Page)))
+
+          # Re-claim output URLs: the edit may have introduced or resolved a
+          # slug/alias collision, and a stale winner map would keep
+          # suppressing (or racing) writes for the rest of the serve session.
+          @output_url_winners = compute_output_url_winners((site.pages + site.sections).as(Array(Models::Page)))
 
           # --- 2. Incrementally update relationships ---
           # Run taxonomy update on ALL re-parsed pages first (including those about
@@ -721,12 +727,14 @@ module Hwaro
 
           # Selective re-render: same template set, fully static graph
           affected_templates : Set(String)? = nil
+          changed_template_names : Set(String)? = nil
           if @per_page_template_hash && deps && old_templates &&
              old_templates.keys.sort! == templates.keys.sort!
             changed = Set(String).new
             templates.each do |name, source|
               changed << name if old_templates[name]? != source
             end
+            changed_template_names = changed
             if changed.empty? && (force_pages.nil? || force_pages.empty?)
               Logger.info "Template change detected, but contents are identical — nothing to re-render."
               return
@@ -768,15 +776,33 @@ module Hwaro
             Logger.info "  #{pages_to_render.size} of #{renderable_pages.size} pages affected."
           end
 
-          # Recompute <!-- more --> summaries for the render set with the
-          # reloaded templates: a shortcode template edit changes summary
-          # output too, and pages re-parsed by run_incremental_then_rerender
-          # arrive here with summary_html reset to nil.
-          render_page_summaries(pages_to_render, site, templates, highlight, link_targets: all_pages)
-
           global_vars = build_global_vars(site, options.cache_busting)
           @pages_by_path = build_pages_by_path(site)
           cache = @cache || Cache.new(enabled: false)
+
+          # Recompute <!-- more --> summaries with the reloaded templates —
+          # but only when they can actually change: a shortcode/hook template
+          # edit, an unclassifiable template change (changed_template_names
+          # nil), or force_pages arriving from run_incremental_then_rerender
+          # with summary_html reset to nil by parse_single_page. A layout-only
+          # edit skips the recompute entirely (it can't affect summaries and
+          # would re-run per-page Crinja work on every keystroke).
+          forced = force_pages || [] of Models::Page
+          summaries_affected = !forced.empty? ||
+                               changed_template_names.nil? ||
+                               changed_template_names.any? { |n| n.starts_with?("shortcodes/") || n.starts_with?("hooks/") }
+          if summaries_affected
+            # force_pages with render:true are already in pages_to_render;
+            # render:false ones are excluded from the render set but their
+            # summaries still feed listings and feeds.
+            summary_pages = pages_to_render + forced.reject(&.render)
+            render_page_summaries(summary_pages, site, templates, highlight,
+              link_targets: all_pages, global_vars: global_vars)
+          end
+
+          # Re-claim output URLs (see run_incremental): forced content edits
+          # may have introduced or resolved a slug/alias collision.
+          @output_url_winners = compute_output_url_winners(all_pages)
 
           error_overlay = options.error_overlay
           count = if pages_to_render.empty?

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -440,10 +440,14 @@ module Hwaro::Core::Build::Phases::Initialize
   # the existing "config change invalidates all entries" path. Returns "" when
   # there is no `data/` directory.
   private def compute_data_hash : String
-    return "" unless Dir.exists?("data")
+    return "" unless Dir.exists?("data") || Dir.exists?("i18n")
 
     paths = [] of String
-    Dir.glob("data/**/*.{yml,yaml,json,toml}") do |path|
+    # i18n translations feed every localized string the same way data files
+    # feed templates — an i18n edit must invalidate cached pages too, or
+    # `build --cache` ships stale translations while `serve` (which watches
+    # i18n/) rebuilds correctly.
+    Dir.glob("data/**/*.{yml,yaml,json,toml}", "i18n/**/*.{yml,yaml,json,toml}") do |path|
       next if File.directory?(path)
       paths << path
     end

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -30,7 +30,74 @@ module Hwaro::Core::Build::Phases::ParseContent
     collect_assets(ctx)
     populate_taxonomies(ctx)
 
+    # Render <!-- more --> summaries with the body's pipeline now that every
+    # page's URL is final (internal-link resolution) — and before Transform,
+    # which bakes summary_html into Crinja page values.
+    if (site = @site) && (templates = @templates)
+      render_page_summaries(ctx.all_pages, site, templates, ctx.options.highlight && site.config.highlight.enabled)
+    end
+
     Lifecycle::HookResult::Continue
+  end
+
+  # Render each page's `<!-- more -->` summary through the same sub-pipeline
+  # as the body: shortcodes → configured Markdown (extensions, safe mode,
+  # emoji) → placeholder replacement → internal-link resolution. Rendering
+  # the raw chunk with bare Markdown.render leaked literal `{{ … }}` syntax
+  # into list pages / feeds / meta descriptions and silently dropped
+  # tables, footnotes, and emoji the body renders fine.
+  #
+  # Runs single-fiber between the parse fan-out and Transform. Site
+  # relationships (taxonomies, related posts) are not assembled yet, so a
+  # summary shortcode that queries them sees pre-Transform state — fine for
+  # the presentational shortcodes summaries realistically contain.
+  # `link_targets` is the page set internal `@/` links may point at —
+  # defaults to `pages`, which is correct for the full build (all pages) but
+  # must be passed explicitly by incremental callers that re-render only a
+  # subset. It can't come from `site.pages`: Transform populates that AFTER
+  # this runs in the full build (`site.pages = ctx.pages`, transform.cr).
+  private def render_page_summaries(
+    pages : Array(Models::Page),
+    site : Models::Site,
+    templates : Hash(String, String),
+    use_highlight : Bool,
+    link_targets : Array(Models::Page) = pages,
+  )
+    md_config = site.config.markdown
+    pages_by_path : Hash(String, Models::Page)? = nil
+
+    pages.each do |page|
+      summary_md = page.extract_summary
+      next unless summary_md
+
+      shortcode_results = {} of String => String
+      processed = if content_may_contain_shortcodes?(summary_md)
+                    context = build_template_variables(page, site, "", "", "")
+                    process_shortcodes_jinja(summary_md, templates, context, shortcode_results)
+                  else
+                    summary_md
+                  end
+
+      html, _ = Processor::Markdown.render(processed, use_highlight, md_config.safe, md_config.lazy_loading, md_config.emoji, markdown_config: md_config)
+      html = replace_shortcode_placeholders(html, shortcode_results)
+
+      pbp = (pages_by_path ||= begin
+        map = {} of String => Models::Page
+        link_targets.each { |p| map[p.path] ||= p }
+        map
+      end)
+      html = Content::Processors::InternalLinkResolver.resolve(html, pbp, page.path, site.config.base_url)
+      html = Content::Processors::InternalLinkResolver.prefix_root_relative_links(html, site.config.base_url)
+
+      page.summary_html = html
+    rescue ex
+      # A broken shortcode in a summary must not abort the whole parse
+      # phase — fall back to the plain-Markdown rendering and let the
+      # body render surface the real error with full diagnostics.
+      Logger.debug "Summary render failed for #{page.path}: #{ex.message}"
+      fallback, _ = Processor::Markdown.render(summary_md.to_s, markdown_config: md_config)
+      page.summary_html = fallback
+    end
   end
 
   # Default parsing when no hooks are registered.
@@ -197,14 +264,12 @@ module Hwaro::Core::Build::Phases::ParseContent
     page.calculate_word_count
     page.calculate_reading_time
 
-    # Extract summary from <!-- more --> marker. Stores the raw markdown
-    # chunk on the model; render it to HTML now so `page.summary` can
-    # expose proper HTML (not raw `# Heading` text) at template time —
-    # see https://github.com/hahwul/hwaro/issues/491.
-    if summary_md = page.extract_summary
-      summary_html, _ = Processor::Markdown.render(summary_md)
-      page.summary_html = summary_html
-    end
+    # Extract the <!-- more --> summary chunk (raw markdown) onto the model.
+    # Rendering to HTML happens in render_page_summaries after the parse
+    # fan-out — it needs every page's final URL (internal links) and the
+    # body's full pipeline (shortcodes, markdown extensions, emoji), none of
+    # which are available while pages are still being parsed in parallel.
+    page.extract_summary
 
     if page.is_a?(Models::Section)
       page.transparent = data[:transparent]

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -56,23 +56,32 @@ module Hwaro::Core::Build::Phases::ParseContent
   # must be passed explicitly by incremental callers that re-render only a
   # subset. It can't come from `site.pages`: Transform populates that AFTER
   # this runs in the full build (`site.pages = ctx.pages`, transform.cr).
+  #
+  # `global_vars` is a compute-once optimization for post-Transform callers
+  # (run_rerender). When nil, build_template_variables self-heals by building
+  # globals per shortcode-bearing page — cheap during the full-build call
+  # (site.pages is still empty pre-Transform) but O(site) per page after.
   private def render_page_summaries(
     pages : Array(Models::Page),
     site : Models::Site,
     templates : Hash(String, String),
     use_highlight : Bool,
     link_targets : Array(Models::Page) = pages,
+    global_vars : Hash(String, Crinja::Value)? = nil,
   )
     md_config = site.config.markdown
     pages_by_path : Hash(String, Models::Page)? = nil
 
     pages.each do |page|
-      summary_md = page.extract_summary
+      # parse_single_page already extracted the chunk into page.summary;
+      # extract_summary is only a fallback for hook-based parse paths that
+      # skipped it (it re-scans the whole raw_content, so don't repeat it).
+      summary_md = page.summary || page.extract_summary
       next unless summary_md
 
       shortcode_results = {} of String => String
       processed = if content_may_contain_shortcodes?(summary_md)
-                    context = build_template_variables(page, site, "", "", "")
+                    context = build_template_variables(page, site, "", "", "", global_vars: global_vars)
                     process_shortcodes_jinja(summary_md, templates, context, shortcode_results)
                   else
                     summary_md
@@ -92,10 +101,11 @@ module Hwaro::Core::Build::Phases::ParseContent
       page.summary_html = html
     rescue ex
       # A broken shortcode in a summary must not abort the whole parse
-      # phase — fall back to the plain-Markdown rendering and let the
-      # body render surface the real error with full diagnostics.
-      Logger.debug "Summary render failed for #{page.path}: #{ex.message}"
-      fallback, _ = Processor::Markdown.render(summary_md.to_s, markdown_config: md_config)
+      # phase — fall back to plain-Markdown rendering (same config flags,
+      # critically including safe mode) and let the body render surface
+      # the real error with full diagnostics.
+      Logger.warn "Summary render failed for #{page.path} — falling back to plain Markdown: #{ex.message}"
+      fallback, _ = Processor::Markdown.render(summary_md.to_s, use_highlight, md_config.safe, md_config.lazy_loading, md_config.emoji, markdown_config: md_config)
       page.summary_html = fallback
     end
   end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -58,36 +58,10 @@ module Hwaro::Core::Build::Phases::Render
 
     error_overlay = ctx.options.error_overlay
 
-    # Detect duplicate output paths (slug collisions and alias collisions)
-    # and pick a deterministic winner: the first claimant in source-path
-    # order. Losers skip writing that output — under parallel render the
-    # colliding file's bytes used to be whichever worker finished last,
-    # so a misconfigured slug flapped run-to-run.
-    seen_urls = Hash(String, String).new
-    suppressed = Hash(String, Set(String)).new
-    all_pages.sort_by(&.path).each do |page|
-      url = page.url
-      if prev_path = seen_urls[url]?
-        Logger.warn "Duplicate output path '#{url}' — '#{page.path}' collides with '#{prev_path}' and is not written"
-        (suppressed[page.path] ||= Set(String).new) << url
-      else
-        seen_urls[url] = page.path
-      end
-      # Alias destinations also produce output files; a second page claiming the
-      # same alias (or an alias clashing with a real page URL) would otherwise
-      # overwrite silently and render-order-dependently.
-      page.aliases.each do |a|
-        norm = a.starts_with?("/") ? a : "/#{a}"
-        norm = "#{norm}/" unless norm.ends_with?("/") || norm.ends_with?(".html") || norm.ends_with?(".htm")
-        if prev_path = seen_urls[norm]?
-          Logger.warn "Duplicate alias output path '#{norm}' — alias on '#{page.path}' collides with '#{prev_path}' and is not written"
-          (suppressed[page.path] ||= Set(String).new) << norm
-        else
-          seen_urls[norm] = page.path
-        end
-      end
-    end
-    @collision_suppressed = suppressed.empty? ? nil : suppressed
+    # Claim a deterministic owner for every output URL (slug collisions and
+    # alias collisions) — under parallel render the colliding file's bytes
+    # used to be whichever worker finished last, flapping run-to-run.
+    @output_url_winners = compute_output_url_winners(all_pages)
 
     # Fast-start mode: render only homepage + most recent N pages on this
     # pass and stash the rest on the Builder so a background fiber in
@@ -440,8 +414,14 @@ module Hwaro::Core::Build::Phases::Render
   # `cache.update` call: computing page_template_hash costs a shortcode-regex
   # scan over the raw content plus an MD5 per page, so it must be skipped
   # entirely when the cache is off.
+  #
+  # A collision loser gets NO cache entry: its output file holds the
+  # winner's bytes, and recording it as up-to-date would let
+  # filter_changed_pages skip the page forever — even after the collision
+  # is resolved and it becomes the rightful writer.
   private def record_page_cache_entry(page : Models::Page, cache : Cache, templates : Hash(String, String), site : Models::Site, output_dir : String)
     return unless cache.enabled?
+    return if collision_suppressed?(page, page.url)
     source_path, output_path = cache_paths_for(page, output_dir)
     fmt_paths = format_output_paths(page, output_dir, effective_output_formats(page, site.config))
     cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site), output_paths: fmt_paths)
@@ -821,8 +801,12 @@ module Hwaro::Core::Build::Phases::Render
       write_output(page, output_dir, final_html, verbose)
     end
 
-    render_output_formats(page, site, templates, output_dir, html_content, toc_html, toc_headers, verbose, global_vars,
-      crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+    # A collision loser must not write its sibling output-format files
+    # (index.json, index.md, …) either — they live at the same claimed URL.
+    unless collision_suppressed?(page, page.url)
+      render_output_formats(page, site, templates, output_dir, html_content, toc_html, toc_headers, verbose, global_vars,
+        crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+    end
 
     generate_aliases(page, site, output_dir, verbose)
   end
@@ -848,15 +832,59 @@ module Hwaro::Core::Build::Phases::Render
     Content::Processors::RenderHooks::HookRenderContext.new(registry, env, cache, cache_mutex, page_vars, site.config.markdown.mermaid)
   end
 
-  # True when this page lost the output-path collision for `url_key` (see the
-  # duplicate-output detection in execute_render_phase) and must not write it.
-  private def collision_suppressed?(page : Models::Page, url_key : String) : Bool
-    if sup = @collision_suppressed
-      if urls = sup[page.path]?
-        return urls.includes?(url_key)
+  # Claim a deterministic owner (page.path) for every output URL. Two passes,
+  # both in source-path order so a collision resolves identically on every
+  # build: real page URLs claim first — a page's own content always beats a
+  # redirect stub, whatever the path order — then aliases claim what's left.
+  # Pages with render=false never write output and therefore claim nothing.
+  #
+  # Recomputed by the full build and by the incremental/rerender paths, so a
+  # collision resolved (or introduced) during a serve session doesn't leave
+  # a stale winner suppressing writes until restart.
+  private def compute_output_url_winners(all_pages : Array(Models::Page)) : Hash(String, String)
+    winners = Hash(String, String).new
+    writers = all_pages.select(&.render).sort_by!(&.path)
+
+    writers.each do |page|
+      url = page.url
+      if prev_path = winners[url]?
+        Logger.warn "Duplicate output path '#{url}' — '#{page.path}' collides with '#{prev_path}' and is not written"
+      else
+        winners[url] = page.path
       end
     end
-    false
+
+    writers.each do |page|
+      page.aliases.each do |a|
+        norm = normalize_alias_url(a)
+        if prev_path = winners[norm]?
+          # An alias duplicating its OWN page's URL is silently ignored at
+          # write time (generate_aliases); only cross-page collisions warn.
+          unless prev_path == page.path
+            Logger.warn "Duplicate alias output path '#{norm}' — alias on '#{page.path}' collides with '#{prev_path}' and is not written"
+          end
+        else
+          winners[norm] = page.path
+        end
+      end
+    end
+
+    winners
+  end
+
+  # Shared by collision detection and alias writing so the suppression keys
+  # can never drift from the written paths.
+  private def normalize_alias_url(alias_path : String) : String
+    norm = alias_path.starts_with?("/") ? alias_path : "/#{alias_path}"
+    return norm if norm.ends_with?("/") || norm.ends_with?(".html") || norm.ends_with?(".htm")
+    "#{norm}/"
+  end
+
+  # True when this page is not the deterministic owner of `url_key` (see
+  # compute_output_url_winners) and must not write it.
+  private def collision_suppressed?(page : Models::Page, url_key : String) : Bool
+    return false unless winners = @output_url_winners
+    (winner = winners[url_key]?) ? winner != page.path : false
   end
 
   private def generate_redirect_page(
@@ -946,6 +974,8 @@ module Hwaro::Core::Build::Phases::Render
   end
 
   private def write_paginated_output(page : Models::Page, page_number : Int32, output_dir : String, content : String, verbose : Bool, paginate_path : String = "page")
+    # /page/N/ outputs live under the section's claimed URL.
+    return if collision_suppressed?(page, page.url)
     url_path = Utils::PathUtils.sanitize_path(page.url.lchop("/").rstrip("/"))
     output_path = File.join(output_dir, url_path, paginate_path, page_number.to_s, "index.html")
     return unless Utils::OutputGuard.within_output_dir?(output_path, output_dir)
@@ -1000,10 +1030,12 @@ module Hwaro::Core::Build::Phases::Render
   end
 
   private def generate_aliases(page : Models::Page, site : Models::Site, output_dir : String, verbose : Bool)
+    own_url = normalize_alias_url(page.url)
     page.aliases.each do |alias_path|
-      # Same normalization as the collision detection in execute_render_phase.
-      norm = alias_path.starts_with?("/") ? alias_path : "/#{alias_path}"
-      norm = "#{norm}/" unless norm.ends_with?("/") || norm.ends_with?(".html") || norm.ends_with?(".htm")
+      norm = normalize_alias_url(alias_path)
+      # An alias pointing at the page's own URL would overwrite the real
+      # content with a redirect stub to itself.
+      next if norm == own_url
       next if collision_suppressed?(page, norm)
 
       alias_clean = Utils::PathUtils.sanitize_path(alias_path.lchop("/"))

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -640,6 +640,15 @@ module Hwaro::Core::Build::Phases::Render
   ) : Int32
     count = 0
     safe = site.config.markdown.safe
+
+    # Mirror the parallel path's failure handling: render every page,
+    # accumulate failures, then fail loud once with the full picture.
+    # Aborting on the first bad page gave `--no-parallel` (the natural
+    # debugging flag) and incremental serve rebuilds *worse* diagnostics
+    # than the default build.
+    classified_error : Hwaro::HwaroError? = nil
+    failures = [] of NamedTuple(page_path: String, message: String)
+
     pages.each do |page|
       page_start = profiler ? Time.instant : nil
       render_page(page, site, templates, output_dir, minify, highlight, safe, verbose, global_vars, error_overlay: error_overlay, profiler: profiler)
@@ -650,7 +659,31 @@ module Hwaro::Core::Build::Phases::Render
       end
       record_page_cache_entry(page, cache, templates, site, output_dir)
       count += 1
+    rescue ex : Hwaro::HwaroError
+      classified_error ||= ex
+      failures << {page_path: page.path, message: ex.message.to_s}
+    rescue ex
+      failures << {page_path: page.path, message: ex.message.to_s}
+      Logger.debug "  Backtrace: #{ex.backtrace?.try(&.first(3).join("\n    ")) || "unavailable"}"
     end
+
+    report_render_failures(failures, verbose) unless failures.empty?
+
+    # Same contract as process_files_parallel: surface the first classified
+    # error for the documented exit code, and promote generic exceptions so
+    # a crash can't report success.
+    if err = classified_error
+      raise err
+    end
+
+    unless failures.empty?
+      first = failures.first
+      raise Hwaro::HwaroError.new(
+        code: Hwaro::Errors::HWARO_E_TEMPLATE,
+        message: "Render failed for #{failures.size} page(s); first failure on #{first[:page_path]}: #{first[:message]}",
+      )
+    end
+
     count
   end
 

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -538,24 +538,32 @@ module Hwaro::Core::Build::Phases::Render
       count += 1 if results.receive
     end
 
-    # Emit the (deduped) failure summary before surfacing the classified
-    # error, so users see both the list of affected pages and the final
-    # `Error [HWARO_E_TEMPLATE]: …` line.
+    finalize_render_failures(failures, classified_error, verbose)
+
+    count
+  end
+
+  # Shared failure epilogue for the parallel and sequential render loops —
+  # one copy of the exit-code/message contract so the two paths can't drift.
+  #
+  # Emits the (deduped) failure summary first, then surfaces the first
+  # classified error so the CLI sees the documented exit code / JSON payload
+  # instead of a silent `status=ok, pages_generated=0`. Generic exceptions
+  # (Crystal-level bugs, non-Crinja crashes) used to slip through — with no
+  # classified error to raise the build returned its success count and the
+  # CLI happily printed `Build complete!` even when pages crashed. Promote
+  # the first such failure to `HWARO_E_TEMPLATE` so the build fails loud (#490).
+  private def finalize_render_failures(
+    failures : Array(NamedTuple(page_path: String, message: String)),
+    classified_error : Hwaro::HwaroError?,
+    verbose : Bool,
+  )
     report_render_failures(failures, verbose) unless failures.empty?
 
-    # Surface the first classified error now that all workers have drained
-    # so the CLI sees the documented exit code / JSON payload instead of
-    # a silent `status=ok, pages_generated=0`.
     if err = classified_error
       raise err
     end
 
-    # Generic exceptions (Crystal-level bugs, non-Crinja crashes) used to
-    # slip through here — workers logged them to `failures`, but with no
-    # classified error to raise the build returned its success count and
-    # the CLI happily printed `Build complete! Generated 2 pages` even
-    # when 9 pages crashed. Promote the first such failure to a
-    # `HWARO_E_TEMPLATE` so the build fails loud (#490).
     unless failures.empty?
       first = failures.first
       raise Hwaro::HwaroError.new(
@@ -563,8 +571,6 @@ module Hwaro::Core::Build::Phases::Render
         message: "Render failed for #{failures.size} page(s); first failure on #{first[:page_path]}: #{first[:message]}",
       )
     end
-
-    count
   end
 
   # Collapse identical errors raised across many pages (typical of a
@@ -647,22 +653,7 @@ module Hwaro::Core::Build::Phases::Render
       Logger.debug "  Backtrace: #{ex.backtrace?.try(&.first(3).join("\n    ")) || "unavailable"}"
     end
 
-    report_render_failures(failures, verbose) unless failures.empty?
-
-    # Same contract as process_files_parallel: surface the first classified
-    # error for the documented exit code, and promote generic exceptions so
-    # a crash can't report success.
-    if err = classified_error
-      raise err
-    end
-
-    unless failures.empty?
-      first = failures.first
-      raise Hwaro::HwaroError.new(
-        code: Hwaro::Errors::HWARO_E_TEMPLATE,
-        message: "Render failed for #{failures.size} page(s); first failure on #{first[:page_path]}: #{first[:message]}",
-      )
-    end
+    finalize_render_failures(failures, classified_error, verbose)
 
     count
   end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -59,11 +59,17 @@ module Hwaro::Core::Build::Phases::Render
     error_overlay = ctx.options.error_overlay
 
     # Detect duplicate output paths (slug collisions and alias collisions)
+    # and pick a deterministic winner: the first claimant in source-path
+    # order. Losers skip writing that output — under parallel render the
+    # colliding file's bytes used to be whichever worker finished last,
+    # so a misconfigured slug flapped run-to-run.
     seen_urls = Hash(String, String).new
-    all_pages.each do |page|
+    suppressed = Hash(String, Set(String)).new
+    all_pages.sort_by(&.path).each do |page|
       url = page.url
       if prev_path = seen_urls[url]?
-        Logger.warn "Duplicate output path '#{url}' — '#{page.path}' overwrites '#{prev_path}'"
+        Logger.warn "Duplicate output path '#{url}' — '#{page.path}' collides with '#{prev_path}' and is not written"
+        (suppressed[page.path] ||= Set(String).new) << url
       else
         seen_urls[url] = page.path
       end
@@ -74,12 +80,14 @@ module Hwaro::Core::Build::Phases::Render
         norm = a.starts_with?("/") ? a : "/#{a}"
         norm = "#{norm}/" unless norm.ends_with?("/") || norm.ends_with?(".html") || norm.ends_with?(".htm")
         if prev_path = seen_urls[norm]?
-          Logger.warn "Duplicate alias output path '#{norm}' — '#{page.path}' overwrites '#{prev_path}'"
+          Logger.warn "Duplicate alias output path '#{norm}' — alias on '#{page.path}' collides with '#{prev_path}' and is not written"
+          (suppressed[page.path] ||= Set(String).new) << norm
         else
           seen_urls[norm] = page.path
         end
       end
     end
+    @collision_suppressed = suppressed.empty? ? nil : suppressed
 
     # Fast-start mode: render only homepage + most recent N pages on this
     # pass and stash the rest on the Builder so a background fiber in
@@ -807,6 +815,17 @@ module Hwaro::Core::Build::Phases::Render
     Content::Processors::RenderHooks::HookRenderContext.new(registry, env, cache, cache_mutex, page_vars, site.config.markdown.mermaid)
   end
 
+  # True when this page lost the output-path collision for `url_key` (see the
+  # duplicate-output detection in execute_render_phase) and must not write it.
+  private def collision_suppressed?(page : Models::Page, url_key : String) : Bool
+    if sup = @collision_suppressed
+      if urls = sup[page.path]?
+        return urls.includes?(url_key)
+      end
+    end
+    false
+  end
+
   private def generate_redirect_page(
     page : Models::Page,
     output_dir : String,
@@ -814,6 +833,7 @@ module Hwaro::Core::Build::Phases::Render
   )
     redirect_url = page.redirect_to
     return unless redirect_url
+    return if collision_suppressed?(page, page.url)
 
     url_path = Utils::PathUtils.sanitize_path(page.url.lchop("/"))
     candidate = File.join(output_dir, url_path, "index.html")
@@ -948,6 +968,11 @@ module Hwaro::Core::Build::Phases::Render
 
   private def generate_aliases(page : Models::Page, site : Models::Site, output_dir : String, verbose : Bool)
     page.aliases.each do |alias_path|
+      # Same normalization as the collision detection in execute_render_phase.
+      norm = alias_path.starts_with?("/") ? alias_path : "/#{alias_path}"
+      norm = "#{norm}/" unless norm.ends_with?("/") || norm.ends_with?(".html") || norm.ends_with?(".htm")
+      next if collision_suppressed?(page, norm)
+
       alias_clean = Utils::PathUtils.sanitize_path(alias_path.lchop("/"))
       # An alias that already names an HTML file (`/legacy.html`,
       # `/old/index.html`) is written to that exact path; only "pretty"

--- a/src/core/build/phases/write.cr
+++ b/src/core/build/phases/write.cr
@@ -169,6 +169,9 @@ module Hwaro::Core::Build::Phases::Write
   end
 
   private def write_output(page : Models::Page, output_dir : String, content : String, verbose : Bool)
+    # A page that lost an output-path collision renders normally (its content
+    # still feeds listings/feeds/search) but must not race the winner on disk.
+    return if collision_suppressed?(page, page.url)
     output_path = get_output_path(page, output_dir)
 
     ensure_dir(Path[output_path].dirname.to_s)

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -12,6 +12,7 @@
 
 require "crinja"
 require "../../utils/logger"
+require "../../content/processors/fence_tracker"
 require "./builtin_shortcodes"
 
 module Hwaro
@@ -67,23 +68,13 @@ module Hwaro
         def content_may_contain_shortcodes?(content : String) : Bool
           return false unless content.includes?("{{") || content.includes?("{%")
 
-          in_fence = false
-          fence_marker = ""
+          # FenceTracker (shared with the table/definition/math walkers and,
+          # critically, process_shortcodes_jinja below) so the skip decision
+          # and the actual expansion can never disagree about what's fenced.
+          tracker = Content::Processors::FenceTracker.new
 
           content.each_line(chomp: false) do |line|
-            if in_fence
-              if fence_close_line?(line, fence_marker)
-                in_fence = false
-                fence_marker = ""
-              end
-              next
-            end
-
-            if match = line.match(/^\s*(`{3,}|~{3,})/)
-              in_fence = true
-              fence_marker = match[1]
-              next
-            end
+            next if tracker.fence_line?(line)
 
             # Outside fence: check whether any {{ or {% survives inline-code stripping
             if line.includes?("{{") || line.includes?("{%")
@@ -94,16 +85,6 @@ module Hwaro
           end
 
           false
-        end
-
-        # A fence-closing line is the opening marker alone, surrounded only by
-        # whitespace — equivalent to the previous per-fence compiled regex
-        # `^\s*MARKER\s*$` (Crystal regexes run with UCP, so `\s` and
-        # `String#strip` agree on Unicode whitespace). A longer run (e.g.
-        # ```` closing ```) does not match, same as before. The comparison
-        # replaces a PCRE2 compile per fenced block per page render.
-        private def fence_close_line?(line : String, fence_marker : String) : Bool
-          line.strip == fence_marker
         end
 
         private def has_shortcode_token_outside_inline_code?(line : String) : Bool
@@ -126,9 +107,13 @@ module Hwaro
         private def process_shortcodes_jinja(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)? = nil, crinja_env_override : Crinja? = nil, template_cache_override : Hash(UInt64, Crinja::Template)? = nil) : String
           # Avoid processing shortcodes inside fenced code blocks (``` / ~~~),
           # so documentation can show literal `{{ ... }}` examples safely.
+          # Fence semantics come from the shared CommonMark-faithful
+          # FenceTracker (indent rules, closer-length rule, backtick-in-info
+          # rule) — the previous ad-hoc regex opened on indented ``` (literal
+          # text in CommonMark) and never closed on a longer closer run,
+          # desyncing fence state for the rest of the document.
           String.build do |io|
-            in_fence = false
-            fence_marker = ""
+            tracker = Content::Processors::FenceTracker.new
             buffer = String::Builder.new
             # Nesting depth of open block shortcodes. While > 0 we must NOT treat
             # a fence line as a buffer boundary, otherwise a block shortcode whose
@@ -137,12 +122,9 @@ module Hwaro
             block_depth = 0
 
             content.each_line(chomp: false) do |line|
-              if in_fence
+              if tracker.in_fence?
+                tracker.fence_line?(line)
                 io << line
-                if fence_close_line?(line, fence_marker)
-                  in_fence = false
-                  fence_marker = ""
-                end
                 next
               end
 
@@ -161,11 +143,13 @@ module Hwaro
                 block_depth -= 1 if block_depth > 0
               end
 
-              if block_depth == 0 && (match = line.match(/^\s*(`{3,}|~{3,})/))
+              # The tracker is only fed outside block-shortcode bodies (the
+              # short-circuit below), mirroring the previous behaviour where
+              # a fence inside a block body is part of the body, not a chunk
+              # boundary.
+              if block_depth == 0 && tracker.fence_line?(line)
                 io << process_shortcodes_in_text(buffer.to_s, templates, context, shortcode_results, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
                 buffer = String::Builder.new
-                in_fence = true
-                fence_marker = match[1]
                 io << line
               else
                 buffer << line

--- a/src/ext/stb_bindings.cr
+++ b/src/ext/stb_bindings.cr
@@ -26,7 +26,13 @@ lib LibStb
                              quality : LibC::Int, out_buf : UInt8**, out_len : LibC::Int*) : LibC::Int
 
   # --- stb_image_resize2 ---
-  fun stbir_resize_uint8_linear(input_pixels : UInt8*, input_w : LibC::Int, input_h : LibC::Int, input_stride_in_bytes : LibC::Int, output_pixels : UInt8*, output_w : LibC::Int, output_h : LibC::Int, output_stride_in_bytes : LibC::Int, num_channels : LibC::Int) : UInt8*
+  # sRGB-aware resize: JPG/PNG pixel data is gamma-encoded, so filtering must
+  # happen in linear light and re-encode. The `_linear` variant treats sRGB
+  # bytes as linear-light values, which visibly darkens edges/thin lines on
+  # downscale. The last parameter is stbir_pixel_layout; casting the channel
+  # count maps 1→1CHANNEL, 2→2CHANNEL, 3→RGB, 4→RGBA (alpha kept linear and
+  # weighted during filtering), matching how these callers decode.
+  fun stbir_resize_uint8_srgb(input_pixels : UInt8*, input_w : LibC::Int, input_h : LibC::Int, input_stride_in_bytes : LibC::Int, output_pixels : UInt8*, output_w : LibC::Int, output_h : LibC::Int, output_stride_in_bytes : LibC::Int, pixel_layout : LibC::Int) : UInt8*
 
   # --- stb_truetype (via hwaro C wrappers) ---
   # Font info is an opaque pointer managed by hwaro_font_alloc/free

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1239,6 +1239,8 @@ module Hwaro
           end
         end
 
+        warn_unknown_top_level_keys(config.raw, config_path)
+
         config.title = config.raw["title"]?.try(&.as_s?) || config.title
         config.description = config.raw["description"]?.try(&.as_s?) || config.description
         if raw_base_url = config.raw["base_url"]?.try(&.as_s?)
@@ -1289,6 +1291,28 @@ module Hwaro
       end
 
       # --- Private helpers -----------------------------------------------------------
+
+      # Every top-level key `load` reads (scalars + `load_*` section names).
+      # Used to warn on unrecognized keys instead of silently ignoring them —
+      # a typo'd `[markdonw]` or `titel =` otherwise disables a feature with
+      # zero feedback. Templates cannot read arbitrary raw config keys (the
+      # site/config objects expose structured fields only), so an unknown
+      # top-level key is always dead configuration.
+      KNOWN_TOP_LEVEL_KEYS = %w[
+        title description base_url default_language
+        amp assets auto_includes build content deployment doctor feeds
+        highlight image_processing languages llms markdown menus og outputs
+        pagination permalinks plugins pwa related robots search series serve
+        sitemap static taxonomies
+      ]
+
+      private def self.warn_unknown_top_level_keys(raw : Hash(String, TOML::Any), config_path : String)
+        raw.each_key do |key|
+          next if KNOWN_TOP_LEVEL_KEYS.includes?(key)
+          hint = Utils::CommandSuggester.suggest(key, KNOWN_TOP_LEVEL_KEYS).try { |s| " Did you mean '#{s}'?" } || ""
+          Logger.warn "Unknown key '#{key}' in #{config_path} — hwaro does not read it.#{hint}"
+        end
+      end
 
       # Parse a TOML string, re-raising any parser failure as a classified
       # `HWARO_E_CONFIG` error so the CLI maps it to exit code 3 and the

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -236,6 +236,10 @@ module Hwaro
       getter modified_templates : Array(String)
       # Static files that were *modified*
       getter modified_static : Array(String)
+      # Data / i18n files (data/**, i18n/**) that were *modified*. Templates
+      # read `site.data` and translations feed every localized string, so any
+      # page may depend on these — a change here forces a full rebuild.
+      getter modified_data : Array(String)
       # Files that were added (new) – present in current scan but not previous
       getter added_files : Array(String)
       # Files that were removed – present in previous scan but not current
@@ -251,6 +255,7 @@ module Hwaro
         @removed_files : Array(String),
         @config_changed : Bool,
         @modified_content_files : Array(String) = [] of String,
+        @modified_data : Array(String) = [] of String,
       )
       end
 
@@ -260,16 +265,19 @@ module Hwaro
           @modified_content_files.empty? &&
           @modified_templates.empty? &&
           @modified_static.empty? &&
+          @modified_data.empty? &&
           @added_files.empty? &&
           @removed_files.empty? &&
           !@config_changed
       end
 
       # True when a full rebuild is unavoidable:
-      # config changed, or files were added / deleted (which affects
-      # section lists, navigation, taxonomy indices, etc.)
+      # config changed, data/i18n changed (any page may read them), or files
+      # were added / deleted (which affects section lists, navigation,
+      # taxonomy indices, etc.)
       def needs_full_rebuild? : Bool
-        @config_changed || !@added_files.empty? || !@removed_files.empty?
+        @config_changed || !@added_files.empty? || !@removed_files.empty? ||
+          !@modified_data.empty?
       end
 
       # True when only template files were modified (no content / static / structural changes)
@@ -278,6 +286,7 @@ module Hwaro
           @modified_content.empty? &&
           @modified_content_files.empty? &&
           @modified_static.empty? &&
+          @modified_data.empty? &&
           @added_files.empty? &&
           @removed_files.empty? &&
           !@config_changed
@@ -289,6 +298,7 @@ module Hwaro
           @modified_content.empty? &&
           @modified_content_files.empty? &&
           @modified_templates.empty? &&
+          @modified_data.empty? &&
           @added_files.empty? &&
           @removed_files.empty? &&
           !@config_changed
@@ -301,6 +311,7 @@ module Hwaro
           @modified_content.empty? &&
           @modified_templates.empty? &&
           @modified_static.empty? &&
+          @modified_data.empty? &&
           @added_files.empty? &&
           @removed_files.empty? &&
           !@config_changed
@@ -310,6 +321,7 @@ module Hwaro
       def content_and_template_only? : Bool
         !@modified_content.empty? &&
           !@modified_templates.empty? &&
+          @modified_data.empty? &&
           @added_files.empty? &&
           @removed_files.empty? &&
           !@config_changed
@@ -320,6 +332,7 @@ module Hwaro
       def content_incremental? : Bool
         !@modified_content.empty? &&
           @modified_templates.empty? &&
+          @modified_data.empty? &&
           @added_files.empty? &&
           @removed_files.empty? &&
           !@config_changed
@@ -350,6 +363,7 @@ module Hwaro
           modified_content_files: (@modified_content_files + other.modified_content_files).uniq,
           modified_templates: (@modified_templates + other.modified_templates).uniq,
           modified_static: (@modified_static + other.modified_static).uniq,
+          modified_data: (@modified_data + other.modified_data).uniq,
           added_files: net_added,
           removed_files: net_removed,
           config_changed: @config_changed || other.config_changed,
@@ -386,6 +400,7 @@ module Hwaro
           "content-asset" => @modified_content_files,
           "template"      => @modified_templates,
           "static"        => @modified_static,
+          "data"          => @modified_data,
           "added"         => @added_files,
           "removed"       => @removed_files,
         }.each do |label, list|
@@ -411,7 +426,7 @@ module Hwaro
 
       private def all_changed_files : Array(String)
         @modified_content + @modified_content_files + @modified_templates +
-          @modified_static + @added_files + @removed_files
+          @modified_static + @modified_data + @added_files + @removed_files
       end
     end
 
@@ -540,7 +555,7 @@ module Hwaro
         serve_receipt = Logger::Receipt.new("serve")
         serve_receipt.row("url", url, Logger::Role::Accent)
         serve_receipt.row("reload", live_reload ? "enabled" : "disabled")
-        serve_receipt.row("watch", "content · templates · static · config")
+        serve_receipt.row("watch", "content · templates · static · data · i18n · config")
         serve_receipt.outcome("ready", "Ctrl+C to stop", :ready)
         serve_receipt.emit
 
@@ -776,6 +791,7 @@ module Hwaro
         modified_content_files = [] of String
         modified_templates = [] of String
         modified_static = [] of String
+        modified_data = [] of String
         added_files = [] of String
         removed_files = [] of String
         config_changed = false
@@ -788,7 +804,7 @@ module Hwaro
             if path == "config.toml"
               config_changed = true
             else
-              classify_modified(path, modified_content, modified_content_files, modified_templates, modified_static)
+              classify_modified(path, modified_content, modified_content_files, modified_templates, modified_static, modified_data)
             end
           else
             # New file (exists now, didn't before)
@@ -808,6 +824,7 @@ module Hwaro
           modified_content_files: modified_content_files,
           modified_templates: modified_templates,
           modified_static: modified_static,
+          modified_data: modified_data,
           added_files: added_files,
           removed_files: removed_files,
           config_changed: config_changed,
@@ -826,6 +843,7 @@ module Hwaro
         content_files : Array(String),
         templates : Array(String),
         static : Array(String),
+        data : Array(String),
       )
         if path.starts_with?("content/")
           if path.downcase.ends_with?(".md")
@@ -837,6 +855,8 @@ module Hwaro
           templates << path
         elsif path.starts_with?("static/")
           static << path
+        elsif path.starts_with?("data/") || path.starts_with?("i18n/")
+          data << path
         end
       end
 
@@ -989,7 +1009,7 @@ module Hwaro
 
       private def scan_mtimes : Hash(String, Time)
         mtimes = {} of String => Time
-        dirs_to_watch = ["content", "templates", "static"]
+        dirs_to_watch = ["content", "templates", "static", "data", "i18n"]
 
         dirs_to_watch.each do |dir|
           next unless Dir.exists?(dir)


### PR DESCRIPTION
## Summary

Seven correctness/DX fixes from an SSG-quality audit of the codebase, one commit per fix:

- **fix(serve): watch `data/` and `i18n/`** — editing a data file or translation now triggers a rebuild + live reload (previously served stale values until restart). Routed to a full rebuild since any page can read `site.data`/translations.
- **fix(build): deterministic winner on URL/alias collisions** — colliding output paths used to be written by whichever parallel worker finished last (run-to-run flapping bytes). First claimant in source-path order now wins; losers still render (feeds/listings intact) but skip the colliding write. An alias can no longer stomp a real page's `index.html`.
- **fix(build): aggregate sequential render failures** — `--no-parallel` and incremental serve rebuilds now render every page, report failures once (deduped), and fail loud with the classified error — matching the parallel path instead of aborting at the first bad page.
- **fix(content): render `<!-- more -->` summaries through the body pipeline** — summaries previously leaked literal `{{ … }}` shortcode syntax and dropped tables/footnotes/emoji/`@/` links in list pages, feeds, and meta descriptions. They now run the body's sub-pipeline (shortcodes → configured Markdown → placeholders → link resolution) between parse and Transform, with incremental/rerender paths covered.
- **fix(shortcodes): shared CommonMark FenceTracker** — the ad-hoc fence regex opened on 4-space-indented ``` (literal text per CommonMark), never closed on a longer closer run (desyncing the rest of the document), and mis-opened backtick fences with a backtick in the info string. Pre-filter and expansion now share one tracker.
- **fix(images): sRGB-correct resizing** — all five resize sites (content, LQIP, responsive variants, OG background/logo) switched from `stbir_resize_uint8_linear` to `stbir_resize_uint8_srgb`; linear filtering of gamma-encoded pixels visibly darkened edges on downscale.
- **feat(config): unknown top-level key warnings** — `[markdonw]` / `titel = …` were silently ignored; the loader now warns with a did-you-mean suggestion. Includes drift guards (SECTION_REGISTRY ⊆ known keys; generated default configs load warning-free).

## Test plan

- Full suite: 6,132 examples, 0 failures (includes new specs for each fix)
- `crystal tool format --check` clean
- End-to-end: docs site builds cleanly with the new binary (no spurious unknown-key warnings, 127 resized images regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)