### PR TITLE
fix(new): harden hwaro new against traversal, hidden files, and silent failures

### DIFF
--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -570,6 +570,85 @@ describe Hwaro::Services::Creator do
       end
     end
 
+    describe "stability guards" do
+      it "raises HWARO_E_USAGE for a --date the build cannot parse, writing nothing" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+            options = Hwaro::Config::Options::NewOptions.new(path: "post.md", title: "T", date: "2026-13-45")
+            err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Creator.new.run(options) }
+            err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+            File.exists?("content/post.md").should be_false
+          end
+        end
+      end
+
+      it "derives the title from the filename when --title is whitespace-only" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+            options = Hwaro::Config::Options::NewOptions.new(path: "my-post.md", title: "   ")
+            Hwaro::Services::Creator.new.run(options)
+            File.read("content/my-post.md").should contain(%(title = "My Post"))
+          end
+        end
+      end
+
+      it "derives the bundle title from the path's last segment when --bundle has no --title" do
+        # Parity: the config-driven `bundle = true` derived the title from the
+        # path, but the explicit `--bundle` flag demanded --title and errored.
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+            options = Hwaro::Config::Options::NewOptions.new(path: "posts/my-bundle", bundle: true)
+            result = Hwaro::Services::Creator.new.run(options)
+            result.should eq("content/posts/my-bundle/index.md")
+            File.read(result).should contain(%(title = "My Bundle"))
+          end
+        end
+      end
+
+      it "refuses a flat page whose URL collides with an existing bundle" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts/foo")
+            File.write("content/posts/foo/index.md", "+++\ntitle = \"F\"\n+++\n")
+            options = Hwaro::Config::Options::NewOptions.new(path: "posts/foo.md", title: "F2")
+            err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Creator.new.run(options) }
+            err.code.should eq(Hwaro::Errors::HWARO_E_IO)
+            File.exists?("content/posts/foo.md").should be_false
+          end
+        end
+      end
+
+      it "refuses a flat page whose URL collides with an existing section index" do
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/sec")
+            File.write("content/sec/_index.md", "+++\ntitle = \"S\"\n+++\n")
+            options = Hwaro::Config::Options::NewOptions.new(path: "sec.md", title: "S2")
+            err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Creator.new.run(options) }
+            err.code.should eq(Hwaro::Errors::HWARO_E_IO)
+            File.exists?("content/sec.md").should be_false
+          end
+        end
+      end
+
+      it "classifies a file squatting on a parent directory segment as HWARO_E_IO" do
+        # Previously this unwound as a bare File::AlreadyExistsError — no
+        # error code, no exit taxonomy, and an empty stdout in --json mode.
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content")
+            File.write("content/blocker.md", "+++\ntitle = \"B\"\n+++\n")
+            options = Hwaro::Config::Options::NewOptions.new(path: "blocker.md/child.md", title: "C")
+            err = expect_raises(Hwaro::HwaroError) { Hwaro::Services::Creator.new.run(options) }
+            err.code.should eq(Hwaro::Errors::HWARO_E_IO)
+          end
+        end
+      end
+    end
+
     describe ".slugify" do
       it "lowercases and hyphenates a title" do
         Hwaro::Services::Creator.slugify("My First Post!").should eq("my-first-post")
@@ -1270,6 +1349,43 @@ describe Hwaro::Services::Creator do
       # foo/../bar.md resolves to bar.md which is still inside content/.
       Hwaro::Services::Creator.validate_and_normalize_path!("foo/../bar.md").should eq("bar.md")
     end
