### PR TITLE
fix(serve): harden watch rebuilds, template-change coverage, and the dev server

### DIFF
--- a/spec/functional/template_deps_spec.cr
+++ b/spec/functional/template_deps_spec.cr
@@ -271,6 +271,22 @@ describe "Template deps: review regressions" do
     deps.shortcodes_used_in(%(a {% badge type="x" %}body{% end %} b)).should eq(Set{"shortcodes/badge"})
   end
 
+  it "records an include edge when no space follows the include keyword" do
+    templates = {
+      "page"            => %({% include"partials/banner.html" %}),
+      "partials/banner" => "<div>banner</div>",
+    }
+    deps = Hwaro::Core::Build::TemplateDeps.new(templates)
+
+    deps.dynamic?.should be_false
+    deps.dependents_closure(Set{"partials/banner"}).should contain("page")
+  end
+
+  it "detects explicit shortcode() calls with a space before the paren" do
+    deps = Hwaro::Core::Build::TemplateDeps.new({"shortcodes/alert" => "<b>!</b>"})
+    deps.shortcodes_used_in(%(a {{ shortcode ("alert", msg="hi") }} b)).should contain("shortcodes/alert")
+  end
+
   it "rebuilds a page using explicit shortcode() syntax when the shortcode changes (cached)" do
     Dir.mktmpdir do |dir|
       Dir.cd(dir) do

--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -21,8 +21,8 @@ module Hwaro::Core::Build
       replace_shortcode_placeholders(html, shortcode_results)
     end
 
-    def test_render_shortcode_jinja(template, args, context, crinja_env_override = nil)
-      render_shortcode_jinja(template, args, context, crinja_env_override: crinja_env_override)
+    def test_render_shortcode_jinja(template, args, context, crinja_env_override = nil, warnings = nil)
+      render_shortcode_jinja(template, args, context, crinja_env_override: crinja_env_override, warnings: warnings)
     end
 
     def test_warn_hugo_shortcode_syntax(raw, path)
@@ -456,15 +456,27 @@ describe Hwaro::Core::Build::Builder do
       result.should eq("<span>Hello World</span>")
     end
 
-    it "returns empty string on template syntax error" do
+    it "returns a visible HTML-comment marker on template syntax error" do
       builder = Hwaro::Core::Build::Builder.new
       env = Crinja.new
       template = "{% if %}"
       args = {} of String => String
       context = {} of String => Crinja::Value
 
+      # Not an empty string: silently vanishing output made mid-edit
+      # template errors invisible during serve (the rebuild "succeeded").
       result = builder.test_render_shortcode_jinja(template, args, context, crinja_env_override: env)
-      result.should eq("")
+      result.should eq("<!-- hwaro: template error in shortcode -->")
+    end
+
+    it "records the template error in the warnings sink when provided" do
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      warnings = [] of String
+
+      builder.test_render_shortcode_jinja("{% if %}", {} of String => String, {} of String => Crinja::Value, crinja_env_override: env, warnings: warnings)
+      warnings.size.should eq(1)
+      warnings.first.should contain("Template error in shortcode")
     end
 
     it "args override context values" do

--- a/spec/unit/file_safe_spec.cr
+++ b/spec/unit/file_safe_spec.cr
@@ -71,4 +71,32 @@ describe Hwaro::Utils::FileSafe do
       end
     end
   end
+
+  describe ".atomic_write" do
+    it "writes content to a new file" do
+      Dir.mktmpdir do |root|
+        path = File.join(root, "index.html")
+        Hwaro::Utils::FileSafe.atomic_write(path, "<p>hello</p>")
+        File.read(path).should eq("<p>hello</p>")
+      end
+    end
+
+    it "replaces an existing file's content" do
+      Dir.mktmpdir do |root|
+        path = File.join(root, "index.html")
+        File.write(path, "old bytes")
+        Hwaro::Utils::FileSafe.atomic_write(path, "new bytes")
+        File.read(path).should eq("new bytes")
+      end
+    end
+
+    it "leaves no temp-file siblings behind" do
+      Dir.mktmpdir do |root|
+        path = File.join(root, "index.html")
+        Hwaro::Utils::FileSafe.atomic_write(path, "content")
+        Dir.glob(File.join(root, "*.tmp")).should be_empty
+        Dir.children(root).should eq(["index.html"])
+      end
+    end
+  end
 end

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -200,8 +200,50 @@ describe Hwaro::Services::IndexRewriteHandler do
 
       handler.call(context)
 
-      response.status_code.should eq(301)
+      response.status_code.should eq(302)
       response.headers["Location"].should eq("/some/dir/")
+      dummy.called.should be_false
+    end
+  end
+
+  it "preserves the query string when redirecting a directory to its slash form" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "search"))
+
+      handler = Hwaro::Services::IndexRewriteHandler.new(dir)
+      dummy = DummyHandler.new
+      handler.next = dummy
+
+      request = HTTP::Request.new("GET", "/search?q=term")
+      io = IO::Memory.new
+      response = HTTP::Server::Response.new(io)
+      context = HTTP::Server::Context.new(request, response)
+
+      handler.call(context)
+
+      response.status_code.should eq(302)
+      response.headers["Location"].should eq("/search/?q=term")
+      dummy.called.should be_false
+    end
+  end
+
+  it "redirects a directory whose last segment contains a dot" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "docs/v1.2"))
+
+      handler = Hwaro::Services::IndexRewriteHandler.new(dir)
+      dummy = DummyHandler.new
+      handler.next = dummy
+
+      request = HTTP::Request.new("GET", "/docs/v1.2")
+      io = IO::Memory.new
+      response = HTTP::Server::Response.new(io)
+      context = HTTP::Server::Context.new(request, response)
+
+      handler.call(context)
+
+      response.status_code.should eq(302)
+      response.headers["Location"].should eq("/docs/v1.2/")
       dummy.called.should be_false
     end
   end
@@ -222,7 +264,7 @@ describe Hwaro::Services::IndexRewriteHandler do
 
       handler.call(context)
 
-      response.status_code.should eq(301)
+      response.status_code.should eq(302)
       location = response.headers["Location"]
       location.should eq("/safe/dir/")
       location.should_not contain("\r")
@@ -308,6 +350,119 @@ describe Hwaro::Services::NotFoundHandler do
       content = io.to_s
       content.should contain("404 Not Found")
     end
+  end
+
+  it "injects the live-reload script into a custom 404.html" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "404.html"), "<html><body>Custom 404</body></html>")
+
+      injector = Hwaro::Services::LiveReloadInjectHandler.new(dir)
+      handler = Hwaro::Services::NotFoundHandler.new(dir, injector)
+
+      request = HTTP::Request.new("GET", "/nonexistent")
+      io = IO::Memory.new
+      response = HTTP::Server::Response.new(io)
+      context = HTTP::Server::Context.new(request, response)
+
+      handler.call(context)
+      response.close
+
+      response.status_code.should eq(404)
+      io.rewind
+      content = io.to_s
+      content.should contain("Custom 404")
+      content.should contain("__hwaro_livereload")
+      # Script lands before the closing </body>, not after it
+      content.index!("__hwaro_livereload").should be < content.rindex!("</body>")
+    end
+  end
+
+  it "injects the live-reload script into the plain-text fallback body" do
+    Dir.mktmpdir do |dir|
+      injector = Hwaro::Services::LiveReloadInjectHandler.new(dir)
+      handler = Hwaro::Services::NotFoundHandler.new(dir, injector)
+
+      request = HTTP::Request.new("GET", "/nonexistent")
+      io = IO::Memory.new
+      response = HTTP::Server::Response.new(io)
+      context = HTTP::Server::Context.new(request, response)
+
+      handler.call(context)
+      response.close
+
+      response.status_code.should eq(404)
+      io.rewind
+      content = io.to_s
+      content.should contain("404 Not Found")
+      content.should contain("__hwaro_livereload")
+    end
+  end
+
+  it "does not inject the live-reload script without an injector" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "404.html"), "<html><body>Custom 404</body></html>")
+
+      handler = Hwaro::Services::NotFoundHandler.new(dir)
+
+      request = HTTP::Request.new("GET", "/nonexistent")
+      io = IO::Memory.new
+      response = HTTP::Server::Response.new(io)
+      context = HTTP::Server::Context.new(request, response)
+
+      handler.call(context)
+      response.close
+
+      io.rewind
+      io.to_s.should_not contain("__hwaro_livereload")
+    end
+  end
+end
+
+# Downstream handler that records the Cache-Control value visible at the
+# time it runs, proving upstream handlers set headers BEFORE call_next.
+class CacheControlCaptureHandler
+  include HTTP::Handler
+
+  getter seen_cache_control : String?
+  property called : Bool = false
+
+  def call(context)
+    @called = true
+    @seen_cache_control = context.response.headers["Cache-Control"]?
+  end
+end
+
+describe Hwaro::Services::NoCacheHandler do
+  it "sets Cache-Control: no-store on the response" do
+    handler = Hwaro::Services::NoCacheHandler.new
+    dummy = DummyHandler.new
+    handler.next = dummy
+
+    request = HTTP::Request.new("GET", "/index.html")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler.call(context)
+
+    response.headers["Cache-Control"].should eq("no-store")
+    dummy.called.should be_true
+  end
+
+  it "sets the header before delegating so mid-body flushes carry it" do
+    handler = Hwaro::Services::NoCacheHandler.new
+    capture = CacheControlCaptureHandler.new
+    handler.next = capture
+
+    request = HTTP::Request.new("GET", "/big-file.bin")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler.call(context)
+
+    capture.called.should be_true
+    capture.seen_cache_control.should eq("no-store")
   end
 end
 
@@ -1343,11 +1498,21 @@ describe Hwaro::Services::ChangeSet do
   end
 end
 
-# Expose private detect_changes and classify_modified for testing
+# Expose private detect_changes and classify_modified for testing.
+# The Time-keyed overload converts to FileStamp (size 0) so specs that only
+# care about mtime semantics stay concise; the FileStamp overload passes
+# stamps through for size-delta cases.
 module Hwaro
   module Services
     class Server
       def test_detect_changes(old_mtimes : Hash(String, Time), new_mtimes : Hash(String, Time)) : ChangeSet
+        detect_changes(
+          old_mtimes.transform_values { |t| {t, 0_i64} },
+          new_mtimes.transform_values { |t| {t, 0_i64} },
+        )
+      end
+
+      def test_detect_changes(old_mtimes : Hash(String, FileStamp), new_mtimes : Hash(String, FileStamp)) : ChangeSet
         detect_changes(old_mtimes, new_mtimes)
       end
     end
@@ -1427,6 +1592,19 @@ describe "Server#detect_changes" do
     cs.added_files.should be_empty
     cs.removed_files.should be_empty
     cs.config_changed.should be_false
+  end
+
+  it "detects a size change with an identical mtime (coarse-mtime filesystems)" do
+    server = Hwaro::Services::Server.new
+    t1 = Time.utc(2025, 1, 1, 0, 0, 0)
+
+    old = {"content/posts/hello.md" => {t1, 10_i64}}
+    new_m = {"content/posts/hello.md" => {t1, 42_i64}}
+
+    cs = server.test_detect_changes(old, new_m)
+    cs.modified_content.should eq(["content/posts/hello.md"])
+    cs.added_files.should be_empty
+    cs.removed_files.should be_empty
   end
 
   it "detects modified template files" do
@@ -2620,6 +2798,15 @@ describe "watcher ignore patterns" do
     Hwaro::Services::Server.test_watcher_ignored?("templates/tmpl.html").should be_false
     Hwaro::Services::Server.test_watcher_ignored?("content/posts/14913.md").should be_false
     Hwaro::Services::Server.test_watcher_ignored?("static/img/4913.png").should be_false
