### PR TITLE
perf(highlight): parallelize server-side syntax highlighting

### DIFF
--- a/spec/unit/scaffolds_assets_spec.cr
+++ b/spec/unit/scaffolds_assets_spec.cr
@@ -59,10 +59,11 @@ describe "Scaffold embedded assets" do
   end
 
   describe "ember-warm syntax highlighting" do
-    # The default is client-side Highlight.js (`mode = "client"`): the
-    # server/Tartrazine path is not multi-thread-safe, and the release binary
-    # is built `-Dpreview_mt`, so a parallel `hwaro build` could corrupt
-    # highlighted output. The warm theme is inlined either way.
+    # The default is client-side Highlight.js (`mode = "client"`). The
+    # server/Tartrazine path is multi-thread-safe nowadays (see
+    # ext/tartrazine_mt_fix.cr), so this is a product default — zero
+    # build-time cost and full hljs theme compatibility — rather than a
+    # safety requirement. The warm theme is inlined either way.
     it "defaults to client-side highlighting (mode = \"client\")" do
       {
         Hwaro::Services::Scaffolds::Simple.new,

--- a/spec/unit/syntax_highlighter_spec.cr
+++ b/spec/unit/syntax_highlighter_spec.cr
@@ -391,3 +391,30 @@ describe "fence options rendering (server mode)" do
     reset_fence_options_state
   end
 end
+
+describe Hwaro::Content::Processors::ServerHighlighter do
+  describe ".highlight" do
+    it "escapes HTML special characters in highlighted output" do
+      html = Hwaro::Content::Processors::ServerHighlighter.highlight(%q(puts "<b>&"), "crystal")
+      html.should_not be_nil
+      html.not_nil!.should contain("&lt;b&gt;")
+      html.not_nil!.should_not contain("<b>")
+    end
+
+    it "sanitizes invalid UTF-8 in tokenized output to U+FFFD like HTML.escape" do
+      # The tokenizer's Error fallback emits unmatched input one BYTE at a
+      # time, so a multi-byte character no rule matches arrives as lone
+      # lead/continuation bytes — an invalid-UTF-8 token value. The old
+      # unconditional HTML.escape replaced those bytes with U+FFFD; the
+      # needs_html_escape? fast path must preserve that instead of copying
+      # the raw bytes into the output HTML.
+      code = String.new(Bytes[0x68_u8, 0x69_u8, 0x20_u8, 0xE2_u8, 0x0A_u8]) # "hi " + lone lead byte + "\n"
+      html = Hwaro::Content::Processors::ServerHighlighter.highlight(code, "json")
+      html.should_not be_nil
+      html.not_nil!.valid_encoding?.should be_true
+      # The lone 0xE2 must surface as U+FFFD — this both pins the
+      # sanitization and proves the invalid-byte path was exercised.
+      html.not_nil!.should contain("�")
+    end
+  end
+end

--- a/src/content/processors/syntax_highlighter.cr
+++ b/src/content/processors/syntax_highlighter.cr
@@ -16,6 +16,7 @@
 
 require "markd"
 require "tartrazine"
+require "../../ext/tartrazine_mt_fix"
 require "digest/md5"
 require "./table_parser"
 require "./markdown_extensions"
@@ -91,21 +92,34 @@ module Hwaro
         @@unknown_languages = Set(String).new
         @@unknown_mutex = Mutex.new
 
-        # Serializes ALL Tartrazine work (lexer acquisition + tokenization).
-        # The shard's compiled rules each hold a single PCRE2 match_data
-        # buffer reused by every match() call (bytes_regex.cr), and those
-        # rules are shared across lexer instances via the template cache —
-        # so two -Dpreview_mt workers tokenizing the same language corrupt
-        # each other's matches. That raised intermittently, and the rescue
-        # below silently degraded random code blocks to plain output,
-        # making build output nondeterministic.
-        @@tartrazine_mutex = Mutex.new
+        # Tokenization runs in parallel across -Dpreview_mt workers.
+        # It used to be serialized behind a global mutex here: the shard's
+        # compiled rules each held a single PCRE2 match_data buffer reused
+        # by every match() call and shared across lexer instances via the
+        # template cache, so two workers tokenizing the same language
+        # corrupted each other's matches (raising intermittently, which the
+        # rescue below degraded to nondeterministic plain output). That
+        # shared state — and the template cache's unsynchronized fast path,
+        # and `combined` actions mutating the shared states Hash — is fixed
+        # at the source in ext/tartrazine_mt_fix.cr, so correctness no
+        # longer needs a lock around Tartrazine work.
+        #
+        # Concurrency is still BOUNDED, not unlimited: tokenization is
+        # allocation-dense (token values, per-rule arrays), and past ~4
+        # simultaneous tokenizers the Boehm GC's global allocation lock
+        # becomes a convoy that slows the WHOLE build (measured: a
+        # 5k-page site with 10k unique code blocks at 8 workers built
+        # ~25% slower fully unbounded than with this cap, while small and
+        # mid-size sites kept their full parallel speedup). A buffered
+        # channel acts as a counting semaphore; blocked fibers suspend —
+        # the worker thread moves on to other pages meanwhile.
+        TOKENIZE_SLOTS = 4
+        @@tokenize_gate = Channel(Nil).new(TOKENIZE_SLOTS)
 
         # Highlighted-output memo keyed by (language, code digest). Output
         # is a pure function of the input pair, so identical code blocks —
         # repeated install snippets, shortcode bodies, serve-mode rebuilds —
-        # skip tokenization entirely. Also keeps the serialized section
-        # above from becoming a bottleneck on code-heavy sites. `nil`
+        # skip tokenization entirely. `nil`
         # (tokenization failed, deterministic now) is cached too.
         #
         # Cache holds pre-wrap span HTML only; key (lang, md5(code)) stays
@@ -138,31 +152,35 @@ module Hwaro
             end
           end
 
-          result = @@tartrazine_mutex.synchronize do
-            lexer = begin
-              Tartrazine.lexer(normalized)
-            rescue
-              @@unknown_mutex.synchronize { @@unknown_languages << normalized }
-              Logger.debug "Server highlight: no lexer for '#{normalized}', falling back to plain output"
-              return
-            end
+          lexer = begin
+            Tartrazine.lexer(normalized)
+          rescue
+            @@unknown_mutex.synchronize { @@unknown_languages << normalized }
+            Logger.debug "Server highlight: no lexer for '#{normalized}', falling back to plain output"
+            return
+          end
 
-            begin
-              String.build do |io|
-                lexer.tokenizer(code).each do |token|
-                  value = HTML.escape(token[:value])
-                  if css_class = class_for(token[:type])
-                    io << %(<span class=") << css_class << %(">) << value << "</span>"
-                  else
-                    io << value
-                  end
+          @@tokenize_gate.send(nil)
+          result = begin
+            String.build do |io|
+              lexer.tokenizer(code).each do |token|
+                value = token[:value]
+                # Most tokens (keywords, identifiers, whitespace) need no
+                # escaping — skip HTML.escape's char-by-char rebuild for them.
+                value = HTML.escape(value) if needs_html_escape?(value)
+                if css_class = class_for(token[:type])
+                  io << %(<span class=") << css_class << %(">) << value << "</span>"
+                else
+                  io << value
                 end
               end
-            rescue ex
-              # A lexer bug must never take down the build — degrade to plain.
-              Logger.debug "Server highlight failed for '#{lang}': #{ex.message}"
-              nil
             end
+          rescue ex
+            # A lexer bug must never take down the build — degrade to plain.
+            Logger.debug "Server highlight failed for '#{lang}': #{ex.message}"
+            nil
+          ensure
+            @@tokenize_gate.receive
           end
 
           if cache_key
@@ -172,6 +190,34 @@ module Hwaro
             end
           end
           result
+        end
+
+        # True when `value` contains any character HTML.escape substitutes
+        # (`& < > " '` — see HTML::SUBSTITUTIONS) or any non-ASCII byte.
+        # The five specials are ASCII, so the byte scan is exact for UTF-8.
+        #
+        # Bytes >= 0x80 are routed through HTML.escape too — NOT because
+        # they need escaping, but because a token can be invalid UTF-8:
+        # the tokenizer's Error fallback emits unmatched input one BYTE at
+        # a time, so a multi-byte character no rule matched arrives as
+        # lone lead/continuation bytes. The String-returning HTML.escape
+        # iterates chars and replaces those with U+FFFD, exactly like the
+        # pre-fast-path code always did; skipping it would leak invalid
+        # UTF-8 into the output HTML. (Valid multi-byte text passes
+        # through escape content-unchanged, so this only costs the clean
+        # fast path for non-ASCII tokens — do not "optimize" this onto
+        # the HTML.escape(value, io) overload, which copies raw bytes and
+        # performs no U+FFFD replacement.)
+        private def needs_html_escape?(value : String) : Bool
+          value.each_byte do |byte|
+            case byte
+            when 0x26_u8, 0x3C_u8, 0x3E_u8, 0x22_u8, 0x27_u8 # & < > " '
+              return true
+            else
+              return true if byte >= 0x80_u8
+            end
+          end
+          false
         end
 
         private def class_for(token_type : String) : String?
@@ -346,8 +392,8 @@ module Hwaro
       # Wraps already-highlighted (or plain-escaped) code body HTML with
       # per-line `<span class="line">` markup for line numbers / highlighted
       # lines — pure string post-processing, zero Tartrazine calls, applied
-      # AFTER (and outside) `ServerHighlighter`'s mutex-guarded tokenization,
-      # over its already-cached result.
+      # AFTER (and outside) `ServerHighlighter`'s gated tokenization, over
+      # its already-cached result.
       module LineWrapper
         extend self
 

--- a/src/content/processors/table_parser.cr
+++ b/src/content/processors/table_parser.cr
@@ -197,45 +197,66 @@ module Hwaro
         # code-span guard a cell like `` `a|b` `` gets split mid-span, which
         # corrupts the code span (dangling backticks) and pushes a stray extra
         # `<td>` past the column count.
+        # Scans BYTES rather than a materialized Array(Char): every byte the
+        # scanner branches on (`\`, `` ` ``, `|`) is ASCII, and in UTF-8 the
+        # bytes of a multi-byte character are all >= 0x80, so they can never
+        # be mistaken for a delimiter — non-special stretches are copied to
+        # the cell verbatim. This runs for every row of every table on a
+        # page; the per-row Array(Char) it replaces was one of the largest
+        # allocation sources under parallel rendering (the Boehm GC
+        # allocation lock is the contention point across workers).
         private def split_row(line : String) : Array(String)
+          # `strip` must stay a String op (it handles Unicode whitespace);
+          # it returns self when there is nothing to strip. The leading /
+          # trailing pipe trims are ASCII, so instead of lchop/rchop —
+          # which each heap-allocate a fresh String for the common
+          # `| a | b |` shape — narrow the slice view (subslicing copies
+          # nothing). Ordering matches the old sequential lchop-then-rchop:
+          # the trailing check runs on the remainder, so a lone "|" trims
+          # to "" exactly as before.
           stripped = line.strip
-
-          # Remove leading pipe if present
-          stripped = stripped.lchop('|') if stripped.starts_with?('|')
-
-          # Remove trailing pipe if present
-          stripped = stripped.rchop('|') if stripped.ends_with?('|')
+          bytes = stripped.to_slice
+          if bytes.size > 0 && bytes[0] == 0x7C_u8 # leading '|'
+            bytes = bytes[1, bytes.size - 1]
+          end
+          if bytes.size > 0 && bytes[bytes.size - 1] == 0x7C_u8 # trailing '|'
+            bytes = bytes[0, bytes.size - 1]
+          end
 
           cells = [] of String
           current = String::Builder.new
+          len = bytes.size
           i = 0
-          chars = stripped.chars
 
-          while i < chars.size
-            char = chars[i]
-            if char == '\\' && i + 1 < chars.size && chars[i + 1] == '|'
+          while i < len
+            byte = bytes[i]
+            if byte == 0x5C_u8 && i + 1 < len && bytes[i + 1] == 0x7C_u8 # '\' '|'
               # Escaped pipe - include literal pipe
               current << '|'
               i += 2
-            elsif char == '`'
+            elsif byte == 0x60_u8 # '`'
               # Inline code span: keep an interior `|` from splitting the cell.
               # An opening run of N backticks is closed by the next run of
               # exactly N; with no closer the backtick is literal and scanning
               # resumes from the next character. `\|` is still unescaped to a
               # bare pipe inside the span (GFM tables collapse it before the
               # code span is rendered — see the spec's `b `\|` az` example).
-              run_len = backtick_run_length(chars, i)
-              close = find_closing_backtick_run(chars, i + run_len, run_len)
+              run_len = backtick_run_length(bytes, i)
+              close = find_closing_backtick_run(bytes, i + run_len, run_len)
               if close
                 end_index = close + run_len
                 k = i
                 while k < end_index
-                  if chars[k] == '\\' && k + 1 < end_index && chars[k + 1] == '|'
+                  if bytes[k] == 0x5C_u8 && k + 1 < end_index && bytes[k + 1] == 0x7C_u8
                     current << '|'
                     k += 2
                   else
-                    current << chars[k]
+                    span_start = k
                     k += 1
+                    while k < end_index && bytes[k] != 0x5C_u8
+                      k += 1
+                    end
+                    current.write(bytes[span_start, k - span_start])
                   end
                 end
                 i = end_index
@@ -243,13 +264,20 @@ module Hwaro
                 run_len.times { current << '`' }
                 i += run_len
               end
-            elsif char == '|'
+            elsif byte == 0x7C_u8 # '|'
               cells << current.to_s
               current = String::Builder.new
               i += 1
             else
-              current << char
+              # Copy verbatim up to the next byte the scanner cares about.
+              span_start = i
               i += 1
+              while i < len
+                b = bytes[i]
+                break if b == 0x5C_u8 || b == 0x60_u8 || b == 0x7C_u8
+                i += 1
+              end
+              current.write(bytes[span_start, i - span_start])
             end
           end
           cells << current.to_s
@@ -258,9 +286,9 @@ module Hwaro
         end
 
         # Number of consecutive backticks starting at `start`.
-        private def backtick_run_length(chars : Array(Char), start : Int32) : Int32
+        private def backtick_run_length(bytes : Bytes, start : Int32) : Int32
           run = 0
-          while start + run < chars.size && chars[start + run] == '`'
+          while start + run < bytes.size && bytes[start + run] == 0x60_u8
             run += 1
           end
           run
@@ -270,11 +298,11 @@ module Hwaro
         # begins, scanning from `start`. Returns nil when the span is never
         # closed (the opening run is then treated as literal text). Runs of a
         # different length are skipped, per CommonMark's code-span rule.
-        private def find_closing_backtick_run(chars : Array(Char), start : Int32, run_len : Int32) : Int32?
+        private def find_closing_backtick_run(bytes : Bytes, start : Int32, run_len : Int32) : Int32?
           i = start
-          while i < chars.size
-            if chars[i] == '`'
-              run = backtick_run_length(chars, i)
+          while i < bytes.size
+            if bytes[i] == 0x60_u8
+              run = backtick_run_length(bytes, i)
               return i if run == run_len
               i += run
             else

--- a/src/ext/tartrazine_mt_fix.cr
+++ b/src/ext/tartrazine_mt_fix.cr
@@ -1,0 +1,237 @@
+# Monkey-patches for Tartrazine's tokenizer — kept here so we don't fork
+# the vendored library, mirroring ext/crinja_resolve_fix.cr.
+#
+# Upstream Tartrazine is not safe to run from multiple -Dpreview_mt
+# workers at once, which forced ServerHighlighter to funnel EVERY
+# tokenization through one global mutex (see syntax_highlighter.cr
+# history). Patches 1-4 below remove each piece of cross-thread shared
+# mutable state so highlighting can run genuinely in parallel; patches
+# 5-6 are allocation cuts on the tokenize hot path that are safe to drop
+# independently of the thread-safety patches.
+#
+# Behavior is unchanged single-threaded: same match results (the
+# per-thread buffer is sized from the same per-pattern capacity as the
+# buffer it replaces), same tokens, same fallbacks. The no-match empty
+# arrays are shared frozen constants — callers never mutate them
+# (UnconditionalRule::NO_MATCH set that precedent upstream).
+#
+# No upstream issue is filed yet for any of these (as of 2026-07).
+# Removal criteria are listed per patch; a tartrazine version bump must
+# re-check each section against the shard's source.
+
+require "tartrazine"
+
+# === 1. Thread-safe PCRE2 matching ======================================
+# Upstream BytesRegex::Regex allocates ONE match_data buffer per compiled
+# pattern and reuses it for every match() call. Compiled rules are shared
+# between all lexer instances via the template cache, so two workers
+# matching the same rule corrupted each other's ovectors. Matching now
+# writes into a per-thread scratch buffer — PCRE2 compiled patterns
+# themselves are read-only and explicitly documented as safe to share
+# across threads.
+# Remove when: upstream stops sharing match_data across concurrent
+# match() calls (per-call, per-thread, or lock-guarded).
+module BytesRegex
+  class Regex
+    # Shared empty result for the no-match path (allocation cut — misses
+    # vastly outnumber hits). Callers only ever read it (`match.size == 0`
+    # / indexing after a hit), so one instance serves every miss.
+    EMPTY_MATCHES = [] of Match
+
+    # Capacity the pattern needs (capture_count + 1), memoized from the
+    # stock per-pattern @match_data on first use so the hot path skips
+    # the FFI call. 0 is never a valid ovector count (minimum is 1), so
+    # it doubles as the unset sentinel. Concurrent first-time writers all
+    # store the same value — an idempotent, aligned 32-bit store.
+    @ovector_pairs : UInt32 = 0_u32
+
+    # One scratch match_data per OS thread, grown to the widest pattern
+    # that thread has matched so far. A fiber cannot be preempted between
+    # acquiring the buffer and reading its ovector (there is no yield
+    # point inside #match), and fibers never migrate threads mid-call,
+    # so the buffer is exclusive for the duration of each match. The
+    # buffer is freed only when it grows; a thread that exits keeps its
+    # last buffer alive — a bounded one-per-thread leak that is moot
+    # while preview_mt workers live for the whole process.
+    @[ThreadLocal]
+    @@scratch_md = Pointer(LibPCRE2::MatchData).null
+    @[ThreadLocal]
+    @@scratch_pairs = 0_u32
+
+    protected def self.scratch_match_data(pairs : UInt32) : LibPCRE2::MatchData*
+      if @@scratch_md.null? || @@scratch_pairs < pairs
+        LibPCRE2.match_data_free(@@scratch_md) unless @@scratch_md.null?
+        @@scratch_md = LibPCRE2.match_data_create(pairs, nil)
+        @@scratch_pairs = pairs
+      end
+      @@scratch_md
+    end
+
+    def match(str : Bytes, pos = 0) : Array(Match)
+      # The stock @match_data still exists (created from the pattern at
+      # compile time and freed by the stock finalize); it is no longer
+      # written to — its capacity is read once to size the thread-local
+      # buffer.
+      pairs = @ovector_pairs
+      if pairs == 0
+        pairs = @ovector_pairs = LibPCRE2.get_ovector_count(@match_data)
+      end
+      match_data = Regex.scratch_match_data(pairs)
+
+      rc = LibPCRE2.match(
+        @re,
+        str,
+        str.size,
+        pos,
+        LibPCRE2::NO_UTF_CHECK,
+        match_data,
+        nil)
+      if rc > 0
+        ovector = LibPCRE2.get_ovector_pointer(match_data)
+        (0...rc).map do |i|
+          m_start = ovector[2 * i]
+          m_end = ovector[2 * i + 1]
+          if m_start == m_end
+            m_value = Bytes.new(0)
+          else
+            m_value = str[m_start...m_end]
+          end
+          Match.new(m_value, m_start, m_end - m_start)
+        end
+      else
+        EMPTY_MATCHES
+      end
+    end
+  end
+end
+
+module Tartrazine
+  # Shared empty result for rule misses (allocation cut, see patch 5).
+  # Never mutated: the only consumer iterates it into a deque.
+  EMPTY_TOKENS = [] of Token
+
+  # === 2. Synchronized template cache ===================================
+  # The stock fast path read @@lexer_templates without the mutex while
+  # first-use writers mutated it inside the mutex (double-checked locking
+  # on a non-atomic Hash). Template parsing happens once per language per
+  # process; a plain full synchronize costs one lock per lexer
+  # ACQUISITION (per code block), which is noise next to tokenization.
+  # Remove when: upstream guards the cached-read path (mutex, RWLock, or
+  # atomic snapshot).
+  private def self.get_or_create_template(lexer_file_name : String) : LexerTemplate
+    @@template_mutex.synchronize do
+      if template = @@lexer_templates[lexer_file_name]?
+        return template
+      end
+
+      xml = LexerFiles.get("/#{lexer_file_name}.xml").gets_to_end
+      template = parse_xml_to_template(xml)
+      @@lexer_templates[lexer_file_name] = template
+      template
+    end
+  end
+
+  # === 3. Per-instance states Hash ======================================
+  # Stock handed every lexer instance the TEMPLATE's own states Hash. A
+  # `combined` action then inserted its synthesized state into that
+  # shared Hash mid-tokenization — a data race, and a leak (random-named
+  # states accumulated in the template forever). Each instance now gets a
+  # shallow copy; the State structs and their immutable rule arrays stay
+  # shared.
+  # Remove when: upstream isolates per-instance state mutation (own Hash
+  # per lexer, or combined-state storage moved off the shared template).
+  private def self.create_from_template(lexer_file_name : String) : BaseLexer
+    template = get_or_create_template(lexer_file_name)
+
+    lexer = RegexLexer.new
+    lexer.config = {
+      name:             template.config[:name].as(String),
+      priority:         template.config[:priority].as(Float64),
+      case_insensitive: template.config[:case_insensitive].as(Bool),
+      dot_all:          template.config[:dot_all].as(Bool),
+      not_multiline:    template.config[:not_multiline].as(Bool),
+      ensure_nl:        template.config[:ensure_nl].as(Bool),
+    }
+    lexer.states = template.states.dup
+    lexer
+  end
+
+  # === 4. Deterministic combined-state names ============================
+  # Stock named combined states with Random.base58, and the base58
+  # shard's global RNG is not documented thread-safe. The name only needs
+  # to be unique within one lexer instance's (now private, see patch 3)
+  # states Hash, so derive it deterministically from the operand names.
+  # The NUL separator cannot appear in XML-sourced state names, so a
+  # synthesized name can only collide with the SAME combination — which
+  # maps to identical rules anyway.
+  # Remove when: upstream names combined states without shared RNG state
+  # (and patch 3 is no longer needed).
+  struct State
+    def +(other : State)
+      new_state = State.new
+      new_state.name = "#{name}\0+\0#{other.name}"
+      new_state.rules = rules + other.rules
+      new_state
+    end
+  end
+
+  # === 5. Allocation cuts in rule matching (perf only) ==================
+  # Stock allocated `[] of Token` (and `[] of Match` inside BytesRegex)
+  # on every failed rule attempt — one GC allocation per rule per
+  # position scanned — plus a flat_map re-copy of the emitted tokens for
+  # the overwhelmingly common single-action rule. Safe to drop without
+  # affecting thread-safety.
+  struct Rule
+    def match(text : Bytes, pos, tokenizer) : Tuple(Bool, Int32, Array(Token))
+      match = pattern.match(text, pos)
+
+      return false, pos, EMPTY_TOKENS if match.size == 0
+      # `flat_map` over a 1-element actions array only re-copies the
+      # Array(Token) that #emit just built (flattening one level of an
+      # already-flat array) — return emit's array directly instead.
+      # Callers only ever iterate the result.
+      tokens = if @actions.size == 1
+                 @actions.unsafe_fetch(0).emit(match, tokenizer)
+               else
+                 @actions.flat_map(&.emit(match, tokenizer))
+               end
+      return true, pos + match[0].size, tokens
+    end
+  end
+
+  struct IncludeStateRule
+    def match(text : Bytes, pos : Int32, tokenizer : Tokenizer) : Tuple(Bool, Int32, Array(Token))
+      tokenizer.@lexer.states[@state].rules.each do |rule|
+        matched, new_pos, new_tokens = rule.match(text, pos, tokenizer)
+        return true, new_pos, new_tokens if matched
+      end
+      return false, pos, EMPTY_TOKENS
+    end
+  end
+
+  # === 6. Identity fast path in split_tokens (perf only) ================
+  # Stock rebuilt a fresh Array(Token) on every rule hit even though
+  # token values only rarely contain a newline. When none does, the split
+  # is the identity transform (each token maps to itself in order), so
+  # return the input array untouched — the only caller iterates it into
+  # the deque and never mutates it.
+  class Tokenizer
+    def split_tokens(tokens : Array(Token)) : Array(Token)
+      return tokens unless tokens.any?(&.[:value].includes?('\n'))
+
+      split_tokens = [] of Token
+      tokens.each do |token|
+        if token[:value].includes?("\n")
+          values = token[:value].split("\n")
+          values.each_with_index do |value, index|
+            value += "\n" if index < values.size - 1
+            split_tokens << {type: token[:type], value: value}
+          end
+        else
+          split_tokens << token
+        end
+      end
+      split_tokens
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Server-mode syntax highlighting was serialized behind a single global mutex — every code block on every page, across all `-Dpreview_mt` render workers, tokenized one at a time. This PR makes tokenization genuinely parallel while keeping build output **byte-identical**.

### Why the mutex existed

The tartrazine shard is not MT-safe: compiled rules share one PCRE2 `match_data` buffer via the global lexer-template cache, the template cache read its Hash outside the mutex (double-checked locking), `combined` actions mutate the shared template states Hash mid-tokenization, and combined-state names come from a global RNG. Concurrent tokenization corrupted matches nondeterministically, so hwaro serialized everything.

### What this PR does

- **`src/ext/tartrazine_mt_fix.cr` (new)** — fixes the shared state at the source, mirroring the `crinja_resolve_fix.cr` monkeypatch precedent (numbered sections, per-patch removal criteria, thread-safety patches separated from perf-only patches):
  1. per-thread PCRE2 scratch `match_data` (pattern capacity memoized per compiled regex)
  2. fully synchronized template cache
  3. per-instance lexer `states` Hash (shallow copy; immutable rules stay shared)
  4. deterministic combined-state names (no shared RNG)
  5. allocation cuts: shared empty-array constants, single-action fast path, `split_tokens` identity fast path
- **`syntax_highlighter.cr`** — global mutex removed. Concurrency is bounded at 4 slots via a channel semaphore: past ~4 simultaneous tokenizers the Boehm GC allocation lock convoys and slows the *whole* build (measured ~25% slower unbounded at 8 workers on a 5k-page site with 10k unique code blocks). Tokens with nothing to escape skip `HTML.escape`; bytes ≥ 0x80 still route through it so invalid-UTF-8 `Error` tokens keep the U+FFFD sanitization (pinned by a new spec).
- **`table_parser.cr`** — `split_row` byte-scans rows instead of materializing a per-row `Array(Char)`, and trims pipe delimiters by narrowing the slice view instead of `lchop`/`rchop` (2 fewer String allocations per row). All delimiters are ASCII, so the scan is UTF-8-exact.

### Performance (cold builds, interleaved A/B vs `main`)

| site | workers | main | this PR |
|---|---|---|---|
| 1,000 pages / 2,000 code blocks | 4 (default) | ~410ms | ~270ms (**-35%**) |
| 1,000 pages | 8 | ~400ms | ~310ms (**-23%**) |
| 5,000 pages / 10,000 unique blocks | 4 / 8 | ~2.9s | ~2.8s (parity) |
| docs site (69 pages) | default | ~800ms | ~800ms (OG/image-bound) |

### Verification

- Output **byte-identical** (SHA-256 of every file) vs `main` on the docs site (333 files), a 1k-page synthetic site (1,004 files), and a 5k-page site (5,004 files)
- Deterministic across 10+ repeated 8-worker parallel builds (the old failure mode was nondeterministic corruption)
- `crystal spec`: 6,138 examples, 0 failures (includes 2 new regression specs)
- `just test-friends`: 4/4 external hwaro sites build
- ameba + `crystal tool format` clean
- Multi-angle adversarial review (10 finder angles + per-finding verification): the one confirmed behavioral divergence found (invalid-UTF-8 Error tokens bypassing U+FFFD sanitization) is fixed and spec-pinned here

🤖 Generated with [Claude Code](https://claude.com/claude-code)