+
+    it "rejects hidden (dot-leading) segments the build would ignore" do
+      # Content discovery globs `content/**/*`, which skips hidden entries —
+      # a scaffolded `.md` / `.hidden/foo.md` would never render.
+      expect_raises(ArgumentError, /hidden segment/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!(".md")
+      end
+      expect_raises(ArgumentError, /hidden segment/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!(".hidden/foo.md")
+      end
+      expect_raises(ArgumentError, /hidden segment/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!("posts/.hidden/foo.md")
+      end
+      expect_raises(ArgumentError, /hidden segment/) do
+        Hwaro::Services::Creator.validate_and_normalize_path!("...")
+      end
+    end
+  end
+
+  describe ".parseable_content_date?" do
+    it "accepts the formats the build's front-matter parser accepts" do
+      Hwaro::Services::Creator.parseable_content_date?("2026-03-22").should be_true
+      Hwaro::Services::Creator.parseable_content_date?("2026-03-22 10:30:00").should be_true
+      Hwaro::Services::Creator.parseable_content_date?("2026-03-22T10:30:00").should be_true
+      Hwaro::Services::Creator.parseable_content_date?("2026-03-22T10:30:00Z").should be_true
+      Hwaro::Services::Creator.parseable_content_date?("2026-03-22T10:30:00+09:00").should be_true
+    end
+
+    it "rejects out-of-range and garbage dates" do
+      # `2026-13-45` matches the TOML datetime *pattern* and used to be
+      # emitted unquoted — invalid TOML that broke the whole generated file.
+      Hwaro::Services::Creator.parseable_content_date?("2026-13-45").should be_false
+      Hwaro::Services::Creator.parseable_content_date?("2026-02-30").should be_false
+      Hwaro::Services::Creator.parseable_content_date?("not-a-date").should be_false
+      Hwaro::Services::Creator.parseable_content_date?("").should be_false
+      Hwaro::Services::Creator.parseable_content_date?("   ").should be_false
+    end
   end
 
   describe ".url_safe_path?" do
@@ -1342,6 +1458,14 @@ describe Hwaro::Services::Creator do
       expect_raises(ArgumentError, /no URL-safe characters/) do
         Hwaro::Services::Creator.sanitize_url_path("!!!/???")
       end
+    end
+
+    it "drops segments that sanitize to pure dots instead of synthesizing `..`" do
+      # `>.>.` → `-.-.` → hyphen/dot collapse → `..` — a traversal segment
+      # fabricated AFTER validate_and_normalize_path! already ran. It must
+      # vanish like any empty segment, never join the on-disk path.
+      Hwaro::Services::Creator.sanitize_url_path("posts/>.>./foo.md").should eq("posts/foo.md")
+      Hwaro::Services::Creator.sanitize_url_path("a/>.>./>.>./b.md").should eq("a/b.md")
     end
   end
 end

--- a/spec/unit/new_command_spec.cr
+++ b/spec/unit/new_command_spec.cr
@@ -124,6 +124,30 @@ describe Hwaro::CLI::Commands::NewCommand do
       _, json_output = cmd.parse_options(["post.md"])
       json_output.should be_false
     end
+
+    it "raises on extra positional arguments instead of silently dropping them" do
+      # `hwaro new post.md --title My Post` (unquoted title) used to scaffold
+      # `post.md` and silently discard `Post` — now it's a classified error.
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      err = expect_raises(Hwaro::HwaroError) do
+        cmd.parse_options(["a.md", "b.md"])
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      (err.message || "").should contain("b.md")
+    end
+
+    it "accepts a leading-dash path after `--`" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      options, _json = cmd.parse_options(["--", "-dash.md"])
+      options.path.should eq("-dash.md")
+    end
+
+    it "still reports unknown flags as invalid options, not extra arguments" do
+      cmd = Hwaro::CLI::Commands::NewCommand.new
+      expect_raises(OptionParser::InvalidOption) do
+        cmd.parse_options(["--bogus", "x.md"])
+      end
+    end
   end
 
   # A malformed `config.toml` must surface as the same classified
@@ -264,6 +288,56 @@ describe Hwaro::CLI::Commands::NewCommand do
           # No phantom dir from the stray slash.
           Dir.exists?("content/posts/").should be_true
           Dir.children("content/posts").includes?("").should be_false
+        end
+      end
+    end
+
+    it "rejects paths whose sanitized form would synthesize `..` (no file escapes content/)" do
+      # `.>.` is not `..`, so it survived the first structural validation —
+      # but sanitizing `>` → `-` and collapsing hyphens against dots turned it
+      # into `..`, and the file landed OUTSIDE the project directory.
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = ""\n))
+          FileUtils.mkdir_p("content")
+          err = expect_raises(Hwaro::HwaroError) do
+            Hwaro::CLI::Commands::NewCommand.new.run(["posts/.>./.>./.>./evil.md", "-t", "X"])
+          end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+
+          File.exists?(File.join(dir, "evil.md")).should be_false
+          File.exists?(File.join(dir, "..", "evil.md")).should be_false
+        end
+      end
+    end
+
+    it "rejects a path that sanitizes to a hidden filename" do
+      # `!.md` sanitizes to `.md` — a dotfile the build's glob never sees.
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = ""\n))
+          FileUtils.mkdir_p("content")
+          err = expect_raises(Hwaro::HwaroError) do
+            Hwaro::CLI::Commands::NewCommand.new.run(["!.md", "-t", "X"])
+          end
+          err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+          (err.message || "").should contain("hidden segment")
+          File.exists?("content/.md").should be_false
+        end
+      end
+    end
+
+    it "normalizes a case-variant .MD extension instead of double-suffixing" do
+      # `Foo.MD` slipped past every `ends_with?(".md")` heuristic and
+      # scaffolded `Foo.MD.md`.
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = ""\n))
+          FileUtils.mkdir_p("content")
+          Hwaro::CLI::Commands::NewCommand.new.run(["Foo.MD", "-t", "T"])
+
+          File.exists?("content/Foo.md").should be_true
+          File.exists?("content/Foo.MD.md").should be_false
         end
       end
     end