+  end
+
+  it "ignores hidden editor/VCS state directories inside watched roots" do
+    Hwaro::Services::Server.test_watcher_ignored?("content/.obsidian/workspace.json").should be_true
+    Hwaro::Services::Server.test_watcher_ignored?("content/.git/index").should be_true
+  end
+
+  it "does NOT ignore publishable dot-directories like .well-known" do
+    Hwaro::Services::Server.test_watcher_ignored?("static/.well-known/security.txt").should be_false
   end
 
   it "excludes matched files from scan_mtimes" do

--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -138,15 +138,17 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
   end
 
   describe "malformed shortcodes" do
-    it "returns empty string when the shortcode template has a Crinja error" do
+    it "returns a visible HTML-comment marker when the shortcode template has a Crinja error" do
       builder = Hwaro::Core::Build::Builder.new
-      # Unbalanced/invalid Jinja syntax in the template
+      # Unbalanced/invalid Jinja syntax in the template. Not an empty
+      # string: silently vanishing output made mid-edit template errors
+      # invisible during serve (the rebuild "succeeded").
       result = builder.test_sc_render_jinja(
         "{% if %}",
         {} of String => String,
         {} of String => Crinja::Value,
       )
-      result.should eq("")
+      result.should eq("<!-- hwaro: template error in shortcode -->")
     end
 
     it "treats a stray {% end %} preceding shortcodes as literal text" do

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -109,7 +109,16 @@ module Hwaro
 
           start = Time.instant
           begin
-            builder.run(options)
+            unless builder.run(options)
+              # The build aborted without raising (pre-hook failure or a
+              # phase abort from a non-classified exception). It used to
+              # slip through as exit 0 / `"status": "ok"` — fail loud with
+              # the same envelope classified errors get.
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_INTERNAL,
+                message: "Build failed — see the log above for the failing phase or hook.",
+              )
+            end
           rescue ex : Hwaro::HwaroError
             # Classified errors (config, template, content, …) are raised at
             # their source sites now, so we just forward the payload / rethrow.

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -83,7 +83,7 @@ module Hwaro
         # Write search file
         filename = File.basename(config.search.filename)
         search_path = File.join(output_dir, filename)
-        File.write(search_path, content)
+        Hwaro::Utils::FileSafe.atomic_write(search_path, content)
         Logger.action :create, search_path if verbose
         Logger.info "  Generated search index with #{search_pages.size} pages." if verbose
       end

--- a/src/content/seo/amp.cr
+++ b/src/content/seo/amp.cr
@@ -62,7 +62,7 @@ module Hwaro
             end
             dir = File.dirname(amp_output)
             Hwaro::Utils::FileSafe.mkdir_p(dir) unless Dir.exists?(dir)
-            File.write(amp_output, amp_html)
+            Hwaro::Utils::FileSafe.atomic_write(amp_output, amp_html)
 
             # Inject <link rel="amphtml"> into the canonical page
             inject_amphtml_link(canonical_path, page, config, prefix)
@@ -260,7 +260,7 @@ module Hwaro
 
           if html.matches?(/<\/head>/i)
             updated = html.sub(/<\/head>/i, "#{link_tag}\n</head>")
-            File.write(canonical_path, updated)
+            Hwaro::Utils::FileSafe.atomic_write(canonical_path, updated)
           else
             Logger.warn "AMP: no </head> in #{canonical_path}; cannot inject rel=amphtml link."
           end

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -170,7 +170,7 @@ module Hwaro
 
           # Write feed file (basename prevents path traversal via config filename)
           feed_path = File.join(output_dir, File.basename(filename))
-          File.write(feed_path, feed_content)
+          Hwaro::Utils::FileSafe.atomic_write(feed_path, feed_content)
           Logger.action :create, feed_path if verbose
         end
 

--- a/src/content/seo/llms.cr
+++ b/src/content/seo/llms.cr
@@ -29,7 +29,7 @@ module Hwaro
 
           filename = File.basename(config.llms.filename.empty? ? "llms.txt" : config.llms.filename)
           file_path = File.join(output_dir, filename)
-          File.write(file_path, build_index(config, pages))
+          Hwaro::Utils::FileSafe.atomic_write(file_path, build_index(config, pages))
           Logger.action :create, file_path if verbose
           Logger.info "  Generated #{filename}" if verbose
 
@@ -146,7 +146,7 @@ module Hwaro
           content = build_full_document(pages, config)
           content += "\n" unless content.ends_with?("\n")
 
-          File.write(file_path, content)
+          Hwaro::Utils::FileSafe.atomic_write(file_path, content)
           Logger.action :create, file_path if verbose
           Logger.info "  Generated #{filename}" if verbose
         end

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -477,14 +477,14 @@ module Hwaro
                   # Fallback to SVG on render failure
                   svg_filename = "#{slug}.svg"
                   svg = render_svg(page, config, logo_data_uri, bg_data_uri)
-                  File.write(File.join(img_dir, svg_filename), svg)
+                  Hwaro::Utils::FileSafe.atomic_write(File.join(img_dir, svg_filename), svg)
                   page.image = "/#{ai.output_dir}/#{svg_filename}"
                   Logger.warn "  PNG render failed for #{slug}, falling back to SVG"
                 end
               else
                 svg_filename = "#{slug}.svg"
                 svg = render_svg(page, config, logo_data_uri, bg_data_uri)
-                File.write(File.join(img_dir, svg_filename), svg)
+                Hwaro::Utils::FileSafe.atomic_write(File.join(img_dir, svg_filename), svg)
                 page.image = "/#{ai.output_dir}/#{svg_filename}"
               end
               Logger.debug "  OG image: #{page.image}" if verbose

--- a/src/content/seo/pwa.cr
+++ b/src/content/seo/pwa.cr
@@ -56,7 +56,7 @@ module Hwaro
           end
 
           path = File.join(output_dir, "manifest.json")
-          File.write(path, manifest)
+          Hwaro::Utils::FileSafe.atomic_write(path, manifest)
           Logger.action :create, path if verbose
           Logger.info "  Generated manifest.json"
         end
@@ -165,7 +165,7 @@ module Hwaro
             JS
 
           path = File.join(output_dir, "sw.js")
-          File.write(path, sw_content)
+          Hwaro::Utils::FileSafe.atomic_write(path, sw_content)
           Logger.action :create, path if verbose
           Logger.info "  Generated sw.js"
         end

--- a/src/content/seo/robots.cr
+++ b/src/content/seo/robots.cr
@@ -47,7 +47,7 @@ module Hwaro
 
           filename = File.basename(config.robots.filename)
           file_path = File.join(output_dir, filename)
-          File.write(file_path, content)
+          Hwaro::Utils::FileSafe.atomic_write(file_path, content)
           Logger.action :create, file_path if verbose
           Logger.info "  Generated robots.txt" if verbose
         end

--- a/src/content/seo/sitemap.cr
+++ b/src/content/seo/sitemap.cr
@@ -116,7 +116,7 @@ module Hwaro
 
           filename = File.basename(site.config.sitemap.filename)
           sitemap_path = Path[output_dir, filename].to_s
-          File.write(sitemap_path, xml_content)
+          Hwaro::Utils::FileSafe.atomic_write(sitemap_path, xml_content)
           Logger.action :create, sitemap_path if verbose
           Logger.info "  Generated sitemap with #{sitemap_pages.size} URLs." if verbose
         end

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -526,7 +526,7 @@ module Hwaro
         end
 
         Hwaro::Utils::FileSafe.mkdir_p(Path[output_path].dirname)
-        File.write(output_path, content)
+        Hwaro::Utils::FileSafe.atomic_write(output_path, content)
         Logger.action :create, output_path if verbose
       end
 

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -97,6 +97,12 @@ module Hwaro
         # Static extends/include/import graph over the loaded templates.
         # Rebuilt whenever templates reload; nil before the first load.
         @template_deps : TemplateDeps?
+        # Content hashes of extension-shadowed template files (foo.j2 while
+        # foo.html holds the "foo" slot), keyed by source path. Renders can
+        # reach these by explicit name through the loader's disk fallback,
+        # so run_rerender must treat their edits as template changes even
+        # though the snapshot hash itself is unchanged.
+        @shadowed_template_hashes : Hash(String, String) = {} of String => String
         # Combined checksum of all templates for the current build — the
         # fallback per-entry template hash when dependency tracking is off.
         @global_templates_hash : String = ""
@@ -238,6 +244,13 @@ module Hwaro
           @context
         end
 
+        # The most recently loaded site config (nil before the first build).
+        # The serve watcher reads it to diff restart-only [serve] settings
+        # after a config-triggered rebuild.
+        def config : Models::Config?
+          @config
+        end
+
         # Register all cache layers with the unified manager
         private def setup_cache_manager
           @cache_manager.register("compiled_templates", "Compiled Crinja template ASTs", runtime: true) do
@@ -281,7 +294,10 @@ module Hwaro
           self
         end
 
