### PR TITLE
feat(sass): built-in pure-Crystal SCSS compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Built-in Sass/SCSS compilation (`[sass]` config) — pure Crystal, no external tools: variables with `!default`/`!global`, nested rules with `&`, partials via `@use` (namespaces) / `@import`, mixins with defaults, keyword args and `@content`, `#{...}` interpolation, and `@media`/`@supports` bubbling. `static/**/*.scss` entries compile to sibling `.css`, `.scss` bundle entries compile before concatenation, and `hwaro serve` recompiles on change with errors in the browser overlay. Unsupported directives (`@if`, `@each`, `@function`, `@extend`, ...) fail the build with located errors instead of emitting broken CSS.
+
 ## v0.17.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Hwaro processes Markdown content with TOML, YAML, or JSON front matter and Jinja
 - Incremental build caching
 - Streaming build mode with memory limits
 - Pre/post build hooks
+- Built-in Sass/SCSS compilation (pure Crystal, no external tools)
 - CSS/JS bundling, minification, and content-hash fingerprinting
 - Lazy loading images
 - Environment-specific config (`config.production.toml`, `config.staging.toml`, etc.)

--- a/docs/content/features/asset-pipeline.md
+++ b/docs/content/features/asset-pipeline.md
@@ -33,7 +33,7 @@ name = "app.js"
 files = ["js/util.js", "js/app.js"]
 ```
 
-Bundle `files` may also name `.scss` sources — they compile through the [built-in Sass compiler](/features/sass/) before concatenation, then minify and fingerprint like any other CSS.
+Bundle `files` may also name `.scss` sources — while `[sass]` is enabled they compile through the [built-in Sass compiler](/features/sass/) before concatenation, then minify and fingerprint like any other CSS. Name such bundles with a `.css` extension so the output serves with the right type.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|

--- a/docs/content/features/asset-pipeline.md
+++ b/docs/content/features/asset-pipeline.md
@@ -1,7 +1,7 @@
 +++
 title = "Asset Pipeline"
 description = "Built-in CSS/JS bundling, minification, and fingerprinting"
-weight = 16
+weight = 17
 toc = true
 +++
 
@@ -32,6 +32,8 @@ files = ["css/reset.css", "css/style.css"]
 name = "app.js"
 files = ["js/util.js", "js/app.js"]
 ```
+
+Bundle `files` may also name `.scss` sources — they compile through the [built-in Sass compiler](/features/sass/) before concatenation, then minify and fingerprint like any other CSS.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|

--- a/docs/content/features/build-hooks.md
+++ b/docs/content/features/build-hooks.md
@@ -29,7 +29,7 @@ hooks.post = ["npm run minify", "npx pagefind --site public"]
 Pre-build hooks run **before** any content processing begins. They are ideal for:
 
 - Installing dependencies
-- Compiling assets (TypeScript, Sass, etc.)
+- Compiling assets (TypeScript, Tailwind/PostCSS, etc. — SCSS has a [built-in compiler](/features/sass/))
 - Running data fetching scripts
 - Preprocessing content
 

--- a/docs/content/features/cache-busting.md
+++ b/docs/content/features/cache-busting.md
@@ -1,7 +1,7 @@
 +++
 title = "Cache Busting"
 description = "Append content hashes to asset URLs for cache invalidation"
-weight = 17
+weight = 18
 toc = true
 +++
 