--- a/src/cli/commands/new_command.cr
+++ b/src/cli/commands/new_command.cr
@@ -114,16 +114,6 @@ module Hwaro
           # Empty / absolute / content-escaping paths fail here with a
           # classified usage error instead of silently landing at an
           # unexpected filesystem location.
-          begin
-            normalized = Services::Creator.validate_and_normalize_path!(raw_path)
-          rescue ex : ArgumentError
-            raise Hwaro::HwaroError.new(
-              code: Hwaro::Errors::HWARO_E_USAGE,
-              message: ex.message || "Invalid <path> argument",
-              hint: "Usage: hwaro new <path> [options] — run 'hwaro new --help' for details.",
-            )
-          end
-
           # Auto-sanitize URL-unsafe characters (spaces, `!@#$%…`) in each
           # path segment so the on-disk directory also works as a clean URL
           # path once the site is built. CJK / Unicode letters, digits, and
@@ -131,7 +121,13 @@ module Hwaro
           # surface the rewrite via `Logger.info` so the author sees what
           # landed on disk — silent transformation would be confusing.
           begin
+            normalized = Services::Creator.validate_and_normalize_path!(raw_path)
             sanitized = Services::Creator.sanitize_url_path(normalized)
+            # Sanitizing rewrites characters, and the rewrite can change the
+            # path's *structure* (segments dropped, dots collapsing together),
+            # so the structural guard must run again on the result —
+            # sanitization must never be able to undo validation.
+            sanitized = Services::Creator.validate_and_normalize_path!(sanitized) if sanitized != normalized
           rescue ex : ArgumentError
             raise Hwaro::HwaroError.new(
               code: Hwaro::Errors::HWARO_E_USAGE,
@@ -141,6 +137,16 @@ module Hwaro
           end
           if sanitized != normalized
             Logger.info "Sanitized path: '#{normalized}' → '#{sanitized}' (URL-unsafe characters replaced)"
+          end
+
+          # A case-variant extension (`Foo.MD`) would slip past every
+          # `ends_with?(".md")` heuristic downstream and scaffold
+          # `Foo.MD.md`; the build's content scan only accepts exactly
+          # `.md`, so normalize the extension and tell the author.
+          if sanitized.size > 3 && sanitized[-3..].downcase == ".md" && !sanitized.ends_with?(".md")
+            fixed = sanitized[0...-3] + ".md"
+            Logger.info "Normalized extension: '#{sanitized}' → '#{fixed}'"
+            sanitized = fixed
           end
 
           # --section is joined to the on-disk path just like <path>, so it
@@ -260,8 +266,24 @@ module Hwaro
             parser.on("--json", "Emit machine-readable JSON output") { json_output = true }
             CLI.register_flag(parser, QUIET_FLAG) { |_| Logger.quiet = true }
             CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
-            parser.unknown_args do |unknown|
-              path = unknown.first if unknown.present?
+            parser.unknown_args do |before_dash, after_dash|
+              # Accept the single <path> from either side of `--` (the latter
+              # lets authors create leading-dash filenames). Anything beyond
+              # one positional is almost always an unquoted multi-word title
+              # (`--title My Post`) — silently dropping the extras used to
+              # scaffold a file the author didn't ask for, so reject instead.
+              # Flag-looking leftovers (`--bogus`) are not positionals — leave
+              # them for OptionParser's invalid-option error, which names the
+              # actual offending flag.
+              positionals = before_dash.reject(&.starts_with?('-')) + after_dash
+              if positionals.size > 1
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "unexpected extra argument(s): '#{positionals[1..].join("', '")}'",
+                  hint: "hwaro new takes a single <path>. Quote multi-word values, e.g. --title \"My Post\".",
+                )
+              end
+              path = positionals.first?
             end
           end
 