-        def run(options : Config::Options::BuildOptions)
+        # Returns false when the build failed without raising (pre-hook
+        # failure or a phase abort) — the serve watcher branches on this to
+        # surface the failure instead of live-reloading onto a broken site.
+        def run(options : Config::Options::BuildOptions) : Bool
           @render_workers = options.workers
           run(
             output_dir: options.output_dir,
@@ -319,7 +335,7 @@ module Hwaro
         # - Re-links navigation only for affected sections
         # - Recomputes series/related posts only for affected pages
         # - Selectively invalidates Crinja caches
-        def run_incremental(changed_content_files : Array(String), options : Config::Options::BuildOptions)
+        def run_incremental(changed_content_files : Array(String), options : Config::Options::BuildOptions) : Bool
           @render_workers = options.workers
           config = @config
           site = @site
@@ -344,6 +360,11 @@ module Hwaro
           affected_sections = Set(String).new
           old_taxonomies_snapshot = {} of String => Hash(String, Array(String))
           old_series_names = {} of String => String?
+          # Output files each changed page occupied BEFORE re-parse — a slug/
+          # custom_path edit relocates the page, and the original file would
+          # otherwise keep serving 200 for the rest of the session (and ship
+          # if `public/` is deployed from it).
+          old_output_paths = {} of String => Array(String)
 
           # Build O(1) lookup map for changed file matching
           pages_map = @pages_by_path || build_pages_by_path(site)
@@ -362,10 +383,15 @@ module Hwaro
 
             page = pages_map[relative_path]?
             unless page
-              # A section _index that isn't in the site model (e.g. its own
-              # front matter says draft = true) can still cascade to its
-              # descendants — an edit to it is untrackable incrementally.
-              if File.basename(relative_path).starts_with?("_index.")
+              # Not in the site model: an excluded page (draft / future /
+              # expired / parse-failed at startup) whose edit may have just
+              # made it publishable, or a filtered section _index whose
+              # [cascade] still reaches descendants. Incremental bookkeeping
+              # can't see either — un-drafting a post used to be silently
+              # skipped here until serve restart. A full rebuild re-admits
+              # whatever this save changed. Files gone from disk are the
+              # watcher's removed-file path; still skip those.
+              if File.exists?(file)
                 Logger.info "  Changed #{relative_path} is not in the site model — running full rebuild."
                 return run(options)
               end
@@ -378,6 +404,7 @@ module Hwaro
             old_series_names[page.path] = page.series
             old_neighbors[page.path] = {page.lower, page.higher}
             old_cascade = page.is_a?(Models::Section) ? page.cascade : nil
+            old_output_paths[page.path] = collect_page_output_paths(page, output_dir)
 
             # Re-read, re-parse front-matter and recalculate URL
             parse_single_page(page)
@@ -403,7 +430,7 @@ module Hwaro
 
           if changed_pages.empty?
             Logger.info "  No matching pages found – skipping."
-            return
+            return true
           end
 
           # Re-render <!-- more --> summaries for the re-parsed pages with the
@@ -418,11 +445,11 @@ module Hwaro
           @output_url_winners = compute_output_url_winners((site.pages + site.sections).as(Array(Models::Page)))
 
           # --- 2. Incrementally update relationships ---
-          # Run taxonomy update on ALL re-parsed pages first (including those about
-          # to be excluded), so excluded pages' old entries are properly removed.
-          update_taxonomies_incremental(site, changed_pages, old_taxonomies_snapshot)
-
-          # Now identify pages that should be excluded (draft/expired/future)
+          # Identify pages that should be excluded (draft/expired/future)
+          # BEFORE the taxonomy update, so their re-parsed terms don't get
+          # re-added to site.taxonomies — pages rendered in this same pass
+          # would otherwise still show the drafted page in tag clouds and
+          # term counts until the next full build.
           excluded_pages = [] of Models::Page
           now = Time.utc
           # Re-stamp the publication window on re-parsed pages so pages kept
@@ -430,31 +457,42 @@ module Hwaro
           # artifacts and listings (same contract as the full parse phase).
           changed_pages.each(&.refresh_unpublished!(now))
           unless include_drafts
-            excluded = changed_pages.select(&.draft)
-            excluded_pages.concat(excluded)
+            excluded_pages.concat(changed_pages.select(&.draft))
             changed_pages.reject!(&.draft)
           end
           unless options.include_expired
-            expired = changed_pages.select { |p| p.expires.try { |e| e <= now } || false }
-            excluded_pages.concat(expired)
+            excluded_pages.concat(changed_pages.select { |p| p.expires.try { |e| e <= now } || false })
             changed_pages.reject! { |p| p.expires.try { |e| e <= now } || false }
           end
           unless options.include_future
-            future = changed_pages.select { |p| p.date.try { |d| d > now } || false }
-            excluded_pages.concat(future)
+            excluded_pages.concat(changed_pages.select { |p| p.date.try { |d| d > now } || false })
             changed_pages.reject! { |p| p.date.try { |d| d > now } || false }
           end
+          excluded_paths = excluded_pages.map(&.path).to_set
+
+          # Run taxonomy update on ALL re-parsed pages (including the excluded
+          # ones — their OLD entries must be removed; excluded_paths keeps
+          # their new terms from being re-added).
+          update_taxonomies_incremental(site, changed_pages + excluded_pages, old_taxonomies_snapshot, excluded_paths)
 
           # Remove excluded pages from site indices and delete stale output files
           unless excluded_pages.empty?
-            excluded_paths = excluded_pages.map(&.path).to_set
             site.pages.reject! { |p| excluded_paths.includes?(p.path) }
             site.sections.reject! { |p| excluded_paths.includes?(p.path) }
             excluded_pages.each do |p|
-              stale_output = get_output_path(p, output_dir)
-              File.delete(stale_output) if File.exists?(stale_output)
+              stale = old_output_paths[p.path]? || [get_output_path(p, output_dir)]
+              delete_orphaned_outputs(stale, output_dir)
             end
           end
+
+          # Delete originals of pages whose edit relocated their output file
+          # (slug/custom_path change) — excluded pages were handled above.
+          relocated = [] of String
+          changed_pages.each do |page|
+            next unless olds = old_output_paths[page.path]?
+            relocated.concat(olds) if olds.first? != get_output_path(page, output_dir)
+          end
+          delete_orphaned_outputs(relocated, output_dir) unless relocated.empty?
 
           all_pages = (site.pages + site.sections).as(Array(Models::Page))
 
@@ -475,8 +513,7 @@ module Hwaro
 
           # Recompute related posts selectively (if enabled). Pass the excluded
           # pages' paths so pages that listed a now-removed page as related drop it.
-          excluded_related_paths = excluded_pages.map(&.path).to_set
-          related_pages_updated = recompute_related_posts_for_pages(site, changed_pages, excluded_related_paths)
+          related_pages_updated = recompute_related_posts_for_pages(site, changed_pages, excluded_paths)
 
           # Invalidate Crinja caches for affected pages/sections
           invalidate_caches_for_pages(changed_pages, affected_sections)
@@ -572,6 +609,11 @@ module Hwaro
 
           # --- 4. Re-render the affected pages ---
           global_vars = build_global_vars(site, options.cache_busting)
+          # Refresh the stash render_global_vars_or_build serves — taxonomy
+          # pages regenerated below (and any later 404 rebuild) would
+          # otherwise render against the site snapshot of the last FULL
+          # build: old titles, old term sets, old menus.
+          @render_global_vars = global_vars
           @pages_by_path = build_pages_by_path(site)
           cache = @cache || Cache.new(enabled: false)
 
@@ -604,11 +646,12 @@ module Hwaro
           elapsed = Time.instant - start_time
           Logger.outcome("rebuilt", "#{render_list.size} / #{all_pages.size} pages", :result, elapsed.total_milliseconds)
           report_cache_stats(options.verbose)
+          true
         end
 
         # Incremental parse of changed content + full re-render with reloaded templates.
         # Used when both content and templates changed simultaneously.
-        def run_incremental_then_rerender(changed_content_files : Array(String), options : Config::Options::BuildOptions)
+        def run_incremental_then_rerender(changed_content_files : Array(String), options : Config::Options::BuildOptions) : Bool
           @render_workers = options.workers
           config = @config
           site = @site
@@ -619,11 +662,13 @@ module Hwaro
 
           Logger.info "Re-parsing #{changed_content_files.size} changed file(s) before full re-render..."
 
+          output_dir = options.output_dir
           pages_map = @pages_by_path || build_pages_by_path(site)
           changed_pages = [] of Models::Page
           affected_sections = Set(String).new
           old_taxonomies_snapshot = {} of String => Hash(String, Array(String))
           old_series_names = {} of String => String?
+          old_output_paths = {} of String => Array(String)
 
           # Same cascade context as run_incremental — re-parsed pages must
           # get their inherited section defaults back before rendering.
@@ -634,9 +679,10 @@ module Hwaro
 
             page = pages_map[relative_path]?
             unless page
-              # See run_incremental: an excluded section's _index can still
-              # cascade to descendants — escalate rather than miss it.
-              if File.basename(relative_path).starts_with?("_index.")
+              # See run_incremental: an excluded page's edit may have just
+              # made it publishable, and an excluded section's _index can
+              # still cascade to descendants — escalate rather than miss it.
+              if File.exists?(file)
                 Logger.info "  Changed #{relative_path} is not in the site model — running full rebuild."
                 return run(options)
               end
@@ -648,6 +694,7 @@ module Hwaro
             old_taxonomies_snapshot[page.path] = snapshot_page_taxonomies(page, site)
             old_series_names[page.path] = page.series
             old_cascade = page.is_a?(Models::Section) ? page.cascade : nil
+            old_output_paths[page.path] = collect_page_output_paths(page, output_dir)
 
             parse_single_page(page)
             page.generate_permalink(config.base_url)
@@ -667,12 +714,55 @@ module Hwaro
             page.ancestors.each { |ancestor| affected_sections << ancestor.section }
           end
 
-          # Update all derived relationships before full re-render
-          update_taxonomies_incremental(site, changed_pages, old_taxonomies_snapshot)
+          # Exclusion pass, mirroring run_incremental: a save that flips a
+          # page to draft (or into the expired/future window) alongside a
+          # template edit used to leave it published — still in listings,
+          # feeds, and on disk — because only the content-only strategy
+          # applied the filters.
+          excluded_pages = [] of Models::Page
+          now = Time.utc
+          changed_pages.each(&.refresh_unpublished!(now))
+          unless options.drafts
+            excluded_pages.concat(changed_pages.select(&.draft))
+            changed_pages.reject!(&.draft)
+          end
+          unless options.include_expired
+            excluded_pages.concat(changed_pages.select { |p| p.expires.try { |e| e <= now } || false })
+            changed_pages.reject! { |p| p.expires.try { |e| e <= now } || false }
+          end
+          unless options.include_future
+            excluded_pages.concat(changed_pages.select { |p| p.date.try { |d| d > now } || false })
+            changed_pages.reject! { |p| p.date.try { |d| d > now } || false }
+          end
+          excluded_paths = excluded_pages.map(&.path).to_set
+
+          # Update all derived relationships before full re-render (removal
+          # runs for every re-parsed page; excluded pages' new terms are not
+          # re-added — see update_taxonomies_incremental).
+          update_taxonomies_incremental(site, changed_pages + excluded_pages, old_taxonomies_snapshot, excluded_paths)
+
+          unless excluded_pages.empty?
+            site.pages.reject! { |p| excluded_paths.includes?(p.path) }
+            site.sections.reject! { |p| excluded_paths.includes?(p.path) }
+            excluded_pages.each do |p|
+              stale = old_output_paths[p.path]? || [get_output_path(p, output_dir)]
+              delete_orphaned_outputs(stale, output_dir)
+            end
+          end
+
+          # Delete originals of pages whose edit relocated their output file
+          # (slug/custom_path change) — mirrors run_incremental.
+          relocated = [] of String
+          changed_pages.each do |page|
+            next unless olds = old_output_paths[page.path]?
+            relocated.concat(olds) if olds.first? != get_output_path(page, output_dir)
+          end
+          delete_orphaned_outputs(relocated, output_dir) unless relocated.empty?
+
           site.build_lookup_index
           relink_navigation_for_sections(site, affected_sections)
           recompute_series_for_pages(site, changed_pages, old_series_names) if site.config.series.enabled
-          recompute_related_posts_for_pages(site, changed_pages) if site.config.related.enabled
+          recompute_related_posts_for_pages(site, changed_pages, excluded_paths) if site.config.related.enabled
 
           # Re-render with reloaded templates. The selective path inside
           # run_rerender only covers template-affected pages, so the content
@@ -692,7 +782,7 @@ module Hwaro
         # the selective path can't skip a content-changed page. Their taxonomy
         # membership may have changed too, so taxonomy pages regenerate
         # whenever force_pages are present.
-        def run_rerender(options : Config::Options::BuildOptions, force_pages : Array(Models::Page)? = nil)
+        def run_rerender(options : Config::Options::BuildOptions, force_pages : Array(Models::Page)? = nil) : Bool
           @render_workers = options.workers
           config = @config
           site = @site
@@ -706,6 +796,7 @@ module Hwaro
           # Reload templates from disk & reset all runtime caches.
           # Keep the old sources so the dependency graph can diff them.
           old_templates = @templates
+          old_shadowed = @shadowed_template_hashes
           @templates = nil
           @cache_manager.clear_runtime
           templates = load_templates
@@ -725,11 +816,20 @@ module Hwaro
           all_pages = (site.pages + site.sections).as(Array(Models::Page))
           renderable_pages = all_pages.select(&.render)
 
-          # Selective re-render: same template set, fully static graph
+          # Selective re-render: same template set, fully static graph.
+          # `old_shadowed` guards extension-shadowed variants (foo.j2 next to
+          # foo.html): they aren't in the snapshot hash, but an explicit
+          # `{% include "foo.j2" %}` reads them from disk — an edit there
+          # used to hit the "contents are identical" early return forever.
           affected_templates : Set(String)? = nil
           changed_template_names : Set(String)? = nil
+          # True when the change can alter page CONTENT and summaries
+          # (shortcode/hook templates in the affected closure), not just the
+          # layout — drives the summary recompute and SEO-surface refresh.
+          content_semantics_changed = false
           if @per_page_template_hash && deps && old_templates &&
-             old_templates.keys.sort! == templates.keys.sort!
+             old_templates.keys.sort! == templates.keys.sort! &&
+             old_shadowed == @shadowed_template_hashes
             changed = Set(String).new
             templates.each do |name, source|
               changed << name if old_templates[name]? != source
@@ -737,17 +837,22 @@ module Hwaro
             changed_template_names = changed
             if changed.empty? && (force_pages.nil? || force_pages.empty?)
               Logger.info "Template change detected, but contents are identical — nothing to re-render."
-              return
+              return true
             end
-            if changed.any?(&.starts_with?("hooks/"))
+            affected = deps.dependents_closure(changed)
+            if affected.any? { |n| n.starts_with?("hooks/") || n.starts_with?("shortcodes/") }
               # Hook templates aren't in the {% include %}/{% extends %}
               # dependency graph (they're invoked from Markdown rendering,
-              # not template rendering) — dependents_closure has no way to
-              # know which pages a hook change affects, so fall back to a
-              # full re-render.
+              # not template rendering), and shortcode output is embedded in
+              # page content AND summaries that listing pages and feeds
+              # re-print — the per-page graph can't scope either, so fall
+              # back to a full re-render. Checking the CLOSURE (not just the
+              # changed set) also catches a partial included by a
+              # shortcode/hook template.
               affected_templates = nil
+              content_semantics_changed = true
             else
-              affected_templates = deps.dependents_closure(changed)
+              affected_templates = affected
             end
             Logger.info "Template change detected (#{changed.join(", ")}). Re-rendering affected pages..." if options.verbose && !changed.empty?
           else
@@ -777,20 +882,25 @@ module Hwaro
           end
 
           global_vars = build_global_vars(site, options.cache_busting)
+          # Refresh the stash render_global_vars_or_build serves — the 404
+          # page and taxonomy regeneration below would otherwise render
+          # against the site snapshot of the last FULL build.
+          @render_global_vars = global_vars
           @pages_by_path = build_pages_by_path(site)
           cache = @cache || Cache.new(enabled: false)
 
           # Recompute <!-- more --> summaries with the reloaded templates —
           # but only when they can actually change: a shortcode/hook template
-          # edit, an unclassifiable template change (changed_template_names
-          # nil), or force_pages arriving from run_incremental_then_rerender
-          # with summary_html reset to nil by parse_single_page. A layout-only
+          # anywhere in the affected closure (content_semantics_changed), an
+          # unclassifiable template change (changed_template_names nil), or
+          # force_pages arriving from run_incremental_then_rerender with
+          # summary_html reset to nil by parse_single_page. A layout-only
           # edit skips the recompute entirely (it can't affect summaries and
           # would re-run per-page Crinja work on every keystroke).
           forced = force_pages || [] of Models::Page
           summaries_affected = !forced.empty? ||
                                changed_template_names.nil? ||
-                               changed_template_names.any? { |n| n.starts_with?("shortcodes/") || n.starts_with?("hooks/") }
+                               content_semantics_changed
           if summaries_affected
             # force_pages with render:true are already in pages_to_render;
             # render:false ones are excluded from the render set but their
@@ -798,6 +908,20 @@ module Hwaro
             summary_pages = pages_to_render + forced.reject(&.render)
             render_page_summaries(summary_pages, site, templates, highlight,
               link_targets: all_pages, global_vars: global_vars)
+
+            # The Crinja value caches and `global_vars` above were built
+            # BEFORE the recompute, so they still embed the OLD summary_html
+            # — a listing page printing `{{ p.summary }}` would re-render
+            # with the stale output (page body new, its summary everywhere
+            # else old). Drop the page-value caches and rebuild the globals
+            # from the fresh summaries.
+            @crinja_cache_mutex.synchronize do
+              @page_crinja_value_cache.clear
+              @section_pages_crinja_cache.clear
+              @section_pages_url_index_cache.clear
+            end
+            global_vars = build_global_vars(site, options.cache_busting)
+            @render_global_vars = global_vars
           end
 
           # Re-claim output URLs (see run_incremental): forced content edits
@@ -830,11 +954,12 @@ module Hwaro
                                 [] of Models::Section
                               end
 
-          # Content changed in this pass (run_incremental_then_rerender):
-          # sitemap/feeds/search/llms read page content and metadata, so
-          # refresh them like run_incremental does. Pure template edits skip
-          # this — template output doesn't feed the SEO surfaces.
-          if (forced = force_pages) && !forced.empty?
+          # Content semantics changed in this pass — either re-parsed content
+          # (run_incremental_then_rerender) or shortcode/hook template edits
+          # that rewrote the page.content / summary_html that sitemap, feeds,
+          # search, and llms embed. Refresh those surfaces. A pure layout
+          # edit still skips this — template output doesn't feed them.
+          if summaries_affected
             seo_pages = (site.pages + site.sections).as(Array(Models::Page))
             seo_pages += taxonomy_sections unless taxonomy_sections.empty?
             regenerate_seo_surfaces(seo_pages, site, output_dir, verbose, options.parallel, include_robots: true)
@@ -845,6 +970,7 @@ module Hwaro
           elapsed = Time.instant - start_time
           Logger.outcome("rebuilt", "#{count} pages · re-render", :result, elapsed.total_milliseconds)
           report_cache_stats(verbose)
+          true
         end
 
         # Are there any pages stashed by `--fast-start` waiting to render?
@@ -918,6 +1044,8 @@ module Hwaro
           @lifecycle.trigger(Lifecycle::HookPoint::BeforeRender, deferred_ctx)
 
           global_vars = build_global_vars(site, options.cache_busting)
+          # Keep the 404/taxonomy stash in sync (see run_incremental).
+          @render_global_vars = global_vars
           @pages_by_path = build_pages_by_path(site)
           renderable = pages.select(&.render)
 
@@ -1034,7 +1162,9 @@ module Hwaro
               if path.downcase.ends_with?(".md")
                 next unless site
                 rel = path.lchop("content/")
-                if page = site.pages.find { |p| p.path == rel }
+                # Section _index pages live in site.sections, not site.pages —
+                # deleting one used to leave its index.html served forever.
+                if page = site.pages.find { |p| p.path == rel } || site.sections.find { |s| s.path == rel }
                   outputs << get_output_path(page, output_dir)
 
                   # Sibling output-format files (see `[outputs]`): prefer what
@@ -1056,6 +1186,38 @@ module Hwaro
             end
           end
           outputs
+        end
+
+        # Primary output file plus output-format siblings for a page — used
+        # to prune the old files when an edit relocates the page's URL or
+        # excludes the page from the site.
+        private def collect_page_output_paths(page : Models::Page, output_dir : String) : Array(String)
+          paths = [get_output_path(page, output_dir)]
+          if cfg = @config
+            paths.concat(format_output_paths(page, output_dir, effective_output_formats(page, cfg)))
+          end
+          paths
+        end
+
+        # Delete output files an incremental rebuild has orphaned (slug
+        # change, page newly excluded), pruning directories the deletion
+        # leaves empty. Guarded so a corrupt path can never delete outside
+        # the output directory. Mirrors Server#remove_stale_outputs.
+        private def delete_orphaned_outputs(paths : Array(String), output_dir : String)
+          paths.each do |path|
+            next unless File.exists?(path)
+            next unless Utils::OutputGuard.within_output_dir?(path, output_dir)
+            File.delete(path)
+            Logger.info "  Removed stale output: #{path}"
+
+            dir = File.dirname(path)
+            while dir != output_dir && Utils::OutputGuard.within_output_dir?(dir, output_dir) && Dir.exists?(dir) && Dir.empty?(dir)
+              Dir.delete(dir)
+              dir = File.dirname(dir)
+            end
+          rescue ex
+            Logger.debug "  Could not remove stale output #{path}: #{ex.message}"
+          end
         end
 
         def run(
@@ -1082,7 +1244,7 @@ module Hwaro
           skip_image_processing : Bool = false,
           preserve_output : Bool = false,
           cache_busting : Bool = true,
-        )
+        ) : Bool
           # Load config once and reuse throughout the build.
           # `Models::Config.load` raises `HwaroError(HWARO_E_CONFIG)` directly
           # for missing files and TOML parse failures, so callers (and