--- a/docs/content/features/sass.md
+++ b/docs/content/features/sass.md
@@ -50,7 +50,7 @@ Every non-partial `*.scss` compiles to a sibling `.css` in the output (`static/c
 - **Entries** — `*.scss` files whose name does not start with `_` compile to a sibling `.css` at the same relative path in the output.
 - **Partials** — `_*.scss` files never compile standalone and never publish; they are only reachable via `@use`/`@import`.
 - **Raw sources are not published** — while `[sass]` is enabled, `.scss` files are excluded from the verbatim static copy.
-- **Bundles** — `[[assets.bundles]]` `files` entries may name `.scss` files; they compile before concatenation and then flow through the normal minify → fingerprint pipeline. (This works even with `[sass]` disabled — naming a `.scss` file in a bundle is explicit intent.)
+- **Bundles** — `[[assets.bundles]]` `files` entries may name `.scss` files; while `[sass]` is enabled they compile before concatenation and then flow through the normal minify → fingerprint pipeline. With `[sass]` disabled, bundle entries concatenate verbatim (the escape hatch for pre-compiled or out-of-subset sources).
 - **Watch** — `hwaro serve` recompiles on `.scss` changes. Editing a partial recompiles every entry (there is no dependency graph — whole-tree recompilation is fast at static-site scale). Compile errors appear in the browser error overlay.
 
 ## Configuration
@@ -96,6 +96,9 @@ Error [HWARO_E_CONTENT]: Sass: static/css/style.scss:14:3: @if is not supported 
 - `&` substitution is textual — `&__elem` concatenates without validating the compound selector.
 - Custom property values are verbatim: `$var` stays literal, only `#{...}` interpolates (dart-sass semantics), but leading/trailing whitespace is trimmed.
 - `@import` of the same file re-emits its CSS each time (classic Sass behavior); `@use` loads once.
+- Declarations placed *after* a nested rule merge into the parent's single output block (`.a { color: red; .b {} color: blue; }` emits one `.a` block); dart-sass splits them in source order. Avoid relying on cascade order between a parent's trailing declarations and its nested rules.
+- Values are substituted as text: interpolating a variable whose value contains an unbalanced quote character can confuse downstream whitespace/quote handling. Keep quote characters inside quoted strings.
+- Only lowercase `.scss` extensions are treated as Sass sources; other casings publish verbatim like any static file.
 
 ## Errors
 

--- a/docs/content/features/sass.md
+++ b/docs/content/features/sass.md
@@ -1,0 +1,114 @@
++++
+title = "Sass/SCSS"
+description = "Built-in SCSS compilation — pure Crystal, no external tools"
+weight = 16
+toc = true
++++
+
+Hwaro compiles SCSS at build time with a built-in, pure-Crystal compiler. There is no dart-sass binary to install, no npm toolchain, and no C library — consistent with Hwaro's zero-external-dependency philosophy.
+
+## Quick Start
+
+```toml
+[sass]
+enabled = true
+```
+
+Put SCSS files under `static/`:
+
+```
+static/
+├── css/
+│   ├── _variables.scss   # partial — never published
+│   ├── _mixins.scss      # partial — never published
+│   └── style.scss        # entry — compiles to /css/style.css
+```
+
+```scss
+// static/css/style.scss
+@use "variables";
+@use "mixins";
+
+.card {
+  color: variables.$primary;
+  &:hover { color: variables.$accent; }
+
+  @include mixins.respond(768px) {
+    padding: 2rem;
+  }
+}
+```
+
+Every non-partial `*.scss` compiles to a sibling `.css` in the output (`static/css/style.scss` → `/css/style.css`), so stylesheets keep stable URLs:
+
+```html
+<link rel="stylesheet" href="{{ url_for(path="/css/style.css") }}">
+```
+
+## Rules
+
+- **Entries** — `*.scss` files whose name does not start with `_` compile to a sibling `.css` at the same relative path in the output.
+- **Partials** — `_*.scss` files never compile standalone and never publish; they are only reachable via `@use`/`@import`.
+- **Raw sources are not published** — while `[sass]` is enabled, `.scss` files are excluded from the verbatim static copy.
+- **Bundles** — `[[assets.bundles]]` `files` entries may name `.scss` files; they compile before concatenation and then flow through the normal minify → fingerprint pipeline. (This works even with `[sass]` disabled — naming a `.scss` file in a bundle is explicit intent.)
+- **Watch** — `hwaro serve` recompiles on `.scss` changes. Editing a partial recompiles every entry (there is no dependency graph — whole-tree recompilation is fast at static-site scale). Compile errors appear in the browser error overlay.
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable SCSS compilation |
+| `minify` | bool | `true` | Minify compiled CSS (same minifier as the asset pipeline) |
+
+## Supported Subset
+
+Hwaro implements a practical SCSS subset — the features hand-written site stylesheets actually use:
+
+| Feature | Support |
+|---------|---------|
+| `$variables` | ✅ with `!default` / `!global`, lexical scoping and shadowing |
+| Nested rules | ✅ including selector lists (cartesian combination) |
+| `&` parent selector | ✅ `&:hover`, `&.mod`, BEM `&__elem` / `&--mod` |
+| `#{...}` interpolation | ✅ selectors, property names, values, at-rule preludes, strings, `url()` |
+| Partials + `@use` | ✅ namespaces (`colors.$primary`), `as x`, `as *`, load-once |
+| `@import` (Sass files) | ✅ classic global-merge semantics; plain-CSS forms pass through |
+| `@mixin` / `@include` | ✅ default values, keyword arguments, `@content` blocks |
+| `@media` / `@supports` in rules | ✅ bubbled out of nesting automatically |
+| `@keyframes`, `@font-face`, custom properties | ✅ pass through correctly |
+| Plain CSS | ✅ any valid `.css` compiles to itself (whitespace-normalized) |
+
+Unknown functions (`calc()`, `var()`, `rgba()`, `clamp()`, `color-mix()`, …) pass through untouched.
+
+### Not supported (yet)
+
+Control flow (`@if`/`@else`/`@each`/`@for`/`@while`), SassScript arithmetic and comparison operators, built-in function modules (`math.*`, `color.*`, string/list/map functions), `@function`, `@extend`, `@forward`, `@use ... with (...)`, variadic arguments (`$args...`), `@content(args)` / `using`, nested properties (`font: { family: ... }`), the indented `.sass` syntax, and source maps.
+
+**Unsupported directives fail the build with a located error** — Hwaro never emits silently broken CSS:
+
+```
+Error [HWARO_E_CONTENT]: Sass: static/css/style.scss:14:3: @if is not supported by hwaro's Sass subset (yet)
+```
+
+### Deviations from dart-sass
+
+- Variables in at-rule preludes and values substitute directly (`@media (min-width: $bp)` works); selectors and property names require `#{...}` interpolation (same as dart-sass).
+- `@media` nested inside `@media` emits literally nested blocks (dart-sass merges the conditions).
+- `&` substitution is textual — `&__elem` concatenates without validating the compound selector.
+- Custom property values are verbatim: `$var` stays literal, only `#{...}` interpolates (dart-sass semantics), but leading/trailing whitespace is trimmed.
+- `@import` of the same file re-emits its CSS each time (classic Sass behavior); `@use` loads once.
+
+## Errors
+
+Compile failures are classified content errors (exit code 5) with `path:line:column` locations:
+
+```
+Error [HWARO_E_CONTENT]: Sass: static/css/_mixins.scss:7:12: undefined variable: "$primry"
+```
+
+During `hwaro serve`, errors show in the browser overlay and the previous output stays on disk.
+
+## Interplay with Other Features
+
+- **Asset pipeline** — compiled standalone entries keep stable (non-fingerprinted) URLs and resolve through `asset()`'s passthrough. For fingerprinting, reference the `.scss` file from a bundle instead.
+- **Build hooks** — Tailwind/PostCSS and full dart-sass projects can still run through `[build] hooks.pre` and point Hwaro at the compiled output.
+- **Cache** — Sass recompiles on every full build (it does not participate in the incremental page cache). Deleting an entry `.scss` leaves its previously compiled `.css` in a stale output dir; clean builds remove it.

--- a/docs/content/start/config.md
+++ b/docs/content/start/config.md
@@ -211,6 +211,7 @@ Each feature has its own documentation with full configuration details. Below is
 | `[pagination]` | [Pagination](/features/pagination/) | Section pagination |
 | `[auto_includes]` | [Auto Includes](/features/auto-includes/) | Auto-include CSS/JS files |
 | `[assets]` | [Asset Pipeline](/features/asset-pipeline/) | CSS/JS minification & fingerprinting |
+| `[sass]` | [Sass/SCSS](/features/sass/) | Built-in SCSS compilation (pure Crystal) |
 | `[image_processing]` | [Image Processing](/features/image-processing/) | Image resizing & LQIP |
 | `[image_processing.lqip]` | [Image Processing](/features/image-processing/#lqip-low-quality-image-placeholders) | Base64 blur-up placeholders |
 | `[content.files]` | [Content Files](/features/content-files/) | Publish non-Markdown files |
@@ -277,7 +278,7 @@ url = "/posts/"
 
 # Feature sections — see Feature Configuration Reference above
 # [feeds], [sitemap], [robots], [og], [search], [highlight],
-# [pagination], [auto_includes], [assets], [image_processing],
+# [pagination], [auto_includes], [assets], [sass], [image_processing],
 # [series], [related], [llms], [pwa], [amp], [deployment], etc.
 ```
 

--- a/skills/hwaro-design/SKILL.md
+++ b/skills/hwaro-design/SKILL.md
@@ -208,11 +208,16 @@ sites).
    `{{ asset(name='main.css') }}`; you get concatenation, minification, and
    content-hash fingerprinting (cache busting) for free.
 
-> **There is no built-in Sass/SCSS or Tailwind step, and no component
-> framework.** You write modern plain CSS (custom properties, nesting where
-> supported, `color-mix()`, `clamp()`), *or* run Sass/Tailwind/PostCSS yourself
-> via **build hooks** and point Hwaro at the compiled output. Don't assume a
-> preprocessor or an npm design system exists. When a brief names an aesthetic
+> **There is a built-in SCSS compiler (opt-in via `[sass] enabled = true`),
+> but no Tailwind step and no component framework.** The built-in compiler
+> covers the practical subset — variables, nesting/`&`, partials with
+> `@use`/`@import`, mixins with `@content`, interpolation — but NOT control
+> flow (`@if`/`@each`), arithmetic, or built-in functions (`lighten()` etc.),
+> so framework-grade SCSS won't compile. Default to modern plain CSS (custom
+> properties, nesting where supported, `color-mix()`, `clamp()`); use `[sass]`
+> when the brief calls for it, or run Tailwind/PostCSS/full dart-sass via
+> **build hooks** and point Hwaro at the compiled output. Don't assume an npm
+> design system exists. When a brief names an aesthetic
 > (glass, bento, brutalist, editorial, dark tech, aurora), that's a CSS
 > language you build honestly by hand — there is no official package for any of
 > them, on any stack.

--- a/spec/functional/sass_spec.cr
+++ b/spec/functional/sass_spec.cr
@@ -1,13 +1,13 @@
 require "./support/build_helper"
 
 private SASS_CONFIG = <<-TOML
-title = "Sass Test"
-base_url = "https://example.com"
+  title = "Sass Test"
+  base_url = "https://example.com"
 
-[sass]
-enabled = true
-minify = false
-TOML
+  [sass]
+  enabled = true
+  minify = false
+  TOML
 
 private INDEX_MD      = "# Hello\n"
 private PAGE_TEMPLATE = "<html><body>{{ content }}</body></html>"
@@ -49,9 +49,9 @@ describe "Sass build integration" do
 
   it "copies raw scss verbatim when [sass] is disabled (back-compat)" do
     config = <<-TOML
-    title = "No Sass"
-    base_url = "https://example.com"
-    TOML
+      title = "No Sass"
+      base_url = "https://example.com"
+      TOML
     build_site(
       config,
       content_files: {"index.md" => INDEX_MD},
@@ -65,21 +65,21 @@ describe "Sass build integration" do
 
   it "compiles scss entries referenced by asset bundles" do
     config = <<-TOML
-    title = "Bundle"
-    base_url = "https://example.com"
+      title = "Bundle"
+      base_url = "https://example.com"
 
-    [sass]
-    enabled = true
+      [sass]
+      enabled = true
 
-    [assets]
-    enabled = true
-    minify = false
-    fingerprint = false
+      [assets]
+      enabled = true
+      minify = false
+      fingerprint = false
 
-    [[assets.bundles]]
-    name = "main.css"
-    files = ["css/style.scss", "css/extra.css"]
-    TOML
+      [[assets.bundles]]
+      name = "main.css"
+      files = ["css/style.scss", "css/extra.css"]
+      TOML
     build_site(
       config,
       content_files: {"index.md" => INDEX_MD},
@@ -98,18 +98,18 @@ describe "Sass build integration" do
 
   it "concatenates bundle .scss entries verbatim when [sass] is disabled" do
     config = <<-TOML
-    title = "Bundle Verbatim"
-    base_url = "https://example.com"
+      title = "Bundle Verbatim"
+      base_url = "https://example.com"
 
-    [assets]
-    enabled = true
-    minify = false
-    fingerprint = false
+      [assets]
+      enabled = true
+      minify = false
+      fingerprint = false
 
-    [[assets.bundles]]
-    name = "main.css"
-    files = ["css/style.scss"]
-    TOML
+      [[assets.bundles]]
+      name = "main.css"
+      files = ["css/style.scss"]
+      TOML
     build_site(
       config,
       content_files: {"index.md" => INDEX_MD},

--- a/spec/functional/sass_spec.cr
+++ b/spec/functional/sass_spec.cr
@@ -96,6 +96,31 @@ describe "Sass build integration" do
     end
   end
 
+  it "concatenates bundle .scss entries verbatim when [sass] is disabled" do
+    config = <<-TOML
+    title = "Bundle Verbatim"
+    base_url = "https://example.com"
+
+    [assets]
+    enabled = true
+    minify = false
+    fingerprint = false
+
+    [[assets.bundles]]
+    name = "main.css"
+    files = ["css/style.scss"]
+    TOML
+    build_site(
+      config,
+      content_files: {"index.md" => INDEX_MD},
+      template_files: {"index.html" => PAGE_TEMPLATE, "page.html" => PAGE_TEMPLATE},
+      static_files: {"css/style.scss" => "$c: blue;\n.a { color: $c; }"},
+    ) do
+      bundle = File.read("public/assets/main.css")
+      bundle.should contain("$c: blue;") # raw passthrough, no compilation
+    end
+  end
+
   it "recompiles all entries when a partial changes (serve recompile path)" do
     Dir.mktmpdir do |dir|
       Dir.cd(dir) do
@@ -117,6 +142,11 @@ describe "Sass build integration" do
         File.write("static/css/_vars.scss", "$primary: #222222;")
         builder.recompile_sass("public")
         File.read("public/css/style.css").should contain("#222222")
+
+        # A removed entry's stale artifact is the compiled sibling, not the
+        # never-published raw source.
+        stale = builder.stale_outputs_for_removed(["static/css/style.scss"], "public")
+        stale.should contain(File.join("public", "css", "style.css"))
       end
     end
   end

--- a/spec/functional/sass_spec.cr
+++ b/spec/functional/sass_spec.cr
@@ -1,0 +1,112 @@
+require "./support/build_helper"
+
+private SASS_CONFIG = <<-TOML
+title = "Sass Test"
+base_url = "https://example.com"
+
+[sass]
+enabled = true
+minify = false
+TOML
+
+private INDEX_MD      = "# Hello\n"
+private PAGE_TEMPLATE = "<html><body>{{ content }}</body></html>"
+
+describe "Sass build integration" do
+  it "compiles static scss entries to sibling css and drops raw sources" do
+    build_site(
+      SASS_CONFIG,
+      content_files: {"index.md" => INDEX_MD},
+      template_files: {"index.html" => PAGE_TEMPLATE, "page.html" => PAGE_TEMPLATE},
+      static_files: {
+        "css/_vars.scss" => "$primary: #123456;",
+        "css/style.scss" => "@use \"vars\";\n.app { color: vars.$primary; .nested { margin: 0; } }",
+        "css/plain.css"  => ".plain { color: red; }",
+      },
+    ) do
+      css = File.read("public/css/style.css")
+      css.should contain(".app {\n  color: #123456;")
+      css.should contain(".app .nested {")
+
+      File.exists?("public/css/style.scss").should be_false
+      File.exists?("public/css/_vars.scss").should be_false
+      File.exists?("public/css/plain.css").should be_true
+    end
+  end
+
+  it "minifies compiled output when [sass] minify is on" do
+    config = SASS_CONFIG.sub("minify = false", "minify = true")
+    build_site(
+      config,
+      content_files: {"index.md" => INDEX_MD},
+      template_files: {"index.html" => PAGE_TEMPLATE, "page.html" => PAGE_TEMPLATE},
+      static_files: {"css/style.scss" => "$c: red;\n.a { color: $c; }"},
+    ) do
+      css = File.read("public/css/style.css")
+      css.should contain(".a{color:red}")
+    end
+  end
+
+  it "copies raw scss verbatim when [sass] is disabled (back-compat)" do
+    config = <<-TOML
+    title = "No Sass"
+    base_url = "https://example.com"
+    TOML
+    build_site(
+      config,
+      content_files: {"index.md" => INDEX_MD},
+      template_files: {"index.html" => PAGE_TEMPLATE, "page.html" => PAGE_TEMPLATE},
+      static_files: {"css/style.scss" => "$c: red;\n.a { color: $c; }"},
+    ) do
+      File.exists?("public/css/style.css").should be_false
+      File.read("public/css/style.scss").should contain("$c: red;")
+    end
+  end
+
+  it "compiles scss entries referenced by asset bundles" do
+    config = <<-TOML
+    title = "Bundle"
+    base_url = "https://example.com"
+
+    [sass]
+    enabled = true
+
+    [assets]
+    enabled = true
+    minify = false
+    fingerprint = false
+
+    [[assets.bundles]]
+    name = "main.css"
+    files = ["css/style.scss", "css/extra.css"]
+    TOML
+    build_site(
+      config,
+      content_files: {"index.md" => INDEX_MD},
+      template_files: {"index.html" => PAGE_TEMPLATE, "page.html" => PAGE_TEMPLATE},
+      static_files: {
+        "css/style.scss" => "$c: blue;\n.a { color: $c; }",
+        "css/extra.css"  => ".b { color: green; }",
+      },
+    ) do
+      bundle = File.read("public/assets/main.css")
+      bundle.should contain("color: blue;")
+      bundle.should contain(".b { color: green; }")
+      bundle.should_not contain("$c")
+    end
+  end
+
+  it "fails the build with a located content error on invalid scss" do
+    ex = expect_raises(Hwaro::HwaroError) do
+      build_site(
+        SASS_CONFIG,
+        content_files: {"index.md" => INDEX_MD},
+        template_files: {"index.html" => PAGE_TEMPLATE, "page.html" => PAGE_TEMPLATE},
+        static_files: {"css/bad.scss" => ".a {\n  color: $missing;\n}"},
+      ) { }
+    end
+    ex.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+    ex.message.not_nil!.should contain("bad.scss:2:")
+    ex.message.not_nil!.should contain("undefined variable")
+  end
+end

--- a/spec/functional/sass_spec.cr
+++ b/spec/functional/sass_spec.cr
@@ -96,6 +96,31 @@ describe "Sass build integration" do
     end
   end
 
+  it "recompiles all entries when a partial changes (serve recompile path)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", SASS_CONFIG)
+        FileUtils.mkdir_p("content")
+        File.write("content/index.md", INDEX_MD)
+        FileUtils.mkdir_p("templates")
+        File.write("templates/index.html", PAGE_TEMPLATE)
+        File.write("templates/page.html", PAGE_TEMPLATE)
+        FileUtils.mkdir_p("static/css")
+        File.write("static/css/_vars.scss", "$primary: #111111;")
+        File.write("static/css/style.scss", "@use \"vars\";\n.app { color: vars.$primary; }")
+
+        builder = Hwaro::Core::Build::Builder.new
+        Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+        builder.run(output_dir: "public", verbose: false).should be_true
+        File.read("public/css/style.css").should contain("#111111")
+
+        File.write("static/css/_vars.scss", "$primary: #222222;")
+        builder.recompile_sass("public")
+        File.read("public/css/style.css").should contain("#222222")
+      end
+    end
+  end
+
   it "fails the build with a located content error on invalid scss" do
     ex = expect_raises(Hwaro::HwaroError) do
       build_site(

--- a/spec/unit/content_hooks_spec.cr
+++ b/spec/unit/content_hooks_spec.cr
@@ -8,9 +8,9 @@ describe Hwaro::Content::Hooks do
       hooks.should be_a(Array(Hwaro::Core::Lifecycle::Hookable))
     end
 
-    it "returns exactly 7 hooks" do
+    it "returns exactly 8 hooks" do
       hooks = Hwaro::Content::Hooks.all
-      hooks.size.should eq(7)
+      hooks.size.should eq(8)
     end
 
     it "includes ImageHooks" do

--- a/spec/unit/sass/compile_spec.cr
+++ b/spec/unit/sass/compile_spec.cr
@@ -45,6 +45,16 @@ describe Hwaro::Assets::Sass do
       css.should contain(".b {\n  color: blue;")
     end
 
+    it "treats hyphens and underscores as equivalent in identifiers" do
+      css = compile(<<-'SCSS')
+      $brand-color: #123;
+      .a { color: $brand_color; }
+      .b { color: $brand-color; }
+      SCSS
+      css.should contain(".a {\n  color: #123;")
+      css.should contain(".b {\n  color: #123;")
+    end
+
     it "errors on undefined variables with a location" do
       ex = expect_raises(Hwaro::Assets::Sass::SyntaxError, /undefined variable: "\$missing"/) do
         compile(".a { color: $missing; }", path: "y.scss")
@@ -219,6 +229,19 @@ describe Hwaro::Assets::Sass do
       css.should contain("@import url(theme.css);")
       css.should contain(%q{@import "https://example.com/x.css";})
       css.should contain(%q{@import "print.css" print;})
+    end
+
+    it "does not mis-unquote non-string @import arguments" do
+      # `"a" + "b"` has matching first/last quotes but is not one string —
+      # it must pass through instead of becoming an ImportNode for `a" + "b`.
+      css = compile(%q{@import "a" + "b";})
+      css.should contain(%q{@import "a" + "b";})
+    end
+
+    it "does not wrap descriptor at-rules nested in rules with a selector" do
+      css = compile(".a { @font-face { font-family: X; src: url(x.woff2); } }")
+      css.should contain("@font-face {\n  font-family: X;")
+      css.should_not contain("@font-face {\n  .a")
     end
 
     # =========================================================================

--- a/spec/unit/sass/compile_spec.cr
+++ b/spec/unit/sass/compile_spec.cr
@@ -16,15 +16,15 @@ describe Hwaro::Assets::Sass do
     end
 
     it "shadows outer variables in nested rules" do
-      css = compile(<<-'SCSS')
-      $c: red;
-      .outer {
-        $c: blue;
-        color: $c;
-        .inner { color: $c; }
-      }
-      .after { color: $c; }
-      SCSS
+      css = compile(<<-SCSS)
+        $c: red;
+        .outer {
+          $c: blue;
+          color: $c;
+          .inner { color: $c; }
+        }
+        .after { color: $c; }
+        SCSS
       css.should contain(".outer {\n  color: blue;")
       css.should contain(".outer .inner {\n  color: blue;")
       css.should contain(".after {\n  color: red;")
@@ -37,20 +37,20 @@ describe Hwaro::Assets::Sass do
     end
 
     it "writes root scope with !global" do
-      css = compile(<<-'SCSS')
-      $c: red;
-      .a { $c: blue !global; }
-      .b { color: $c; }
-      SCSS
+      css = compile(<<-SCSS)
+        $c: red;
+        .a { $c: blue !global; }
+        .b { color: $c; }
+        SCSS
       css.should contain(".b {\n  color: blue;")
     end
 
     it "treats hyphens and underscores as equivalent in identifiers" do
-      css = compile(<<-'SCSS')
-      $brand-color: #123;
-      .a { color: $brand_color; }
-      .b { color: $brand-color; }
-      SCSS
+      css = compile(<<-SCSS)
+        $brand-color: #123;
+        .a { color: $brand_color; }
+        .b { color: $brand-color; }
+        SCSS
       css.should contain(".a {\n  color: #123;")
       css.should contain(".b {\n  color: #123;")
     end
@@ -83,7 +83,7 @@ describe Hwaro::Assets::Sass do
     end
 
     it "keeps & literal inside strings and attribute selectors" do
-      css = compile(%q{.a { [data-x="&"] { color: red; } }})
+      css = compile(%q(.a { [data-x="&"] { color: red; } }))
       css.should contain(".a [data-x=\"&\"]")
     end
 
@@ -104,16 +104,16 @@ describe Hwaro::Assets::Sass do
     # =========================================================================
     it "interpolates in selectors, property names, and values" do
       css = compile(<<-'SCSS')
-      $name: card;
-      $side: left;
-      .#{$name} {
-        margin-#{$side}: 4px;
-        content: "hello #{$name}";
-      }
-      SCSS
+        $name: card;
+        $side: left;
+        .#{$name} {
+          margin-#{$side}: 4px;
+          content: "hello #{$name}";
+        }
+        SCSS
       css.should contain(".card {")
       css.should contain("margin-left: 4px;")
-      css.should contain(%q{content: "hello card";})
+      css.should contain(%q(content: "hello card";))
     end
 
     it "interpolates in at-rule preludes and substitutes prelude variables" do
@@ -169,16 +169,16 @@ describe Hwaro::Assets::Sass do
     # Plain-CSS passthrough
     # =========================================================================
     it "passes through @font-face, custom properties, and data URIs" do
-      css = compile(<<-'SCSS')
-      @charset "utf-8";
-      :root { --brand: #f00; --gap:  4px   8px; }
-      @font-face { font-family: "X"; src: url(x.woff2) format("woff2"); }
-      .grid { background: url(data:image/png;base64,AAA/BBB==); }
-      SCSS
-      css.should contain(%q{@charset "utf-8";})
+      css = compile(<<-SCSS)
+        @charset "utf-8";
+        :root { --brand: #f00; --gap:  4px   8px; }
+        @font-face { font-family: "X"; src: url(x.woff2) format("woff2"); }
+        .grid { background: url(data:image/png;base64,AAA/BBB==); }
+        SCSS
+      css.should contain(%q(@charset "utf-8";))
       css.should contain("--brand: #f00;")
       css.should contain("--gap: 4px   8px;")
-      css.should contain(%q{src: url(x.woff2) format("woff2");})
+      css.should contain(%q(src: url(x.woff2) format("woff2");))
       css.should contain("url(data:image/png;base64,AAA/BBB==)")
     end
 
@@ -189,10 +189,10 @@ describe Hwaro::Assets::Sass do
     end
 
     it "passes through quoted braces, semicolons, and escapes" do
-      css = compile(<<-'SCSS')
-      a[href^="https://"]::after { content: " (ext, a{b;c})"; }
-      .q { content: "quote \" and brace {"; }
-      SCSS
+      css = compile(<<-SCSS)
+        a[href^="https://"]::after { content: " (ext, a{b;c})"; }
+        .q { content: "quote \\" and brace {"; }
+        SCSS
       css.should contain("content: \" (ext, a{b;c})\";")
       css.should contain("content: \"quote \\\" and brace {\";")
     end
@@ -216,26 +216,26 @@ describe Hwaro::Assets::Sass do
     end
 
     it "passes through grid-template-areas string stacks" do
-      css = compile(%q{.g { grid-template-areas: "a a" "b b"; }})
-      css.should contain(%q{grid-template-areas: "a a" "b b";})
+      css = compile(%q(.g { grid-template-areas: "a a" "b b"; }))
+      css.should contain(%q(grid-template-areas: "a a" "b b";))
     end
 
     it "passes through plain-CSS @import forms" do
-      css = compile(<<-'SCSS')
-      @import url(theme.css);
-      @import "https://example.com/x.css";
-      @import "print.css" print;
-      SCSS
+      css = compile(<<-SCSS)
+        @import url(theme.css);
+        @import "https://example.com/x.css";
+        @import "print.css" print;
+        SCSS
       css.should contain("@import url(theme.css);")
-      css.should contain(%q{@import "https://example.com/x.css";})
-      css.should contain(%q{@import "print.css" print;})
+      css.should contain(%q(@import "https://example.com/x.css";))
+      css.should contain(%q(@import "print.css" print;))
     end
 
     it "does not mis-unquote non-string @import arguments" do
       # `"a" + "b"` has matching first/last quotes but is not one string —
       # it must pass through instead of becoming an ImportNode for `a" + "b`.
-      css = compile(%q{@import "a" + "b";})
-      css.should contain(%q{@import "a" + "b";})
+      css = compile(%q(@import "a" + "b";))
+      css.should contain(%q(@import "a" + "b";))
     end
 
     it "does not wrap descriptor at-rules nested in rules with a selector" do
@@ -258,7 +258,7 @@ describe Hwaro::Assets::Sass do
 
     it "rejects @use with configuration" do
       expect_raises(Hwaro::Assets::Sass::SyntaxError, /with \(\.\.\.\) configuration is not supported/) do
-        compile(%q{@use "x" with ($a: 1);})
+        compile(%q(@use "x" with ($a: 1);))
       end
     end
 
@@ -273,7 +273,7 @@ describe Hwaro::Assets::Sass do
 
     it "reports unterminated strings" do
       expect_raises(Hwaro::Assets::Sass::SyntaxError, /unterminated string/) do
-        compile(%q{.a { content: "oops; }})
+        compile(%q(.a { content: "oops; }))
       end
     end
 

--- a/spec/unit/sass/compile_spec.cr
+++ b/spec/unit/sass/compile_spec.cr
@@ -1,0 +1,269 @@
+require "../../spec_helper"
+require "../../../src/assets/sass"
+
+private def compile(scss : String, path : String = "test.scss") : String
+  Hwaro::Assets::Sass.compile(scss, path)
+end
+
+describe Hwaro::Assets::Sass do
+  describe ".compile" do
+    # =========================================================================
+    # Variables & scoping
+    # =========================================================================
+    it "substitutes variables in values" do
+      css = compile("$c: #336699;\n.a { color: $c; }")
+      css.should contain("color: #336699;")
+    end
+
+    it "shadows outer variables in nested rules" do
+      css = compile(<<-'SCSS')
+      $c: red;
+      .outer {
+        $c: blue;
+        color: $c;
+        .inner { color: $c; }
+      }
+      .after { color: $c; }
+      SCSS
+      css.should contain(".outer {\n  color: blue;")
+      css.should contain(".outer .inner {\n  color: blue;")
+      css.should contain(".after {\n  color: red;")
+    end
+
+    it "honors !default only when unset" do
+      css = compile("$a: 1px;\n$a: 2px !default;\n$b: 3px !default;\n.x { margin: $a; padding: $b; }")
+      css.should contain("margin: 1px;")
+      css.should contain("padding: 3px;")
+    end
+
+    it "writes root scope with !global" do
+      css = compile(<<-'SCSS')
+      $c: red;
+      .a { $c: blue !global; }
+      .b { color: $c; }
+      SCSS
+      css.should contain(".b {\n  color: blue;")
+    end
+
+    it "errors on undefined variables with a location" do
+      ex = expect_raises(Hwaro::Assets::Sass::SyntaxError, /undefined variable: "\$missing"/) do
+        compile(".a { color: $missing; }", path: "y.scss")
+      end
+      ex.path.should eq("y.scss")
+      ex.line.should eq(1)
+    end
+
+    # =========================================================================
+    # Nesting & parent selector
+    # =========================================================================
+    it "flattens nested rules with descendant combinators" do
+      css = compile(".a { .b { color: red; } }")
+      css.should contain(".a .b {")
+    end
+
+    it "combines selector lists as a cartesian product" do
+      css = compile(".a, .b { .c & { color: red; } }")
+      css.should contain(".c .a,\n.c .b {")
+    end
+
+    it "substitutes & for pseudo-classes and BEM suffixes" do
+      css = compile(".block { &:hover { color: red; } &__elem { color: blue; } }")
+      css.should contain(".block:hover {")
+      css.should contain(".block__elem {")
+    end
+
+    it "keeps & literal inside strings and attribute selectors" do
+      css = compile(%q{.a { [data-x="&"] { color: red; } }})
+      css.should contain(".a [data-x=\"&\"]")
+    end
+
+    it "errors on top-level &" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /top-level selectors may not contain "&"/) do
+        compile("&:hover { color: red; }")
+      end
+    end
+
+    it "errors on nested properties" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /nested properties are not supported/) do
+        compile(".a { font: { family: serif; } }")
+      end
+    end
+
+    # =========================================================================
+    # Interpolation
+    # =========================================================================
+    it "interpolates in selectors, property names, and values" do
+      css = compile(<<-'SCSS')
+      $name: card;
+      $side: left;
+      .#{$name} {
+        margin-#{$side}: 4px;
+        content: "hello #{$name}";
+      }
+      SCSS
+      css.should contain(".card {")
+      css.should contain("margin-left: 4px;")
+      css.should contain(%q{content: "hello card";})
+    end
+
+    it "interpolates in at-rule preludes and substitutes prelude variables" do
+      css = compile("$bp: 600px;\n@media (min-width: #{"\#{$bp}"}) { .a { color: red; } }")
+      css.should contain("@media (min-width: 600px) {")
+      css2 = compile("$bp: 700px;\n@media (min-width: $bp) { .a { color: red; } }")
+      css2.should contain("@media (min-width: 700px) {")
+    end
+
+    it "errors on unterminated interpolation" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /unterminated/) do
+        compile(".a { color: #{"\#{$x"}; }")
+      end
+    end
+
+    # =========================================================================
+    # At-rule bubbling
+    # =========================================================================
+    it "bubbles @media out of nested rules" do
+      css = compile(".a { color: red; @media (min-width: 600px) { color: blue; } }")
+      css.should contain("@media (min-width: 600px) {\n  .a {\n    color: blue;")
+    end
+
+    it "keeps rules nested inside @media" do
+      css = compile("@media print { .a { color: red; } }")
+      css.should contain("@media print {\n  .a {\n    color: red;")
+    end
+
+    it "bubbles @supports" do
+      css = compile(".a { @supports (display: grid) { display: grid; } }")
+      css.should contain("@supports (display: grid) {\n  .a {\n    display: grid;")
+    end
+
+    it "nests @media inside @media literally" do
+      css = compile("@media screen { @media (min-width: 5px) { .a { color: red; } } }")
+      css.should contain("@media screen {\n  @media (min-width: 5px) {")
+    end
+
+    it "does not join @keyframes frame selectors with outer rules" do
+      css = compile(".a { @keyframes spin { from { opacity: 0; } to { opacity: 1; } } }")
+      css.should contain("@keyframes spin {")
+      css.should contain("  from {")
+      css.should_not contain(".a from")
+    end
+
+    it "omits empty rules and at-rules" do
+      css = compile(".a { }\n@media print { .b { } }")
+      css.should_not contain(".a")
+      css.should_not contain("@media")
+    end
+
+    # =========================================================================
+    # Plain-CSS passthrough
+    # =========================================================================
+    it "passes through @font-face, custom properties, and data URIs" do
+      css = compile(<<-'SCSS')
+      @charset "utf-8";
+      :root { --brand: #f00; --gap:  4px   8px; }
+      @font-face { font-family: "X"; src: url(x.woff2) format("woff2"); }
+      .grid { background: url(data:image/png;base64,AAA/BBB==); }
+      SCSS
+      css.should contain(%q{@charset "utf-8";})
+      css.should contain("--brand: #f00;")
+      css.should contain("--gap: 4px   8px;")
+      css.should contain(%q{src: url(x.woff2) format("woff2");})
+      css.should contain("url(data:image/png;base64,AAA/BBB==)")
+    end
+
+    it "keeps $var literal in custom property values" do
+      css = compile("$c: red;\n.a { --x: $c; color: $c; }")
+      css.should contain("--x: $c;")
+      css.should contain("color: red;")
+    end
+
+    it "passes through quoted braces, semicolons, and escapes" do
+      css = compile(<<-'SCSS')
+      a[href^="https://"]::after { content: " (ext, a{b;c})"; }
+      .q { content: "quote \" and brace {"; }
+      SCSS
+      css.should contain("content: \" (ext, a{b;c})\";")
+      css.should contain("content: \"quote \\\" and brace {\";")
+    end
+
+    it "preserves !important" do
+      css = compile(".a { color: red !important; }")
+      css.should contain("color: red !important;")
+    end
+
+    it "preserves loud comments and drops silent comments" do
+      css = compile("/* keep */\n.a { color: red; // gone\n }")
+      css.should contain("/* keep */")
+      css.should_not contain("gone")
+    end
+
+    it "passes through unknown functions untouched" do
+      css = compile(".a { width: calc(100% - 2px); color: rgba(0, 0, 0, 0.5); inset: clamp(1px, 2vw, 3px); }")
+      css.should contain("width: calc(100% - 2px);")
+      css.should contain("color: rgba(0, 0, 0, 0.5);")
+      css.should contain("inset: clamp(1px, 2vw, 3px);")
+    end
+
+    it "passes through grid-template-areas string stacks" do
+      css = compile(%q{.g { grid-template-areas: "a a" "b b"; }})
+      css.should contain(%q{grid-template-areas: "a a" "b b";})
+    end
+
+    it "passes through plain-CSS @import forms" do
+      css = compile(<<-'SCSS')
+      @import url(theme.css);
+      @import "https://example.com/x.css";
+      @import "print.css" print;
+      SCSS
+      css.should contain("@import url(theme.css);")
+      css.should contain(%q{@import "https://example.com/x.css";})
+      css.should contain(%q{@import "print.css" print;})
+    end
+
+    # =========================================================================
+    # Unsupported directives fail loudly
+    # =========================================================================
+    %w[if each for while function extend forward at-root].each do |directive|
+      it "rejects @#{directive} with a located error" do
+        ex = expect_raises(Hwaro::Assets::Sass::SyntaxError, /@#{directive} is not supported/) do
+          compile("@#{directive} x { color: red; }", path: "d.scss")
+        end
+        ex.location.should eq("d.scss:1:1")
+      end
+    end
+
+    it "rejects @use with configuration" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /with \(\.\.\.\) configuration is not supported/) do
+        compile(%q{@use "x" with ($a: 1);})
+      end
+    end
+
+    # =========================================================================
+    # Parse errors carry locations
+    # =========================================================================
+    it "reports unterminated blocks" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /unterminated block/) do
+        compile(".a {\n  color: red;")
+      end
+    end
+
+    it "reports unterminated strings" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /unterminated string/) do
+        compile(%q{.a { content: "oops; }})
+      end
+    end
+
+    it "reports unmatched closing braces" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /unmatched "}"/) do
+        compile(".a { color: red; }\n}")
+      end
+    end
+
+    it "reports a missing colon in a declaration" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /expected "{"/) do
+        compile(".a { nonsense; }")
+      end
+    end
+  end
+end

--- a/spec/unit/sass/importer_spec.cr
+++ b/spec/unit/sass/importer_spec.cr
@@ -1,0 +1,151 @@
+require "../../spec_helper"
+require "../../../src/assets/sass"
+
+private def compile_with(files : Hash(String, String), entry : String) : String
+  loader = Hwaro::Assets::Sass::MemoryLoader.new(files)
+  Hwaro::Assets::Sass.compile(files[entry], path: entry, loader: loader)
+end
+
+describe "Hwaro::Assets::Sass imports" do
+  describe "@import" do
+    it "merges partials into the current scope" do
+      css = compile_with({
+        "sass/_vars.scss" => "$c: #123;",
+        "sass/main.scss"  => "@import \"vars\";\n.a { color: $c; }",
+      }, "sass/main.scss")
+      css.should contain("color: #123;")
+    end
+
+    it "emits imported CSS at the import site and re-emits on repeat" do
+      css = compile_with({
+        "sass/_base.scss" => ".base { margin: 0; }",
+        "sass/main.scss"  => "@import \"base\";\n@import \"base\";",
+      }, "sass/main.scss")
+      css.scan(/\.base \{/).size.should eq(2)
+    end
+
+    it "resolves relative to the importing file" do
+      css = compile_with({
+        "sass/nested/_deep.scss" => ".deep { color: red; }",
+        "sass/_mid.scss"         => "@import \"nested/deep\";",
+        "sass/main.scss"         => "@import \"mid\";",
+      }, "sass/main.scss")
+      css.should contain(".deep {")
+    end
+
+    it "probes _partial, plain, and index candidates" do
+      css = compile_with({
+        "sass/lib/_index.scss" => ".lib { color: red; }",
+        "sass/main.scss"       => "@import \"lib\";",
+      }, "sass/main.scss")
+      css.should contain(".lib {")
+    end
+
+    it "errors on missing imports with the directive location" do
+      ex = expect_raises(Hwaro::Assets::Sass::SyntaxError, /can't find stylesheet to import: "ghost"/) do
+        compile_with({"sass/main.scss" => "@import \"ghost\";"}, "sass/main.scss")
+      end
+      ex.path.should eq("sass/main.scss")
+    end
+
+    it "errors when partial and non-partial are ambiguous" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /ambiguous import/) do
+        compile_with({
+          "sass/_dup.scss" => ".a { color: red; }",
+          "sass/dup.scss"  => ".b { color: blue; }",
+          "sass/main.scss" => "@import \"dup\";",
+        }, "sass/main.scss")
+      end
+    end
+
+    it "errors on circular imports with the chain" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /circular @use\/@import/) do
+        compile_with({
+          "sass/_a.scss"   => "@import \"b\";",
+          "sass/_b.scss"   => "@import \"a\";",
+          "sass/main.scss" => "@import \"a\";",
+        }, "sass/main.scss")
+      end
+    end
+
+    it "rejects imports escaping the project root" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /outside the project directory/) do
+        compile_with({"sass/main.scss" => "@import \"../../../../etc/passwd.scss\";"}, "sass/main.scss")
+      end
+    end
+  end
+
+  describe "@use" do
+    it "exposes members under the default namespace" do
+      css = compile_with({
+        "sass/_colors.scss" => "$primary: #123456;\n@mixin themed { border-color: $primary; }",
+        "sass/main.scss"    => "@use \"colors\";\n.app { color: colors.$primary; @include colors.themed; }",
+      }, "sass/main.scss")
+      css.should contain("color: #123456;")
+      css.should contain("border-color: #123456;")
+    end
+
+    it "supports namespace aliases" do
+      css = compile_with({
+        "sass/_colors.scss" => "$primary: red;",
+        "sass/main.scss"    => "@use \"colors\" as c;\n.a { color: c.$primary; }",
+      }, "sass/main.scss")
+      css.should contain("color: red;")
+    end
+
+    it "merges into globals with as *" do
+      css = compile_with({
+        "sass/_colors.scss" => "$primary: red;",
+        "sass/main.scss"    => "@use \"colors\" as *;\n.a { color: $primary; }",
+      }, "sass/main.scss")
+      css.should contain("color: red;")
+    end
+
+    it "emits module CSS once before the using file" do
+      css = compile_with({
+        "sass/_base.scss" => ".base { margin: 0; }",
+        "sass/_one.scss"  => "@use \"base\";\n.one { color: red; }",
+        "sass/_two.scss"  => "@use \"base\";\n.two { color: blue; }",
+        "sass/main.scss"  => "@use \"one\";\n@use \"two\";\n.app { color: green; }",
+      }, "sass/main.scss")
+      css.scan(/\.base \{/).size.should eq(1)
+      css.index(".base {").not_nil!.should be < css.index(".one {").not_nil!
+      css.index(".one {").not_nil!.should be < css.index(".app {").not_nil!
+    end
+
+    it "errors on undefined namespace members" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /undefined variable: "colors\.\$nope"/) do
+        compile_with({
+          "sass/_colors.scss" => "$primary: red;",
+          "sass/main.scss"    => "@use \"colors\";\n.a { color: colors.$nope; }",
+        }, "sass/main.scss")
+      end
+    end
+
+    it "errors on unknown namespaces" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /no module namespace "ghost"/) do
+        compile_with({"sass/main.scss" => ".a { color: ghost.$x; }"}, "sass/main.scss")
+      end
+    end
+
+    it "errors on namespace collisions" do
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /namespace "c" is already taken/) do
+        compile_with({
+          "sass/_a.scss"   => "$x: 1;",
+          "sass/_b.scss"   => "$x: 2;",
+          "sass/main.scss" => "@use \"a\" as c;\n@use \"b\" as c;",
+        }, "sass/main.scss")
+      end
+    end
+
+    it "allows re-using the same module under the same namespace" do
+      css = compile_with({
+        "sass/_colors.scss" => "$primary: red;",
+        "sass/_widget.scss" => "@use \"colors\";\n.widget { color: colors.$primary; }",
+        "sass/main.scss"    => "@use \"colors\";\n@use \"widget\";\n.a { color: colors.$primary; }",
+      }, "sass/main.scss")
+      css.should contain(".widget {")
+      css.should contain(".a {")
+    end
+  end
+end

--- a/spec/unit/sass/importer_spec.cr
+++ b/spec/unit/sass/importer_spec.cr
@@ -109,8 +109,8 @@ describe "Hwaro::Assets::Sass imports" do
         "sass/main.scss"  => "@use \"one\";\n@use \"two\";\n.app { color: green; }",
       }, "sass/main.scss")
       css.scan(/\.base \{/).size.should eq(1)
-      css.index(".base {").not_nil!.should be < css.index(".one {").not_nil!
-      css.index(".one {").not_nil!.should be < css.index(".app {").not_nil!
+      css.index!(".base {").should be < css.index!(".one {")
+      css.index!(".one {").should be < css.index!(".app {")
     end
 
     it "errors on undefined namespace members" do

--- a/spec/unit/sass/mixins_spec.cr
+++ b/spec/unit/sass/mixins_spec.cr
@@ -1,0 +1,131 @@
+require "../../spec_helper"
+require "../../../src/assets/sass"
+
+private def compile(scss : String, path : String = "test.scss") : String
+  Hwaro::Assets::Sass.compile(scss, path)
+end
+
+describe "Hwaro::Assets::Sass mixins" do
+  it "expands a parameterless mixin" do
+    css = compile(<<-'SCSS')
+    @mixin reset { margin: 0; padding: 0; }
+    .a { @include reset; }
+    SCSS
+    css.should contain(".a {\n  margin: 0;\n  padding: 0;")
+  end
+
+  it "binds positional arguments and defaults" do
+    css = compile(<<-'SCSS')
+    @mixin button($bg, $fg: white) { background: $bg; color: $fg; }
+    .a { @include button(#333); }
+    .b { @include button(#333, black); }
+    SCSS
+    css.should contain(".a {\n  background: #333;\n  color: white;")
+    css.should contain(".b {\n  background: #333;\n  color: black;")
+  end
+
+  it "binds keyword arguments" do
+    css = compile(<<-'SCSS')
+    @mixin box($w: 1px, $h: 2px) { width: $w; height: $h; }
+    .a { @include box($h: 9px); }
+    SCSS
+    css.should contain("width: 1px;")
+    css.should contain("height: 9px;")
+  end
+
+  it "lets defaults reference earlier parameters" do
+    css = compile(<<-'SCSS')
+    @mixin square($w, $h: $w) { width: $w; height: $h; }
+    .a { @include square(5px); }
+    SCSS
+    css.should contain("height: 5px;")
+  end
+
+  it "keeps comma-containing arguments intact inside parens" do
+    css = compile(<<-'SCSS')
+    @mixin shadow($v) { box-shadow: $v; }
+    .a { @include shadow(rgba(0, 0, 0, 0.5) 0 1px); }
+    SCSS
+    css.should contain("box-shadow: rgba(0, 0, 0, 0.5) 0 1px;")
+  end
+
+  it "evaluates @content in the caller's scope" do
+    css = compile(<<-'SCSS')
+    $c: caller;
+    @mixin respond($bp: 768px) {
+      $c: mixin;
+      @media (min-width: $bp) { @content; }
+    }
+    .a {
+      @include respond(1024px) { content: "#{$c}"; }
+    }
+    SCSS
+    css.should contain("@media (min-width: 1024px) {")
+    css.should contain(%q{content: "caller";})
+  end
+
+  it "emits nothing for @content without a passed block" do
+    css = compile(<<-'SCSS')
+    @mixin maybe { @content; }
+    .a { color: red; @include maybe; }
+    SCSS
+    css.should contain(".a {\n  color: red;\n}")
+  end
+
+  it "closes over the definition environment" do
+    css = compile(<<-'SCSS')
+    $theme: dark;
+    @mixin themed { content: "#{$theme}"; }
+    .a {
+      $theme: local;
+      @include themed;
+    }
+    SCSS
+    # dart-sass resolves $theme against the innermost matching scope at
+    # call time via lexical chain of the definition (root) — the local
+    # shadow is invisible to the mixin body.
+    css.should contain(%q{content: "dark";})
+  end
+
+  it "errors on undefined mixins" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /undefined mixin: "nope"/) do
+      compile(".a { @include nope; }")
+    end
+  end
+
+  it "errors on unknown keyword arguments" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /no parameter named \$oops/) do
+      compile("@mixin m($a: 1) { width: $a; }\n.x { @include m($oops: 2); }")
+    end
+  end
+
+  it "errors on missing required arguments" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /missing argument \$bg/) do
+      compile("@mixin m($bg) { background: $bg; }\n.x { @include m; }")
+    end
+  end
+
+  it "errors on too many positional arguments" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /takes 1 argument\(s\) but 2 were passed/) do
+      compile("@mixin m($a) { width: $a; }\n.x { @include m(1, 2); }")
+    end
+  end
+
+  it "errors on runaway @include recursion" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /too much recursion/) do
+      compile("@mixin loop { @include loop; }\n.x { @include loop; }")
+    end
+  end
+
+  it "rejects variadic parameters" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /variadic parameters/) do
+      compile("@mixin m($args...) { width: 0; }")
+    end
+  end
+
+  it "rejects @include using clauses" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /using \(\.\.\.\) is not supported/) do
+      compile("@mixin m { @content; }\n.x { @include m using ($a) { width: $a; } }")
+    end
+  end
+end

--- a/spec/unit/sass/mixins_spec.cr
+++ b/spec/unit/sass/mixins_spec.cr
@@ -87,6 +87,14 @@ describe "Hwaro::Assets::Sass mixins" do
     css.should contain(%q{content: "dark";})
   end
 
+  it "treats hyphens and underscores as equivalent in mixin and parameter names" do
+    css = compile(<<-'SCSS')
+    @mixin drop-shadow($shadow-size: 2px) { box-shadow: 0 $shadow-size; }
+    .a { @include drop_shadow($shadow_size: 5px); }
+    SCSS
+    css.should contain("box-shadow: 0 5px;")
+  end
+
   it "errors on undefined mixins" do
     expect_raises(Hwaro::Assets::Sass::SyntaxError, /undefined mixin: "nope"/) do
       compile(".a { @include nope; }")

--- a/spec/unit/sass/mixins_spec.cr
+++ b/spec/unit/sass/mixins_spec.cr
@@ -7,91 +7,91 @@ end
 
 describe "Hwaro::Assets::Sass mixins" do
   it "expands a parameterless mixin" do
-    css = compile(<<-'SCSS')
-    @mixin reset { margin: 0; padding: 0; }
-    .a { @include reset; }
-    SCSS
+    css = compile(<<-SCSS)
+      @mixin reset { margin: 0; padding: 0; }
+      .a { @include reset; }
+      SCSS
     css.should contain(".a {\n  margin: 0;\n  padding: 0;")
   end
 
   it "binds positional arguments and defaults" do
-    css = compile(<<-'SCSS')
-    @mixin button($bg, $fg: white) { background: $bg; color: $fg; }
-    .a { @include button(#333); }
-    .b { @include button(#333, black); }
-    SCSS
+    css = compile(<<-SCSS)
+      @mixin button($bg, $fg: white) { background: $bg; color: $fg; }
+      .a { @include button(#333); }
+      .b { @include button(#333, black); }
+      SCSS
     css.should contain(".a {\n  background: #333;\n  color: white;")
     css.should contain(".b {\n  background: #333;\n  color: black;")
   end
 
   it "binds keyword arguments" do
-    css = compile(<<-'SCSS')
-    @mixin box($w: 1px, $h: 2px) { width: $w; height: $h; }
-    .a { @include box($h: 9px); }
-    SCSS
+    css = compile(<<-SCSS)
+      @mixin box($w: 1px, $h: 2px) { width: $w; height: $h; }
+      .a { @include box($h: 9px); }
+      SCSS
     css.should contain("width: 1px;")
     css.should contain("height: 9px;")
   end
 
   it "lets defaults reference earlier parameters" do
-    css = compile(<<-'SCSS')
-    @mixin square($w, $h: $w) { width: $w; height: $h; }
-    .a { @include square(5px); }
-    SCSS
+    css = compile(<<-SCSS)
+      @mixin square($w, $h: $w) { width: $w; height: $h; }
+      .a { @include square(5px); }
+      SCSS
     css.should contain("height: 5px;")
   end
 
   it "keeps comma-containing arguments intact inside parens" do
-    css = compile(<<-'SCSS')
-    @mixin shadow($v) { box-shadow: $v; }
-    .a { @include shadow(rgba(0, 0, 0, 0.5) 0 1px); }
-    SCSS
+    css = compile(<<-SCSS)
+      @mixin shadow($v) { box-shadow: $v; }
+      .a { @include shadow(rgba(0, 0, 0, 0.5) 0 1px); }
+      SCSS
     css.should contain("box-shadow: rgba(0, 0, 0, 0.5) 0 1px;")
   end
 
   it "evaluates @content in the caller's scope" do
     css = compile(<<-'SCSS')
-    $c: caller;
-    @mixin respond($bp: 768px) {
-      $c: mixin;
-      @media (min-width: $bp) { @content; }
-    }
-    .a {
-      @include respond(1024px) { content: "#{$c}"; }
-    }
-    SCSS
+      $c: caller;
+      @mixin respond($bp: 768px) {
+        $c: mixin;
+        @media (min-width: $bp) { @content; }
+      }
+      .a {
+        @include respond(1024px) { content: "#{$c}"; }
+      }
+      SCSS
     css.should contain("@media (min-width: 1024px) {")
-    css.should contain(%q{content: "caller";})
+    css.should contain(%q(content: "caller";))
   end
 
   it "emits nothing for @content without a passed block" do
-    css = compile(<<-'SCSS')
-    @mixin maybe { @content; }
-    .a { color: red; @include maybe; }
-    SCSS
+    css = compile(<<-SCSS)
+      @mixin maybe { @content; }
+      .a { color: red; @include maybe; }
+      SCSS
     css.should contain(".a {\n  color: red;\n}")
   end
 
   it "closes over the definition environment" do
     css = compile(<<-'SCSS')
-    $theme: dark;
-    @mixin themed { content: "#{$theme}"; }
-    .a {
-      $theme: local;
-      @include themed;
-    }
-    SCSS
+      $theme: dark;
+      @mixin themed { content: "#{$theme}"; }
+      .a {
+        $theme: local;
+        @include themed;
+      }
+      SCSS
     # dart-sass resolves $theme against the innermost matching scope at
     # call time via lexical chain of the definition (root) — the local
     # shadow is invisible to the mixin body.
-    css.should contain(%q{content: "dark";})
+    css.should contain(%q(content: "dark";))
   end
 
   it "treats hyphens and underscores as equivalent in mixin and parameter names" do
-    css = compile(<<-'SCSS')
-    @mixin drop-shadow($shadow-size: 2px) { box-shadow: 0 $shadow-size; }
-    .a { @include drop_shadow($shadow_size: 5px); }
-    SCSS
+    css = compile(<<-SCSS)
+      @mixin drop-shadow($shadow-size: 2px) { box-shadow: 0 $shadow-size; }
+      .a { @include drop_shadow($shadow_size: 5px); }
+      SCSS
     css.should contain("box-shadow: 0 5px;")
   end
 

--- a/spec/unit/sass_config_spec.cr
+++ b/spec/unit/sass_config_spec.cr
@@ -18,13 +18,13 @@ describe Hwaro::Models::SassConfig do
 
   it "parses the [sass] section" do
     config = load_config(<<-TOML)
-    title = "T"
-    base_url = "https://example.com"
+      title = "T"
+      base_url = "https://example.com"
 
-    [sass]
-    enabled = true
-    minify = false
-    TOML
+      [sass]
+      enabled = true
+      minify = false
+      TOML
     config.sass.enabled.should be_true
     config.sass.minify.should be_false
   end

--- a/spec/unit/sass_config_spec.cr
+++ b/spec/unit/sass_config_spec.cr
@@ -30,13 +30,14 @@ describe Hwaro::Models::SassConfig do
   end
 
   describe "#sass_source?" do
-    it "matches .scss paths only while enabled" do
+    it "matches lowercase .scss paths only while enabled" do
       config = Hwaro::Models::Config.new
       config.sass_source?("css/style.scss").should be_false
 
       config.sass.enabled = true
       config.sass_source?("css/style.scss").should be_true
-      config.sass_source?("css/STYLE.SCSS").should be_true
+      # Other casings publish verbatim, matching the compiler's glob.
+      config.sass_source?("css/STYLE.SCSS").should be_false
       config.sass_source?("css/style.css").should be_false
     end
   end

--- a/spec/unit/sass_config_spec.cr
+++ b/spec/unit/sass_config_spec.cr
@@ -1,0 +1,43 @@
+require "../spec_helper"
+
+private def load_config(toml : String) : Hwaro::Models::Config
+  Dir.mktmpdir do |dir|
+    path = File.join(dir, "config.toml")
+    File.write(path, toml)
+    return Hwaro::Models::Config.load(path)
+  end
+  raise "unreachable"
+end
+
+describe Hwaro::Models::SassConfig do
+  it "defaults to disabled with minify on" do
+    config = Hwaro::Models::Config.new
+    config.sass.enabled.should be_false
+    config.sass.minify.should be_true
+  end
+
+  it "parses the [sass] section" do
+    config = load_config(<<-TOML)
+    title = "T"
+    base_url = "https://example.com"
+
+    [sass]
+    enabled = true
+    minify = false
+    TOML
+    config.sass.enabled.should be_true
+    config.sass.minify.should be_false
+  end
+
+  describe "#sass_source?" do
+    it "matches .scss paths only while enabled" do
+      config = Hwaro::Models::Config.new
+      config.sass_source?("css/style.scss").should be_false
+
+      config.sass.enabled = true
+      config.sass_source?("css/style.scss").should be_true
+      config.sass_source?("css/STYLE.SCSS").should be_true
+      config.sass_source?("css/style.css").should be_false
+    end
+  end
+end

--- a/src/assets/pipeline.cr
+++ b/src/assets/pipeline.cr
@@ -9,6 +9,7 @@ require "../utils/css_minifier"
 require "../utils/js_minifier"
 require "../utils/logger"
 require "../models/config"
+require "./sass_compiler"
 
 module Hwaro
   module Assets
@@ -49,7 +50,13 @@ module Hwaro
               next
             end
             io << "\n" if i > 0
-            io << File.read(source)
+            content = File.read(source)
+            # `.scss` bundle entries compile before concatenation; naming
+            # one in a bundle is explicit intent, independent of [sass].
+            if file.downcase.ends_with?(".scss")
+              content = SassCompiler.compile_source(content, source)
+            end
+            io << content
           end
         end
 

--- a/src/assets/pipeline.cr
+++ b/src/assets/pipeline.cr
@@ -18,7 +18,11 @@ module Hwaro
       # e.g. "main.css" => "/assets/main.a1b2c3d4.css"
       getter manifest : Hash(String, String)
 
-      def initialize(@config : Models::AssetsConfig, @base_url : String)
+      # `sass_enabled` mirrors `[sass].enabled`: `.scss` bundle entries
+      # compile through the built-in compiler only when the feature is on;
+      # otherwise they concatenate verbatim (pre-Sass behavior, and the
+      # escape hatch for sources outside the supported subset).
+      def initialize(@config : Models::AssetsConfig, @base_url : String, @sass_enabled : Bool = false)
         @manifest = {} of String => String
       end
 
@@ -51,9 +55,9 @@ module Hwaro
             end
             io << "\n" if i > 0
             content = File.read(source)
-            # `.scss` bundle entries compile before concatenation; naming
-            # one in a bundle is explicit intent, independent of [sass].
-            if file.downcase.ends_with?(".scss")
+            # `.scss` bundle entries compile before concatenation when the
+            # built-in Sass feature is on; verbatim otherwise.
+            if @sass_enabled && file.ends_with?(".scss")
               content = SassCompiler.compile_source(content, source)
             end
             io << content
@@ -63,6 +67,12 @@ module Hwaro
         if contents.empty?
           Logger.warn "Asset pipeline: bundle '#{bundle.name}' produced empty output"
           return
+        end
+
+        # A `.scss`-named bundle would publish with a non-CSS extension and
+        # skip the extension-keyed minifier — almost certainly a mistake.
+        if bundle.name.ends_with?(".scss")
+          Logger.warn "Asset pipeline: bundle '#{bundle.name}' keeps the .scss extension in output — name the bundle '#{bundle.name.sub(/\.scss\z/, ".css")}' to serve it as CSS."
         end
 
         # Minify if enabled

--- a/src/assets/sass.cr
+++ b/src/assets/sass.cr
@@ -1,0 +1,42 @@
+# Built-in pure-Crystal SCSS compiler (practical subset).
+#
+# Supported: `$variables` (with !default/!global), nested rules with `&`,
+# partials via @use (namespaces) / @import (classic merge), @mixin /
+# @include with defaults, keyword args and @content, `#{...}`
+# interpolation, and @media/@supports bubbling through nesting. Valid
+# plain CSS compiles to itself (whitespace-normalized). Unsupported Sass
+# directives (@if/@each/@function/@extend/...) fail loudly with a located
+# error — never silent garbage output.
+#
+# See docs/content/features/sass.md for the full support matrix and the
+# documented deviations from dart-sass.
+
+require "./sass/errors"
+require "./sass/scanner"
+require "./sass/ast"
+require "./sass/parser"
+require "./sass/environment"
+require "./sass/css"
+require "./sass/importer"
+require "./sass/evaluator"
+
+module Hwaro
+  module Assets
+    module Sass
+      # Compiles SCSS source to expanded CSS. `path` is used for error
+      # locations and as the base for @use/@import resolution; `root`
+      # bounds import resolution to the project directory. Raises
+      # `Sass::SyntaxError` — build-facing callers convert it to a
+      # classified `HwaroError`.
+      def self.compile(source : String, path : String = "(inline)",
+                       loader : Loader = FileLoader.new, root : String = Dir.current) : String
+        sheet = Parser.parse(source, path)
+        importer = Importer.new(loader, root)
+        evaluator = Evaluator.new(importer, path)
+        evaluator.seed_load_stack(File.expand_path(path, importer.root)) unless path == "(inline)"
+        nodes = evaluator.evaluate(sheet)
+        Css::Serializer.serialize(nodes)
+      end
+    end
+  end
+end

--- a/src/assets/sass/ast.cr
+++ b/src/assets/sass/ast.cr
@@ -1,0 +1,192 @@
+# AST for the SCSS subset.
+#
+# Values, selectors, property names, and at-rule preludes are represented
+# as `TextTemplate`s — verbatim source text runs with embedded dynamic
+# pieces (`$var` references and `#{...}` interpolation). Keeping unparsed
+# CSS verbatim is what guarantees plain-CSS passthrough; richer expression
+# parsing (arithmetic, functions) slots in later by deepening how a
+# template's string pieces are parsed, without changing statement nodes.
+
+module Hwaro
+  module Assets
+    module Sass
+      module Ast
+        # A `$name` / `ns.$name` reference. `lexeme` preserves the original
+        # spelling so contexts that must not substitute variables (custom
+        # property values) can restore the literal text.
+        class VarRef
+          getter name : String
+          getter namespace : String?
+          getter line : Int32
+          getter column : Int32
+
+          def initialize(@name, @namespace, @line, @column)
+          end
+
+          def lexeme : String
+            ns = @namespace
+            ns ? "#{ns}.$#{@name}" : "$#{@name}"
+          end
+        end
+
+        # `#{ ... }` — the inner content is itself a template (text and
+        # variable references in v1).
+        class Interp
+          getter inner : TextTemplate
+          getter line : Int32
+          getter column : Int32
+
+          def initialize(@inner, @line, @column)
+          end
+        end
+
+        alias Piece = String | VarRef | Interp
+
+        class TextTemplate
+          getter pieces : Array(Piece)
+          getter line : Int32
+          getter column : Int32
+
+          def initialize(@pieces : Array(Piece), @line : Int32, @column : Int32)
+          end
+
+          def empty? : Bool
+            @pieces.all? { |p| p.is_a?(String) && p.blank? }
+          end
+
+          # Literal source text with variable references restored — used for
+          # custom property values, where Sass leaves `$var` untouched.
+          def to_literal : String
+            String.build do |io|
+              @pieces.each do |piece|
+                case piece
+                in String then io << piece
+                in VarRef then io << piece.lexeme
+                in Interp then io << piece # unreachable in literal contexts
+                end
+              end
+            end
+          end
+        end
+
+        abstract class Node
+          getter line : Int32
+          getter column : Int32
+
+          def initialize(@line : Int32, @column : Int32)
+          end
+        end
+
+        class Stylesheet < Node
+          getter children : Array(Node)
+
+          def initialize(@children, line = 1, column = 1)
+            super(line, column)
+          end
+        end
+
+        class RuleNode < Node
+          getter selector : TextTemplate
+          getter children : Array(Node)
+
+          def initialize(@selector, @children, line, column)
+            super(line, column)
+          end
+        end
+
+        class DeclarationNode < Node
+          getter name : TextTemplate
+          getter value : TextTemplate
+          getter important : Bool
+          getter custom_property : Bool
+
+          def initialize(@name, @value, @important, @custom_property, line, column)
+            super(line, column)
+          end
+        end
+
+        class VarDeclNode < Node
+          getter name : String
+          getter value : TextTemplate
+          getter default : Bool
+          getter global : Bool
+
+          def initialize(@name, @value, @default, @global, line, column)
+            super(line, column)
+          end
+        end
+
+        record Param, name : String, default : TextTemplate?
+
+        class MixinDefNode < Node
+          getter name : String
+          getter params : Array(Param)
+          getter body : Array(Node)
+
+          def initialize(@name, @params, @body, line, column)
+            super(line, column)
+          end
+        end
+
+        record Arg, name : String?, value : TextTemplate
+
+        class IncludeNode < Node
+          getter name : String
+          getter namespace : String?
+          getter args : Array(Arg)
+          getter body : Array(Node)?
+
+          def initialize(@name, @namespace, @args, @body, line, column)
+            super(line, column)
+          end
+        end
+
+        class ContentNode < Node
+        end
+
+        # `@use "url"` / `@use "url" as ns` / `@use "url" as *`.
+        # namespace: nil = default (basename), "*" = merge into globals.
+        class UseNode < Node
+          getter url : String
+          getter namespace : String?
+
+          def initialize(@url, @namespace, line, column)
+            super(line, column)
+          end
+        end
+
+        # Sass `@import "local"` (classic global-merge semantics).
+        class ImportNode < Node
+          getter url : String
+
+          def initialize(@url, line, column)
+            super(line, column)
+          end
+        end
+
+        # Any other at-rule. `children` is nil for the statement form
+        # (`@charset "utf-8";`, plain-CSS `@import url(...);`); bodied
+        # forms (@media, @supports, @keyframes, @font-face, unknown) carry
+        # their block statements.
+        class RawAtRuleNode < Node
+          getter name : String
+          getter prelude : TextTemplate
+          getter children : Array(Node)?
+
+          def initialize(@name, @prelude, @children, line, column)
+            super(line, column)
+          end
+        end
+
+        # Loud comment kept at statement position.
+        class CommentNode < Node
+          getter text : String
+
+          def initialize(@text, line, column)
+            super(line, column)
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/assets/sass/ast.cr
+++ b/src/assets/sass/ast.cr
@@ -53,20 +53,6 @@ module Hwaro
           def empty? : Bool
             @pieces.all? { |p| p.is_a?(String) && p.blank? }
           end
-
-          # Literal source text with variable references restored — used for
-          # custom property values, where Sass leaves `$var` untouched.
-          def to_literal : String
-            String.build do |io|
-              @pieces.each do |piece|
-                case piece
-                in String then io << piece
-                in VarRef then io << piece.lexeme
-                in Interp then io << piece # unreachable in literal contexts
-                end
-              end
-            end
-          end
         end
 
         abstract class Node

--- a/src/assets/sass/css.cr
+++ b/src/assets/sass/css.cr
@@ -1,0 +1,129 @@
+# Flat CSS output tree + expanded-style serializer.
+#
+# The evaluator flattens SCSS nesting into this small model: style rules
+# hold declarations (and passthrough comments); at-rules hold either
+# declarations (@font-face), nested rules (@media after bubbling), or
+# both. Minification is not a serializer concern — compiled output flows
+# through the existing Utils::CssMinifier when [sass] minify is on.
+
+module Hwaro
+  module Assets
+    module Sass
+      module Css
+        abstract class Node
+        end
+
+        record Decl, name : String, value : String, important : Bool
+
+        class Comment < Node
+          getter text : String
+
+          def initialize(@text)
+          end
+        end
+
+        class Rule < Node
+          getter selectors : Array(String)
+          getter items = [] of Decl | Comment
+
+          def initialize(@selectors)
+          end
+
+          def decls? : Bool
+            @items.any?(Decl)
+          end
+        end
+
+        class AtRule < Node
+          getter name : String
+          getter prelude : String
+          getter items = [] of Decl | Comment
+          getter children = [] of Node
+
+          def initialize(@name, @prelude)
+          end
+        end
+
+        # Statement at-rule kept verbatim (@charset, plain-CSS @import, ...).
+        class Raw < Node
+          getter text : String
+
+          def initialize(@text)
+          end
+        end
+
+        module Serializer
+          extend self
+
+          def serialize(nodes : Array(Node)) : String
+            out = String.build do |io|
+              write_nodes(io, nodes, 0)
+            end
+            out.empty? ? out : out.chomp + "\n"
+          end
+
+          # Empty rules and empty at-rule blocks are omitted (dart-sass
+          # behavior); comment-only rules still render.
+          private def emit?(node : Node) : Bool
+            case node
+            when Rule
+              !node.items.empty?
+            when AtRule
+              !node.items.empty? || node.children.any? { |c| emit?(c) }
+            else
+              true
+            end
+          end
+
+          private def write_nodes(io : IO, nodes : Array(Node), indent : Int32) : Nil
+            emitted = false
+            nodes.each do |node|
+              next unless emit?(node)
+              io << "\n" if emitted
+              write_node(io, node, indent)
+              emitted = true
+            end
+          end
+
+          private def write_node(io : IO, node : Node, indent : Int32) : Nil
+            pad = "  " * indent
+            case node
+            when Rule
+              io << pad << node.selectors.join(",\n#{pad}") << " {\n"
+              write_items(io, node.items, indent + 1)
+              io << pad << "}\n"
+            when AtRule
+              io << pad << "@" << node.name
+              io << " " << node.prelude unless node.prelude.empty?
+              io << " {\n"
+              write_items(io, node.items, indent + 1)
+              unless node.children.empty?
+                io << "\n" unless node.items.empty?
+                write_nodes(io, node.children, indent + 1)
+              end
+              io << pad << "}\n"
+            when Raw
+              io << pad << node.text << "\n"
+            when Comment
+              io << pad << node.text << "\n"
+            end
+          end
+
+          private def write_items(io : IO, items : Array(Decl | Comment), indent : Int32) : Nil
+            pad = "  " * indent
+            items.each do |item|
+              case item
+              in Decl
+                io << pad << item.name << ": " << item.value
+                io << " !important" if item.important
+                io << ";\n"
+              in Comment
+                io << pad << item.text << "\n"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/assets/sass/environment.cr
+++ b/src/assets/sass/environment.cr
@@ -1,0 +1,113 @@
+# Lexical scoping for the SCSS evaluator.
+#
+# Values are plain Strings in the v1 subset (verbatim CSS text after
+# variable/interpolation substitution). When SassScript arithmetic lands,
+# a Value hierarchy (Number/Color/Bool/List) replaces the String alias —
+# the Environment API is already shaped for it.
+
+require "./ast"
+
+module Hwaro
+  module Assets
+    module Sass
+      # Mixins close over their definition environment (dart-sass
+      # semantics); `path` keeps error locations pointing at the file the
+      # mixin was defined in, not the include site.
+      record MixinClosure, node : Ast::MixinDefNode, env : Environment, path : String
+
+      # A loaded `@use` module: its root-scope members plus nothing else
+      # (module-private state stays in the closed-over environments).
+      class SassModule
+        getter variables : Hash(String, String)
+        getter mixins : Hash(String, MixinClosure)
+
+        def initialize(@variables, @mixins)
+        end
+      end
+
+      class Environment
+        getter parent : Environment?
+        getter variables = {} of String => String
+        getter mixins = {} of String => MixinClosure
+        # `@use`d modules — only ever populated on a file's root scope.
+        getter modules = {} of String => SassModule
+
+        def initialize(@parent : Environment? = nil)
+        end
+
+        def root? : Bool
+          @parent.nil?
+        end
+
+        def root : Environment
+          env = self
+          while parent = env.parent
+            env = parent
+          end
+          env
+        end
+
+        def lookup_var(name : String) : String?
+          env : Environment? = self
+          while env
+            if value = env.variables[name]?
+              return value
+            end
+            env = env.parent
+          end
+          nil
+        end
+
+        # Assignment semantics (dart-sass-flavored):
+        # - `!global` writes the root scope (skipped by `!default` when set).
+        # - `!default` is a no-op when the name resolves anywhere in scope.
+        # - Otherwise the innermost non-root scope already declaring the
+        #   name is updated; failing that, the name is declared here —
+        #   which shadows a root/global variable rather than mutating it.
+        def assign_var(name : String, value : String, default : Bool, global : Bool) : Nil
+          if global
+            return if default && root.variables.has_key?(name)
+            root.variables[name] = value
+            return
+          end
+          return if default && lookup_var(name)
+          env : Environment? = self
+          while env && !env.root?
+            if env.variables.has_key?(name)
+              env.variables[name] = value
+              return
+            end
+            env = env.parent
+          end
+          @variables[name] = value
+        end
+
+        def lookup_mixin(name : String) : MixinClosure?
+          env : Environment? = self
+          while env
+            if closure = env.mixins[name]?
+              return closure
+            end
+            env = env.parent
+          end
+          nil
+        end
+
+        def declare_mixin(name : String, closure : MixinClosure) : Nil
+          @mixins[name] = closure
+        end
+
+        def declare_module(namespace : String, mod : SassModule) : Bool
+          scope = root
+          return false if scope.modules.has_key?(namespace)
+          scope.modules[namespace] = mod
+          true
+        end
+
+        def module?(namespace : String) : SassModule?
+          root.modules[namespace]?
+        end
+      end
+    end
+  end
+end

--- a/src/assets/sass/environment.cr
+++ b/src/assets/sass/environment.cr
@@ -10,6 +10,14 @@ require "./ast"
 module Hwaro
   module Assets
     module Sass
+      # Sass treats `-` and `_` as interchangeable in identifiers
+      # (variables, mixins, namespaces — not selectors). All identifier
+      # storage and lookup normalizes to the hyphen form so
+      # `$brand-color` and `$brand_color` resolve to the same variable.
+      def self.normalize_ident(name : String) : String
+        name.tr("_", "-")
+      end
+
       # Mixins close over their definition environment (dart-sass
       # semantics); `path` keeps error locations pointing at the file the
       # mixin was defined in, not the include site.
@@ -48,6 +56,7 @@ module Hwaro
         end
 
         def lookup_var(name : String) : String?
+          name = Sass.normalize_ident(name)
           env : Environment? = self
           while env
             if value = env.variables[name]?
@@ -65,6 +74,7 @@ module Hwaro
         #   name is updated; failing that, the name is declared here —
         #   which shadows a root/global variable rather than mutating it.
         def assign_var(name : String, value : String, default : Bool, global : Bool) : Nil
+          name = Sass.normalize_ident(name)
           if global
             return if default && root.variables.has_key?(name)
             root.variables[name] = value
@@ -83,6 +93,7 @@ module Hwaro
         end
 
         def lookup_mixin(name : String) : MixinClosure?
+          name = Sass.normalize_ident(name)
           env : Environment? = self
           while env
             if closure = env.mixins[name]?
@@ -94,10 +105,11 @@ module Hwaro
         end
 
         def declare_mixin(name : String, closure : MixinClosure) : Nil
-          @mixins[name] = closure
+          @mixins[Sass.normalize_ident(name)] = closure
         end
 
         def declare_module(namespace : String, mod : SassModule) : Bool
+          namespace = Sass.normalize_ident(namespace)
           scope = root
           return false if scope.modules.has_key?(namespace)
           scope.modules[namespace] = mod
@@ -105,7 +117,7 @@ module Hwaro
         end
 
         def module?(namespace : String) : SassModule?
-          root.modules[namespace]?
+          root.modules[Sass.normalize_ident(namespace)]?
         end
       end
     end

--- a/src/assets/sass/errors.cr
+++ b/src/assets/sass/errors.cr
@@ -1,0 +1,27 @@
+# Compiler-internal error type for the built-in SCSS compiler.
+#
+# Raised for lexing, parsing, evaluation, and import-resolution failures.
+# Carries a 1-based line/column and the path of the file that failed so
+# the build boundary (SassCompiler / asset pipeline) can convert it into
+# a classified `HwaroError` with a precise `path:line:col` location.
+
+module Hwaro
+  module Assets
+    module Sass
+      class SyntaxError < Exception
+        getter path : String
+        getter line : Int32
+        getter column : Int32
+
+        def initialize(message : String, @path : String, @line : Int32, @column : Int32)
+          super(message)
+        end
+
+        # "css/style.scss:14:3"
+        def location : String
+          "#{@path}:#{@line}:#{@column}"
+        end
+      end
+    end
+  end
+end

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -1,0 +1,599 @@
+# Evaluator: SCSS AST → flat CSS tree.
+#
+# Handles variable scoping, selector nesting and `&` resolution,
+# conditional at-rule bubbling (@media/@supports inside rules), mixin
+# expansion with @content, and @use/@import module loading. Values are
+# verbatim strings after substitution; unknown functions (calc, var,
+# rgba, ...) pass through untouched — that property is what makes valid
+# plain CSS compile to itself.
+#
+# Extension seams for the full language: `eval_node`'s dispatch gains
+# arms for @if/@each/@for nodes; richer value types and a function
+# registry slot into the template-resolution path.
+
+require "./ast"
+require "./environment"
+require "./css"
+require "./importer"
+require "./parser"
+
+module Hwaro
+  module Assets
+    module Sass
+      class Evaluator
+        MAX_INCLUDE_DEPTH = 100
+
+        # A `{ ... }` block passed to `@include`; evaluated at `@content`
+        # with the caller's variable scope (dart-sass lexical semantics).
+        # :nodoc:
+        class ContentBlock
+          getter nodes : Array(Ast::Node)
+          getter env : Environment
+          getter outer : ContentBlock?
+          getter path : String
+
+          def initialize(@nodes, @env, @outer, @path)
+          end
+        end
+
+        @env : Environment
+        @sink : Array(Css::Node)
+        @current_rule : Css::Rule?
+        @current_at : Css::AtRule?
+        @parent_selectors : Array(String)?
+        @content : ContentBlock?
+        @in_keyframes : Bool
+        @include_depth : Int32
+        @path : String
+
+        def initialize(@importer : Importer, path : String)
+          @env = Environment.new
+          @sink = [] of Css::Node
+          @current_rule = nil
+          @current_at = nil
+          @parent_selectors = nil
+          @content = nil
+          @in_keyframes = false
+          @include_depth = 0
+          @path = path
+          @loaded_modules = {} of String => SassModule
+          @load_stack = [] of String
+          @module_css = [] of Css::Node
+        end
+
+        # Registers the entry file's canonical path so a self-import cycle
+        # is caught at the first hop.
+        def seed_load_stack(canonical : String) : Nil
+          @load_stack << canonical
+        end
+
+        def evaluate(sheet : Ast::Stylesheet) : Array(Css::Node)
+          eval_nodes(sheet.children)
+          @module_css + @sink
+        end
+
+        private def eval_nodes(nodes : Array(Ast::Node)) : Nil
+          nodes.each { |node| eval_node(node) }
+        end
+
+        private def eval_node(node : Ast::Node) : Nil
+          case node
+          when Ast::VarDeclNode
+            @env.assign_var(node.name, resolve_value(node.value), node.default, node.global)
+          when Ast::MixinDefNode
+            @env.declare_mixin(node.name, MixinClosure.new(node, @env, @path))
+          when Ast::RuleNode
+            eval_rule(node)
+          when Ast::DeclarationNode
+            eval_declaration(node)
+          when Ast::IncludeNode
+            eval_include(node)
+          when Ast::ContentNode
+            eval_content
+          when Ast::UseNode
+            eval_use(node)
+          when Ast::ImportNode
+            eval_import(node)
+          when Ast::RawAtRuleNode
+            eval_at_rule(node)
+          when Ast::CommentNode
+            emit_comment(node.text)
+          end
+        end
+
+        # ---------------------------------------------------------------
+        # Rules & declarations
+        # ---------------------------------------------------------------
+
+        private def eval_rule(node : Ast::RuleNode) : Nil
+          text = resolve_template(node.selector, allow_vars: false)
+          parts = Parser.split_top_level_commas(text).map { |s| collapse_ws(s) }.reject(&.empty?)
+          error_at(node.line, node.column, "expected selector") if parts.empty?
+
+          selectors = @in_keyframes ? parts : combine_selectors(parts, node)
+          rule = Css::Rule.new(selectors)
+          @sink << rule
+
+          saved_rule = @current_rule
+          saved_parents = @parent_selectors
+          saved_env = @env
+          @current_rule = rule
+          @parent_selectors = selectors
+          @env = Environment.new(saved_env) # each block is a variable scope
+          eval_nodes(node.children)
+          @current_rule = saved_rule
+          @parent_selectors = saved_parents
+          @env = saved_env
+        end
+
+        private def combine_selectors(parts : Array(String), node : Ast::RuleNode) : Array(String)
+          parents = @parent_selectors
+          result = [] of String
+          parts.each do |part|
+            _, has_amp = substitute_parent(part, nil)
+            if parents.nil?
+              if has_amp
+                error_at(node.line, node.column, "top-level selectors may not contain \"&\"")
+              end
+              result << part
+            elsif has_amp
+              parents.each do |parent|
+                substituted, _ = substitute_parent(part, parent)
+                result << substituted
+              end
+            else
+              parents.each { |parent| result << "#{parent} #{part}" }
+            end
+          end
+          result
+        end
+
+        # Replaces top-level `&` with the parent selector; `&` inside
+        # quoted strings and attribute brackets is literal. With a nil
+        # replacement the input is returned unchanged (detection only).
+        private def substitute_parent(selector : String, replacement : String?) : {String, Bool}
+          found = false
+          chars = selector.chars
+          out = String.build do |io|
+            i = 0
+            while i < chars.size
+              c = chars[i]
+              case c
+              when '"', '\''
+                quote = c
+                io << c
+                i += 1
+                while i < chars.size
+                  sc = chars[i]
+                  io << sc
+                  if sc == '\\' && i + 1 < chars.size
+                    i += 1
+                    io << chars[i]
+                  elsif sc == quote
+                    break
+                  end
+                  i += 1
+                end
+              when '['
+                io << c
+                i += 1
+                while i < chars.size && chars[i] != ']'
+                  io << chars[i]
+                  i += 1
+                end
+                io << ']' if i < chars.size
+              when '&'
+                found = true
+                io << (replacement || "&")
+              else
+                io << c
+              end
+              i += 1
+            end
+          end
+          {out, found}
+        end
+
+        private def eval_declaration(node : Ast::DeclarationNode) : Nil
+          name = collapse_ws(resolve_template(node.name, allow_vars: false))
+          value =
+            if node.custom_property
+              resolve_template(node.value, allow_vars: true).strip
+            else
+              resolve_value(node.value)
+            end
+          decl = Css::Decl.new(name, value, node.important)
+          if rule = @current_rule
+            rule.items << decl
+          elsif at = @current_at
+            at.items << decl
+          else
+            error_at(node.line, node.column, "declarations may only appear within style rules")
+          end
+        end
+
+        private def emit_comment(text : String) : Nil
+          if rule = @current_rule
+            rule.items << Css::Comment.new(text)
+          elsif at = @current_at
+            at.items << Css::Comment.new(text)
+          else
+            @sink << Css::Comment.new(text)
+          end
+        end
+
+        # ---------------------------------------------------------------
+        # At-rules
+        # ---------------------------------------------------------------
+
+        private def eval_at_rule(node : Ast::RawAtRuleNode) : Nil
+          prelude = collapse_ws(resolve_template(node.prelude, allow_vars: true))
+
+          children = node.children
+          unless children
+            text = prelude.empty? ? "@#{node.name};" : "@#{node.name} #{prelude};"
+            @sink << Css::Raw.new(text)
+            return
+          end
+
+          at = Css::AtRule.new(node.name, prelude)
+          @sink << at
+
+          saved_sink = @sink
+          saved_rule = @current_rule
+          saved_at = @current_at
+          saved_parents = @parent_selectors
+          saved_keyframes = @in_keyframes
+          saved_env = @env
+
+          @sink = at.children
+          @current_at = at
+          @env = Environment.new(saved_env)
+          if keyframes?(node.name)
+            @current_rule = nil
+            @parent_selectors = nil
+            @in_keyframes = true
+          elsif rule = saved_rule
+            # Conditional at-rule nested in a style rule: bubble the
+            # at-rule out and re-wrap the declarations in the rule's
+            # selector (`.a { @media (x) { color } }` →
+            # `@media (x) { .a { color } }`).
+            synthetic = Css::Rule.new(rule.selectors)
+            at.children << synthetic
+            @current_rule = synthetic
+          else
+            @current_rule = nil
+          end
+
+          eval_nodes(children)
+
+          @sink = saved_sink
+          @current_rule = saved_rule
+          @current_at = saved_at
+          @parent_selectors = saved_parents
+          @in_keyframes = saved_keyframes
+          @env = saved_env
+        end
+
+        private def keyframes?(name : String) : Bool
+          name == "keyframes" || name.ends_with?("-keyframes")
+        end
+
+        # ---------------------------------------------------------------
+        # Mixins & @content
+        # ---------------------------------------------------------------
+
+        private def eval_include(node : Ast::IncludeNode) : Nil
+          closure = lookup_mixin(node)
+
+          @include_depth += 1
+          if @include_depth > MAX_INCLUDE_DEPTH
+            error_at(node.line, node.column, "too much recursion in @include")
+          end
+
+          call_env = Environment.new(closure.env)
+          bind_arguments(node, closure, call_env)
+
+          content =
+            if body = node.body
+              ContentBlock.new(body, @env, @content, @path)
+            else
+              nil
+            end
+
+          saved_env = @env
+          saved_content = @content
+          saved_path = @path
+          @env = call_env
+          @content = content
+          @path = closure.path
+          begin
+            eval_nodes(closure.node.body)
+          ensure
+            @env = saved_env
+            @content = saved_content
+            @path = saved_path
+            @include_depth -= 1
+          end
+        end
+
+        private def lookup_mixin(node : Ast::IncludeNode) : MixinClosure
+          if ns = node.namespace
+            mod = @env.module?(ns)
+            error_at(node.line, node.column, "there is no module namespace \"#{ns}\"") unless mod
+            mod.mixins[node.name]? ||
+              error_at(node.line, node.column, "undefined mixin: \"#{ns}.#{node.name}\"")
+          else
+            @env.lookup_mixin(node.name) ||
+              error_at(node.line, node.column, "undefined mixin: \"#{node.name}\"")
+          end
+        end
+
+        private def bind_arguments(node : Ast::IncludeNode, closure : MixinClosure, call_env : Environment) : Nil
+          params = closure.node.params
+          positional = [] of String
+          kwargs = {} of String => String
+
+          node.args.each do |arg|
+            value = resolve_value(arg.value) # evaluated in the caller's scope
+            if name = arg.name
+              unless params.any? { |p| p.name == name }
+                error_at(node.line, node.column, "no parameter named $#{name} in mixin #{node.name}")
+              end
+              if kwargs.has_key?(name)
+                error_at(node.line, node.column, "duplicate argument $#{name}")
+              end
+              kwargs[name] = value
+            else
+              unless kwargs.empty?
+                error_at(node.line, node.column, "positional arguments must precede keyword arguments")
+              end
+              positional << value
+            end
+          end
+
+          if positional.size > params.size
+            error_at(node.line, node.column,
+              "mixin #{node.name} takes #{params.size} argument(s) but #{positional.size} were passed")
+          end
+
+          params.each_with_index do |param, i|
+            value =
+              if i < positional.size
+                if kwargs.has_key?(param.name)
+                  error_at(node.line, node.column, "$#{param.name} was passed both by position and by name")
+                end
+                positional[i]
+              elsif kw = kwargs[param.name]?
+                kw
+              elsif default = param.default
+                # Defaults see earlier parameters (dart-sass semantics).
+                saved = @env
+                @env = call_env
+                begin
+                  resolve_value(default)
+                ensure
+                  @env = saved
+                end
+              else
+                error_at(node.line, node.column, "missing argument $#{param.name} for mixin #{node.name}")
+              end
+            call_env.variables[param.name] = value
+          end
+        end
+
+        private def eval_content : Nil
+          block = @content
+          return unless block # @include without a body: @content emits nothing
+
+          saved_env = @env
+          saved_content = @content
+          saved_path = @path
+          @env = Environment.new(block.env)
+          @content = block.outer
+          @path = block.path
+          begin
+            eval_nodes(block.nodes)
+          ensure
+            @env = saved_env
+            @content = saved_content
+            @path = saved_path
+          end
+        end
+
+        # ---------------------------------------------------------------
+        # @use / @import
+        # ---------------------------------------------------------------
+
+        private def eval_use(node : Ast::UseNode) : Nil
+          canonical, source = @importer.load(node.url, @path, @path, node.line, node.column)
+
+          mod = @loaded_modules[canonical]?
+          unless mod
+            check_cycle(canonical, node.line, node.column)
+            display = @importer.display_path(canonical)
+            sheet = Parser.parse(source, display)
+
+            saved_env = @env
+            saved_sink = @sink
+            saved_rule = @current_rule
+            saved_at = @current_at
+            saved_parents = @parent_selectors
+            saved_content = @content
+            saved_keyframes = @in_keyframes
+            saved_path = @path
+
+            module_env = Environment.new
+            module_sink = [] of Css::Node
+            @env = module_env
+            @sink = module_sink
+            @current_rule = nil
+            @current_at = nil
+            @parent_selectors = nil
+            @content = nil
+            @in_keyframes = false
+            @path = display
+            @load_stack << canonical
+            begin
+              eval_nodes(sheet.children)
+            ensure
+              @load_stack.pop
+              @env = saved_env
+              @sink = saved_sink
+              @current_rule = saved_rule
+              @current_at = saved_at
+              @parent_selectors = saved_parents
+              @content = saved_content
+              @in_keyframes = saved_keyframes
+              @path = saved_path
+            end
+
+            mod = SassModule.new(module_env.variables, module_env.mixins)
+            @loaded_modules[canonical] = mod
+            # A module's CSS is emitted once, before the code that uses it.
+            @module_css.concat(module_sink)
+          end
+
+          register_module(node, mod)
+        end
+
+        private def register_module(node : Ast::UseNode, mod : SassModule) : Nil
+          case ns = node.namespace
+          when "*"
+            scope = @env.root
+            mod.variables.each { |name, value| scope.variables[name] = value }
+            mod.mixins.each { |name, closure| scope.mixins[name] = closure }
+          else
+            ns ||= default_namespace(node.url)
+            unless @env.declare_module(ns, mod)
+              # Re-declaring the same module under the same namespace is
+              # a no-op; a different module is a collision.
+              unless @env.module?(ns).same?(mod)
+                error_at(node.line, node.column, "module namespace \"#{ns}\" is already taken")
+              end
+            end
+          end
+        end
+
+        private def default_namespace(url : String) : String
+          base = File.basename(url)
+          base = base.chomp(".scss").lchop("_")
+          if base == "index"
+            parent = File.basename(File.dirname(url))
+            base = parent unless parent == "." || parent.empty?
+          end
+          base
+        end
+
+        private def eval_import(node : Ast::ImportNode) : Nil
+          canonical, source = @importer.load(node.url, @path, @path, node.line, node.column)
+          check_cycle(canonical, node.line, node.column)
+          display = @importer.display_path(canonical)
+          sheet = Parser.parse(source, display)
+
+          saved_path = @path
+          @path = display
+          @load_stack << canonical
+          begin
+            # Classic import: evaluated inline in the current scope/sink.
+            eval_nodes(sheet.children)
+          ensure
+            @load_stack.pop
+            @path = saved_path
+          end
+        end
+
+        private def check_cycle(canonical : String, line : Int32, column : Int32) : Nil
+          return unless @load_stack.includes?(canonical)
+          chain = (@load_stack + [canonical]).map { |p| @importer.display_path(p) }.join(" → ")
+          error_at(line, column, "circular @use/@import: #{chain}")
+        end
+
+        # ---------------------------------------------------------------
+        # Template resolution
+        # ---------------------------------------------------------------
+
+        private def resolve_value(template : Ast::TextTemplate) : String
+          collapse_ws(resolve_template(template, allow_vars: true))
+        end
+
+        private def resolve_template(template : Ast::TextTemplate, allow_vars : Bool) : String
+          String.build do |io|
+            template.pieces.each do |piece|
+              case piece
+              in String
+                io << piece
+              in Ast::VarRef
+                unless allow_vars
+                  error_at(piece.line, piece.column,
+                    "variables aren't allowed here (use \#{#{piece.lexeme}} interpolation)")
+                end
+                io << lookup_var_ref(piece)
+              in Ast::Interp
+                io << resolve_template(piece.inner, allow_vars: true)
+              end
+            end
+          end
+        end
+
+        private def lookup_var_ref(ref : Ast::VarRef) : String
+          if ns = ref.namespace
+            mod = @env.module?(ns)
+            error_at(ref.line, ref.column, "there is no module namespace \"#{ns}\"") unless mod
+            mod.variables[ref.name]? ||
+              error_at(ref.line, ref.column, "undefined variable: \"#{ns}.$#{ref.name}\"")
+          else
+            @env.lookup_var(ref.name) ||
+              error_at(ref.line, ref.column, "undefined variable: \"$#{ref.name}\"")
+          end
+        end
+
+        # Collapses whitespace runs to single spaces outside quoted
+        # strings and trims the ends.
+        private def collapse_ws(text : String) : String
+          chars = text.chars
+          result = String.build do |io|
+            emitted = false
+            pending = false
+            i = 0
+            while i < chars.size
+              c = chars[i]
+              if c == '"' || c == '\''
+                io << ' ' if pending && emitted
+                pending = false
+                quote = c
+                io << c
+                i += 1
+                while i < chars.size
+                  sc = chars[i]
+                  io << sc
+                  if sc == '\\' && i + 1 < chars.size
+                    i += 1
+                    io << chars[i]
+                  elsif sc == quote
+                    break
+                  end
+                  i += 1
+                end
+                emitted = true
+              elsif c.ascii_whitespace?
+                pending = true
+              else
+                io << ' ' if pending && emitted
+                pending = false
+                io << c
+                emitted = true
+              end
+              i += 1
+            end
+          end
+          result
+        end
+
+        private def error_at(line : Int32, column : Int32, message : String) : NoReturn
+          raise SyntaxError.new(message, @path, line, column)
+        end
+      end
+    end
+  end
+end

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -333,8 +333,6 @@ module Hwaro
           content =
             if body = node.body
               ContentBlock.new(body, @env, @content, @path)
-            else
-              nil
             end
 
           saved_env = @env

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -130,7 +130,7 @@ module Hwaro
           parents = @parent_selectors
           result = [] of String
           parts.each do |part|
-            _, has_amp = substitute_parent(part, nil)
+            has_amp = contains_parent_ref?(part)
             if parents.nil?
               if has_amp
                 error_at(node.line, node.column, "top-level selectors may not contain \"&\"")
@@ -138,8 +138,7 @@ module Hwaro
               result << part
             elsif has_amp
               parents.each do |parent|
-                substituted, _ = substitute_parent(part, parent)
-                result << substituted
+                result << substitute_parent(part, parent)
               end
             else
               parents.each { |parent| result << "#{parent} #{part}" }
@@ -148,13 +147,42 @@ module Hwaro
           result
         end
 
-        # Replaces top-level `&` with the parent selector; `&` inside
-        # quoted strings and attribute brackets is literal. With a nil
-        # replacement the input is returned unchanged (detection only).
-        private def substitute_parent(selector : String, replacement : String?) : {String, Bool}
-          found = false
+        # True when the selector contains a `&` outside quoted strings and
+        # attribute brackets — a scan-only twin of substitute_parent.
+        private def contains_parent_ref?(selector : String) : Bool
           chars = selector.chars
-          out = String.build do |io|
+          i = 0
+          while i < chars.size
+            case c = chars[i]
+            when '"', '\''
+              quote = c
+              i += 1
+              while i < chars.size
+                sc = chars[i]
+                if sc == '\\'
+                  i += 1
+                elsif sc == quote
+                  break
+                end
+                i += 1
+              end
+            when '['
+              while i < chars.size && chars[i] != ']'
+                i += 1
+              end
+            when '&'
+              return true
+            end
+            i += 1
+          end
+          false
+        end
+
+        # Replaces top-level `&` with the parent selector; `&` inside
+        # quoted strings and attribute brackets is literal.
+        private def substitute_parent(selector : String, replacement : String) : String
+          chars = selector.chars
+          String.build do |io|
             i = 0
             while i < chars.size
               c = chars[i]
@@ -183,15 +211,13 @@ module Hwaro
                 end
                 io << ']' if i < chars.size
               when '&'
-                found = true
-                io << (replacement || "&")
+                io << replacement
               else
                 io << c
               end
               i += 1
             end
           end
-          {out, found}
         end
 
         private def eval_declaration(node : Ast::DeclarationNode) : Nil
@@ -253,11 +279,13 @@ module Hwaro
             @current_rule = nil
             @parent_selectors = nil
             @in_keyframes = true
-          elsif rule = saved_rule
+          elsif (rule = saved_rule) && conditional_group?(node.name)
             # Conditional at-rule nested in a style rule: bubble the
             # at-rule out and re-wrap the declarations in the rule's
             # selector (`.a { @media (x) { color } }` →
-            # `@media (x) { .a { color } }`).
+            # `@media (x) { .a { color } }`). Descriptor at-rules
+            # (@font-face, @page, @property, ...) never take a selector
+            # wrapper — their declarations belong to the at-rule itself.
             synthetic = Css::Rule.new(rule.selectors)
             at.children << synthetic
             @current_rule = synthetic
@@ -277,6 +305,14 @@ module Hwaro
 
         private def keyframes?(name : String) : Bool
           name == "keyframes" || name.ends_with?("-keyframes")
+        end
+
+        # Grouping at-rules whose bodies contain style rules — these get a
+        # synthetic selector wrapper when bubbled out of a rule.
+        CONDITIONAL_GROUP_AT_RULES = %w[media supports container layer document scope]
+
+        private def conditional_group?(name : String) : Bool
+          CONDITIONAL_GROUP_AT_RULES.includes?(name)
         end
 
         # ---------------------------------------------------------------
@@ -321,7 +357,7 @@ module Hwaro
           if ns = node.namespace
             mod = @env.module?(ns)
             error_at(node.line, node.column, "there is no module namespace \"#{ns}\"") unless mod
-            mod.mixins[node.name]? ||
+            mod.mixins[Sass.normalize_ident(node.name)]? ||
               error_at(node.line, node.column, "undefined mixin: \"#{ns}.#{node.name}\"")
           else
             @env.lookup_mixin(node.name) ||
@@ -331,13 +367,15 @@ module Hwaro
 
         private def bind_arguments(node : Ast::IncludeNode, closure : MixinClosure, call_env : Environment) : Nil
           params = closure.node.params
+          param_names = params.map { |p| Sass.normalize_ident(p.name) }
           positional = [] of String
           kwargs = {} of String => String
 
           node.args.each do |arg|
             value = resolve_value(arg.value) # evaluated in the caller's scope
             if name = arg.name
-              unless params.any? { |p| p.name == name }
+              name = Sass.normalize_ident(name)
+              unless param_names.includes?(name)
                 error_at(node.line, node.column, "no parameter named $#{name} in mixin #{node.name}")
               end
               if kwargs.has_key?(name)
@@ -358,13 +396,14 @@ module Hwaro
           end
 
           params.each_with_index do |param, i|
+            param_name = param_names[i]
             value =
               if i < positional.size
-                if kwargs.has_key?(param.name)
+                if kwargs.has_key?(param_name)
                   error_at(node.line, node.column, "$#{param.name} was passed both by position and by name")
                 end
                 positional[i]
-              elsif kw = kwargs[param.name]?
+              elsif kw = kwargs[param_name]?
                 kw
               elsif default = param.default
                 # Defaults see earlier parameters (dart-sass semantics).
@@ -378,7 +417,7 @@ module Hwaro
               else
                 error_at(node.line, node.column, "missing argument $#{param.name} for mixin #{node.name}")
               end
-            call_env.variables[param.name] = value
+            call_env.variables[param_name] = value
           end
         end
 
@@ -540,7 +579,7 @@ module Hwaro
           if ns = ref.namespace
             mod = @env.module?(ns)
             error_at(ref.line, ref.column, "there is no module namespace \"#{ns}\"") unless mod
-            mod.variables[ref.name]? ||
+            mod.variables[Sass.normalize_ident(ref.name)]? ||
               error_at(ref.line, ref.column, "undefined variable: \"#{ns}.$#{ref.name}\"")
           else
             @env.lookup_var(ref.name) ||

--- a/src/assets/sass/importer.cr
+++ b/src/assets/sass/importer.cr
@@ -8,12 +8,14 @@
 # inside the project root.
 
 require "./errors"
+require "../../utils/path_utils"
 
 module Hwaro
   module Assets
     module Sass
       module Loader
         abstract def read(path : String) : String?
+        abstract def exists?(path : String) : Bool
       end
 
       class FileLoader
@@ -22,6 +24,10 @@ module Hwaro
         def read(path : String) : String?
           return nil unless File.file?(path)
           File.read(path)
+        end
+
+        def exists?(path : String) : Bool
+          File.file?(path)
         end
       end
 
@@ -39,6 +45,10 @@ module Hwaro
 
         def read(path : String) : String?
           @files[path]?
+        end
+
+        def exists?(path : String) : Bool
+          @files.has_key?(path)
         end
       end
 
@@ -96,20 +106,28 @@ module Hwaro
                                  url : String, path : String, line : Int32, column : Int32) : {String, String}?
           partial_path = guard(File.expand_path(partial, base_dir), url, path, line, column)
           plain_path = guard(File.expand_path(plain, base_dir), url, path, line, column)
-          partial_src = @loader.read(partial_path)
-          plain_src = @loader.read(plain_path)
-          if partial_src && plain_src
+          if @loader.exists?(partial_path) && @loader.exists?(plain_path)
             raise SyntaxError.new(
               "ambiguous import \"#{url}\": both #{display_path(partial_path)} and #{display_path(plain_path)} exist",
               path, line, column)
           end
-          return {partial_path, partial_src} if partial_src
-          return {plain_path, plain_src} if plain_src
+          if src = @loader.read(partial_path)
+            return {partial_path, src}
+          end
+          if src = @loader.read(plain_path)
+            return {plain_path, src}
+          end
           nil
         end
 
         private def guard(expanded : String, url : String, path : String, line : Int32, column : Int32) : String
           unless expanded == @root || expanded.starts_with?(@root + File::SEPARATOR)
+            raise SyntaxError.new("import \"#{url}\" resolves outside the project directory", path, line, column)
+          end
+          # A symlinked source whose target escapes the project would leak
+          # outside content into compiled CSS — same policy as the static
+          # copy's symlink guard.
+          if File.exists?(expanded) && !Hwaro::Utils::PathUtils.resolves_within?(expanded, @root)
             raise SyntaxError.new("import \"#{url}\" resolves outside the project directory", path, line, column)
           end
           expanded

--- a/src/assets/sass/importer.cr
+++ b/src/assets/sass/importer.cr
@@ -22,7 +22,7 @@ module Hwaro
         include Loader
 
         def read(path : String) : String?
-          return nil unless File.file?(path)
+          return unless File.file?(path)
           File.read(path)
         end
 

--- a/src/assets/sass/importer.cr
+++ b/src/assets/sass/importer.cr
@@ -1,0 +1,120 @@
+# @use/@import resolution for the SCSS compiler.
+#
+# Probe order for `@use "u"` / `@import "u"` (relative to the importing
+# file's directory): `_u.scss`, `u.scss`, `u/_index.scss`, `u/index.scss`;
+# an explicit `.scss` extension probes only the exact name and its `_`
+# partial variant. Both a partial and a non-partial matching the same url
+# is an ambiguity error (dart-sass behavior). Resolved paths must stay
+# inside the project root.
+
+require "./errors"
+
+module Hwaro
+  module Assets
+    module Sass
+      module Loader
+        abstract def read(path : String) : String?
+      end
+
+      class FileLoader
+        include Loader
+
+        def read(path : String) : String?
+          return nil unless File.file?(path)
+          File.read(path)
+        end
+      end
+
+      # In-memory loader for specs; keys are expanded so relative paths in
+      # test sources resolve like real files.
+      class MemoryLoader
+        include Loader
+
+        def initialize(files : Hash(String, String), root : String = Dir.current)
+          @files = {} of String => String
+          files.each do |path, content|
+            @files[File.expand_path(path, root)] = content
+          end
+        end
+
+        def read(path : String) : String?
+          @files[path]?
+        end
+      end
+
+      class Importer
+        getter root : String
+
+        def initialize(@loader : Loader, root : String = Dir.current)
+          @root = File.expand_path(root)
+        end
+
+        # Resolves `url` from `from_file` and returns {canonical_path,
+        # source}. Raises SyntaxError (located at the directive) when the
+        # target is missing, ambiguous, or escapes the project root.
+        def load(url : String, from_file : String, path : String, line : Int32, column : Int32) : {String, String}
+          base_dir = File.dirname(File.expand_path(from_file, @root))
+          dir = File.dirname(url)
+          base = File.basename(url)
+
+          candidates =
+            if base.ends_with?(".scss")
+              [join_url(dir, "_#{base}"), join_url(dir, base)]
+            else
+              [join_url(dir, "_#{base}.scss"), join_url(dir, "#{base}.scss")]
+            end
+
+          found = resolve_pair(candidates[0], candidates[1], base_dir, url, path, line, column)
+          if found.nil? && !base.ends_with?(".scss")
+            found = resolve_pair(join_url(url, "_index.scss"), join_url(url, "index.scss"),
+              base_dir, url, path, line, column)
+          end
+
+          unless found
+            raise SyntaxError.new("can't find stylesheet to import: \"#{url}\"", path, line, column)
+          end
+          found
+        end
+
+        # Path shown in error messages / parsed module ASTs — project-
+        # relative when possible.
+        def display_path(canonical : String) : String
+          if canonical == @root
+            canonical
+          elsif canonical.starts_with?(@root + File::SEPARATOR)
+            canonical[(@root.size + 1)..]
+          else
+            canonical
+          end
+        end
+
+        private def join_url(dir : String, base : String) : String
+          dir == "." ? base : File.join(dir, base)
+        end
+
+        private def resolve_pair(partial : String, plain : String, base_dir : String,
+                                 url : String, path : String, line : Int32, column : Int32) : {String, String}?
+          partial_path = guard(File.expand_path(partial, base_dir), url, path, line, column)
+          plain_path = guard(File.expand_path(plain, base_dir), url, path, line, column)
+          partial_src = @loader.read(partial_path)
+          plain_src = @loader.read(plain_path)
+          if partial_src && plain_src
+            raise SyntaxError.new(
+              "ambiguous import \"#{url}\": both #{display_path(partial_path)} and #{display_path(plain_path)} exist",
+              path, line, column)
+          end
+          return {partial_path, partial_src} if partial_src
+          return {plain_path, plain_src} if plain_src
+          nil
+        end
+
+        private def guard(expanded : String, url : String, path : String, line : Int32, column : Int32) : String
+          unless expanded == @root || expanded.starts_with?(@root + File::SEPARATOR)
+            raise SyntaxError.new("import \"#{url}\" resolves outside the project directory", path, line, column)
+          end
+          expanded
+        end
+      end
+    end
+  end
+end

--- a/src/assets/sass/parser.cr
+++ b/src/assets/sass/parser.cr
@@ -479,9 +479,7 @@ module Hwaro
           first_colon = nil
           first_decl_colon = nil
 
-          until @s.eof?
-            c = @s.peek.not_nil!
-
+          while c = @s.peek
             if depth == 0 && stops.includes?(c)
               terminator = c
               break
@@ -573,13 +571,12 @@ module Hwaro
 
         # Quoted string with `#{...}` support (cursor on the opening quote).
         private def read_string_into(buf : Buf, pieces : Array(Ast::Piece)) : Nil
-          quote = @s.peek.not_nil!
           start_line = @s.line
           start_col = @s.column
+          quote = @s.peek || @s.error("expected string", start_line, start_col)
           buf << @s.advance
           loop do
-            @s.error("unterminated string", start_line, start_col) if @s.eof?
-            c = @s.peek.not_nil!
+            c = @s.peek || @s.error("unterminated string", start_line, start_col)
             if c == '\\'
               buf << @s.advance
               buf << @s.advance unless @s.eof?
@@ -603,8 +600,7 @@ module Hwaro
           start_col = @s.column
           buf << @s.advance # '('
           loop do
-            @s.error("unterminated url(", start_line, start_col) if @s.eof?
-            c = @s.peek.not_nil!
+            c = @s.peek || @s.error("unterminated url(", start_line, start_col)
             case c
             when ')'
               buf << @s.advance

--- a/src/assets/sass/parser.cr
+++ b/src/assets/sass/parser.cr
@@ -271,11 +271,27 @@ module Hwaro
             url.starts_with?("//") || url.ends_with?(".css")
         end
 
+        # True only for a single closed string literal — `"a" + "b"` has
+        # matching first/last quotes but is NOT one string and must fall
+        # through to plain-CSS passthrough instead of being mis-unquoted.
         private def quoted_string?(text : String) : Bool
           return false if text.size < 2
           quote = text[0]
           return false unless quote == '"' || quote == '\''
-          text[-1] == quote
+          chars = text.chars
+          i = 1
+          while i < chars.size
+            case chars[i]
+            when '\\'
+              i += 2
+            when quote
+              # The first unescaped closing quote must be the final char.
+              return i == chars.size - 1
+            else
+              i += 1
+            end
+          end
+          false
         end
 
         private def parse_mixin(line : Int32, column : Int32) : Ast::Node

--- a/src/assets/sass/parser.cr
+++ b/src/assets/sass/parser.cr
@@ -1,0 +1,739 @@
+# Recursive-descent parser for the SCSS subset.
+#
+# Statement-level constructs ($var decls, @mixin/@include/@use/@import,
+# rules, declarations, at-rules) are parsed structurally; selectors,
+# property names, values, and at-rule preludes are captured as
+# `TextTemplate`s — verbatim text with `#{...}` / `$var` pieces — so that
+# any CSS we don't model passes through untouched.
+#
+# The classic SCSS ambiguity (declaration vs nested rule) is resolved by
+# scanning the prelude to its terminator: `{` starts a rule, `;`/`}` ends
+# a declaration split at its first top-level colon. A colon immediately
+# followed by an identifier (`a:hover`) is treated as a pseudo-selector
+# colon for the nested-property check only.
+
+require "./scanner"
+require "./ast"
+
+module Hwaro
+  module Assets
+    module Sass
+      class Parser
+        # Sass directives outside the supported subset. Rejected loudly with
+        # a located error — never silently emitted as broken CSS. Each of
+        # these becomes a real AST node + evaluator arm when implemented.
+        UNSUPPORTED_DIRECTIVES = %w[if else each for while function return extend forward at-root debug warn error]
+
+        private record TemplateScan,
+          template : Ast::TextTemplate,
+          terminator : Char?,
+          first_colon : {Int32, Int32}?,
+          first_decl_colon : {Int32, Int32}?
+
+        # Mutable text accumulator shared between the template scanner and
+        # its string/url sub-scanners. A plain String::Builder can't be
+        # passed around because flushing replaces the builder instance.
+        private class Buf
+          getter size : Int32
+
+          def initialize
+            @io = String::Builder.new
+            @size = 0
+          end
+
+          def <<(c : Char) : self
+            @io << c
+            @size += 1
+            self
+          end
+
+          def append(s : String) : self
+            @io << s
+            @size += s.size
+            self
+          end
+
+          def flush_into(pieces : Array(Ast::Piece)) : Nil
+            return if @size == 0
+            pieces << @io.to_s
+            @io = String::Builder.new
+            @size = 0
+          end
+        end
+
+        def initialize(source : String, path : String)
+          @s = Scanner.new(source, path)
+        end
+
+        def self.parse(source : String, path : String) : Ast::Stylesheet
+          new(source, path).parse
+        end
+
+        def parse : Ast::Stylesheet
+          children = parse_statements(top_level: true)
+          Ast::Stylesheet.new(children)
+        end
+
+        # Splits selector-ish text on commas outside strings/brackets/parens.
+        # Shared with the evaluator's selector resolution.
+        def self.split_top_level_commas(text : String) : Array(String)
+          parts = [] of String
+          depth = 0
+          current = String::Builder.new
+          chars = text.chars
+          i = 0
+          while i < chars.size
+            c = chars[i]
+            case c
+            when '(', '['
+              depth += 1
+              current << c
+            when ')', ']'
+              depth -= 1
+              current << c
+            when '"', '\''
+              quote = c
+              current << c
+              i += 1
+              while i < chars.size
+                sc = chars[i]
+                current << sc
+                if sc == '\\' && i + 1 < chars.size
+                  i += 1
+                  current << chars[i]
+                elsif sc == quote
+                  break
+                end
+                i += 1
+              end
+            when ','
+              if depth == 0
+                parts << current.to_s
+                current = String::Builder.new
+              else
+                current << c
+              end
+            else
+              current << c
+            end
+            i += 1
+          end
+          parts << current.to_s
+          parts
+        end
+
+        private def parse_statements(top_level : Bool) : Array(Ast::Node)
+          nodes = [] of Ast::Node
+          loop do
+            @s.skip_ws { |text, line, col| nodes << Ast::CommentNode.new(text, line, col) }
+            break if @s.eof?
+            case @s.peek
+            when '}'
+              @s.error("unmatched \"}\"") if top_level
+              break
+            when ';'
+              @s.advance
+            when '$'
+              nodes << parse_var_decl
+            when '@'
+              parse_at_rule(nodes)
+            else
+              nodes << parse_rule_or_declaration
+            end
+          end
+          nodes
+        end
+
+        # Consumes "{ ... }" (cursor on the opening brace).
+        private def parse_block : Array(Ast::Node)
+          open_line = @s.line
+          open_col = @s.column
+          @s.advance # '{'
+          nodes = parse_statements(top_level: false)
+          @s.error("unterminated block", open_line, open_col) if @s.eof?
+          @s.advance # '}'
+          nodes
+        end
+
+        private def parse_var_decl : Ast::Node
+          line = @s.line
+          column = @s.column
+          @s.advance # '$'
+          name = @s.read_ident
+          @s.error("expected variable name after \"$\"", line, column) if name.empty?
+          @s.skip_ws
+          @s.error("expected \":\" after $#{name}") unless @s.peek == ':'
+          @s.advance
+          scan = read_template(stops: ";}", value_vars: true)
+          template, flags = strip_flags(scan.template, {"default", "global"})
+          template = trim_template(template)
+          @s.error("expected value for $#{name}", line, column) if template.empty?
+          @s.advance if scan.terminator == ';'
+          Ast::VarDeclNode.new(name, template, flags.includes?("default"), flags.includes?("global"), line, column)
+        end
+
+        private def parse_at_rule(nodes : Array(Ast::Node)) : Nil
+          line = @s.line
+          column = @s.column
+          @s.advance # '@'
+          name = @s.read_ident
+          @s.error("expected at-rule name after \"@\"", line, column) if name.empty?
+
+          if UNSUPPORTED_DIRECTIVES.includes?(name)
+            @s.error("@#{name} is not supported by hwaro's Sass subset (yet)", line, column)
+          end
+
+          case name
+          when "use"
+            nodes << parse_use(line, column)
+          when "import"
+            parse_import(nodes, line, column)
+          when "mixin"
+            nodes << parse_mixin(line, column)
+          when "include"
+            nodes << parse_include(line, column)
+          when "content"
+            @s.skip_ws
+            if @s.peek == '('
+              @s.error("@content arguments are not supported", line, column)
+            end
+            @s.advance if @s.peek == ';'
+            nodes << Ast::ContentNode.new(line, column)
+          else
+            nodes << parse_raw_at_rule(name, line, column)
+          end
+        end
+
+        private def parse_use(line : Int32, column : Int32) : Ast::Node
+          @s.skip_ws
+          unless @s.peek == '"' || @s.peek == '\''
+            @s.error("expected quoted url after @use", line, column)
+          end
+          url = unquote(@s.read_quoted)
+          namespace = nil
+          loop do
+            @s.skip_ws
+            break unless @s.ident_start?(@s.peek)
+            word_line = @s.line
+            word_col = @s.column
+            word = @s.read_ident
+            case word
+            when "as"
+              @s.skip_ws
+              if @s.peek == '*'
+                @s.advance
+                namespace = "*"
+              else
+                ns = @s.read_ident
+                @s.error("expected namespace after \"as\"", word_line, word_col) if ns.empty?
+                namespace = ns
+              end
+            when "with"
+              @s.error("@use ... with (...) configuration is not supported", word_line, word_col)
+            else
+              @s.error("unexpected \"#{word}\" in @use", word_line, word_col)
+            end
+          end
+          @s.error("expected \";\" after @use") unless @s.peek == ';'
+          @s.advance
+          Ast::UseNode.new(url, namespace, line, column)
+        end
+
+        # Sass imports of local files become ImportNodes; plain-CSS forms
+        # (url(...), remote urls, ".css", media-query suffixes) pass through
+        # as raw statement at-rules.
+        private def parse_import(nodes : Array(Ast::Node), line : Int32, column : Int32) : Nil
+          scan = read_template(stops: ";}", value_vars: false)
+          @s.advance if scan.terminator == ';'
+          template = trim_template(scan.template)
+
+          if template.pieces.size == 1 && (text = template.pieces[0].as?(String))
+            parts = Parser.split_top_level_commas(text)
+            if parts.all? { |p| quoted_string?(p.strip) }
+              parts.each do |part|
+                url = unquote(part.strip)
+                if plain_css_import?(url)
+                  prelude = Ast::TextTemplate.new([part.strip.as(Ast::Piece)], line, column)
+                  nodes << Ast::RawAtRuleNode.new("import", prelude, nil, line, column)
+                else
+                  nodes << Ast::ImportNode.new(url, line, column)
+                end
+              end
+              return
+            end
+          end
+          # url(...), media-query suffixes, interpolation: plain CSS passthrough.
+          nodes << Ast::RawAtRuleNode.new("import", template, nil, line, column)
+        end
+
+        private def plain_css_import?(url : String) : Bool
+          url.starts_with?("http://") || url.starts_with?("https://") ||
+            url.starts_with?("//") || url.ends_with?(".css")
+        end
+
+        private def quoted_string?(text : String) : Bool
+          return false if text.size < 2
+          quote = text[0]
+          return false unless quote == '"' || quote == '\''
+          text[-1] == quote
+        end
+
+        private def parse_mixin(line : Int32, column : Int32) : Ast::Node
+          @s.skip_ws
+          name = @s.read_ident
+          @s.error("expected mixin name after @mixin", line, column) if name.empty?
+          @s.skip_ws
+          params = @s.peek == '(' ? parse_params : [] of Ast::Param
+          @s.skip_ws
+          @s.error("expected \"{\" for @mixin #{name}", line, column) unless @s.peek == '{'
+          body = parse_block
+          Ast::MixinDefNode.new(name, params, body, line, column)
+        end
+
+        private def parse_params : Array(Ast::Param)
+          params = [] of Ast::Param
+          @s.advance # '('
+          loop do
+            @s.skip_ws
+            break if @s.peek == ')'
+            @s.error("unterminated parameter list") if @s.eof?
+            @s.error("expected \"$\" in mixin parameter list") unless @s.peek == '$'
+            @s.advance
+            name = @s.read_ident
+            @s.error("expected parameter name after \"$\"") if name.empty?
+            @s.skip_ws
+            if @s.peek == '.' && @s.peek(1) == '.' && @s.peek(2) == '.'
+              @s.error("variadic parameters ($#{name}...) are not supported")
+            end
+            default = nil
+            if @s.peek == ':'
+              @s.advance
+              scan = read_template(stops: ",)", value_vars: true, depth_relative_stops: true)
+              default = trim_template(scan.template)
+            end
+            params << Ast::Param.new(name, default)
+            @s.skip_ws
+            @s.advance if @s.peek == ','
+          end
+          @s.error("unterminated parameter list") if @s.eof?
+          @s.advance # ')'
+          params
+        end
+
+        private def parse_include(line : Int32, column : Int32) : Ast::Node
+          @s.skip_ws
+          first = @s.read_ident
+          @s.error("expected mixin name after @include", line, column) if first.empty?
+          namespace = nil
+          name = first
+          if @s.peek == '.'
+            @s.advance
+            namespace = first
+            name = @s.read_ident
+            @s.error("expected mixin name after \"#{first}.\"", line, column) if name.empty?
+          end
+          @s.skip_ws
+          args = @s.peek == '(' ? parse_args : [] of Ast::Arg
+          @s.skip_ws
+          body = nil
+          if @s.ident_start?(@s.peek)
+            word_line = @s.line
+            word_col = @s.column
+            word = @s.read_ident
+            if word == "using"
+              @s.error("@include ... using (...) is not supported", word_line, word_col)
+            else
+              @s.error("unexpected \"#{word}\" after @include #{name}", word_line, word_col)
+            end
+          end
+          if @s.peek == '{'
+            body = parse_block
+          elsif @s.peek == ';'
+            @s.advance
+          end
+          Ast::IncludeNode.new(name, namespace, args, body, line, column)
+        end
+
+        private def parse_args : Array(Ast::Arg)
+          args = [] of Ast::Arg
+          @s.advance # '('
+          loop do
+            @s.skip_ws
+            break if @s.peek == ')'
+            @s.error("unterminated argument list") if @s.eof?
+            kwarg = nil
+            if @s.peek == '$'
+              # `$name: value` is a keyword argument; a bare `$var` is a
+              # positional value. Peek past the identifier for the colon.
+              offset = 1
+              while @s.ident_char?(@s.peek(offset))
+                offset += 1
+              end
+              while @s.peek(offset).try(&.ascii_whitespace?)
+                offset += 1
+              end
+              if @s.peek(offset) == ':' && @s.peek(offset + 1) != ':'
+                @s.advance # '$'
+                kwarg = @s.read_ident
+                @s.skip_ws
+                @s.advance # ':'
+              end
+            end
+            scan = read_template(stops: ",)", value_vars: true, depth_relative_stops: true)
+            value = trim_template(scan.template)
+            @s.error("expected argument value") if value.empty?
+            args << Ast::Arg.new(kwarg, value)
+            @s.skip_ws
+            @s.advance if @s.peek == ','
+          end
+          @s.error("unterminated argument list") if @s.eof?
+          @s.advance # ')'
+          args
+        end
+
+        private def parse_raw_at_rule(name : String, line : Int32, column : Int32) : Ast::Node
+          # Preludes get variable substitution too: `@media (min-width: $bp)`
+          # is the standard breakpoint-mixin pattern (dart-sass parity).
+          scan = read_template(stops: "{;}", value_vars: true)
+          prelude = trim_template(scan.template)
+          if scan.terminator == '{'
+            children = parse_block
+            Ast::RawAtRuleNode.new(name, prelude, children, line, column)
+          else
+            @s.advance if scan.terminator == ';'
+            Ast::RawAtRuleNode.new(name, prelude, nil, line, column)
+          end
+        end
+
+        private def parse_rule_or_declaration : Ast::Node
+          line = @s.line
+          column = @s.column
+          scan = read_template(stops: "{;}", value_vars: true)
+
+          if scan.terminator == '{'
+            if (colon = scan.first_decl_colon) && blank_after?(scan.template, colon)
+              @s.error("nested properties are not supported", line, column)
+            end
+            selector = trim_template(scan.template)
+            @s.error("expected selector", line, column) if selector.empty?
+            children = parse_block
+            return Ast::RuleNode.new(selector, children, line, column)
+          end
+
+          # Declaration: split at the first top-level colon.
+          colon = scan.first_colon
+          @s.error("expected \"{\"", line, column) unless colon
+          @s.advance if scan.terminator == ';'
+          name_t, value_t = split_at(scan.template, colon)
+          name_t = trim_template(name_t)
+          @s.error("expected property name", line, column) if name_t.empty?
+          custom = name_t.pieces[0].as?(String).try(&.starts_with?("--")) || false
+          important = false
+          if custom
+            # Custom property values are verbatim: `$var` stays literal,
+            # only `#{...}` interpolates (dart-sass semantics).
+            value_t = literalize_vars(value_t)
+          else
+            value_t, flags = strip_flags(value_t, {"important"})
+            important = flags.includes?("important")
+            value_t = trim_template(value_t)
+            @s.error("expected value for property", line, column) if value_t.empty? && !important
+          end
+          Ast::DeclarationNode.new(name_t, value_t, important, custom, line, column)
+        end
+
+        # ---------------------------------------------------------------
+        # Template scanning
+        # ---------------------------------------------------------------
+
+        # Reads verbatim text until one of `stops` at nesting depth 0 (the
+        # terminator is not consumed; nil terminator = EOF). Handles quoted
+        # strings, url(...) spans, comments (dropped, replaced by a space),
+        # `#{...}` interpolation, and — when `value_vars` — `$var` and
+        # `ns.$var` references. With `depth_relative_stops` the caller has
+        # already consumed an opening paren, so a `)` stop is expected at
+        # depth 0 rather than being an unmatched-paren error.
+        private def read_template(stops : String, value_vars : Bool, depth_relative_stops : Bool = false) : TemplateScan
+          start_line = @s.line
+          start_col = @s.column
+          pieces = [] of Ast::Piece
+          buf = Buf.new
+          depth = 0
+          terminator = nil
+          first_colon = nil
+          first_decl_colon = nil
+
+          until @s.eof?
+            c = @s.peek.not_nil!
+
+            if depth == 0 && stops.includes?(c)
+              terminator = c
+              break
+            end
+
+            case c
+            when '"', '\''
+              read_string_into(buf, pieces)
+            when '/'
+              if @s.peek(1) == '*'
+                @s.read_loud_comment
+                buf << ' '
+              elsif @s.peek(1) == '/'
+                @s.advance
+                @s.advance
+                until @s.eof? || @s.peek == '\n'
+                  @s.advance
+                end
+              else
+                buf << @s.advance
+              end
+            when '#'
+              if @s.peek(1) == '{'
+                buf.flush_into(pieces)
+                pieces << parse_interp
+              else
+                buf << @s.advance
+              end
+            when '$'
+              if value_vars
+                var_line = @s.line
+                var_col = @s.column
+                @s.advance
+                name = @s.read_ident
+                @s.error("expected identifier after \"$\"", var_line, var_col) if name.empty?
+                buf.flush_into(pieces)
+                pieces << Ast::VarRef.new(name, nil, var_line, var_col)
+              else
+                buf << @s.advance
+              end
+            when '(', '['
+              depth += 1
+              buf << @s.advance
+            when ')'
+              @s.error("unmatched \")\"") if depth == 0
+              depth -= 1
+              buf << @s.advance
+            when ']'
+              @s.error("unmatched \"]\"") if depth == 0
+              depth -= 1
+              buf << @s.advance
+            when ':'
+              if depth == 0
+                first_colon ||= {pieces.size, buf.size}
+                nxt = @s.peek(1)
+                pseudo_like = @s.ident_start?(nxt) || nxt == ':'
+                first_decl_colon ||= {pieces.size, buf.size} unless pseudo_like
+              end
+              buf << @s.advance
+            else
+              if value_vars && @s.ident_start?(c)
+                ident = @s.read_ident
+                if @s.peek == '.' && @s.peek(1) == '$'
+                  # `ns.$var` — namespaced variable reference.
+                  var_line = @s.line
+                  var_col = @s.column
+                  @s.advance # '.'
+                  @s.advance # '$'
+                  name = @s.read_ident
+                  @s.error("expected identifier after \"#{ident}.$\"", var_line, var_col) if name.empty?
+                  buf.flush_into(pieces)
+                  pieces << Ast::VarRef.new(name, ident, var_line, var_col)
+                elsif ident.compare("url", case_insensitive: true) == 0 && @s.peek == '('
+                  buf.append(ident)
+                  read_url_span(buf, pieces)
+                else
+                  buf.append(ident)
+                end
+              else
+                buf << @s.advance
+              end
+            end
+          end
+
+          buf.flush_into(pieces)
+          template = Ast::TextTemplate.new(pieces, start_line, start_col)
+          TemplateScan.new(template, terminator, first_colon, first_decl_colon)
+        end
+
+        # Quoted string with `#{...}` support (cursor on the opening quote).
+        private def read_string_into(buf : Buf, pieces : Array(Ast::Piece)) : Nil
+          quote = @s.peek.not_nil!
+          start_line = @s.line
+          start_col = @s.column
+          buf << @s.advance
+          loop do
+            @s.error("unterminated string", start_line, start_col) if @s.eof?
+            c = @s.peek.not_nil!
+            if c == '\\'
+              buf << @s.advance
+              buf << @s.advance unless @s.eof?
+            elsif c == '#' && @s.peek(1) == '{'
+              buf.flush_into(pieces)
+              pieces << parse_interp
+            elsif c == quote
+              buf << @s.advance
+              break
+            else
+              buf << @s.advance
+            end
+          end
+        end
+
+        # Raw `url(...)` span (cursor on '('): unquoted url contents are
+        # token soup (data URIs contain `;` and `,`), so everything up to
+        # the closing paren is verbatim except quoted strings and `#{...}`.
+        private def read_url_span(buf : Buf, pieces : Array(Ast::Piece)) : Nil
+          start_line = @s.line
+          start_col = @s.column
+          buf << @s.advance # '('
+          loop do
+            @s.error("unterminated url(", start_line, start_col) if @s.eof?
+            c = @s.peek.not_nil!
+            case c
+            when ')'
+              buf << @s.advance
+              break
+            when '"', '\''
+              read_string_into(buf, pieces)
+            when '#'
+              if @s.peek(1) == '{'
+                buf.flush_into(pieces)
+                pieces << parse_interp
+              else
+                buf << @s.advance
+              end
+            else
+              buf << @s.advance
+            end
+          end
+        end
+
+        # `#{ ... }` (cursor on '#').
+        private def parse_interp : Ast::Interp
+          line = @s.line
+          column = @s.column
+          @s.advance # '#'
+          @s.advance # '{'
+          scan = read_template(stops: "}", value_vars: true)
+          @s.error("unterminated \"\#{\"", line, column) unless scan.terminator == '}'
+          @s.advance # '}'
+          inner = trim_template(scan.template)
+          @s.error("empty \"\#{}\"", line, column) if inner.empty?
+          Ast::Interp.new(inner, line, column)
+        end
+
+        # ---------------------------------------------------------------
+        # Template helpers
+        # ---------------------------------------------------------------
+
+        private def unquote(text : String) : String
+          text[1...-1]
+        end
+
+        private def split_at(template : Ast::TextTemplate, colon : {Int32, Int32}) : {Ast::TextTemplate, Ast::TextTemplate}
+          piece_idx, offset = colon
+          left = [] of Ast::Piece
+          right = [] of Ast::Piece
+          template.pieces.each_with_index do |piece, i|
+            if i < piece_idx
+              left << piece
+            elsif i == piece_idx
+              text = piece.as(String)
+              head = text[0, offset]
+              tail = text[offset + 1..]
+              left << head unless head.empty?
+              right << tail unless tail.empty?
+            else
+              right << piece
+            end
+          end
+          {Ast::TextTemplate.new(left, template.line, template.column),
+           Ast::TextTemplate.new(right, template.line, template.column)}
+        end
+
+        private def trim_template(template : Ast::TextTemplate) : Ast::TextTemplate
+          pieces = template.pieces.dup
+          if (first = pieces.first?) && first.is_a?(String)
+            stripped = first.lstrip
+            if stripped.empty?
+              pieces.shift
+            else
+              pieces[0] = stripped
+            end
+          end
+          if (last = pieces.last?) && last.is_a?(String)
+            stripped = last.rstrip
+            if stripped.empty?
+              pieces.pop
+            else
+              pieces[-1] = stripped
+            end
+          end
+          Ast::TextTemplate.new(pieces, template.line, template.column)
+        end
+
+        # Strips trailing `!flag` markers (!default, !global, !important)
+        # off a value template.
+        private def strip_flags(template : Ast::TextTemplate, allowed : Tuple) : {Ast::TextTemplate, Set(String)}
+          flags = Set(String).new
+          pieces = template.pieces.dup
+          loop do
+            last = pieces.last?
+            break unless last.is_a?(String)
+            stripped = last.rstrip
+            matched = false
+            allowed.each do |flag|
+              marker = "!#{flag}"
+              next unless stripped.downcase.ends_with?(marker)
+              flags << flag
+              stripped = stripped[0, stripped.size - marker.size].rstrip
+              matched = true
+              break
+            end
+            break unless matched
+            if stripped.empty?
+              pieces.pop
+            else
+              pieces[-1] = stripped
+            end
+          end
+          {Ast::TextTemplate.new(pieces, template.line, template.column), flags}
+        end
+
+        # Converts VarRef pieces back into literal `$name` text (custom
+        # property values must not substitute variables).
+        private def literalize_vars(template : Ast::TextTemplate) : Ast::TextTemplate
+          pieces = [] of Ast::Piece
+          template.pieces.each do |piece|
+            if piece.is_a?(Ast::VarRef)
+              if (last = pieces.last?) && last.is_a?(String)
+                pieces[-1] = last + piece.lexeme
+              else
+                pieces << piece.lexeme
+              end
+            else
+              pieces << piece
+            end
+          end
+          Ast::TextTemplate.new(pieces, template.line, template.column)
+        end
+
+        # True when nothing but whitespace follows the given colon position
+        # (the `font: { ... }` nested-property shape).
+        private def blank_after?(template : Ast::TextTemplate, colon : {Int32, Int32}) : Bool
+          piece_idx, offset = colon
+          template.pieces.each_with_index do |piece, i|
+            next if i < piece_idx
+            if i == piece_idx
+              tail = piece.as(String)[offset + 1..]
+              return false unless tail.blank?
+            else
+              return false unless piece.is_a?(String) && piece.blank?
+            end
+          end
+          true
+        end
+      end
+    end
+  end
+end

--- a/src/assets/sass/scanner.cr
+++ b/src/assets/sass/scanner.cr
@@ -1,0 +1,149 @@
+# Low-level character scanner for the SCSS parser.
+#
+# Tracks 1-based line/column positions and provides the small set of
+# lexical primitives the parser is built on (identifiers, quoted strings,
+# comments). Values and selectors are kept as verbatim text runs rather
+# than a token stream — SCSS is CSS token soup, and preserving the source
+# text exactly (minus comments) is what makes plain-CSS passthrough safe.
+#
+# Uses an Array(Char) for O(1) indexing; SCSS sources are small enough
+# that the copy is irrelevant next to positional correctness.
+
+require "./errors"
+
+module Hwaro
+  module Assets
+    module Sass
+      class Scanner
+        getter path : String
+        getter line : Int32
+        getter column : Int32
+
+        def initialize(source : String, @path : String)
+          @chars = source.chars
+          @pos = 0
+          @line = 1
+          @column = 1
+        end
+
+        def eof? : Bool
+          @pos >= @chars.size
+        end
+
+        def peek(offset : Int32 = 0) : Char?
+          idx = @pos + offset
+          idx < @chars.size ? @chars[idx] : nil
+        end
+
+        def advance : Char
+          c = @chars[@pos]
+          @pos += 1
+          if c == '\n'
+            @line += 1
+            @column = 1
+          else
+            @column += 1
+          end
+          c
+        end
+
+        def error(message : String, line : Int32 = @line, column : Int32 = @column) : NoReturn
+          raise SyntaxError.new(message, @path, line, column)
+        end
+
+        def ident_start?(c : Char?) : Bool
+          return false unless c
+          c.ascii_letter? || c == '_' || c == '-' || c.ord > 0x7F
+        end
+
+        def ident_char?(c : Char?) : Bool
+          return false unless c
+          c.ascii_alphanumeric? || c == '_' || c == '-' || c.ord > 0x7F
+        end
+
+        # Reads an identifier (CSS ident charset; no escape support).
+        def read_ident : String
+          String.build do |io|
+            while ident_char?(peek)
+              io << advance
+            end
+          end
+        end
+
+        # Skips whitespace and comments. Loud (/* */) comments are returned
+        # to the caller one at a time when `yield_comments` is true so the
+        # parser can preserve them as statement-level nodes; silent (//)
+        # comments are always dropped.
+        def skip_ws(& : String, Int32, Int32 -> Nil) : Nil
+          loop do
+            c = peek
+            if c && c.ascii_whitespace?
+              advance
+            elsif c == '/' && peek(1) == '/'
+              advance
+              advance
+              until eof? || peek == '\n'
+                advance
+              end
+            elsif c == '/' && peek(1) == '*'
+              start_line = @line
+              start_col = @column
+              text = read_loud_comment
+              yield text, start_line, start_col
+            else
+              break
+            end
+          end
+        end
+
+        def skip_ws : Nil
+          skip_ws { |_text, _line, _col| nil }
+        end
+
+        # Consumes "/* ... */" (cursor on the leading '/') and returns it
+        # verbatim including delimiters.
+        def read_loud_comment : String
+          start_line = @line
+          start_col = @column
+          String.build do |io|
+            io << advance # '/'
+            io << advance # '*'
+            loop do
+              error("unterminated comment", start_line, start_col) if eof?
+              c = advance
+              io << c
+              if c == '*' && peek == '/'
+                io << advance
+                break
+              end
+            end
+          end
+        end
+
+        # Consumes a quoted string (cursor on the opening quote) and returns
+        # it verbatim including quotes and escapes. Stops the scan at `#{`
+        # boundaries only when the caller handles interpolation itself —
+        # this primitive is interpolation-blind and used where a literal
+        # string is required (e.g. @use/@import urls).
+        def read_quoted : String
+          quote = peek
+          start_line = @line
+          start_col = @column
+          String.build do |io|
+            io << advance # opening quote
+            loop do
+              error("unterminated string", start_line, start_col) if eof?
+              c = advance
+              io << c
+              if c == '\\' && !eof?
+                io << advance
+              elsif c == quote
+                break
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/assets/sass_compiler.cr
+++ b/src/assets/sass_compiler.cr
@@ -29,8 +29,7 @@ module Hwaro
 
         count = 0
         glob_match = File::MatchOptions.glob_default | File::MatchOptions::DotFiles
-        Dir.glob(File.join(@source_dir, "**", "*"), match: glob_match) do |src_path|
-          next unless src_path.downcase.ends_with?(".scss")
+        Dir.glob(File.join(@source_dir, "**", "*.scss"), match: glob_match) do |src_path|
           next unless File.file?(src_path)
           next if File.basename(src_path).starts_with?("_")
 

--- a/src/assets/sass_compiler.cr
+++ b/src/assets/sass_compiler.cr
@@ -1,0 +1,66 @@
+# Build orchestrator for the built-in SCSS compiler (peer of Pipeline).
+#
+# Scans the static tree for non-partial `*.scss` entry files, compiles
+# each with Assets::Sass, optionally minifies through the existing CSS
+# minifier, and writes sibling `.css` files into the output directory.
+# Compiler errors surface as classified HwaroErrors (HWARO_E_CONTENT)
+# with a `path:line:col` location.
+
+require "./sass"
+require "../utils/css_minifier"
+require "../utils/errors"
+require "../utils/logger"
+require "../models/config"
+
+module Hwaro
+  module Assets
+    class SassCompiler
+      def initialize(@config : Models::SassConfig, @static_config : Models::StaticConfig,
+                     @source_dir : String = "static")
+      end
+
+      # Compiles every entry file and returns the compiled count. Partials
+      # (`_*.scss`) and statically-excluded paths are skipped; the raw
+      # sources themselves are excluded from the static copy separately
+      # (Models::Config#sass_source?).
+      def compile_all(output_dir : String) : Int32
+        return 0 unless @config.enabled
+        return 0 unless Dir.exists?(@source_dir)
+
+        count = 0
+        glob_match = File::MatchOptions.glob_default | File::MatchOptions::DotFiles
+        Dir.glob(File.join(@source_dir, "**", "*"), match: glob_match) do |src_path|
+          next unless src_path.downcase.ends_with?(".scss")
+          next unless File.file?(src_path)
+          next if File.basename(src_path).starts_with?("_")
+
+          relative = Path[src_path].relative_to(@source_dir).to_s
+          next if @static_config.excluded?(relative)
+
+          css = SassCompiler.compile_source(File.read(src_path), src_path)
+          css = Utils::CssMinifier.minify(css) if @config.minify
+
+          dest_path = File.join(output_dir, relative.sub(/\.scss\z/i, ".css"))
+          Hwaro::Utils::FileSafe.mkdir_p(File.dirname(dest_path))
+          File.write(dest_path, css)
+          Logger.debug "  Sass: #{relative} → #{relative.sub(/\.scss\z/i, ".css")} (#{css.bytesize} bytes)"
+          count += 1
+        end
+        count
+      end
+
+      # Compiles one SCSS source, converting compiler errors into
+      # classified build errors. Also used by the asset pipeline for
+      # `.scss` bundle entries.
+      def self.compile_source(source : String, path : String) : String
+        Sass.compile(source, path: path)
+      rescue ex : Sass::SyntaxError
+        raise Hwaro::HwaroError.new(
+          Hwaro::Errors::HWARO_E_CONTENT,
+          "Sass: #{ex.location}: #{ex.message}",
+          hint: "Fix the SCSS source at the location above. The supported subset and its limits are documented in features/sass."
+        )
+      end
+    end
+  end
+end

--- a/src/content/hooks.cr
+++ b/src/content/hooks.cr
@@ -4,6 +4,7 @@
 
 require "./hooks/seo_hooks"
 require "./hooks/taxonomy_hooks"
+require "./hooks/sass_hooks"
 require "./hooks/asset_hooks"
 require "./hooks/pwa_hooks"
 require "./hooks/amp_hooks"
@@ -25,6 +26,7 @@ module Hwaro
         [
           SeoHooks.new,
           TaxonomyHooks.new,
+          SassHooks.new,
           AssetHooks.new,
           PwaHooks.new,
           AmpHooks.new,

--- a/src/content/hooks/asset_hooks.cr
+++ b/src/content/hooks/asset_hooks.cr
@@ -32,7 +32,7 @@ module Hwaro
           config = ctx.config
           return unless config && config.assets.enabled
 
-          pipeline = Assets::Pipeline.new(config.assets, config.base_url)
+          pipeline = Assets::Pipeline.new(config.assets, config.base_url, config.sass.enabled)
           pipeline.process(ctx.output_dir)
 
           @@manifest_mutex.synchronize { @@manifest = pipeline.manifest }

--- a/src/content/hooks/sass_hooks.cr
+++ b/src/content/hooks/sass_hooks.cr
@@ -1,0 +1,35 @@
+# Sass compilation hook for the build lifecycle.
+#
+# Runs at AfterInitialize with priority 50 — after the Initialize phase's
+# static copy (which excludes raw `.scss` sources) and before
+# assets:process (priority 40; hook priority is descending), so bundles
+# can reference compiled output on disk.
+
+require "../../core/lifecycle"
+require "../../assets/sass_compiler"
+
+module Hwaro
+  module Content
+    module Hooks
+      class SassHooks
+        include Core::Lifecycle::Hookable
+
+        def register_hooks(manager : Core::Lifecycle::Manager)
+          manager.on(Core::Lifecycle::HookPoint::AfterInitialize, priority: 50, name: "sass:compile") do |ctx|
+            compile_sass(ctx)
+            Core::Lifecycle::HookResult::Continue
+          end
+        end
+
+        private def compile_sass(ctx : Core::Lifecycle::BuildContext)
+          config = ctx.config
+          return unless config && config.sass.enabled
+
+          compiler = Assets::SassCompiler.new(config.sass, config.static)
+          count = compiler.compile_all(ctx.output_dir)
+          Logger.info "  Sass: #{count} file(s) compiled." if count > 0
+        end
+      end
+    end
+  end
+end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1094,6 +1094,7 @@ module Hwaro
 
             relative = path_relative_to(src_path, "static")
             next if static_config.excluded?(relative)
+            next if @config.try(&.sass_source?(relative))
             dest_path = File.join(output_dir, relative)
 
             Hwaro::Utils::FileSafe.mkdir_p(File.dirname(dest_path))

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1104,6 +1104,18 @@ module Hwaro
           Logger.outcome("copied", "#{copied} static #{copied == 1 ? "file" : "files"}") if copied > 0
         end
 
+        # Recompile all SCSS entries into the output directory. Used by
+        # serve mode when a `.scss` source changes — such files publish as
+        # compiled `.css`, never verbatim. No-ops unless [sass] is enabled.
+        def recompile_sass(output_dir : String)
+          config = @config
+          return unless config && config.sass.enabled
+
+          compiler = Assets::SassCompiler.new(config.sass, config.static)
+          count = compiler.compile_all(output_dir)
+          Logger.outcome("compiled", "#{count} sass #{count == 1 ? "file" : "files"}") if count > 0
+        end
+
         # Republish non-Markdown content assets (images, etc.) to the output
         # directory, preserving their path relative to `content/`. Mirrors what
         # the full build does via the raw-files path in the Write phase, but

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1169,7 +1169,13 @@ module Hwaro
           site = @site
           removed_paths.each do |path|
             if path.starts_with?("static/")
-              dest = File.join(output_dir, path.lchop("static/"))
+              relative = path.lchop("static/")
+              # SCSS sources publish as compiled `.css`, never verbatim — the
+              # stale artifact of a removed entry is the compiled sibling.
+              if @config.try(&.sass_source?(relative))
+                relative = relative.sub(/\.scss\z/, ".css")
+              end
+              dest = File.join(output_dir, relative)
               outputs << dest if Utils::OutputGuard.within_output_dir?(dest, output_dir)
             elsif path.starts_with?("content/")
               if path.downcase.ends_with?(".md")

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -204,6 +204,9 @@ module Hwaro::Core::Build::Phases::Initialize
 
       relative = Path[src_path].relative_to(src_dir).to_s
       next if static_config.excluded?(relative)
+      # SCSS sources compile via the sass:compile hook instead of
+      # publishing raw.
+      next if @config.try(&.sass_source?(relative))
 
       dest_path = File.join(output_dir, relative)
       # `info` from above already carries the source mtime — re-statting

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1257,9 +1257,11 @@ module Hwaro
 
       # True when built-in Sass compilation is on and `relative_path` is an
       # SCSS source — such files compile to `.css` instead of publishing
-      # verbatim through the static copy.
+      # verbatim through the static copy. The extension must be lowercase
+      # `.scss`, matching what the compiler's glob picks up — other casings
+      # keep publishing verbatim.
       def sass_source?(relative_path : String) : Bool
-        sass.enabled && relative_path.downcase.ends_with?(".scss")
+        sass.enabled && relative_path.ends_with?(".scss")
       end
 
       def self.load(config_path : String = "config.toml", env : String? = nil) : Config

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -826,6 +826,27 @@ module Hwaro
       end
     end
 
+    # Built-in Sass/SCSS compilation (pure Crystal, no external tools).
+    #
+    # When enabled, non-partial `*.scss` files under the static dir compile
+    # to sibling `.css` files in the output, `_*.scss` partials are only
+    # reachable via @use/@import, and raw `.scss` sources are excluded from
+    # the verbatim static copy.
+    #
+    # Config example (config.toml):
+    #   [sass]
+    #   enabled = true
+    #   minify = true
+    class SassConfig
+      property enabled : Bool
+      property minify : Bool
+
+      def initialize
+        @enabled = false
+        @minify = true
+      end
+    end
+
     # Image processing configuration
     #
     # Enables automatic image resizing during build using stb (statically linked).
@@ -1057,6 +1078,7 @@ module Hwaro
       property related : RelatedConfig
       property deployment : DeploymentConfig
       property assets : AssetsConfig
+      property sass : SassConfig
       property pwa : PwaConfig
       property amp : AmpConfig
       property image_processing : ImageProcessingConfig
@@ -1095,6 +1117,7 @@ module Hwaro
         @related = RelatedConfig.new
         @deployment = DeploymentConfig.new
         @assets = AssetsConfig.new
+        @sass = SassConfig.new
         @pwa = PwaConfig.new
         @amp = AmpConfig.new
         @image_processing = ImageProcessingConfig.new
@@ -1232,6 +1255,13 @@ module Hwaro
         end
       end
 
+      # True when built-in Sass compilation is on and `relative_path` is an
+      # SCSS source — such files compile to `.css` instead of publishing
+      # verbatim through the static copy.
+      def sass_source?(relative_path : String) : Bool
+        sass.enabled && relative_path.downcase.ends_with?(".scss")
+      end
+
       def self.load(config_path : String = "config.toml", env : String? = nil) : Config
         config = new
 
@@ -1307,6 +1337,7 @@ module Hwaro
         load_related(config)
         load_permalinks(config)
         load_assets(config)
+        load_sass(config)
         load_pwa(config)
         load_amp(config)
         load_image_processing(config)
@@ -1901,6 +1932,13 @@ module Hwaro
             config.assets.bundles << AssetBundleConfig.new(name: name, files: files)
           end
         end
+      end
+
+      private def self.load_sass(config : Config)
+        return unless s = config.raw["sass"]?.try(&.as_h?)
+
+        config.sass.enabled = bool_value(s["enabled"]?, config.sass.enabled)
+        config.sass.minify = bool_value(s["minify"]?, config.sass.minify)
       end
 
       private def self.load_amp(config : Config)

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1361,8 +1361,8 @@ module Hwaro
         title description base_url default_language
         amp assets auto_includes build content deployment doctor feeds
         highlight image_processing languages llms markdown menus og outputs
-        pagination permalinks plugins pwa related robots search series serve
-        sitemap static taxonomies
+        pagination permalinks plugins pwa related robots sass search series
+        serve sitemap static taxonomies
       ]
 
       private def self.warn_unknown_top_level_keys(raw : Hash(String, TOML::Any), config_path : String)

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -35,6 +35,7 @@ module Hwaro
         "permalinks"       => {description: "URL path overrides", snippet: -> { permalinks(commented: true) }},
         "auto_includes"    => {description: "Automatic CSS/JS loading", snippet: -> { auto_includes(commented: true) }},
         "assets"           => {description: "Asset pipeline (bundling, minification)", snippet: -> { assets(commented: true) }},
+        "sass"             => {description: "Built-in Sass/SCSS compilation", snippet: -> { sass(commented: true) }},
         "deployment"       => {description: "Deployment targets", snippet: -> { deployment(commented: true) }},
         "image_processing" => {description: "Image resizing and LQIP placeholder generation", snippet: -> { image_processing(commented: true) }},
         "pwa"              => {description: "Progressive Web App (manifest.json, service worker)", snippet: -> { pwa(commented: true) }},
@@ -850,6 +851,38 @@ module Hwaro
             # [[assets.bundles]]
             # name = "app.js"
             # files = ["js/util.js", "js/app.js"]
+
+            TOML
+        end
+      end
+
+      def self.sass(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+            # =============================================================================
+            # Sass/SCSS Compilation (Optional)
+            # =============================================================================
+
+            # [sass]
+            # enabled = true
+            # minify = true
+
+            TOML
+        else
+          <<-TOML
+
+            # =============================================================================
+            # Sass/SCSS Compilation (Optional)
+            # =============================================================================
+            # Compile static/**/*.scss to sibling .css files at build time.
+            # Pure Crystal — no external tools. Partials (_*.scss) are only
+            # reachable via @use/@import and never publish; raw .scss sources
+            # are excluded from the static copy while enabled.
+
+            # [sass]
+            # enabled = true
+            # minify = true
 
             TOML
         end

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -220,6 +220,8 @@ module Hwaro
         "build", "deployment", "permalinks", "auto_includes",
         # Asset pipeline (many prefer manual or external bundlers)
         "assets",
+        # Built-in Sass compilation (opt-in)
+        "sass",
         # Useful but not essential to nag about
         "related", "series", "pagination",
         # Navigation menus — many sites hardcode nav in the theme instead

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -1095,6 +1095,14 @@ module Hwaro
       private def copy_static(changeset : ChangeSet, build_options : Config::Options::BuildOptions)
         output_dir = sanitize_output_dir(build_options.output_dir)
         @builder.copy_changed_static(changeset.modified_static, output_dir, build_options.verbose)
+        # SCSS sources never publish verbatim — when one changed, recompile
+        # the entries instead. A partial edit must rebuild every entry that
+        # imports it, and there is no dependency graph, so the whole tree
+        # recompiles (cheap at static-site scale). Compile errors raise and
+        # reach the watcher rescue → browser overlay.
+        if changeset.modified_static.any? { |p| p.downcase.ends_with?(".scss") }
+          @builder.recompile_sass(output_dir)
+        end
       end
 
       private def copy_content_files(changeset : ChangeSet, build_options : Config::Options::BuildOptions)

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -1099,8 +1099,9 @@ module Hwaro
         # the entries instead. A partial edit must rebuild every entry that
         # imports it, and there is no dependency graph, so the whole tree
         # recompiles (cheap at static-site scale). Compile errors raise and
-        # reach the watcher rescue → browser overlay.
-        if changeset.modified_static.any? { |p| p.downcase.ends_with?(".scss") }
+        # reach the watcher rescue → browser overlay. The predicate is the
+        # same one the copy paths use, so the gate can't drift.
+        if (config = @builder.config) && changeset.modified_static.any? { |p| config.sass_source?(p) }
           @builder.recompile_sass(output_dir)
         end
       end


### PR DESCRIPTION
## Summary

Adds built-in Sass/SCSS compilation — closing the biggest single feature gap vs Jekyll and Zola — as a **pure-Crystal compiler** with zero external dependencies (no dart-sass binary, no libsass, no npm), consistent with hwaro's philosophy.

### Supported subset (v1)
- `$variables` with `!default`/`!global`, lexical scoping & shadowing
- Nested rules with full `&` resolution (selector lists = cartesian combination, BEM suffixes)
- `#{...}` interpolation in selectors, property names, values, at-rule preludes, strings, and `url()`
- Partials + `@use` (namespaces, `as x`, `as *`, load-once) and classic `@import`
- `@mixin`/`@include` with default values, keyword arguments, and `@content` blocks
- `@media`/`@supports` bubbling through nesting; `@keyframes`/`@font-face`/custom-property passthrough
- **Plain-CSS passthrough guarantee**: valid CSS compiles to itself (whitespace-normalized)
- Unsupported directives (`@if`, `@each`, `@function`, `@extend`, ...) fail loudly with `path:line:col` errors — never silent garbage. The architecture leaves explicit seams for control flow / arithmetic / built-in functions later.

### Integration
- New `[sass]` config section (`enabled`, `minify`) + doctor/config-snippets registration
- `sass:compile` hook at AfterInitialize (priority 50, before `assets:process`): `static/**/*.scss` entries → sibling `.css`; `_*.scss` partials and raw sources never publish
- `.scss` entries in `[[assets.bundles]]` compile before concatenation (minify → fingerprint unchanged)
- `hwaro serve`: `.scss` edits now recompile (previously the raw file was just re-copied); compile errors surface in the browser error overlay
- Errors are classified `HWARO_E_CONTENT` (exit 5)

### Docs
New `features/sass` page with the support matrix and documented dart-sass deviations; config reference, asset-pipeline/build-hooks cross-links, hwaro-design skill update, README, CHANGELOG.

## Testing
- 81 new specs: compiler core (nesting/&/interpolation/at-rule bubbling/passthrough corpus/errors), mixins/@content, importer (@use/@import/cycles/ambiguity/root-escape), config, and functional build/bundle/serve-recompile/error paths
- Full suite: 6377 examples, 0 failures
- E2E: scaffolded site (`hwaro init --scaffold simple`) with `@use` + mixin/@content + media bubbling builds correctly; raw `.scss` excluded from output

🤖 Generated with [Claude Code](https://claude.com/claude-code)