--- a/src/cli/commands/new_wizard.cr
+++ b/src/cli/commands/new_wizard.cr
@@ -115,7 +115,9 @@ module Hwaro
         # IO hiccup) simply yields no hint rather than failing the wizard.
         private def detect_sections : Array(String)
           return [] of String unless Dir.exists?(CONTENT_DIR)
-          Dir.children(CONTENT_DIR).select { |c| Dir.exists?(File.join(CONTENT_DIR, c)) }.sort!
+          # Skip dot-dirs (.obsidian, .git worktrees, …) — they are ignored by
+          # the build, so suggesting them as sections would be misleading.
+          Dir.children(CONTENT_DIR).select { |c| !c.starts_with?('.') && Dir.exists?(File.join(CONTENT_DIR, c)) }.sort!
         rescue
           [] of String
         end

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -62,7 +62,22 @@ module Hwaro
           )
         end
 
-        full[root_prefix.size..]
+        relative = full[root_prefix.size..]
+
+        # Dot-leading segments (`.md`, `.hidden/foo.md`, `...`) are invisible
+        # to the build: content discovery globs `content/**/*`, which skips
+        # hidden entries. Creating one here would scaffold a page the site
+        # then silently never renders — reject it up front instead.
+        relative.split(PATH_SEP).each do |segment|
+          if segment.starts_with?('.')
+            raise ArgumentError.new(
+              "Path '#{raw}' contains a hidden segment '#{segment}' (leading dot). " \
+              "Hidden files are ignored by the build; use a name that does not start with '.'."
+            )
+          end
+        end
+
+        relative
       end
 
       # Path separator used by hwaro-managed content paths. Hwaro stores
@@ -122,9 +137,44 @@ module Hwaro
         title.downcase.gsub(/[^\p{L}\p{N}]+/, "-").strip("-")
       end
 
+      # True when the build's front-matter date parser can produce a real
+      # `Time` from `value`. This mirrors `Processors::Markdown#parse_time`
+      # (format selection included — keep the two in sync) so `hwaro new`
+      # fails fast on a `--date` the build would silently drop (`2026-13-45`,
+      # `not-a-date`) or, worse, emit as an unquoted-but-invalid TOML
+      # datetime that breaks parsing of the whole generated file.
+      def self.parseable_content_date?(value : String) : Bool
+        str = value.strip
+        return false if str.empty?
+
+        fmt = if str.includes?('T')
+                if str.includes?('+') || str.includes?('Z') || str.matches?(/T.+-\d{2}:\d{2}$/) || str.matches?(/\d{2}-\d{2}$/)
+                  begin
+                    Time.parse_rfc3339(str)
+                    return true
+                  rescue Time::Format::Error | ArgumentError
+                    "%Y-%m-%dT%H:%M:%S"
+                  end
+                else
+                  "%Y-%m-%dT%H:%M:%S"
+                end
+              elsif str.size > 10
+                "%Y-%m-%d %H:%M:%S"
+              else
+                "%Y-%m-%d"
+              end
+
+        begin
+          Time.parse(str, fmt, Time::Location.local)
+          true
+        rescue Time::Format::Error | ArgumentError
+          false
+        end
+      end
+
       private def self.sanitize_url_segment(segment : String) : String
         return segment if segment.empty?