@@ -1097,7 +1259,7 @@ module Hwaro
           unless pre_hooks.empty?
             unless Utils::CommandRunner.run_pre_hooks(pre_hooks)
               Logger.error "Build aborted due to pre-build hook failure."
-              return
+              return false
             end
           end
 
@@ -1166,8 +1328,12 @@ module Hwaro
           ctx.stats.end_time = Time.instant
 
           if result == Lifecycle::HookResult::Abort
+            # Phase bodies convert non-classified exceptions into Abort (see
+            # Lifecycle::Manager); returning false lets callers that can't
+            # rely on an exception — the serve watcher, `hwaro build`'s exit
+            # code — still observe the failure.
             Logger.error "Build failed!"
-            return
+            return false
           end
 
           elapsed = Time.instant - start_time
@@ -1207,6 +1373,8 @@ module Hwaro
               Utils::DebugPrinter.print(debug_site)
             end
           end
+
+          true
         end
 
         # Resolve `path` relative to `root`, falling back to a plain prefix

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -260,6 +260,11 @@ module Hwaro::Core::Build::Phases::Initialize
     # Built fresh and swapped in (never mutated in place) so a loader
     # holding the previous snapshot keeps a consistent pair of hashes.
     template_paths = {} of String => String
+    # Extension-shadowed variants (foo.j2 while foo.html won the slot).
+    # They never enter `templates`, but an explicit `{% include "foo.j2" %}`
+    # still reads them from disk via the loader fallback — so run_rerender's
+    # "did anything change?" diff must see their edits too (path → MD5).
+    shadowed_hashes = {} of String => String
     if Dir.exists?("templates")
       # Single glob for all supported template extensions.
       # Priority: html > j2 > jinja2 > jinja > ecr (first loaded wins via ||=)
@@ -274,7 +279,11 @@ module Hwaro::Core::Build::Phases::Initialize
         relative = Path[path].relative_to("templates")
         name = relative.to_s.gsub(Builder::TEMPLATE_EXTENSION_REGEX, "")
         # Don't overwrite if already loaded (higher priority extensions loaded first)
-        unless templates.has_key?(name)
+        if templates.has_key?(name)
+          if source = read_template_source(path)
+            shadowed_hashes[path] = Digest::MD5.hexdigest(source)
+          end
+        else
           if source = read_template_source(path)
             templates[name] = source
             template_paths[name] = path
@@ -292,6 +301,7 @@ module Hwaro::Core::Build::Phases::Initialize
       end
     end
     @template_paths = template_paths
+    @shadowed_template_hashes = shadowed_hashes
 
     # (Re)build the template dependency graph for selective invalidation
     @template_deps = TemplateDeps.new(templates)
@@ -383,6 +393,14 @@ module Hwaro::Core::Build::Phases::Initialize
   # Setup Crinja environment with custom filters, tests, and functions
   private def setup_crinja_env : Crinja
     env = Content::Processors::Template.engine.env
+
+    # The engine is a process-lifetime singleton and Crinja's InMemory
+    # template cache keys entries by (env, name, file, SOURCE) — every
+    # serve-mode template reload would add a fresh generation of compiled
+    # templates without ever evicting the previous one. Start each snapshot
+    # with a fresh cache so long serve sessions don't accumulate every
+    # historical template source in memory.
+    env.cache = Crinja::TemplateCache::InMemory.new
 
     # Set up template loader for template inheritance and includes
     if loader = build_template_loader

