### PR TITLE
fix(markdown): rendering edge-case audit — 10 correctness fixes

### DIFF
--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -372,6 +372,27 @@ describe Hwaro::Core::Build::Builder do
       out.should contain("&lt;!-- more --&gt;")
     end
 
+    it "restores a backticked placeholder as literal code text" do
+      # A placeholder inside a code span must display literally — never be
+      # substituted with rendered HTML by the post-Markdown pass.
+      out = Hwaro::Content::Processors::InlineMarkdown.render(
+        "use `<!--HWARO-SHORTCODE-PLACEHOLDER-0-->` here"
+      )
+      out.should contain("<code>&lt;!--HWARO-SHORTCODE-PLACEHOLDER-0--&gt;</code>")
+      out.should_not contain("<code><!--")
+    end
+
+    it "does not restore raw placeholders into image/link attributes" do
+      # Raw comments inside alt/src/href would let the post-Markdown pass
+      # inject rendered HTML into an attribute value (in-band injection).
+      out = Hwaro::Content::Processors::InlineMarkdown.render(
+        "![<!--HWARO-SHORTCODE-PLACEHOLDER-0-->](a.png) [x](<!--HWARO-SHORTCODE-PLACEHOLDER-1-->)"
+      )
+      out.should contain(%(alt="&lt;!--HWARO-SHORTCODE-PLACEHOLDER-0--&gt;"))
+      out.should_not contain(%(alt="<!--))
+      out.should_not contain(%(href="<!--))
+    end
+
     it "resolves shortcodes inside table cells, definitions, and footnotes" do
       # End-to-end pipe: shortcode substitution → Markdown → placeholder
       # replace. The placeholder used to be HTML-escaped by the inline

--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -355,6 +355,54 @@ describe Hwaro::Core::Build::Builder do
       output.should eq("<b>found</b> <!--HWARO-SHORTCODE-PLACEHOLDER-99-->")
     end
 
+    it "aliases the placeholder regex that InlineMarkdown stashes" do
+      # InlineMarkdown owns the matching regex; the processor owns the
+      # emitted text. Pin them together so neither can drift.
+      placeholder = "#{Hwaro::Core::Build::ShortcodeProcessor::SHORTCODE_PLACEHOLDER_PREFIX}0" \
+                    "#{Hwaro::Core::Build::ShortcodeProcessor::SHORTCODE_PLACEHOLDER_SUFFIX}"
+      Hwaro::Core::Build::ShortcodeProcessor::SHORTCODE_PLACEHOLDER_RE.matches?(placeholder).should be_true
+    end
+
+    it "keeps placeholders unescaped through InlineMarkdown.render" do
+      out = Hwaro::Content::Processors::InlineMarkdown.render(
+        "a <!--HWARO-SHORTCODE-PLACEHOLDER-0--> b <!-- more -->"
+      )
+      out.should contain("<!--HWARO-SHORTCODE-PLACEHOLDER-0-->")
+      # Ordinary comments still escape like any other cell text.
+      out.should contain("&lt;!-- more --&gt;")
+    end
+
+    it "resolves shortcodes inside table cells, definitions, and footnotes" do
+      # End-to-end pipe: shortcode substitution → Markdown → placeholder
+      # replace. The placeholder used to be HTML-escaped by the inline
+      # renderer for all three surfaces, leaking
+      # `&lt;!--HWARO-SHORTCODE-PLACEHOLDER-N--&gt;` into the page.
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      templates = {"shortcodes/badge" => "<em>badge</em>"}
+      context = {} of String => Crinja::Value
+      results = {} of String => String
+
+      content = <<-MD
+        | col |
+        |-----|
+        | {{ badge() }} |
+
+        Term
+        : has a {{ badge() }} definition
+
+        Body text.[^1]
+
+        [^1]: footnote with {{ badge() }}
+        MD
+      substituted = builder.test_process_shortcodes_jinja(content, templates, context, results, crinja_env_override: env)
+      rendered, _ = Hwaro::Processor::Markdown.render(substituted, markdown_config: Hwaro::Models::MarkdownConfig.new)
+      output = builder.test_replace_shortcode_placeholders(rendered, results)
+
+      output.scan("<em>badge</em>").size.should eq 3
+      output.should_not contain("HWARO-SHORTCODE-PLACEHOLDER")
+    end
+
     it "does not wrap block-level shortcode output in <p> when on its own line" do
       # End-to-end pipe: shortcode substitution → Markdown → placeholder replace.
       # Regression test for https://github.com/hahwul/hwaro/issues/473.

--- a/spec/unit/fence_tracker_spec.cr
+++ b/spec/unit/fence_tracker_spec.cr
@@ -19,8 +19,10 @@ describe Hwaro::Content::Processors::FenceTracker do
       feed(["``` `not a fence`", "text"]).should eq [false, false]
     end
 
-    it "does not open on 4-space-indented delimiters" do
-      feed(["    ```", "text"]).should eq [false, false]
+    it "treats a 4-space-indented delimiter as indented code, not a fence" do
+      # Verbatim as indented-code content — but no fence opens, so the
+      # following flush-left line is ordinary markdown again.
+      feed(["    ```", "text"]).should eq [true, false]
     end
 
     it "keeps a blockquoted delimiter literal inside an open top-level fence" do
@@ -59,8 +61,38 @@ describe Hwaro::Content::Processors::FenceTracker do
       feed(["   > ```", "   > code", "   > ```"]).should eq [true, true, true]
     end
 
-    it "does not open on indented code inside a blockquote" do
+    it "does not open a fence on indented code inside a blockquote" do
       feed(["> mono:", ">     ```", "> text"]).should eq [false, false, false]
+    end
+  end
+
+  describe "indented code runs" do
+    it "opens after a blank line and survives interior blanks" do
+      feed(["para", "", "    code", "", "\tmore", "back"])
+        .should eq [false, false, true, true, true, false]
+    end
+
+    it "opens at the start of the document" do
+      feed(["    code", "text"]).should eq [true, false]
+    end
+
+    it "does not open without a preceding blank line" do
+      # Indented code cannot interrupt a paragraph (lazy continuation).
+      feed(["para", "    still para"]).should eq [false, false]
+    end
+
+    it "does not open inside an open list" do
+      feed(["- item", "", "    continuation"]).should eq [false, false, false]
+    end
+
+    it "opens again once a flush-left block has closed the list" do
+      feed(["- item", "", "para", "", "    code"])
+        .should eq [false, false, false, false, true]
+    end
+
+    it "keeps the list open across indented continuations" do
+      feed(["- item", "", "  wrapped", "", "    still list"])
+        .should eq [false, false, false, false, false]
     end
   end
 end

--- a/spec/unit/fence_tracker_spec.cr
+++ b/spec/unit/fence_tracker_spec.cr
@@ -1,0 +1,66 @@
+require "../spec_helper"
+
+private def feed(lines : Array(String)) : Array(Bool)
+  tracker = Hwaro::Content::Processors::FenceTracker.new
+  lines.map { |line| tracker.fence_line?(line) }
+end
+
+describe Hwaro::Content::Processors::FenceTracker do
+  describe "top-level fences" do
+    it "tracks opener, content, and closer" do
+      feed(["```", "code", "```", "after"]).should eq [true, true, true, false]
+    end
+
+    it "requires a closer at least as long as the opener" do
+      feed(["````", "```", "inner", "````", "after"]).should eq [true, true, true, true, false]
+    end
+
+    it "treats a backtick in a backtick fence's info string as inline code" do
+      feed(["``` `not a fence`", "text"]).should eq [false, false]
+    end
+
+    it "does not open on 4-space-indented delimiters" do
+      feed(["    ```", "text"]).should eq [false, false]
+    end
+
+    it "keeps a blockquoted delimiter literal inside an open top-level fence" do
+      feed(["```", "> ```", "still code", "```"]).should eq [true, true, true, true]
+    end
+  end
+
+  describe "blockquoted fences" do
+    it "opens and closes a fence behind a single marker" do
+      feed(["> ```", "> code", "> ```", "> after"]).should eq [true, true, true, false]
+    end
+
+    it "opens and closes a fence behind nested markers" do
+      feed(["> > ```", "> > code", "> > ```", "> > after"]).should eq [true, true, true, false]
+    end
+
+    it "keeps a deeper-quoted delimiter literal inside a quoted fence" do
+      feed(["> ```", "> > ```", "> ```", "> after"]).should eq [true, true, true, false]
+    end
+
+    it "treats marker-only blank lines as fence content" do
+      feed(["> ```", ">", "> code", "> ```"]).should eq [true, true, true, true]
+    end
+
+    it "force-closes when the marker disappears" do
+      # CommonMark: fenced code gets no lazy continuation, so the quote —
+      # and the fence — end at the unmarked line.
+      feed(["> ```", "outside", "~~x~~"]).should eq [true, false, false]
+    end
+
+    it "re-evaluates the force-closing line as a new opener" do
+      feed(["> ```", "```", "code", "```"]).should eq [true, true, true, true]
+    end
+
+    it "allows up to 3 leading spaces before a marker" do
+      feed(["   > ```", "   > code", "   > ```"]).should eq [true, true, true]
+    end
+
+    it "does not open on indented code inside a blockquote" do
+      feed(["> mono:", ">     ```", "> text"]).should eq [false, false, false]
+    end
+  end
+end

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -796,6 +796,39 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
     end
   end
 
+  describe "blockquoted fences" do
+    it "leaves transforms alone inside a > ``` fence" do
+      config = make_config(heading_ids: true, task_lists: true)
+      content = "> ```\n> ~~x~~\n> - [ ] task\n> ## H {#nope}\n> ```\n\n~~real~~"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess(content, config)
+      result.should contain("~~x~~")
+      result.should contain("- [ ] task")
+      result.should_not contain("HID:nope")
+      result.should contain("<del>real</del>")
+    end
+
+    it "leaves $ and $$ alone inside a > ``` fence" do
+      content = "> ```make\n> echo $$PATH $HOME\n> ```"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.should eq(content)
+    end
+
+    it "still transforms blockquote text outside the quoted fence" do
+      content = "> ~~quoted~~\n> ```\n> ~~code~~\n> ```\n> ~~after~~"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess(content, make_config)
+      result.should contain("<del>quoted</del>")
+      result.should contain("~~code~~")
+      result.should contain("<del>after</del>")
+    end
+
+    it "resumes transforms when an unclosed quoted fence ends with its blockquote" do
+      content = "> ```\n> ~~code~~\n\n~~real~~"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess(content, make_config)
+      result.should contain("~~code~~")
+      result.should contain("<del>real</del>")
+    end
+  end
+
   describe "math fence and code-span awareness" do
     it "leaves $$ inside fenced code blocks verbatim" do
       content = "```make\nall:\n\techo $$PATH\n\techo $$HOME\n```"

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -679,6 +679,24 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       result.should contain(%(id="wanted"))
     end
 
+    it "neutralizes an author-typed HID marker in prose" do
+      cfg = make_config(heading_ids: true)
+      html, _ = Hwaro::Processor::Markdown.render(
+        "## Heading <!--HID:evil--> {#real}\n\ntext",
+        markdown_config: cfg,
+      )
+      html.should contain(%(id="real"))
+      html.should_not contain(%(id="evil"))
+    end
+
+    it "keeps author-typed markers verbatim in code spans and fences" do
+      cfg = make_config(heading_ids: true, attributes: true)
+      content = "Use `<!--HID:x-->` inline.\n\n```\n<!--HATTR:41-->\n```"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess(content, cfg)
+      result.should contain("`<!--HID:x-->`")
+      result.should contain("\n<!--HATTR:41-->\n")
+    end
+
     it "resolves the marker on a heading with a quoted '>' attribute" do
       html = %(<h2 title="a > b">Heading <!--HID:wanted--></h2>)
       result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_heading_ids(html)

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -448,6 +448,39 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
       result.should_not contain("math-display")
     end
+
+    it "renders mid-paragraph display math as an inline-safe span" do
+      cfg = make_config(math: true)
+      html, _ = Hwaro::Processor::Markdown.render(
+        "Euler: $$e_a * e_b$$ inline.",
+        markdown_config: cfg,
+      )
+      # Doubled delimiters and escaped `*`/`_` collapse back through Markd's
+      # inline parser — no emphasis, no dropped brackets, wrapper stays a
+      # span inside the paragraph.
+      html.should contain(%(<span class="math math-display">\\[e_a * e_b\\]</span>))
+      html.should_not contain("<em>")
+      html.should_not contain("<div class=\"math math-display\">")
+    end
+
+    it "keeps standalone display math as a div HTML block" do
+      cfg = make_config(math: true)
+      html, _ = Hwaro::Processor::Markdown.render(
+        "before\n\n$$\nx * y\n$$\n\nafter",
+        markdown_config: cfg,
+      )
+      html.should contain(%(<div class="math math-display">\\[))
+      html.should_not contain("math-display\">\\\\[")
+    end
+
+    it "keeps display math in a table cell as a div (raw HTML context)" do
+      cfg = make_config(math: true)
+      html, _ = Hwaro::Processor::Markdown.render(
+        "| f |\n|---|\n| $$x$$ |",
+        markdown_config: cfg,
+      )
+      html.should contain(%(<div class="math math-display">\\[x\\]</div>))
+    end
   end
 
   describe "mermaid (extended)" do

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -829,6 +829,31 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
     end
   end
 
+  describe "indented code blocks" do
+    it "leaves transforms alone inside an indented code run" do
+      config = make_config(math: true)
+      content = "Build:\n\n\techo ${A}/${B}\n\t~~x~~\n\n~~real~~ and $y$"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess(content, config)
+      result.should contain("${A}/${B}")
+      result.should contain("~~x~~")
+      result.should contain("<del>real</del>")
+      result.should contain("math-inline")
+    end
+
+    it "still transforms 4-space list continuations" do
+      content = "- item\n\n    ~~strike~~ continues"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess(content, make_config)
+      result.should contain("<del>strike</del>")
+    end
+
+    it "still converts nested task lists at 4-space indent" do
+      config = make_config(task_lists: true)
+      content = "- [ ] outer\n    - [ ] nested"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess(content, config)
+      result.scan("checkbox").size.should eq 2
+    end
+  end
+
   describe "math fence and code-span awareness" do
     it "leaves $$ inside fenced code blocks verbatim" do
       content = "```make\nall:\n\techo $$PATH\n\techo $$HOME\n```"

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -481,6 +481,13 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       )
       html.should contain(%(<div class="math math-display">\\[x\\]</div>))
     end
+
+    it "keeps a <code> span with a quoted '>' attribute opaque to math" do
+      content = %(<code data-x="a>b">$x$</code> and $y$)
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.should contain("$x$")
+      result.scan("math-inline").size.should eq(1)
+    end
   end
 
   describe "mermaid (extended)" do
@@ -663,6 +670,21 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       result.should contain(%(id="wanted"))
       result.should_not contain("auto-slug")
       result.should contain(%(class="foo"))
+    end
+
+    it "does not mistake data-id for an existing id attribute" do
+      html = %(<h3 data-id="tracker">Heading <!--HID:wanted--></h3>)
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_heading_ids(html)
+      result.should contain(%(data-id="tracker"))
+      result.should contain(%(id="wanted"))
+    end
+
+    it "resolves the marker on a heading with a quoted '>' attribute" do
+      html = %(<h2 title="a > b">Heading <!--HID:wanted--></h2>)
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_heading_ids(html)
+      result.should contain(%(id="wanted"))
+      result.should contain(%(title="a > b"))
+      result.should_not contain("HID:")
     end
 
     it "handles each heading level h1-h6" do

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -418,6 +418,36 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       html.should contain(%(<div class="math math-display">\\[))
       html.should contain(%(\\]</div>))
     end
+
+    it "keeps an escaped dollar inside inline math" do
+      content = "The price $x = \\$5$ is fixed."
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.scan("math-inline").size.should eq(1)
+      # The whole formula (including the escaped dollar) lands in the span;
+      # nothing dangles after it.
+      result.should contain("$5")
+      result.should_not contain("5$")
+    end
+
+    it "leaves a body ending in a lone backslash unmatched" do
+      content = "literal $a\\$ text"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.should_not contain("math-inline")
+    end
+
+    it "does not pair display math across a blank line" do
+      content = "before $$ stray\n\nprose here\n\n$$x$$"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.should contain("$$ stray")
+      result.should contain("prose here")
+      result.scan("math-display").size.should eq(1)
+    end
+
+    it "does not pair display math across a whitespace-only line" do
+      content = "$$ stray\n \t\nprose"
+      result = Hwaro::Content::Processors::MarkdownExtensions.preprocess_math(content)
+      result.should_not contain("math-display")
+    end
   end
 
   describe "mermaid (extended)" do

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -463,6 +463,16 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       html.should_not contain("<div class=\"math math-display\">")
     end
 
+    it "keeps blockquoted standalone display math as a div" do
+      cfg = make_config(math: true)
+      html, _ = Hwaro::Processor::Markdown.render(
+        "> $$x$$",
+        markdown_config: cfg,
+      )
+      html.should contain(%(<div class="math math-display">\\[x\\]</div>))
+      html.should_not contain("math-display\">\\\\[")
+    end
+
     it "keeps standalone display math as a div HTML block" do
       cfg = make_config(math: true)
       html, _ = Hwaro::Processor::Markdown.render(

--- a/spec/unit/markdown_toc_spec.cr
+++ b/spec/unit/markdown_toc_spec.cr
@@ -72,5 +72,33 @@ describe Hwaro::Content::Processors::Markdown do
       # into HTML verbatim.
       toc[0].title.should eq("Tom &amp; Jerry &lt;3")
     end
+
+    it "does not mistake data-id for the heading's own id" do
+      html, toc = Hwaro::Content::Processors::Markdown.new.render(
+        %(<h2 data-id="tracker">Real Title</h2>\n\ntext)
+      )
+
+      toc[0].id.should eq("real-title")
+      html.should contain(%(data-id="tracker"))
+      html.should contain(%(id="real-title"))
+    end
+
+    it "keeps a quoted '>' in heading attributes out of the TOC title" do
+      html, toc = Hwaro::Content::Processors::Markdown.new.render(
+        %(<h2 title="a > b">Quoted</h2>\n\ntext)
+      )
+
+      toc[0].title.should eq("Quoted")
+      toc[0].id.should eq("quoted")
+      html.should contain(%(title="a > b"))
+    end
+
+    it "keeps a quoted '>' in inline HTML out of the TOC title" do
+      _, toc = Hwaro::Content::Processors::Markdown.new.render(
+        %(## Hello <img alt="Home > Docs" src="/x.png"> World\n\ntext)
+      )
+
+      toc[0].title.should eq("Hello  World")
+    end
   end
 end

--- a/spec/unit/page_methods_spec.cr
+++ b/spec/unit/page_methods_spec.cr
@@ -200,6 +200,20 @@ describe Hwaro::Models::Page do
       summary.not_nil!.should eq("Summary text.")
     end
 
+    it "ignores a marker shown inside a fenced code block" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.raw_content = "Intro.\n\n```html\n<!-- more -->\n```\n\nBody.\n\n<!-- more -->\n\nRest."
+      summary = page.extract_summary
+      summary.should_not be_nil
+      summary.not_nil!.should eq("Intro.\n\n```html\n<!-- more -->\n```\n\nBody.")
+    end
+
+    it "returns nil when the only marker sits inside a fence" do
+      page = Hwaro::Models::Page.new("test.md")
+      page.raw_content = "Docs example:\n\n```\n<!-- more -->\n```\n\nNo real marker."
+      page.extract_summary.should be_nil
+    end
+
     it "returns nil for empty content" do
       page = Hwaro::Models::Page.new("test.md")
       page.raw_content = ""

--- a/spec/unit/processors_spec.cr
+++ b/spec/unit/processors_spec.cr
@@ -860,6 +860,20 @@ describe Hwaro::Processor::Markdown do
       html.should_not contain("loading=\"lazy\"")
     end
 
+    it "sees a loading attribute that sits after a quoted '>'" do
+      content = "<img alt=\"Home > Docs\" src=\"a.png\" loading=\"eager\">"
+      html, _ = Hwaro::Processor::Markdown.render(content, lazy_loading: true, safe: false)
+      html.should contain("loading=\"eager\"")
+      html.should_not contain("loading=\"lazy\"")
+    end
+
+    it "does not mistake data-loading for the loading attribute" do
+      content = "<img src=\"a.png\" data-loading=\"spinner\">"
+      html, _ = Hwaro::Processor::Markdown.render(content, lazy_loading: true, safe: false)
+      html.should contain("loading=\"lazy\"")
+      html.should contain("data-loading=\"spinner\"")
+    end
+
     it "works with render_with_anchors" do
       content = "# Title\n![Img](img.jpg)"
       html, _ = Hwaro::Content::Processors::Markdown.new.render_with_anchors(content, lazy_loading: true)

--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -225,6 +225,16 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
       result.should contain("<span>live</span>")
     end
 
+    it "leaves shortcodes inside blockquoted fences untouched" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/note" => "<span>{{ body }}</span>"}
+      # Markd opens a fence behind "> ```", so the example must stay raw.
+      content = "> ```\n> {% note %}body{% end %}\n> ```\n\n{% note %}live{% end %}"
+      result = builder.test_sc_process(content, templates)
+      result.should contain("{% note %}body{% end %}")
+      result.should contain("<span>live</span>")
+    end
+
     # Regression for https://github.com/hahwul/hwaro/issues/477
     # Single-backtick inline code spans should be opaque to the shortcode
     # processor, the same way fenced code blocks already are. The bug was

--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -235,6 +235,26 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
       result.should contain("<span>live</span>")
     end
 
+    it "keeps fence protection after an unbalanced opener in inline code" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/note" => "<span>{{ body }}</span>"}
+      # The literal `{% note %}` in backticks must not count as an open
+      # block tag — that used to pin block_depth > 0 and disable fence
+      # protection for every later fence in the document.
+      content = "Start with `{% note %}`.\n\n```\n{% note %}fenced{% end %}\n```"
+      result = builder.test_sc_process(content, templates)
+      result.should contain("{% note %}fenced{% end %}")
+      result.should_not contain("<span>fenced</span>")
+    end
+
+    it "does not count a fence opener's info string toward block depth" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/note" => "<span>{{ body }}</span>"}
+      content = "``` {% note %}\ncode\n```\n{% note %}live{% end %}"
+      result = builder.test_sc_process(content, templates)
+      result.should contain("<span>live</span>")
+    end
+
     # Regression for https://github.com/hahwul/hwaro/issues/477
     # Single-backtick inline code spans should be opaque to the shortcode
     # processor, the same way fenced code blocks already are. The bug was

--- a/spec/unit/table_parser_spec.cr
+++ b/spec/unit/table_parser_spec.cr
@@ -807,5 +807,18 @@ describe Hwaro::Content::Processors::TableParser do
       out = Hwaro::Content::Processors::TableParser.process(md)
       out.should_not contain("<table")
     end
+
+    it "does not convert a 4-space-indented table example after a blank line" do
+      # CommonMark renders this as an indented code block, not a table.
+      md = "Example:\n\n    | a | b |\n    |---|---|\n    | 1 | 2 |"
+      out = Hwaro::Content::Processors::TableParser.process(md)
+      out.should_not contain("<table")
+    end
+
+    it "still converts a 4-space-indented table inside a list item" do
+      md = "- item\n\n    | a | b |\n    |---|---|\n    | 1 | 2 |"
+      out = Hwaro::Content::Processors::TableParser.process(md)
+      out.should contain("<table>")
+    end
   end
 end

--- a/spec/unit/table_parser_spec.cr
+++ b/spec/unit/table_parser_spec.cr
@@ -801,5 +801,11 @@ describe Hwaro::Content::Processors::TableParser do
       out = Hwaro::Content::Processors::TableParser.process(md)
       out.should_not contain("<table")
     end
+
+    it "does not convert a table example inside a blockquoted fence" do
+      md = "> ```\n> | a | b |\n> |---|---|\n> | 1 | 2 |\n> ```"
+      out = Hwaro::Content::Processors::TableParser.process(md)
+      out.should_not contain("<table")
+    end
   end
 end

--- a/src/content/processors/fence_tracker.cr
+++ b/src/content/processors/fence_tracker.cr
@@ -21,10 +21,21 @@ module Hwaro
       #   "```ruby" lines inside an open fence) verbatim.
       # - Lines indented 4+ spaces (or starting with a tab) are indented-code
       #   context where ```/~~~ is literal text, never a delimiter.
+      # - Fences inside blockquotes (`> ```) are tracked too: the leading
+      #   `>` markers are stripped before the opener/closer rules apply, and
+      #   the marker depth is remembered. Because CommonMark gives fenced
+      #   code no lazy continuation, a line missing the fence's markers ends
+      #   the quote — and the fence with it — and is re-evaluated as a
+      #   potential new opener. Inside an open fence, only the fence's own
+      #   marker depth is stripped, so a `> ```' line stays literal content
+      #   of a top-level fence. Known limits: fences at 4+ absolute indent
+      #   inside list items are still invisible, and tab-formed `>` markers
+      #   (`>\t`) are not recognized.
       class FenceTracker
         @in_fence = false
         @fence_char = '`'
         @fence_len = 0
+        @fence_bq_depth = 0
 
         # True while inside an open fence: after the opener line was fed,
         # until (and excluding) the line after the closer. Lets callers that
@@ -38,20 +49,62 @@ module Hwaro
         # Returns true when the line must pass through verbatim: a fence
         # delimiter or any line inside an open fence.
         def fence_line?(line : String) : Bool
-          eligible = !(line.starts_with?("    ") || line.starts_with?('\t'))
-          stripped = line.lstrip
-
           if @in_fence
-            @in_fence = false if eligible && closes_fence?(stripped)
-            true
-          elsif eligible && (run = opener_run(stripped))
+            content, depth = strip_blockquote_markers(line, @fence_bq_depth)
+            if depth == @fence_bq_depth
+              @in_fence = false if !indented?(content) && closes_fence?(content.lstrip)
+              return true
+            end
+            # The fence's blockquote marker is gone: the quote ends here
+            # and takes the fence with it (no lazy continuation for fenced
+            # code). Fall through so this same line can open a new fence.
+            @in_fence = false
+          end
+
+          content, depth = strip_blockquote_markers(line)
+          return false if indented?(content)
+          stripped = content.lstrip
+          if run = opener_run(stripped)
             @in_fence = true
             @fence_char = stripped[0]
             @fence_len = run
+            @fence_bq_depth = depth
             true
           else
             false
           end
+        end
+
+        private def indented?(content : String) : Bool
+          content.starts_with?("    ") || content.starts_with?('\t')
+        end
+
+        # Consumes up to `max_depth` leading blockquote markers (each up to
+        # 3 spaces, a `>`, and one optional space) and returns the remainder
+        # plus the number of markers consumed. Byte scan: every byte that
+        # can form a marker is ASCII, and ordinary lines exit on the first
+        # byte — this runs several times per line across the walkers.
+        private def strip_blockquote_markers(line : String, max_depth : Int32 = Int32::MAX) : {String, Int32}
+          slice = line.to_slice
+          pos = 0
+          depth = 0
+          while depth < max_depth
+            start = pos
+            spaces = 0
+            while pos < slice.size && slice[pos] === ' ' && spaces < 3
+              pos += 1
+              spaces += 1
+            end
+            unless pos < slice.size && slice[pos] === '>'
+              pos = start
+              break
+            end
+            pos += 1
+            pos += 1 if pos < slice.size && slice[pos] === ' '
+            depth += 1
+          end
+          return {line, 0} if depth.zero?
+          {line.byte_slice(pos, line.bytesize - pos), depth}
         end
 
         private def opener_run(stripped : String) : Int32?

--- a/src/content/processors/fence_tracker.cr
+++ b/src/content/processors/fence_tracker.cr
@@ -58,9 +58,9 @@ module Hwaro
         @prev_blank = true
 
         # True while inside an open fence: after the opener line was fed,
-        # until (and excluding) the line after the closer. Lets callers that
-        # need to route in-fence lines differently (e.g. the shortcode
-        # processor's chunk buffering) branch before feeding the line.
+        # until (and excluding) the line after the closer. Lets callers
+        # that need to route in-fence lines differently branch before
+        # feeding the line.
         def in_fence? : Bool
           @in_fence
         end

--- a/src/content/processors/fence_tracker.cr
+++ b/src/content/processors/fence_tracker.cr
@@ -20,7 +20,18 @@ module Hwaro
       #   this is what keeps ``` examples nested inside ```` fences (and
       #   "```ruby" lines inside an open fence) verbatim.
       # - Lines indented 4+ spaces (or starting with a tab) are indented-code
-      #   context where ```/~~~ is literal text, never a delimiter.
+      #   context where ```/~~~ is literal text, never a delimiter. Whole
+      #   indented-code *runs* are tracked as verbatim too: a 4+-indented
+      #   non-blank line after a blank line opens a run — unless a list is
+      #   open, where the same indent is item continuation, not code — and
+      #   the run survives blanks until the first non-blank line back under
+      #   4 columns. The list heuristic is deliberately sticky (a marker
+      #   opens it; only a blank followed by a flush-left non-marker line
+      #   closes it): staying "in list" too long merely keeps today's
+      #   under-protective behavior, while leaving it too early would newly
+      #   skip transforms on real list content. Known limits: code indented
+      #   6+ columns inside list items is not recognized (unchanged), and
+      #   a fence closer followed directly by indented code opens no run.
       # - Fences inside blockquotes (`> ```) are tracked too: the leading
       #   `>` markers are stripped before the opener/closer rules apply, and
       #   the marker depth is remembered. Because CommonMark gives fenced
@@ -32,10 +43,19 @@ module Hwaro
       #   inside list items are still invisible, and tab-formed `>` markers
       #   (`>\t`) are not recognized.
       class FenceTracker
+        # A bullet or ordered-list marker at up to 3 spaces indent. The
+        # trailing space/tab is required — CommonMark's empty-item form
+        # (a bare "-") is intentionally not matched; a missed marker only
+        # keeps the list heuristic closed in a case too rare to matter.
+        LIST_MARKER_RE = /\A {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]/
+
         @in_fence = false
         @fence_char = '`'
         @fence_len = 0
         @fence_bq_depth = 0
+        @in_indented_code = false
+        @in_list = false
+        @prev_blank = true
 
         # True while inside an open fence: after the opener line was fed,
         # until (and excluding) the line after the closer. Lets callers that
@@ -53,6 +73,7 @@ module Hwaro
             content, depth = strip_blockquote_markers(line, @fence_bq_depth)
             if depth == @fence_bq_depth
               @in_fence = false if !indented?(content) && closes_fence?(content.lstrip)
+              @prev_blank = false
               return true
             end
             # The fence's blockquote marker is gone: the quote ends here
@@ -62,15 +83,45 @@ module Hwaro
           end
 
           content, depth = strip_blockquote_markers(line)
-          return false if indented?(content)
+          blank = content.blank?
+
+          if @in_indented_code
+            if blank
+              @prev_blank = true
+              return true
+            elsif indented?(content)
+              @prev_blank = false
+              return true
+            end
+            # First non-blank line back under 4 columns ends the run and
+            # is evaluated normally below.
+            @in_indented_code = false
+          end
+
+          if !blank && indented?(content) && @prev_blank && !@in_list
+            @in_indented_code = true
+            @prev_blank = false
+            return true
+          end
+
+          if LIST_MARKER_RE.matches?(content)
+            @in_list = true
+          elsif @in_list && @prev_blank && !blank && !content.starts_with?(' ') && !content.starts_with?('\t')
+            # A flush-left non-marker block after a blank line ends the
+            # list context; indented lines and lazy continuations keep it.
+            @in_list = false
+          end
+
           stripped = content.lstrip
-          if run = opener_run(stripped)
+          if !indented?(content) && (run = opener_run(stripped))
             @in_fence = true
             @fence_char = stripped[0]
             @fence_len = run
             @fence_bq_depth = depth
+            @prev_blank = false
             true
           else
+            @prev_blank = blank
             false
           end
         end

--- a/src/content/processors/inline_markdown.cr
+++ b/src/content/processors/inline_markdown.cr
@@ -76,6 +76,16 @@ module Hwaro
         DISPLAY_MATH_RE = /\$\$(.*?)\$\$/m
         INLINE_MATH_RE  = /(?<![\\$])\$(?!\s)([^\n$]+?)(?<!\s)\$(?!\d)/
 
+        # Placeholder comments left by `Core::Build::ShortcodeProcessor` for
+        # already-rendered shortcodes (canonical home here, next to the other
+        # inline patterns; the shortcode processor aliases it and emits the
+        # matching text). They must ride through `render` untouched: the
+        # HTML.escape at the top would otherwise turn them into
+        # `&lt;!--…--&gt;`, which the post-Markdown replacement pass cannot
+        # find — leaking the escaped comment into table cells, definition
+        # bodies, and footnotes.
+        SHORTCODE_PLACEHOLDER_RE = /<!--HWARO-SHORTCODE-PLACEHOLDER-\d+-->/
+
         # Render a small inline-markdown subset over already-HTML-escaped or
         # raw text. Code spans are extracted first so their content survives
         # the other passes verbatim.
@@ -89,6 +99,14 @@ module Hwaro
         # in addition to math — see `render(text, *, math:)` below, which is
         # the pre-F10 signature every existing caller/spec still uses.
         def render(text : String, *, flags : Flags) : String
+          placeholders = [] of String
+          if text.includes?("<!--HWARO-SHORTCODE-PLACEHOLDER-")
+            text = text.gsub(SHORTCODE_PLACEHOLDER_RE) do |comment|
+              placeholders << comment
+              "\x00SCPH#{placeholders.size - 1}\x00"
+            end
+          end
+
           result = HTML.escape(text)
 
           code_spans = [] of String
@@ -150,6 +168,13 @@ module Hwaro
 
           code_spans.each_with_index do |content, idx|
             result = result.gsub("\x00CODESPAN#{idx}\x00", "<code>#{content}</code>")
+          end
+
+          # Last, so a placeholder that ended up inside a restored code
+          # span still resolves (consistent with paragraph text, where the
+          # comment also rides through Markd verbatim).
+          placeholders.each_with_index do |comment, idx|
+            result = result.sub("\x00SCPH#{idx}\x00", comment)
           end
 
           result

--- a/src/content/processors/inline_markdown.cr
+++ b/src/content/processors/inline_markdown.cr
@@ -73,8 +73,20 @@ module Hwaro
 
         # Math span patterns — canonical home for the whole pipeline
         # (MarkdownExtensions aliases these, mirroring INLINE_STRIKETHROUGH_RE).
-        DISPLAY_MATH_RE = /\$\$(.*?)\$\$/m
-        INLINE_MATH_RE  = /(?<![\\$])\$(?!\s)([^\n$]+?)(?<!\s)\$(?!\d)/
+        #
+        # Display math must not cross a blank line (the tempered dot refuses
+        # to consume a newline that starts one, whitespace-only lines
+        # included): a stray unmatched `$$` would otherwise pair with a
+        # legitimate `$$` several paragraphs later and swallow all the prose
+        # in between. Blank lines are invalid inside LaTeX display math
+        # anyway, so no real formula is lost.
+        #
+        # Inline math admits backslash escapes in the body (`$x = \$5$`) and
+        # requires an unescaped, non-space-preceded closer. A body *ending*
+        # in a literal `\` won't close — meaningless in LaTeX at the end of
+        # a formula.
+        DISPLAY_MATH_RE = /\$\$((?:(?!\n[ \t\r]*\n).)*?)\$\$/m
+        INLINE_MATH_RE  = /(?<![\\$])\$(?!\s)((?:[^\n$\\]|\\[^\n])+?)(?<![\s\\])\$(?!\d)/
 
         # Placeholder comments left by `Core::Build::ShortcodeProcessor` for
         # already-rendered shortcodes (canonical home here, next to the other

--- a/src/content/processors/inline_markdown.cr
+++ b/src/content/processors/inline_markdown.cr
@@ -97,6 +97,7 @@ module Hwaro
         # find — leaking the escaped comment into table cells, definition
         # bodies, and footnotes.
         SHORTCODE_PLACEHOLDER_RE = /<!--HWARO-SHORTCODE-PLACEHOLDER-\d+-->/
+        SCPH_TOKEN_RE            = /\x00SCPH(\d+)\x00/
 
         # Render a small inline-markdown subset over already-HTML-escaped or
         # raw text. Code spans are extracted first so their content survives
@@ -140,8 +141,15 @@ module Hwaro
           end
 
           result = result.gsub(INLINE_IMAGE_RE) do
-            alt = $1
-            url = $2
+            # Placeholder tokens landing in ATTRIBUTE values are restored in
+            # escaped form: substituting rendered shortcode HTML into an
+            # attribute after Markdown would break out of it (the same
+            # in-band channel the HID/footnote neutralization defends), and
+            # the escaped comment matches the pre-stash rendering here.
+            # Link TEXT below keeps raw restore — it's element content,
+            # consistent with paragraph text.
+            alt = escape_placeholder_tokens($1, placeholders)
+            url = escape_placeholder_tokens($2, placeholders)
             # `result` was already HTML.escaped at the top, so `url`/`alt` are
             # captured in their escaped form — emit them as-is (re-escaping here
             # would double-encode `&` into `&amp;amp;`). Matches the link branch
@@ -155,7 +163,7 @@ module Hwaro
 
           result = result.gsub(INLINE_LINK_RE) do
             link_text = $1
-            url = $2
+            url = escape_placeholder_tokens($2, placeholders)
             if safe_url?(url)
               %(<a href="#{url}">#{link_text}</a>)
             else
@@ -179,17 +187,34 @@ module Hwaro
           end
 
           code_spans.each_with_index do |content, idx|
-            result = result.gsub("\x00CODESPAN#{idx}\x00", "<code>#{content}</code>")
+            # Tokens inside code spans restore ESCAPED, so a backticked
+            # placeholder displays literally instead of being substituted —
+            # the same thing Markd's own code-span escaping guarantees for
+            # paragraph text.
+            restored = escape_placeholder_tokens(content, placeholders)
+            result = result.gsub("\x00CODESPAN#{idx}\x00", "<code>#{restored}</code>")
           end
 
-          # Last, so a placeholder that ended up inside a restored code
-          # span still resolves (consistent with paragraph text, where the
-          # comment also rides through Markd verbatim).
+          # Remaining tokens sit in element-content positions: restore the
+          # raw comment so the post-Markdown replacement pass resolves it
+          # (consistent with paragraph text, where the comment also rides
+          # through Markd verbatim).
           placeholders.each_with_index do |comment, idx|
             result = result.sub("\x00SCPH#{idx}\x00", comment)
           end
 
           result
+        end
+
+        # Replaces stashed placeholder tokens with the HTML-escaped comment
+        # text — for positions (attribute values, code spans) where the raw
+        # comment must NOT survive to the post-Markdown replacement pass.
+        private def escape_placeholder_tokens(text : String, placeholders : Array(String)) : String
+          return text if placeholders.empty? || !text.includes?('\u{0}')
+          text.gsub(SCPH_TOKEN_RE) do |token|
+            comment = $1.to_i?.try { |idx| placeholders[idx]? }
+            comment ? HTML.escape(comment) : token
+          end
         end
 
         # Pre-F10 signature — delegates to the `Flags` overload with every

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -30,19 +30,22 @@ module Hwaro
     module Processors
       # Markdown processor implementation
       class Markdown < Base
-        # Regex for matching h1-h6 tags with IDs to insert anchor links
-        ANCHOR_LINK_REGEX = /<(h[1-6])([^>]*id="([^"]+)"[^>]*)>(.*?)<\/\1>/m
+        # Regex for matching h1-h6 tags with IDs to insert anchor links.
+        # Attribute scans here and below are quote-aware (a `>` inside a
+        # quoted value, e.g. title="a > b", is legal HTML5 and must not end
+        # the tag) and the `id` key uses a `(?<![\w-])` guard so `data-id=`
+        # never counts as the element's id.
+        ANCHOR_LINK_REGEX = /<(h[1-6])((?:[^>"']|"[^"]*"|'[^']*')*?(?<![\w-])id="([^"]+)"(?:[^>"']|"[^"]*"|'[^']*')*)>(.*?)<\/\1>/m
 
         # Regex for post_process_html — lightweight replacements for XML.parse_html
         # Matches <h1>…</h1> through <h6>…</h6>, capturing tag name, level digit, attributes, and inner HTML
-        HEADING_TAG_REGEX = /<(h([1-6]))(\s[^>]*)?>(.+?)<\/h\2>/mi
+        HEADING_TAG_REGEX = /<(h([1-6]))(\s(?:[^>"']|"[^"]*"|'[^']*')*)?>(.+?)<\/h\2>/mi
         # Matches <img ...> tags that do NOT already have a loading= attribute
-        # Quote-aware attribute scan: a `>` inside a quoted attribute value
-        # (legal HTML5, e.g. alt="Home > Docs") must not be treated as the tag
-        # end, or the lazy-load rewrite corrupts the raw <img> into broken markup.
-        IMG_LAZY_REGEX = /<img(?![^>]*\bloading\s*=)((?:[^>"']|"[^"]*"|'[^']*')*?)\s*\/?>/i
+        # (the lookahead is quote-aware too, so a loading= sitting after a
+        # quoted `>` is still seen, and `data-loading=` doesn't count).
+        IMG_LAZY_REGEX = /<img(?!(?:[^>"']|"[^"]*"|'[^']*')*(?<![\w-])loading\s*=)((?:[^>"']|"[^"]*"|'[^']*')*?)\s*\/?>/i
         # Extracts id="value" from an attribute string
-        ID_ATTR_REGEX = /\bid\s*=\s*["']([^"']+)["']/
+        ID_ATTR_REGEX = /(?<![\w-])id\s*=\s*["']([^"']+)["']/
         # Strips HTML tags to get plain text
         HTML_TAG_STRIP_REGEX = /<[^>]+>/
 
@@ -718,15 +721,25 @@ module Hwaro
               attrs = $3? || "" # existing attributes (may be empty)
               inner_html = $4   # inner content (may contain inline HTML)
 
-              # Extract plain text for TOC title (inline char-level strip avoids regex + alloc)
+              # Extract plain text for TOC title (inline char-level strip
+              # avoids regex + alloc). Quote-aware: a `>` inside a quoted
+              # attribute value must not end the tag, or the value's tail
+              # leaks into the title.
               title = String.build(inner_html.bytesize) do |io|
                 in_tag = false
+                quote = nil.as(Char?)
                 inner_html.each_char do |c|
-                  if c == '<'
+                  if in_tag
+                    if quote
+                      quote = nil if c == quote
+                    elsif c == '"' || c == '\''
+                      quote = c
+                    elsif c == '>'
+                      in_tag = false
+                    end
+                  elsif c == '<'
                     in_tag = true
-                  elsif c == '>'
-                    in_tag = false
-                  elsif !in_tag
+                  else
                     io << c
                   end
                 end

--- a/src/content/processors/markdown_attributes.cr
+++ b/src/content/processors/markdown_attributes.cr
@@ -129,9 +129,11 @@ module Hwaro
           merge_attrs(img_open, parsed)
         end
 
-        ID_ATTR_RE    = /\bid\s*=\s*"[^"]*"/i
-        ID_PRESENT_RE = /\bid\s*=/i
-        CLASS_ATTR_RE = /\bclass\s*=\s*"([^"]*)"/i
+        # `(?<![\w-])` guards keep `data-id=`/`data-class=` from counting
+        # as the element's own id/class.
+        ID_ATTR_RE    = /(?<![\w-])id\s*=\s*"[^"]*"/i
+        ID_PRESENT_RE = /(?<![\w-])id\s*=/i
+        CLASS_ATTR_RE = /(?<![\w-])class\s*=\s*"([^"]*)"/i
 
         # Shared merge logic for both entry points above: id and classes get
         # their own dedicated attribute; every other `key=value` pair is

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -477,8 +477,10 @@ module Hwaro
         # are already consumed), or author-written raw HTML. Their content
         # is code: the strikethrough/footnote/math passes must treat it as
         # opaque, exactly like backtick spans. `[^<]*` keeps the match to a
-        # flat element (generated spans never contain tags).
-        HTML_CODE_SPAN_RE = /<code(?:\s[^>]*)?>[^<]*<\/code>/
+        # flat element (generated spans never contain tags); the attribute
+        # scan is quote-aware so a `>` inside a quoted value doesn't end
+        # the opening tag early.
+        HTML_CODE_SPAN_RE = /<code(?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?>[^<]*<\/code>/
         # CommonMark "type 6" HTML-block start condition (common block tags,
         # including the <table>/<dl>/<div> markup hwaro itself generates).
         # A line opening one of these starts a raw-HTML block that runs to
@@ -888,10 +890,13 @@ module Hwaro
           rewritten
         end
 
-        HEADING_TAG_FOR_HID_RE = /<(h[1-6])([^>]*)>(.*?)<\/\1>/m
+        # Quote-aware attrs (a `>` inside a quoted value must not end the
+        # tag); the id checks guard with `(?<![\w-])` so `data-id=` never
+        # counts as the element's id.
+        HEADING_TAG_FOR_HID_RE = /<(h[1-6])((?:[^>"']|"[^"]*"|'[^']*')*)>(.*?)<\/\1>/m
         HID_MARKER_RE          = /<!--HID:([A-Za-z][\w:-]*)-->/
-        EXISTING_ID_RE         = /\bid\s*=\s*"[^"]*"/i
-        ANY_ID_ATTR_PRESENT_RE = /\bid\s*=/i
+        EXISTING_ID_RE         = /(?<![\w-])id\s*=\s*"[^"]*"/i
+        ANY_ID_ATTR_PRESENT_RE = /(?<![\w-])id\s*=/i
 
         def postprocess_heading_ids(html : String) : String
           return html unless html.includes?("<!--HID:")

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -490,6 +490,10 @@ module Hwaro
         record MathSpan, display : Bool, body : String
 
         MATH_PLACEHOLDER_RE = /\x00MATH(\d+)\x00/
+        # A line whose sole content is one math placeholder — the standalone
+        # display-math case, where the emitted <div> starts at line start and
+        # is a real CommonMark HTML block.
+        BARE_MATH_LINE_RE = /\A\x00MATH\d+\x00\z/
 
         # One-shot math transform (stash + immediate expand). `preprocess`
         # itself uses the two phases separately so the combined pass runs in
@@ -582,9 +586,15 @@ module Hwaro
 
         # Phase 2: expand stashed math spans into final HTML.
         #
-        # Display math always emits single-backslash `\[…\]`: its `<div>` is
-        # an HTML block, opaque to Markd in every context. Inline math
-        # delimiter escaping depends on block context:
+        # Display math emits single-backslash `\[…\]` in a `<div>` when the
+        # div actually lands in HTML-block position — on a line of its own,
+        # or inside a raw HTML block. Mid-paragraph `$$…$$` gets a `<span>`
+        # instead: there the tags are *inline* raw HTML, Markd inline-parses
+        # the content between them (collapsing `\[` to `[`, reading `*`/`_`
+        # as emphasis), and a div can't legally sit inside the paragraph
+        # anyway. KaTeX/MathJax auto-render keys display style off the
+        # `\[…\]` delimiters, not the wrapper tag. Inline math delimiter
+        # escaping depends on block context:
         #
         # - In normal inline context the `<span>` content participates in
         #   CommonMark inline parsing, so the delimiters need an extra
@@ -622,13 +632,20 @@ module Hwaro
               end
 
               raw_context = in_html_block
+              bare_display = line.strip.matches?(BARE_MATH_LINE_RE)
               io << line.gsub(MATH_PLACEHOLDER_RE) do |match|
                 span = $~[1].to_i?.try { |idx| store[idx]? }
                 next match unless span
 
                 escaped = Utils::TextUtils.escape_xml(span.body)
-                if span.display
+                if span.display && (raw_context || bare_display)
                   "<div class=\"math math-display\">\\[#{escaped}\\]</div>"
+                elsif span.display
+                  # Mid-paragraph display math (inline raw HTML): escape the
+                  # body like the inline branch below, and double the
+                  # delimiters' backslashes so `\\[` collapses to `\[`.
+                  inline_escaped = escaped.gsub(/[\\`*_\[\]]/) { |c| "\\#{c}" }
+                  "<span class=\"math math-display\">\\\\[#{inline_escaped}\\\\]</span>"
                 elsif raw_context
                   "<span class=\"math math-inline\">\\(#{escaped}\\)</span>"
                 else

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -514,8 +514,11 @@ module Hwaro
         MATH_PLACEHOLDER_RE = /\x00MATH(\d+)\x00/
         # A line whose sole content is one math placeholder — the standalone
         # display-math case, where the emitted <div> starts at line start and
-        # is a real CommonMark HTML block.
-        BARE_MATH_LINE_RE = /\A\x00MATH\d+\x00\z/
+        # is a real CommonMark HTML block. Leading blockquote markers are
+        # stripped before the check: `> $$x$$` is block position too (the
+        # div becomes an HTML block inside the blockquote).
+        BARE_MATH_LINE_RE     = /\A\x00MATH\d+\x00\z/
+        BLOCKQUOTE_MARKERS_RE = /\A(?:>[ \t]?)+/
 
         # One-shot math transform (stash + immediate expand). `preprocess`
         # itself uses the two phases separately so the combined pass runs in
@@ -654,7 +657,9 @@ module Hwaro
               end
 
               raw_context = in_html_block
-              bare_display = line.strip.matches?(BARE_MATH_LINE_RE)
+              bare_line = line.strip
+              bare_line = bare_line.sub(BLOCKQUOTE_MARKERS_RE, "") if bare_line.starts_with?('>')
+              bare_display = bare_line.matches?(BARE_MATH_LINE_RE)
               io << line.gsub(MATH_PLACEHOLDER_RE) do |match|
                 span = $~[1].to_i?.try { |idx| store[idx]? }
                 next match unless span

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -53,14 +53,34 @@ module Hwaro
           # passes this check transforms exactly as before.
           markers_present = (do_task_lists && (result.includes?("[ ]") || result.includes?("[x]") || result.includes?("[X]"))) ||
                             (do_strikethrough && result.includes?("~~")) ||
-                            (do_heading_ids && result.includes?("{#")) ||
+                            (do_heading_ids && (result.includes?("{#") || result.includes?("<!--HID:"))) ||
                             (do_ins && result.includes?("++")) || (do_mark && result.includes?("==")) ||
                             (do_sub && result.includes?('~')) || (do_sup && result.includes?('^')) ||
-                            (config.attributes && result.includes?('{'))
+                            (config.attributes && (result.includes?('{') || result.includes?("<!--HATTR:")))
 
           if markers_present
             result = process_lines_fence_aware(result) do |line, _in_fence|
               transformed = line
+
+              # Author-typed engine markers are neutralized before the
+              # branches below inject the real ones — same in-band-signaling
+              # protection footnotes get (see preprocess_footnotes), but
+              # per-line and code-span-safe: a literal `<!--HID:x-->` in
+              # inline code or a fenced example stays byte-identical (it's
+              # inert there — Markd entity-escapes it), while one typed in
+              # prose can no longer smuggle an id or attributes onto a
+              # heading.
+              if do_heading_ids && transformed.includes?("<!--HID:")
+                transformed = transform_outside_code_spans(transformed) do |stashed|
+                  stashed.gsub("<!--HID:", "<!-- HID:")
+                end
+              end
+
+              if config.attributes && transformed.includes?("<!--HATTR:")
+                transformed = transform_outside_code_spans(transformed) do |stashed|
+                  stashed.gsub("<!--HATTR:", "<!-- HATTR:")
+                end
+              end
 
               if do_task_lists && !_in_fence &&
                  (transformed.includes?("[ ]") || transformed.includes?("[x]") || transformed.includes?("[X]"))

--- a/src/content/processors/syntax_highlighter.cr
+++ b/src/content/processors/syntax_highlighter.cr
@@ -791,18 +791,27 @@ module Hwaro
         end
 
         # Plain-text extraction mirroring `Markdown#post_process_html`'s
-        # inline char-level tag strip, so a heading's title text is
-        # normalized identically on both the hook path and the stock
-        # `post_process_html` path (see `HeadingIds.assign`).
+        # inline char-level tag strip (including its quote-awareness: a `>`
+        # inside a quoted attribute value must not end the tag), so a
+        # heading's title text is normalized identically on both the hook
+        # path and the stock `post_process_html` path (see
+        # `HeadingIds.assign`).
         private def strip_tags(html : String) : String
           String.build(html.bytesize) do |io|
             in_tag = false
+            quote = nil.as(Char?)
             html.each_char do |c|
-              if c == '<'
+              if in_tag
+                if quote
+                  quote = nil if c == quote
+                elsif c == '"' || c == '\''
+                  quote = c
+                elsif c == '>'
+                  in_tag = false
+                end
+              elsif c == '<'
                 in_tag = true
-              elsif c == '>'
-                in_tag = false
-              elsif !in_tag
+              else
                 io << c
               end
             end

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -13,6 +13,7 @@
 require "crinja"
 require "../../utils/logger"
 require "../../content/processors/fence_tracker"
+require "../../content/processors/inline_markdown"
 require "./builtin_shortcodes"
 
 module Hwaro
@@ -50,7 +51,10 @@ module Hwaro
         # the regex is used by `replace_shortcode_placeholders` after Markdown.
         SHORTCODE_PLACEHOLDER_PREFIX = "<!--HWARO-SHORTCODE-PLACEHOLDER-"
         SHORTCODE_PLACEHOLDER_SUFFIX = "-->"
-        SHORTCODE_PLACEHOLDER_RE     = /#{Regex.escape(SHORTCODE_PLACEHOLDER_PREFIX)}\d+#{Regex.escape(SHORTCODE_PLACEHOLDER_SUFFIX)}/
+        # The matching regex lives in InlineMarkdown, which must stash the
+        # comment before its HTML.escape pass (a spec pins the alias against
+        # PREFIX/SUFFIX so the two can't drift).
+        SHORTCODE_PLACEHOLDER_RE = Content::Processors::InlineMarkdown::SHORTCODE_PLACEHOLDER_RE
 
         # Matches CommonMark-style inline code spans on a single line
         # (1 to 3 leading backticks; the same count must close the span).

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -122,8 +122,19 @@ module Hwaro
             block_depth = 0
 
             content.each_line(chomp: false) do |line|
-              if tracker.in_fence?
-                tracker.fence_line?(line)
+              # Fence lines flush the pending chunk and pass through
+              # verbatim. This check runs BEFORE the depth scans so fence
+              # content is never depth-counted — a fenced `{% name %}`
+              # example would otherwise pin block_depth > 0 and silently
+              # disable fence protection for the rest of the document.
+              # The tracker is only fed outside block-shortcode bodies:
+              # a fence inside a block body is part of the body, not a
+              # chunk boundary. (A fence can only open at depth 0 and no
+              # scan runs on fence lines, so in_fence ∧ depth > 0 is
+              # unreachable.)
+              if block_depth == 0 && tracker.fence_line?(line)
+                io << process_shortcodes_in_text(buffer.to_s, templates, context, shortcode_results, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+                buffer = String::Builder.new
                 io << line
                 next
               end
@@ -133,27 +144,20 @@ module Hwaro
               # control tags (`{% set %}`, `{% if %}`/`{% endif %}`, …) are
               # ignored — counting them would desync the depth (an unbalanced
               # `{% set %}` would pin depth > 0 and break fence protection).
-              line.scan(BLOCK_OPEN_RE) do |m|
+              # Inline code spans are masked first for the same reason: a
+              # literal `{% alert %}` in backticks must not count.
+              scan_line = line.includes?('`') ? mask_inline_code(line)[0] : line
+              scan_line.scan(BLOCK_OPEN_RE) do |m|
                 tag = m[0]
                 next if CRINJA_CONTROL_TAG_RE.matches?(tag) || BLOCK_ANY_CLOSE_RE.matches?(tag)
                 block_depth += 1
               end
-              line.scan(BLOCK_ANY_CLOSE_RE) do |m|
+              scan_line.scan(BLOCK_ANY_CLOSE_RE) do |m|
                 next if CRINJA_CONTROL_TAG_RE.matches?(m[0])
                 block_depth -= 1 if block_depth > 0
               end
 
-              # The tracker is only fed outside block-shortcode bodies (the
-              # short-circuit below), mirroring the previous behaviour where
-              # a fence inside a block body is part of the body, not a chunk
-              # boundary.
-              if block_depth == 0 && tracker.fence_line?(line)
-                io << process_shortcodes_in_text(buffer.to_s, templates, context, shortcode_results, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
-                buffer = String::Builder.new
-                io << line
-              else
-                buffer << line
-              end
+              buffer << line
             end
 
             io << process_shortcodes_in_text(buffer.to_s, templates, context, shortcode_results, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -1,5 +1,6 @@
 require "html"
 require "../utils/text_utils"
+require "../content/processors/fence_tracker"
 
 module Hwaro
   module Models
@@ -326,12 +327,25 @@ module Hwaro
       # Extract summary from content using <!-- more --> marker
       # Returns content before the marker, or nil if no marker found
       # Note: @raw_content has front matter already stripped during parsing
-      MORE_MARKER_REGEX = /\A(.*?)<!--\s*more\s*-->/mi
+      #
+      # Fence-aware: a marker shown inside a fenced code block (a docs page
+      # demonstrating the feature) is literal text, not a split point. The
+      # per-line pattern no longer matches a marker whose parts sit on
+      # different lines — degenerate input the old multi-line `\s*` accepted.
+      MORE_MARKER_REGEX = /<!--\s*more\s*-->/i
 
       def extract_summary : String?
-        if match = @raw_content.match(MORE_MARKER_REGEX)
-          summary_md = match[1].strip
-          @summary = summary_md unless summary_md.empty?
+        return @summary unless @raw_content.includes?("<!--")
+
+        offset = 0
+        tracker = Content::Processors::FenceTracker.new
+        @raw_content.each_line(chomp: false) do |line|
+          if !tracker.fence_line?(line) && (match = line.match(MORE_MARKER_REGEX))
+            summary_md = @raw_content.byte_slice(0, offset + match.byte_begin(0)).strip
+            @summary = summary_md unless summary_md.empty?
+            return @summary
+          end
+          offset += line.bytesize
         end
         @summary
       end


### PR DESCRIPTION
## Summary

Markdown rendering edge-case audit: 10 correctness bugs fixed across the fence-tracking, shortcode, math, and heading/TOC passes. Every fix only changes output for inputs that render wrong today — the docs site builds **byte-identical** (`diff -r`) after each commit.

## Fixes

| Commit | Bug | Severity |
|---|---|---|
| `recognize blockquoted fences` | `> ```` ` fences were invisible to FenceTracker, so strikethrough/task-list/math/table/shortcode passes corrupted blockquoted fence content that Markd renders as code | HIGH |
| `placeholders survive table cells…` | Shortcode placeholder comments were HTML-escaped by InlineMarkdown in table cells / definition bodies / footnote bodies, leaking literal `&lt;!--HWARO-SHORTCODE-PLACEHOLDER-N--&gt;` into the page and search index | HIGH |
| `protect indented-code content` | 4-space/tab indented code was fed to every transform: tab-indented `${A}/${B}` became math, indented pipe-table examples became `<table>`, `~~x~~` became `<del>` (same class as 1e72f4e, which only covered fenced blocks) | MED |
| `check fences before block-depth tracking` | An unbalanced `{% name %}` inside backticks pinned the shortcode processor's block depth > 0, silently disabling fence protection for the whole rest of the document | MED |
| `mid-paragraph display math` | `text $$E=mc^2$$ text` emitted a `<div>` as inline raw HTML: Markd collapsed `\[`→`[` (KaTeX misses it) and turned `*`/`_` into emphasis. Now an inline-safe `<span class="math math-display">` with doubled delimiters | MED-LOW |
| `harden math delimiter regexes` | A stray unmatched `$$` paired across blank lines and swallowed whole paragraphs into one formula; `$x = \$5$` mis-split on the escaped dollar | LOW-MED |
| `stop misreading data-id and quoted '>'` | `\bid=` matched `data-id=` (heading got no real id, TOC linked to a nonexistent anchor); attribute scans stopped at a quoted `>` (`title="a > b"`), truncating matches and polluting TOC titles | LOW |
| `fence-aware more-marker; neutralize typed HID markers` | A `<!-- more -->` shown in a fenced example truncated the summary; author-typed `<!--HID:x-->` comments were consumed as engine markers (id spoofing) while footnote markers were already neutralized | LOW |

## Invariants established

- **FenceTracker is the single fence/indented-code oracle** — all five consumers (extension line pass, math chunker, definition lists, TableParser, shortcode processor) now agree with Markd on blockquoted fences and indented-code runs.
- **Shortcode block-depth scans never see fence content or inline code** — the depth can no longer desync.
- **`InlineMarkdown.render` passes engine placeholder comments through unescaped** (stash-before-escape, restore-last), same convention as CODESPAN/MATHSPAN tokens.
- **Display math never crosses a blank line**, and its wrapper matches its block context (div at line start / raw HTML blocks, span mid-paragraph).
- **Attribute regexes are quote-aware and `(?<![\w-])`-guarded** across heading/anchor/img/code-span passes.

## Verification

- 60+ new characterizing specs (incl. new `spec/unit/fence_tracker_spec.cr`); full `crystal spec` green
- `crystal tool format --check` + `ameba` clean (405 files)
- Docs site `diff -r` byte-identical against the pre-branch baseline after every commit
- End-to-end smoke site exercising each bug class through `hwaro build` — all render correctly (table-cell shortcode resolves, blockquoted/indented fence content stays literal, mid-paragraph math survives, `data-id` heading gets a real id, typed `<!--HID:evil-->` is defused to an inert comment)

## Known accepted limitations (documented in code)

- Fences at 4+ absolute indent inside list items remain unrecognized (pre-existing)
- Tab-formed blockquote markers (`>\t`) are not stripped
- Indented code directly after a fence closer (no blank line) opens no protected run