-        String.build(segment.bytesize) do |io|
+        result = String.build(segment.bytesize) do |io|
           last_was_hyphen = false
           segment.each_char do |char|
             if url_safe_char?(char)
@@ -143,6 +193,14 @@ module Hwaro
           # hyphen that `strip('-')` cannot reach because the trailing char
           # is the extension, not the hyphen. Collapse both `-.` and `.-`.
           .gsub("-.", ".").gsub(".-", ".")
+
+        # Collapsing hyphens against dots can synthesize a pure-dot segment
+        # (`.>.` → `.-.` → `..`) — exactly the traversal shape the caller
+        # validated away BEFORE sanitizing, so it would escape content/
+        # unchecked. A segment left with only dots has no author-visible
+        # name at all; drop it like any other empty segment.
+        return "" if result.each_char.all? { |c| c == '.' }
+        result
       end
 
       private def self.url_safe_char?(char : Char) : Bool
@@ -155,7 +213,21 @@ module Hwaro
 
       def run(options : Config::Options::NewOptions, config : Models::Config? = nil)
         path = options.path
-        title = options.title || ""
+        # Strip so a whitespace-only `--title "   "` falls back to deriving
+        # the title from the filename instead of scaffolding `title = "   "`.
+        title = (options.title || "").strip
+
+        # Fail fast on a date the build cannot parse — otherwise the page is
+        # created now and its date silently vanishes at build time.
+        if raw_date = options.date
+          unless Creator.parseable_content_date?(raw_date)
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_USAGE,
+              message: "Invalid --date '#{raw_date}': not a date the build can parse.",
+              hint: "Use YYYY-MM-DD, 'YYYY-MM-DD HH:MM:SS', ISO 8601 (2026-03-22T10:00:00), or RFC 3339 with offset.",
+            )
+          end
+        end
 
         # --section overrides the base directory
         if section = resolve_section(options.section, path)
@@ -244,6 +316,14 @@ module Hwaro
             base_dir = path || "content/drafts"
             base_dir = "content/#{base_dir}" unless base_dir.starts_with?("content/")
             full_path = nil
+            # `--bundle <dir-path>` means "the path IS the bundle directory",
+            # so derive the title from its last segment exactly like the flat
+            # heuristics above do. Without this, `hwaro new posts/foo --bundle`
+            # demanded --title while the config-driven `bundle = true` derived
+            # it — the explicit flag was strictly stricter than the default.
+            if title.empty? && path && options.bundle == true
+              title = File.basename(path).split("-").map(&.capitalize).join(" ")
+            end
           end
         end
 
@@ -289,7 +369,7 @@ module Hwaro
           full_path = File.join(base_dir, filename)
         end
 
-        Hwaro::Utils::FileSafe.mkdir_p(base_dir) unless Dir.exists?(base_dir)
+        ensure_dir!(base_dir)
 
         # Draft: CLI flag > path-based detection. Match a path SEGMENT, not a
         # raw substring — `base_dir.includes?("drafts")` flagged unrelated dirs
@@ -368,7 +448,7 @@ module Hwaro
           end
           full_path = candidate
           base_dir = File.dirname(full_path)
-          Hwaro::Utils::FileSafe.mkdir_p(base_dir) unless Dir.exists?(base_dir)
+          ensure_dir!(base_dir)
         end
 
         content = if archetype_content
@@ -411,9 +491,46 @@ module Hwaro
           end
         end
 