--- a/src/core/build/phases/output_formats.cr
+++ b/src/core/build/phases/output_formats.cr
@@ -154,7 +154,7 @@ module Hwaro::Core::Build::Phases::OutputFormats
     end
 
     ensure_dir(Path[output_path].dirname.to_s)
-    File.write(output_path, content)
+    Hwaro::Utils::FileSafe.atomic_write(output_path, content)
     Logger.action :create, output_path if verbose
   end
 

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -71,6 +71,12 @@ module Hwaro::Core::Build::Phases::ParseContent
   )
     md_config = site.config.markdown
     pages_by_path : Hash(String, Models::Page)? = nil
+    # Pages whose summary_html this pass (re)assigns. The shortcode-context
+    # build below caches the page's own Crinja value BEFORE the assignment,
+    # so without invalidation every `{{ p.summary }}` in a listing would
+    # render that poisoned nil-summary value (the raw markdown chunk) for
+    # the rest of the build.
+    recomputed_paths = [] of String
 
     pages.each do |page|
       # parse_single_page already extracted the chunk into page.summary;
@@ -99,6 +105,7 @@ module Hwaro::Core::Build::Phases::ParseContent
       html = Content::Processors::InternalLinkResolver.prefix_root_relative_links(html, site.config.base_url)
 
       page.summary_html = html
+      recomputed_paths << page.path
     rescue ex
       # A broken shortcode in a summary must not abort the whole parse
       # phase — fall back to plain-Markdown rendering (same config flags,
@@ -107,6 +114,19 @@ module Hwaro::Core::Build::Phases::ParseContent
       Logger.warn "Summary render failed for #{page.path} — falling back to plain Markdown: #{ex.message}"
       fallback, _ = Processor::Markdown.render(summary_md.to_s, use_highlight, md_config.safe, md_config.lazy_loading, md_config.emoji, markdown_config: md_config)
       page.summary_html = fallback
+      recomputed_paths << page.path
+    end
+
+    # Drop Crinja values cached before the summaries above were assigned —
+    # only the recomputed pages' entries, so incremental callers don't pay
+    # an O(site) re-conversion on every save. Section lists embed those
+    # page values wholesale, so they go too (rebuilt lazily on next use).
+    unless recomputed_paths.empty?
+      @crinja_cache_mutex.synchronize do
+        recomputed_paths.each { |path| @page_crinja_value_cache.delete(path) }
+        @section_pages_crinja_cache.clear
+        @section_pages_url_index_cache.clear
+      end
     end
   end
 

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -701,8 +701,12 @@ module Hwaro::Core::Build::Phases::Render
 
     processed_content = if has_shortcodes
                           shortcode_context = build_template_variables(page, site, "", "", "", global_vars: global_vars)
+                          # `warnings:` routes shortcode template errors into
+                          # page.build_warnings so the serve error overlay can
+                          # surface them (the render itself "succeeds").
                           process_shortcodes_jinja(raw, templates, shortcode_context, shortcode_results,
-                            crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+                            crinja_env_override: crinja_env_override, template_cache_override: template_cache_override,
+                            warnings: page.build_warnings)
                         else
                           raw
                         end
@@ -902,7 +906,7 @@ module Hwaro::Core::Build::Phases::Render
     end
 
     ensure_dir(Path[output_path].dirname.to_s)
-    File.write(output_path, Utils::RedirectHtml.full_redirect(redirect_url))
+    Hwaro::Utils::FileSafe.atomic_write(output_path, Utils::RedirectHtml.full_redirect(redirect_url))
     Logger.action :create, output_path if verbose
   end
 
@@ -978,7 +982,7 @@ module Hwaro::Core::Build::Phases::Render
     return unless Utils::OutputGuard.within_output_dir?(output_path, output_dir)
 
     ensure_dir(Path[output_path].dirname.to_s)
-    File.write(output_path, content)
+    Hwaro::Utils::FileSafe.atomic_write(output_path, content)
     Logger.action :create, output_path if verbose
   end
 
@@ -1057,7 +1061,7 @@ module Hwaro::Core::Build::Phases::Render
       # `with_base_path` is a no-op for a domain-root deployment.
       target = page.url.starts_with?('/') ? page.url : "/#{page.url}"
       redirect_url = site.config.with_base_path(target)
-      File.write(dest_path, Utils::RedirectHtml.simple_redirect(redirect_url))
+      Hwaro::Utils::FileSafe.atomic_write(dest_path, Utils::RedirectHtml.simple_redirect(redirect_url))
       Logger.action :create, dest_path, Logger::Role::Warn if verbose
     end
   end
@@ -1224,7 +1228,8 @@ module Hwaro::Core::Build::Phases::Render
                              template
                            else
                              process_shortcodes_in_text(template, templates, vars,
-                               crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+                               crinja_env_override: crinja_env_override, template_cache_override: template_cache_override,
+                               warnings: page.build_warnings)
                            end
 
       # Cache compiled Crinja templates by content hash.

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -309,10 +309,17 @@ module Hwaro::Core::Build::Phases::Transform
   # than "name:term" strings: a taxonomy name containing ":" would make the
   # joined form ambiguous to split back apart, silently skipping that term's
   # re-sort below.
+  #
+  # `excluded_paths` are changed pages the caller is about to drop from the
+  # site model (newly draft/expired/future). Their OLD terms still need the
+  # removal pass, but re-adding their NEW terms would resurrect them in
+  # site.taxonomies — every page rendered in the same pass would then show
+  # the drafted page in tag clouds / term counts until the next full build.
   private def update_taxonomies_incremental(
     site : Models::Site,
     changed_pages : Array(Models::Page),
     old_taxonomies_snapshot : Hash(String, Hash(String, Array(String))),
+    excluded_paths : Set(String) = Set(String).new,
   ) : Set({String, String})
     affected_tax_keys = Set({String, String}).new
 
@@ -337,7 +344,11 @@ module Hwaro::Core::Build::Phases::Transform
         end
       end
 
-      # 2. Add new assignments from re-parsed page
+      # 2. Add new assignments from re-parsed page — unless the caller is
+      # about to exclude it from the site model (removal above still ran,
+      # so its old terms are gone; skipping the add keeps it gone).
+      next if excluded_paths.includes?(page_path)
+
       page.taxonomies.each do |name, terms|
         site.taxonomies[name] ||= {} of String => Array(Models::Page)
         terms.each do |term|

--- a/src/core/build/phases/write.cr
+++ b/src/core/build/phases/write.cr
@@ -54,7 +54,7 @@ module Hwaro::Core::Build::Phases::Write
 
     output_path = File.join(output_dir, "404.html")
     Hwaro::Utils::FileSafe.mkdir_p(File.dirname(output_path))
-    File.write(output_path, final_html)
+    Hwaro::Utils::FileSafe.atomic_write(output_path, final_html)
     Logger.action :create, output_path if verbose
   end
 
@@ -84,7 +84,7 @@ module Hwaro::Core::Build::Phases::Write
         )
         result = processor.process(content, context)
         if result.success
-          File.write(output_path, result.content)
+          Hwaro::Utils::FileSafe.atomic_write(output_path, result.content)
         else
           Logger.warn "Failed to process #{raw_file.relative_path}: #{result.error}"
           FileUtils.cp(raw_file.source_path, output_path)
@@ -175,7 +175,7 @@ module Hwaro::Core::Build::Phases::Write
     output_path = get_output_path(page, output_dir)
 
     ensure_dir(Path[output_path].dirname.to_s)
-    File.write(output_path, content)
+    Hwaro::Utils::FileSafe.atomic_write(output_path, content)
     Logger.action :create, output_path if verbose
   end
 

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -108,7 +108,7 @@ module Hwaro
         # Supports two syntax patterns:
         # 1. Explicit: {{ shortcode("name", arg1="value1", arg2="value2") }}
         # 2. Direct:   {{ name(arg1="value1", arg2="value2") }}
-        private def process_shortcodes_jinja(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)? = nil, crinja_env_override : Crinja? = nil, template_cache_override : Hash(UInt64, Crinja::Template)? = nil) : String
+        private def process_shortcodes_jinja(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)? = nil, crinja_env_override : Crinja? = nil, template_cache_override : Hash(UInt64, Crinja::Template)? = nil, warnings : Array(String)? = nil) : String
           # Avoid processing shortcodes inside fenced code blocks (``` / ~~~),
           # so documentation can show literal `{{ ... }}` examples safely.
           # Fence semantics come from the shared CommonMark-faithful
@@ -137,7 +137,7 @@ module Hwaro
               # scan runs on fence lines, so in_fence ∧ depth > 0 is
               # unreachable.)
               if block_depth == 0 && tracker.fence_line?(line)
-                io << process_shortcodes_in_text(buffer.to_s, templates, context, shortcode_results, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+                io << process_shortcodes_in_text(buffer.to_s, templates, context, shortcode_results, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, warnings: warnings)
                 buffer = String::Builder.new
                 io << line
                 next
@@ -164,11 +164,11 @@ module Hwaro
               buffer << line
             end
 
-            io << process_shortcodes_in_text(buffer.to_s, templates, context, shortcode_results, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+            io << process_shortcodes_in_text(buffer.to_s, templates, context, shortcode_results, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, warnings: warnings)
           end
         end
 
-        private def process_shortcodes_in_text(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)? = nil, crinja_env_override : Crinja? = nil, template_cache_override : Hash(UInt64, Crinja::Template)? = nil, depth : Int32 = 0) : String
+        private def process_shortcodes_in_text(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)? = nil, crinja_env_override : Crinja? = nil, template_cache_override : Hash(UInt64, Crinja::Template)? = nil, depth : Int32 = 0, warnings : Array(String)? = nil) : String
           # Inline code spans (`…`, ``…``) are opaque to the shortcode
           # processor — running shortcodes inside `<code>` would both
           # change the visible source the author meant to display and
@@ -184,7 +184,7 @@ module Hwaro
           # Tokens are restored on the shortcode body/args right before
           # rendering and on the final text before returning.
           masked, spans = mask_inline_code(content)
-          processed = process_shortcodes_in_chunk(masked, templates, context, shortcode_results, crinja_env_override, template_cache_override, depth, spans)
+          processed = process_shortcodes_in_chunk(masked, templates, context, shortcode_results, crinja_env_override, template_cache_override, depth, spans, warnings)
           unmask_inline_code(processed, spans)
         end
 
@@ -239,18 +239,18 @@ module Hwaro
           false
         end
 
-        private def process_shortcodes_in_chunk(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)?, crinja_env_override : Crinja?, template_cache_override : Hash(UInt64, Crinja::Template)?, depth : Int32, spans : Array(String) = [] of String) : String
+        private def process_shortcodes_in_chunk(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)?, crinja_env_override : Crinja?, template_cache_override : Hash(UInt64, Crinja::Template)?, depth : Int32, spans : Array(String) = [] of String, warnings : Array(String)? = nil) : String
           # Localized normalization for named closers (only affects shortcode block content).
           # Avoid touching real Jinja/Crinja control tags (endif, endfor, etc.).
           normalized = content.gsub(NAMED_CLOSER_RE, "{% end %}")
 
           # 1. Block shortcodes
-          processed = process_block_shortcodes(normalized, templates, context, shortcode_results, crinja_env_override, template_cache_override, depth, spans)
+          processed = process_block_shortcodes(normalized, templates, context, shortcode_results, crinja_env_override, template_cache_override, depth, spans, warnings)
 
           # 2. Explicit call: {{ shortcode("name", args) }}
           processed = processed.gsub(/\{\{\s*shortcode\s*\(\s*"([^"]+)"(?:\s*,\s*(.*?))?\s*\)\s*\}\}/) do |match|
             args = $2?.try { |a| unmask_inline_code(a, spans) }
-            render_shortcode_result($1, args, templates, context, shortcode_results, match, warn_missing: true, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+            render_shortcode_result($1, args, templates, context, shortcode_results, match, warn_missing: true, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, warnings: warnings)
           end
 
           # 3. Direct call: {{ name(args) }}
@@ -260,7 +260,7 @@ module Hwaro
           # Crinja function — that way real typos surface while legitimate
           # template-function calls in content pass through silently.
           processed.gsub(/\{\{\s*([a-zA-Z_][\w\-]*)\s*\((.*?)\)\s*\}\}/) do |match|
-            render_shortcode_result($1, unmask_inline_code($2, spans), templates, context, shortcode_results, match, warn_missing: true, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+            render_shortcode_result($1, unmask_inline_code($2, spans), templates, context, shortcode_results, match, warn_missing: true, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, warnings: warnings)
           end
         end
 
@@ -314,7 +314,7 @@ module Hwaro
         # `MatchData#begin` converts back, so every tag scanned on a CJK page
         # cost O(document). All offsets come from regex matches, so slices
         # always land on character boundaries.
-        private def process_block_shortcodes(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)?, crinja_env_override : Crinja?, template_cache_override : Hash(UInt64, Crinja::Template)?, depth : Int32, spans : Array(String) = [] of String) : String
+        private def process_block_shortcodes(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)?, crinja_env_override : Crinja?, template_cache_override : Hash(UInt64, Crinja::Template)?, depth : Int32, spans : Array(String) = [] of String, warnings : Array(String)? = nil) : String
           close_re = BLOCK_CLOSE_RE
 
           result = String::Builder.new
@@ -435,7 +435,7 @@ module Hwaro
             # chunk processor directly — re-masking via _in_text would assign
             # fresh span indexes that collide with the outer `spans` tokens.
             if depth < MAX_SHORTCODE_NESTING && (body.includes?("{{") || body.includes?("{%"))
-              body = process_shortcodes_in_chunk(body, templates, context, shortcode_results, crinja_env_override, template_cache_override, depth + 1, spans)
+              body = process_shortcodes_in_chunk(body, templates, context, shortcode_results, crinja_env_override, template_cache_override, depth + 1, spans, warnings)
             end
 
             # Restore inline code spans before rendering: the rendered HTML is
@@ -447,7 +447,7 @@ module Hwaro
 
             extra_args = {"body" => body}
             original_text = content.byte_slice(open_start, pos - open_start)
-            result << render_shortcode_result(name, unmasked_args, templates, context, shortcode_results, original_text, warn_missing: true, extra_args: extra_args, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override)
+            result << render_shortcode_result(name, unmasked_args, templates, context, shortcode_results, original_text, warn_missing: true, extra_args: extra_args, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, warnings: warnings)
           end
 
           result.to_s
@@ -467,6 +467,7 @@ module Hwaro
           extra_args : Hash(String, String)? = nil,
           crinja_env_override : Crinja? = nil,
           template_cache_override : Hash(UInt64, Crinja::Template)? = nil,
+          warnings : Array(String)? = nil,
         ) : String
           template_key = "shortcodes/#{name}"
           template = templates[template_key]? || BuiltinShortcodes.templates[template_key]?
@@ -514,7 +515,7 @@ module Hwaro
             end
           end
 
-          html = render_shortcode_jinja(template, args, context, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, shortcode_name: name)
+          html = render_shortcode_jinja(template, args, context, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, shortcode_name: name, warnings: warnings)
 
           if results = shortcode_results
             placeholder = "#{SHORTCODE_PLACEHOLDER_PREFIX}#{results.size}#{SHORTCODE_PLACEHOLDER_SUFFIX}"
@@ -607,7 +608,7 @@ module Hwaro
         end
 
         # Render a shortcode template with Crinja
-        private def render_shortcode_jinja(template : String, args : Hash(String, String), context : Hash(String, Crinja::Value), crinja_env_override : Crinja? = nil, template_cache_override : Hash(UInt64, Crinja::Template)? = nil, shortcode_name : String? = nil) : String
+        private def render_shortcode_jinja(template : String, args : Hash(String, String), context : Hash(String, Crinja::Value), crinja_env_override : Crinja? = nil, template_cache_override : Hash(UInt64, Crinja::Template)? = nil, shortcode_name : String? = nil, warnings : Array(String)? = nil) : String
           env = crinja_env_override || crinja_env
 
           # Use a local copy of context with args merged to avoid mutating
@@ -655,7 +656,12 @@ module Hwaro
           rescue ex : Crinja::TemplateError
             label = shortcode_name ? "shortcode '#{shortcode_name}'" : "shortcode"
             Logger.warn "Template error in #{label}: #{ex.message}"
-            ""
+            # Record the failure on the page (drives the serve error overlay —
+            # a mid-edit syntax error used to make the shortcode output
+            # silently vanish with a "successful" rebuild) and leave a visible
+            # trace in the HTML instead of an empty string.
+            warnings.try(&.<< "Template error in #{label}: #{ex.message}")
+            "<!-- hwaro: template error in #{label.gsub("--", "‐‐")} -->"
           end
         end
 

--- a/src/core/build/template_deps.cr
+++ b/src/core/build/template_deps.cr
@@ -24,7 +24,13 @@ module Hwaro
       class TemplateDeps
         # `{% extends "base.html" %}`, `{% include 'partials/head.html' %}`,
         # `{% import "macros.html" as m %}`, `{% from "macros.html" import x %}`
-        REFERENCE_TAG_RE = /\{%-?\s*(extends|include|import|from)\s+(.+?)\s*-?%\}/m
+        #
+        # `\b\s*` (not `\s+`) after the keyword: Crinja happily parses
+        # `{% include"x.html" %}` with no space, and a tag this regex fails
+        # to see entirely never reaches the safe `@dynamic = true` fallback —
+        # it just silently drops the dependency edge and the included
+        # template's edits stop re-rendering its dependents during serve.
+        REFERENCE_TAG_RE = /\{%-?\s*(extends|include|import|from)\b\s*(.+?)\s*-?%\}/m
 
         # Per-tag argument shapes where the template name is a plain string
         # literal. The literal must account for the ENTIRE argument (modulo
@@ -72,7 +78,9 @@ module Hwaro
             # `{% name key="v" %}`. Loose on purpose — an over-match only
             # causes an unnecessary rebuild, never a stale page.
             escaped = Regex.escape(name)
-            @shortcode_usage_patterns[name] = /\b#{escaped}\s*\(|\bshortcode\(\s*["']#{escaped}["']|\{%-?\s*#{escaped}\b/
+            # `shortcode\s*\(` — the processor tolerates space before the
+            # paren in the explicit-call form, so the scanner must too.
+            @shortcode_usage_patterns[name] = /\b#{escaped}\s*\(|\bshortcode\s*\(\s*["']#{escaped}["']|\{%-?\s*#{escaped}\b/
           end
 
           templates.each do |name, source|

--- a/src/services/server/live_reload_handler.cr
+++ b/src/services/server/live_reload_handler.cr
@@ -9,8 +9,21 @@ module Hwaro
 
       LIVE_RELOAD_PATH = "/__hwaro_livereload"
 
-      @sockets : Array(HTTP::WebSocket) = [] of HTTP::WebSocket
-      # Guards every access to @sockets and @current_error. Under -Dpreview_mt
+      # A connected client: the socket plus a per-socket write mutex.
+      # HTTP::WebSocket::Protocol#send has no internal lock, so the
+      # connect-time replay (connection fiber) and the watcher fiber's
+      # broadcast could interleave frame bytes on the same socket under
+      # -Dpreview_mt — a WebSocket protocol error that drops the client.
+      private class Client
+        getter socket : HTTP::WebSocket
+        getter write_mutex : Mutex = Mutex.new
+
+        def initialize(@socket)
+        end
+      end
+
+      @clients : Array(Client) = [] of Client
+      # Guards every access to @clients and @current_error. Under -Dpreview_mt
       # (the CI/release build flag) HTTP::Server runs each connection in its own
       # fiber across worker threads, so the per-client `<<`/`delete` callbacks
       # race with the watcher fiber's broadcast. Array#<< triggering a resize
@@ -68,23 +81,32 @@ module Hwaro
           end
 
           ws = HTTP::WebSocketHandler.new do |socket, _ctx|
+            client = Client.new(socket)
             message = @sockets_mutex.synchronize do
-              @sockets << socket
+              @clients << client
               @current_error
             end
             # Replay the current build-error so a tab opened while the
             # build is broken sees the overlay immediately instead of
             # silently rendering whatever stale HTML happens to be on
-            # disk.
-            if message
-              begin
-                socket.send("error:#{{"message" => message}.to_json}")
-              rescue IO::Error | Socket::Error
-                # Connection torn down before the replay; harmless.
+            # disk. With NO pending error, send an explicit clear instead:
+            # a tab that showed the overlay, lost its socket (laptop sleep,
+            # the long recovery rebuild), and reconnected after the fix
+            # would otherwise display "Build failed" forever over a healthy
+            # site — the successful build's `reload` broadcast is long gone.
+            begin
+              client.write_mutex.synchronize do
+                if message
+                  socket.send("error:#{{"message" => message}.to_json}")
+                else
+                  socket.send("clear-error")
+                end
               end
+            rescue IO::Error | Socket::Error
+              # Connection torn down before the replay; harmless.
             end
             socket.on_close do
-              @sockets_mutex.synchronize { @sockets.delete(socket) }
+              @sockets_mutex.synchronize { @clients.delete(client) }
             end
           end
           ws.call(context)
@@ -121,17 +143,19 @@ module Hwaro
 
       private def broadcast(message : String)
         # Snapshot under the lock: a connection fiber may `<<`/`delete` from
-        # @sockets concurrently. We send outside the lock so a slow/blocked
-        # socket doesn't stall connection handling.
-        snapshot = @sockets_mutex.synchronize { @sockets.dup }
-        dead = [] of HTTP::WebSocket
-        snapshot.each do |socket|
-          socket.send(message)
+        # @clients concurrently. We send outside the global lock so a slow/
+        # blocked socket doesn't stall connection handling; the per-client
+        # write mutex only serializes writes to that one socket (against the
+        # connect-time replay).
+        snapshot = @sockets_mutex.synchronize { @clients.dup }
+        dead = [] of Client
+        snapshot.each do |client|
+          client.write_mutex.synchronize { client.socket.send(message) }
         rescue IO::Error | Socket::Error
-          dead << socket
+          dead << client
         end
         unless dead.empty?
-          @sockets_mutex.synchronize { dead.each { |s| @sockets.delete(s) } }
+          @sockets_mutex.synchronize { dead.each { |c| @clients.delete(c) } }
         end
       end
     end
@@ -211,6 +235,15 @@ module Hwaro
 
       def call(context)
         path = context.request.path
+
+        # GET only: StaticFileHandler correctly rejects other methods, and a
+        # full HTML body on HEAD (Crystal never suppresses it for handlers
+        # that print) desyncs spec-conformant keep-alive clients — the body
+        # bytes read as the start of the next response.
+        unless context.request.method == "GET"
+          call_next(context)
+          return
+        end
 
         unless path.ends_with?(".html")
           call_next(context)

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -35,7 +35,12 @@ module Hwaro
 
         if path.ends_with?("/")
           context.request.path += "index.html"
-        elsif File.extname(path).empty?
+        else
+          # No extname pre-filter here: deciding by extension 404'd every
+          # directory with a dot in its last segment (/docs/v1.2, /node.js)
+          # because stdlib's StaticFileHandler only appends the trailing
+          # slash when directory_listing is on. What's on disk decides.
+          #
           # Sanitize to prevent directory traversal before filesystem access
           sanitized = Utils::PathUtils.sanitize_path(path)
           fs_path = Path[@public_dir, sanitized]
@@ -57,10 +62,21 @@ module Hwaro
                        end
                      end
           if resolved && (resolved == public_real || resolved.starts_with?(public_real + "/")) && Dir.exists?(resolved)
-            context.response.status_code = 301
+            # 302, not 301: browsers cache permanent redirects per URL, so a
+            # 301 would keep redirecting to a section long after a rebuild
+            # removed or renamed it (or after a different project reuses the
+            # port) until the user clears their browser cache.
+            context.response.status_code = 302
             # Use the already-sanitized path for the Location header to prevent
-            # CRLF injection and path traversal in the redirect target.
-            context.response.headers["Location"] = "/" + sanitized + "/"
+            # CRLF injection and path traversal in the redirect target. Keep
+            # the query string — /search?q=term must land on /search/?q=term,
+            # not an empty-query page. (A request-line query can't contain
+            # CR/LF; percent-encoded bytes stay encoded.)
+            location = "/" + sanitized + "/"
+            if (query = context.request.query) && !query.empty?
+              location += "?#{query}"
+            end
+            context.response.headers["Location"] = location
             return
           end
         end
@@ -72,7 +88,12 @@ module Hwaro
     class NotFoundHandler
       include HTTP::Handler
 
-      def initialize(@public_dir : String)
+      # With live reload on, 404 responses embed the reload script too: a
+      # tab parked on a not-yet-rendered URL (a page still building, a
+      # --fast-start deferred page) then refreshes itself the moment its
+      # HTML lands on disk, and build-error overlays reach 404 tabs as well.
+      # Without the script those tabs sat on the 404 forever.
+      def initialize(@public_dir : String, @injector : LiveReloadInjectHandler? = nil)
       end
 
       def call(context)
@@ -80,11 +101,29 @@ module Hwaro
         context.response.content_type = "text/html; charset=utf-8"
 
         path_404 = File.join(@public_dir, "404.html")
-        if File.exists?(path_404)
-          context.response.print File.read(path_404)
-        else
-          context.response.print "404 Not Found"
+        body = File.exists?(path_404) ? File.read(path_404) : "404 Not Found"
+        if injector = @injector
+          body = injector.inject_script(body)
         end
+        context.response.print body
+      end
+    end
+
+    # Dev responses must never be cached by the browser: watch rebuilds
+    # rewrite files whose Etag/Last-Modified derive from second-granularity
+    # mtimes, so two quick saves inside one second produce a "new" version
+    # whose validators match the cached one — the browser then 304s onto the
+    # stale copy until a hard refresh. `no-store` matches what other SSG dev
+    # servers ship. The header is set BEFORE call_next so it also reaches
+    # responses that flush their headers mid-body (static files larger than
+    # the response's 8KB output buffer). Skipped entirely when the user
+    # supplies their own Cache-Control via [serve.headers]/--header.
+    class NoCacheHandler
+      include HTTP::Handler
+
+      def call(context)
+        context.response.headers["Cache-Control"] = "no-store"
+        call_next(context)
       end
     end
 
@@ -207,10 +246,21 @@ module Hwaro
       end
 
       def call(context)
+        # Pre-set BEFORE call_next so the values survive responses that
+        # flush their headers mid-body: files larger than the response's
+        # 8KB output buffer serialize headers at first flush, and
+        # post-call_next edits never reach the wire for those.
+        apply_headers(context)
         call_next(context)
+        # Re-assert after so user values still win over anything a
+        # downstream handler set in between (Content-Type charset, CORS)
+        # for the buffered small-response case. Only headers the static
+        # handler itself overwrites (Content-Type, validators) remain
+        # theirs on >8KB responses.
+        apply_headers(context)
+      end
 
-        # Apply after all other handlers so user values override built-ins
-        # (including Content-Type adjustments and dev CORS headers).
+      private def apply_headers(context)
         @headers.each do |name, value|
           # Final guard: never emit control characters in headers even if they
           # somehow made it through config/CLI validation.
@@ -431,6 +481,12 @@ module Hwaro
     end
 
     class Server
+      # What the watcher records per file: mtime plus size. Size catches
+      # same-tick rewrites on coarse-mtime filesystems (Docker bind mounts,
+      # NFS/SMB shares, exFAT) where two quick saves can share a timestamp —
+      # an mtime-only comparison would permanently miss the second save.
+      alias FileStamp = {Time, Int64}
+
       @builder : Core::Build::Builder
       @live_reload_handler : LiveReloadHandler?
       # True after a watch rebuild raised. A failed rebuild can leave the
@@ -440,6 +496,12 @@ module Hwaro
       # unrelated file — so the next changeset escalates to a full rebuild
       # to guarantee convergence, whatever the user saves.
       @rebuild_failed : Bool = false
+      # "config.<env>.toml" when serve runs with --env/HWARO_ENV, nil
+      # otherwise. Watched alongside config.toml (both force full rebuilds).
+      @env_config_file : String? = nil
+      # [serve] table captured at startup — the baseline for warning that a
+      # config edit changed restart-only settings (headers, fast).
+      @startup_serve_config : Models::ServeConfig? = nil
 
       # Debounce interval: after detecting changes, wait this long for
       # additional changes to settle before triggering a rebuild.
@@ -474,8 +536,34 @@ module Hwaro
       end
 
       private def run_with_options(host : String, port : Int32, open_browser : Bool, access_log : Bool, live_reload : Bool, build_options : Config::Options::BuildOptions, json_output : Bool = false, headers : Hash(String, String) = {} of String => String)
+        # The env-specific config overlay (config.<env>.toml) feeds every
+        # rebuild via Models::Config.load, so the watcher must see its edits
+        # — scan_mtimes stats it alongside config.toml.
+        @env_config_file = build_options.env.try { |e| "config.#{e}.toml" }
+
         # The initial build prints its own receipt; no preamble needed.
-        @builder.run(build_options)
+        #
+        # A broken site at startup (template syntax error, failing hook)
+        # used to kill serve before the server or watcher existed — the user
+        # had to fix blind and rerun, while the very same error during a
+        # running session gets the fix-and-save loop plus a browser overlay.
+        # Start anyway: @rebuild_failed forces the first watch rebuild to be
+        # a full one, and the error is replayed to the first live-reload
+        # client so the browser shows the overlay instead of a bare 404.
+        initial_error : String? = nil
+        begin
+          unless @builder.run(build_options)
+            initial_error = "Initial build failed — check the terminal, fix the error, and save to rebuild."
+          end
+        rescue ex : Hwaro::HwaroError
+          initial_error = ex.message || "Initial build failed"
+          Logger.error "Initial build failed: #{ex.message}"
+          ex.hint.try { |hint| Logger.info "  Hint: #{hint}" }
+        end
+        if initial_error
+          @rebuild_failed = true
+          Logger.warn "Serving the previous output (if any) — the watcher will rebuild on your next save."
+        end
 
         # Watch-triggered rebuilds should preserve the already-built output
         # so per-image mtime-skip (and any future incremental hook logic)
@@ -490,6 +578,14 @@ module Hwaro
         watch_options.fast_start = false
 
         output_dir = sanitize_output_dir(build_options.output_dir)
+        # The static handler needs an existing root even when the initial
+        # build failed before creating one.
+        Hwaro::Utils::FileSafe.mkdir_p(output_dir)
+
+        # Baseline for the restart-only [serve.*] warning after config edits.
+        # Nil when the initial build never loaded a config; established lazily
+        # by the first successful config-changed rebuild in that case.
+        @startup_serve_config = @builder.config.try(&.serve)
 
         # Loopback literals plus the concrete bound host (a 0.0.0.0/:: wildcard
         # bind has no single host, so it contributes nothing here). The
@@ -501,11 +597,14 @@ module Hwaro
         handlers = [] of HTTP::Handler
         handlers << HTTP::LogHandler.new if access_log
         # Reflect CORS for loopback/bound origins first so it applies to every
-        # downstream response, including 301 redirects from IndexRewriteHandler
+        # downstream response, including redirects from IndexRewriteHandler
         # and 404s from NotFoundHandler. This preserves the localhost-vs-
         # 127.0.0.1 fetch() ergonomic without granting arbitrary websites
         # cross-origin read access (the old blanket `*`).
         handlers << DevCorsHandler.new(cors_hosts)
+        # Dev cache-busting (see NoCacheHandler). A user-supplied
+        # Cache-Control from [serve.headers]/--header wins outright.
+        handlers << NoCacheHandler.new unless headers.keys.any? { |k| k.downcase == "cache-control" }
         # Run before StaticFileHandler so we can append `; charset=utf-8`
         # to text-shaped Content-Type headers after the static handler
         # sets them — Crystal's `HTTP::Server::Response` buffers the
@@ -516,17 +615,25 @@ module Hwaro
         # - it wraps IndexRewrite / LiveReloadInject (catches their early returns)
         # - it runs after DevCors + Charset on the return path (user values win)
         handlers << CustomHeadersHandler.new(headers) unless headers.empty?
+        inject_handler : LiveReloadInjectHandler? = nil
         if live_reload
           lr_handler = LiveReloadHandler.new
           @live_reload_handler = lr_handler
           handlers << lr_handler
           handlers << IndexRewriteHandler.new(output_dir)
-          handlers << LiveReloadInjectHandler.new(output_dir)
+          inject_handler = LiveReloadInjectHandler.new(output_dir)
+          handlers << inject_handler
         else
           handlers << IndexRewriteHandler.new(output_dir)
         end
         handlers << HTTP::StaticFileHandler.new(output_dir, directory_listing: false, fallthrough: true)
-        handlers << NotFoundHandler.new(output_dir)
+        handlers << NotFoundHandler.new(output_dir, inject_handler)
+
+        # Replay a startup failure to the first live-reload client(s) so the
+        # browser shows the overlay instead of a bare 404/stale page.
+        if (msg = initial_error) && (lr = @live_reload_handler)
+          lr.notify_build_error(msg)
+        end
 
         server = HTTP::Server.new(handlers)
 
@@ -754,7 +861,7 @@ module Hwaro
 
       # Wait for rapid successive changes to settle, merging all detected
       # changesets into one.  Returns the merged changeset.
-      private def debounce_changes(initial : ChangeSet, last_mtimes : Hash(String, Time)) : {ChangeSet, Hash(String, Time)}
+      private def debounce_changes(initial : ChangeSet, last_mtimes : Hash(String, FileStamp)) : {ChangeSet, Hash(String, FileStamp)}
         merged = initial
         current_mtimes = last_mtimes
         iterations = 0
@@ -784,8 +891,8 @@ module Hwaro
 
       # Diff two mtime snapshots and return a categorised ChangeSet.
       private def detect_changes(
-        old_mtimes : Hash(String, Time),
-        new_mtimes : Hash(String, Time),
+        old_mtimes : Hash(String, FileStamp),
+        new_mtimes : Hash(String, FileStamp),
       ) : ChangeSet
         modified_content = [] of String
         modified_content_files = [] of String
@@ -801,7 +908,7 @@ module Hwaro
           if old_mtime = old_mtimes[path]?
             next if old_mtime == new_mtime # unchanged
 
-            if path == "config.toml"
+            if path == "config.toml" || path == @env_config_file
               config_changed = true
             else
               classify_modified(path, modified_content, modified_content_files, modified_templates, modified_static, modified_data)
@@ -890,20 +997,41 @@ module Hwaro
                           @builder.stale_outputs_for_removed(changeset.removed_files, sanitize_output_dir(build_options.output_dir))
                         end
 
-        case strategy
-        when :full
-          @builder.run(build_options)
-        when :templates
-          @builder.run_rerender(build_options)
-        when :incremental
-          @builder.run_incremental(changeset.modified_content, build_options)
-        when :content_and_template
-          @builder.run_incremental_then_rerender(changeset.modified_content, build_options)
-        when :static
-          copy_static(changeset, build_options)
-        when :content_files
-          copy_content_files(changeset, build_options)
+        success = case strategy
+                  when :full
+                    @builder.run(build_options)
+                  when :templates
+                    @builder.run_rerender(build_options)
+                  when :incremental
+                    @builder.run_incremental(changeset.modified_content, build_options)
+                  when :content_and_template
+                    @builder.run_incremental_then_rerender(changeset.modified_content, build_options)
+                  when :static
+                    copy_static(changeset, build_options)
+                    true
+                  when :content_files
+                    copy_content_files(changeset, build_options)
+                    true
+                  else
+                    true
+                  end
+
+        # A build can fail WITHOUT raising: pre-hook failures and phase
+        # aborts (non-classified exceptions become HookResult::Abort) return
+        # false. Treat that exactly like the rescue path in the caller —
+        # flag it so the next changeset escalates to a full rebuild, push
+        # the overlay, and skip the reload so the browser doesn't refresh
+        # onto a half-built site with no visible error.
+        unless success
+          @rebuild_failed = true
+          @live_reload_handler.try(&.notify_build_error("Build failed — check the terminal for details."))
+          return
         end
+
+        # A config edit rebuilt the site with the new values, but [serve.*]
+        # keys were consumed at startup — warn instead of silently looking
+        # like they applied.
+        warn_restart_only_serve_settings if changeset.config_changed
 
         # Copy static files if they changed alongside content/template changes
         if strategy != :static && strategy != :full && !changeset.modified_static.empty?
@@ -922,6 +1050,24 @@ module Hwaro
         remove_stale_outputs(stale_outputs, sanitize_output_dir(build_options.output_dir))
 
         @live_reload_handler.try(&.notify_reload)
+      end
+
+      # [serve.*] keys are consumed once at startup (headers baked into the
+      # handler chain, fast → skip flags in the frozen watch options). A
+      # config edit triggers a full rebuild that LOOKS like it applied them —
+      # say so instead of leaving the user chasing a phantom.
+      private def warn_restart_only_serve_settings
+        current = @builder.config.try(&.serve)
+        return unless current
+        unless startup = @startup_serve_config
+          # Initial build never loaded a config (it failed) — this rebuild's
+          # values become the baseline.
+          @startup_serve_config = current
+          return
+        end
+        if startup.headers != current.headers || startup.fast != current.fast
+          Logger.warn "  [serve] settings changed in config — restart `hwaro serve` to apply them."
+        end
       end
 
       # Delete output files orphaned by removed sources, pruning any
@@ -1000,6 +1146,11 @@ module Hwaro
         /___jb_old___$/,                    # JetBrains safe-write backup
         /(?:\A|\/)\.goutputstream-[^\/]+$/, # GNOME (gedit) atomic save
         /(?:\A|\/)4913$/,                   # vim's write-permission probe
+        # Hidden state directories editors/VCS maintain inside watched roots
+        # (Obsidian vaults under content/ are common). The scan includes
+        # dotfiles — publishable ones like static/.well-known/* must be
+        # watched — so this churn has to be filtered by name.
+        /(?:\A|\/)\.(?:git|obsidian|idea|vscode)\//,
       ]
 
       protected def self.watcher_ignored?(path : String) : Bool