-        File.write(full_path, content)
+        # Mirror of the bundle-over-flat guard above: a flat `<name>.md` next
+        # to an existing `<name>/index.md` bundle (or `<name>/_index.md`
+        # section) renders to the same URL, and the build then drops one of
+        # them with only a warning. Refuse at creation time instead.
+        if base != "index" && base != "_index"
+          {File.join(dir, base, "index.md"), File.join(dir, base, "_index.md")}.each do |nested_sibling|
+            next unless File.exists?(nested_sibling)
+            raise Hwaro::HwaroError.new(
+              code: Hwaro::Errors::HWARO_E_IO,
+              message: "Cannot create #{full_path}: would collide with existing #{nested_sibling} (both resolve to the same URL).",
+              hint: "Pick a different <path>, or edit #{nested_sibling} directly.",
+            )
+          end
+        end
+
+        begin
+          File.write(full_path, content)
+        rescue ex : IO::Error
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_IO,
+            message: "Cannot write #{full_path}: #{ex.message}",
+            hint: "Check write permissions and that the filename is valid for this filesystem.",
+          )
+        end
         Logger.outcome("created", full_path)
         full_path
+      end
+
+      # `mkdir -p` with the failure surfaced as a classified error. Without
+      # this, a file squatting on a parent segment (`content/a.md` when
+      # creating `a.md/child.md`) unwound as a bare exception — no error
+      # code, exit taxonomy, or JSON payload in `--json` mode.
+      private def ensure_dir!(dir : String) : Nil
+        Hwaro::Utils::FileSafe.mkdir_p(dir) unless Dir.exists?(dir)
+      rescue ex : IO::Error
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_IO,
+          message: "Cannot create directory #{dir}: #{ex.message}",
+          hint: "A file may already occupy one of the parent path segments, or you may lack write permission.",
+        )
       end
 
       # Returns `{stripped_content, directives}`. When the archetype's first


### PR DESCRIPTION
## Summary

Adversarial dogfooding of `hwaro new` surfaced **one real path-escape bug** and a cluster of silent-failure footguns. This PR turns all of them into classified errors or safe rewrites, with regression specs for each.

### The escape (the important one)

```
hwaro new 'posts/.>./.>./.>./evil.md' -t x
# before: created ../evil.md — OUTSIDE the project directory
```

`.>.` isn't `..`, so it passed `validate_and_normalize_path!` — but the URL sanitizer then rewrote `>` → `-` and collapsed hyphens against dots (`.-.` → `..`), synthesizing real traversal segments *after* validation had run. Two-layer fix:

1. `sanitize_url_segment` drops any segment that collapses to pure dots (it has no author-visible name anyway).
2. The CLI re-runs the structural guard on the sanitized path — sanitization can never undo validation.

### Silent-failure hardening

| Input | Before | After |
|---|---|---|
| `hwaro new .md` / `posts/.hidden/foo.md` | created files the build's `content/**/*` glob silently never renders | usage error naming the hidden segment |
| `--date 2026-13-45` / `not-a-date` / `""` | page created, date silently dropped at build (or invalid unquoted TOML datetime breaking the whole file) | usage error; validated against the same formats the build's front-matter parser accepts |
| `hwaro new post.md --title My Post` (unquoted) | `Post` silently discarded | usage error with quoting hint; `-- -dash.md` now supported |
| `hwaro new foo.md` next to `foo/index.md` or `foo/_index.md` | duplicate URL, build drops one copy with a warning | refused at creation (mirror of the existing bundle-over-flat guard) |
| parent segment is a file (`a.md/child.md`) | bare `File::AlreadyExistsError`, no error code, **empty stdout in `--json` mode** | classified `HWARO_E_IO` with JSON payload |
| `hwaro new posts/foo --bundle` (no title) | error, while config `bundle = true` derived the title for the same shape | derives title from the last path segment, like the config path |
| `hwaro new Foo.MD` | scaffolded `Foo.MD.md` | extension normalized to `.md` with a log line |
| `--title "   "` | `title = "   "` in front matter | falls back to filename derivation |

Also: the wizard's section hint no longer suggests dot-dirs (`.obsidian`, …).

## Test plan

- 16 new regression specs (creator + new_command) covering every row above
- Full suite: **6277 examples, 0 failures**
- `crystal tool format` clean, ameba full-project run: **405 inspected, 0 failures**
- Manual edge-case battery (18 cases) against the built binary, plus `hwaro build` smoke on the created content