@@ -1007,28 +1158,41 @@ module Hwaro
         WATCHER_IGNORE_PATTERNS.any? { |re| re.matches?(path) || re.matches?(basename) }
       end
 
-      private def scan_mtimes : Hash(String, Time)
-        mtimes = {} of String => Time
+      private def scan_mtimes : Hash(String, FileStamp)
+        mtimes = {} of String => FileStamp
         dirs_to_watch = ["content", "templates", "static", "data", "i18n"]
 
         dirs_to_watch.each do |dir|
           next unless Dir.exists?(dir)
-          Dir.glob(File.join(dir, "**", "*")) do |file|
+          # DotFiles: the build publishes hidden files (static/.well-known/*,
+          # see the equivalent build-side fix), so the watcher must see their
+          # edits too — a default glob never descends into dot-directories,
+          # leaving those files permanently stale during serve. Editor/VCS
+          # noise stays filtered by watcher_ignored?.
+          Dir.glob(File.join(dir, "**", "*"), match: File::MatchOptions.glob_default | File::MatchOptions::DotFiles) do |file|
             next if File.directory?(file)
             next if Server.watcher_ignored?(file)
             begin
-              mtimes[file] = File.info(file).modification_time
+              info = File.info(file)
+              mtimes[file] = {info.modification_time, info.size.to_i64}
             rescue ex
               Logger.debug "Failed to read file info for #{file}: #{ex.message}"
             end
           end
         end
 
-        if File.exists?("config.toml")
+        config_files = ["config.toml"]
+        # The env overlay feeds every rebuild through Models::Config.load —
+        # its edits were invisible to the watcher (silently ignored for the
+        # whole session) before it was stat'ed here.
+        @env_config_file.try { |ec| config_files << ec }
+        config_files.each do |cfg|
+          next unless File.exists?(cfg)
           begin
-            mtimes["config.toml"] = File.info("config.toml").modification_time
+            info = File.info(cfg)
+            mtimes[cfg] = {info.modification_time, info.size.to_i64}
           rescue ex
-            Logger.debug "Failed to read config.toml info: #{ex.message}"
+            Logger.debug "Failed to read #{cfg} info: #{ex.message}"
           end
         end
 

--- a/src/utils/file_safe.cr
+++ b/src/utils/file_safe.cr
@@ -49,6 +49,29 @@ module Hwaro
       rescue ex : File::AlreadyExistsError
         raise ex unless Dir.exists?(path)
       end
+
+      # Write `content` to `path` atomically: write to a same-directory
+      # temp file, then rename over the target. `hwaro serve` rewrites
+      # output files while HTTP fibers stream them to the browser — a plain
+      # `File.write` truncates first, so a request landing mid-rebuild could
+      # read an empty or half-written page. Rename is atomic on the same
+      # filesystem, so readers see either the old bytes or the new bytes.
+      #
+      # The temp name is unique per process AND fiber so parallel render
+      # workers writing sibling outputs can't collide on it.
+      def self.atomic_write(path : String | Path, content : String) : Nil
+        target = path.to_s
+        tmp = "#{target}.#{Process.pid}.#{Fiber.current.object_id}.tmp"
+        begin
+          File.write(tmp, content)
+          File.rename(tmp, target)
+        rescue ex
+          # Never leave the temp file behind — a failed write must look
+          # exactly like the old non-atomic failure (target unchanged).
+          File.delete(tmp) if File.exists?(tmp)
+          raise ex
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Full serve-stability audit (multi-agent bug hunt: 49 raw findings → 29 confirmed after adversarial verification), focused on the template-change paths that kept producing stale output or silent failures during `hwaro serve`. All 29 confirmed findings are fixed here, plus two bonus bugs found while smoke-testing the fixes.

### Rebuild convergence

| Bug | Fix |
|---|---|
| **Un-drafting a page during serve never publishes it** — pages outside the site model (draft/future/expired/parse-failed) were silently skipped by `run_incremental` | escalate to a full rebuild when the changed file still exists on disk |
| Content+template save that sets `draft = true` keeps the page published | `run_incremental_then_rerender` now ports the full exclusion block |
| Drafted page's tags still counted in tag clouds rendered the same pass | exclusion runs before `update_taxonomies_incremental`; excluded pages' new terms aren't re-added |
| Slug/custom_path edit leaves old output serving 200 | previous output paths (incl. format siblings) captured pre-parse and deleted |
| Deleting a section `_index.md` leaves its `index.html` forever | `stale_outputs_for_removed` searches `site.sections` too |
| Aborted builds (failing pre-hook, phase abort) treated as success: no overlay, `@rebuild_failed` cleared, browser reloaded onto a half-built site; `hwaro build` exited 0 | `Builder#run` returns `Bool`; watcher branches on it, `hwaro build` fails loud |
| Taxonomy/404 pages regenerated during serve rendered against the **last cold build's** site snapshot | `@render_global_vars` refreshed on every rebuild path |

### Template-change coverage

| Bug | Fix |
|---|---|
| Editing a shortcode template (or a partial it includes) updated page bodies but left **listing pages, feeds, search, llms** stale | shortcode/hook templates in the affected **closure** force full re-render + summary recompute + SEO refresh |
| Even then, listings re-rendered with **stale summaries** — Crinja page values were built before the recompute | summaries invalidate the page values they poison; globals rebuilt after (also fixes cold builds rendering `{{ p.summary }}` as raw markdown when the summary contains a shortcode — reproduced on main) |
| `{% include"x.html" %}` (no space) / `{{ shortcode ("name") }}` (spaced) invisible to the dependency graph → silently missing edges | regex fixes |
| Editing an extension-shadowed variant (`foo.j2` next to `foo.html`) hits the "contents are identical" early return forever | shadowed files content-hashed and diffed |
| Crinja error in a shortcode template silently deleted its output (build "succeeds", no overlay) | visible HTML-comment marker + `page.build_warnings` → error overlay |
| Singleton Crinja env accumulated every historical template source across reloads | fresh template cache per snapshot load |

### Dev server & watcher

- **Initial build failure no longer kills serve** — server + watcher start, error replays to live-reload clients as an overlay, first save recovers
- Watcher: dotfiles globbed (`static/.well-known/*` edits were invisible for the whole session), `.git`/`.obsidian`/`.idea`/`.vscode` state dirs ignored, `{mtime, size}` stamps (same-tick saves on coarse-mtime filesystems), `config.<env>.toml` watched under `--env`
- 404 responses embed the live-reload script (tabs parked on not-yet-rendered URLs now refresh — this was the documented fast-start behavior that never worked)
- `Cache-Control: no-store` on dev responses (browsers 304'd onto stale assets after rapid rebuilds)
- `IndexRewriteHandler`: 302 instead of 301, query string preserved, dotted directories (`/docs/v1.2`) redirect
- `[serve.headers]` survive >8KB responses; restart-only `[serve.*]` config edits log a warning
- Live reload: per-socket write mutex (`-Dpreview_mt` frame interleave), reconnect after a fixed build clears a stuck error overlay, inject handler GET-only
- Atomic output writes (`FileSafe.atomic_write`, same-dir temp + rename) for all HTML/feed/search/sitemap/llms/OG outputs — no more torn responses mid-rebuild

## Verification

- `crystal spec`: **6293 examples, 0 failures** (15 new specs; 3 updated to the new intended behavior)
- `crystal tool format` + ameba: clean (405 files)
- **Determinism**: `docs/` built with main vs this branch → byte-identical; smoke site diff shows only the intended summary-bug fix
- **Live smoke test** (`hwaro serve` + curl, every scenario): un-draft → 200 + in listing; shortcode edit → listing/summary update; broken shortcode → visible marker + overlay; broken template → overlay, fix → recovery rebuild → 200; slug change → old 404/new 200; `_index` delete → 404; `.well-known` edit → picked up; `Cache-Control: no-store`; 302 + query preserved; dotted-dir redirect; 404 carries WS script; `[serve.headers]` edit → restart warning