### PR TITLE
feat(highlight): build-time highlighting by default, hide_lines/copy, blockquote+table hooks, taxonomy sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 - Built-in Sass/SCSS compilation (`[sass]` config) — pure Crystal, no external tools: variables with `!default`/`!global`, nested rules with `&`, partials via `@use` (namespaces) / `@import`, mixins with defaults, keyword args and `@content`, `#{...}` interpolation, and `@media`/`@supports` bubbling. `static/**/*.scss` entries compile to sibling `.css`, `.scss` bundle entries compile before concatenation, and `hwaro serve` recompiles on change with errors in the browser overlay. Unsupported directives (`@if`, `@each`, `@function`, `@extend`, ...) fail the build with located errors instead of emitting broken CSS.
+- `hide_lines` fence option (`{hide_lines="1 9-12"}`): elide lines from a rendered code block in server mode. Hidden lines keep their physical line numbers, so a `linenos` gutter shows gaps (unlike Zola, which renumbers) — `hl_lines`/`linenostart` keep targeting physical lines; client mode emits an inert `data-hide-lines` attribute
+- `[highlight] copy = true`: copy-to-clipboard button on fenced code blocks via a small inline, dependency-free runtime in `{{ highlight_js }}` (both modes); per-fence `{copy=true|false}` overrides, mermaid fences excluded, byte-identical output when off. New scaffolds enable it
+- Markdown render hooks for blockquotes and tables: `templates/hooks/render-blockquote.html` (`text`) and `templates/hooks/render-table.html` (`html`, `header_html`, `body_html`). GitHub-style `> [!NOTE]` blockquotes keep the admonition pipeline while `[markdown] admonitions = true`; the codeblock hook gains `copy`
+- Taxonomy sorting: per-taxonomy `sort_by` (`date`/`title`/`weight`) and `reverse` order the pages within each term (section semantics — date is newest-first, `reverse` flips), `terms_sort_by` (`name`/`count`) orders the terms list. Term feeds stay reverse-chronological regardless
+
+### Changed
+- **Breaking:** `[highlight] mode` now defaults to `"server"` — code blocks are highlighted at build time (Tartrazine, same `hljs-*` classes, theme CSS keeps working) and `{{ highlight_js }}` renders empty by default. Set `mode = "client"` to restore browser-side Highlight.js; all pages re-render once after upgrading
+- `get_taxonomy().items` is now name-sorted (alphabetical) by default instead of unspecified insertion order; set `terms_sort_by = "count"` for count-descending
 
 ## v0.17.1
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Hwaro processes Markdown content with TOML, YAML, or JSON front matter and Jinja
 - Jinja2 templates (inheritance, includes, macros)
 - Markdown extensions: task lists, footnotes, definition lists, math (KaTeX/MathJax), Mermaid diagrams, emoji, etc
 - Built-in shortcodes (YouTube, Vimeo, Gist, Alert, Figure, Tweet, CodePen) and custom shortcode support
-- Syntax highlighting via Highlight.js
+- Build-time syntax highlighting (Tartrazine, hljs-compatible classes; optional client mode via Highlight.js)
 - Table of contents (TOC) generation
 - Reading time and word count
 - Content summaries via `<!-- more -->` marker

--- a/docs/content/features/syntax-highlighting.md
+++ b/docs/content/features/syntax-highlighting.md
@@ -109,6 +109,7 @@ def main():
 | `linenos` | `true` / `false` | Show a line-number gutter. Overrides the `[highlight] line_numbers` default for this block. |
 | `hl_lines` | e.g. `"2-4 7"` | Highlight these lines — space/comma-separated line numbers and/or ranges. Always the block's own **physical** 1-based lines, never shifted by `linenostart`. |
 | `linenostart` | e.g. `5` | First displayed line number (default `1`). Only affects the numbers shown — it does not change which physical lines `hl_lines` highlights. |
+| `hide_lines` | e.g. `"1 9-12"` | Omit these lines from the rendered output (server mode). Same syntax and physical-line semantics as `hl_lines`. |
 | `name` | e.g. `"main.cr"` | Filename/title label rendered above the block (`title=` is accepted as an alias). Ignored on `mermaid` fences. |
 
 A named block is wrapped for styling (the `<pre>` inside is unchanged):
@@ -132,6 +133,13 @@ Setting `[highlight] line_numbers = true` turns line numbers on for
 *every* fenced code block with a language — a per-block `{linenos=false}`
 opts back out.
 
+Hidden lines keep consuming their physical line numbers, so with
+`linenos=true` the gutter shows a **gap** where lines were elided —
+unlike Zola, which renumbers the remaining lines. This keeps the
+documented invariant that `hl_lines` and `linenostart` always target the
+block's physical lines, hidden or not (highlighting a hidden line is
+simply a no-op).
+
 **Server vs client mode:**
 
 - `mode = "server"` (default) renders the full result at build time: each
@@ -139,9 +147,11 @@ opts back out.
   lines appear with no JavaScript.
 - `mode = "client"` does not re-render the body — instead the
   `<pre>` tag gets `data-linenos="true"`, `data-linenostart="N"` (when
-  greater than 1), and/or `data-hl-lines="2-4 7"` attributes, so a
-  client-side script or custom CSS can act on them. Hwaro ships no such
-  script for client mode; full rendering requires `mode = "server"`.
+  greater than 1), `data-hl-lines="2-4 7"`, and/or
+  `data-hide-lines="1 9-12"` attributes, so a client-side script or
+  custom CSS can act on them. Hwaro ships no such script for client
+  mode; full rendering (and actual line hiding) requires
+  `mode = "server"`.
 
 Scaffold sites style the server-mode markup out of the box. For a
 non-scaffold site, or a custom theme, add:

--- a/docs/content/features/syntax-highlighting.md
+++ b/docs/content/features/syntax-highlighting.md
@@ -59,6 +59,7 @@ mode = "server"
 | use_cdn | bool | true | Load assets from CDN (false = local files) |
 | mode | string | "server" | `"server"` highlights at build time; `"client"` highlights in the browser via Highlight.js |
 | line_numbers | bool | false | Add line numbers to every fenced code block by default (see below) |
+| copy | bool | false | Add a copy-to-clipboard button to fenced code blocks (see below) |
 
 ## Server-Side Highlighting (Default)
 
@@ -110,6 +111,7 @@ def main():
 | `hl_lines` | e.g. `"2-4 7"` | Highlight these lines — space/comma-separated line numbers and/or ranges. Always the block's own **physical** 1-based lines, never shifted by `linenostart`. |
 | `linenostart` | e.g. `5` | First displayed line number (default `1`). Only affects the numbers shown — it does not change which physical lines `hl_lines` highlights. |
 | `hide_lines` | e.g. `"1 9-12"` | Omit these lines from the rendered output (server mode). Same syntax and physical-line semantics as `hl_lines`. |
+| `copy` | `true` / `false` | Show a copy-to-clipboard button on this block. Overrides the `[highlight] copy` default. Ignored on `mermaid` fences. |
 | `name` | e.g. `"main.cr"` | Filename/title label rendered above the block (`title=` is accepted as an alias). Ignored on `mermaid` fences. |
 
 A named block is wrapped for styling (the `<pre>` inside is unchanged):
@@ -163,6 +165,30 @@ pre code .ln { user-select: none; -webkit-user-select: none; opacity: .45; }
 
 (Swap `var(--code-keyword)` for any color that fits your theme if you
 aren't using the Hwaro Ember token system.)
+
+## Copy Button
+
+`[highlight] copy = true` adds a copy-to-clipboard button to every fenced
+code block; a per-fence `{copy=false}` (or `{copy=true}` with the global
+default off) overrides it:
+
+```toml
+[highlight]
+copy = true
+```
+
+The markup contract: each opted-in block's `<pre>` gets a
+`data-copy="true"` attribute, and `{{ highlight_js }}` injects a small
+inline, dependency-free runtime (works in both server and client mode)
+that wraps each `pre[data-copy]` in a `<div class="code-wrapper">`,
+appends a `<button class="code-copy-btn">`, and copies the code's text
+on click. The inline styles are theme-neutral (currentColor,
+hover-reveal); scaffolded sites override them with token-based styles.
+
+`mermaid` fences never get the attribute — their `<pre>` shape is owned
+by the Mermaid pipeline.
+
+New scaffolded sites enable `copy = true` out of the box.
 
 ## Themes
 

--- a/docs/content/features/syntax-highlighting.md
+++ b/docs/content/features/syntax-highlighting.md
@@ -49,7 +49,7 @@ Configure in `config.toml`:
 enabled = true
 theme = "github-dark"
 use_cdn = true
-mode = "client"
+mode = "server"
 ```
 
 | Key | Type | Default | Description |
@@ -57,20 +57,14 @@ mode = "client"
 | enabled | bool | true | Enable syntax highlighting |
 | theme | string | "github" | Highlight.js theme name |
 | use_cdn | bool | true | Load assets from CDN (false = local files) |
-| mode | string | "client" | `"client"` highlights in the browser via Highlight.js; `"server"` highlights at build time |
+| mode | string | "server" | `"server"` highlights at build time; `"client"` highlights in the browser via Highlight.js |
 | line_numbers | bool | false | Add line numbers to every fenced code block by default (see below) |
 
-## Server-Side Highlighting
+## Server-Side Highlighting (Default)
 
-With `mode = "server"`, code blocks are highlighted during the build —
-no JavaScript ships to the browser, and code is colored even with
-JavaScript disabled:
-
-```toml
-[highlight]
-mode = "server"
-theme = "github-dark"
-```
+With `mode = "server"` (the default), code blocks are highlighted during
+the build — no JavaScript ships to the browser, and code is colored even
+with JavaScript disabled.
 
 The build-time highlighter emits Highlight.js-compatible CSS classes, so
 every theme above keeps working unchanged: `{{ highlight_css }}` still
@@ -79,6 +73,21 @@ injects the theme stylesheet, while `{{ highlight_js }}` becomes empty.
 Over 250 languages are supported (via [Tartrazine](https://github.com/ralsina/tartrazine)
 lexers, ported from Pygments/Chroma). Code blocks in languages without a
 lexer fall back to plain, unhighlighted output.
+
+## Client-Side Highlighting
+
+Set `mode = "client"` to highlight in the browser with Highlight.js
+instead:
+
+```toml
+[highlight]
+mode = "client"
+theme = "github-dark"
+```
+
+In client mode `{{ highlight_js }}` injects the Highlight.js script (from
+the CDN or your local assets, see below), and code blocks ship as plain
+`<pre><code class="language-...">` markup for the browser to colorize.
 
 ## Line Numbers and Highlighted Lines
 
@@ -125,10 +134,10 @@ opts back out.
 
 **Server vs client mode:**
 
-- `mode = "server"` renders the full result at build time: each line is
-  wrapped in its own element, so line numbers and highlighted lines
-  appear with no JavaScript.
-- `mode = "client"` (default) does not re-render the body — instead the
+- `mode = "server"` (default) renders the full result at build time: each
+  line is wrapped in its own element, so line numbers and highlighted
+  lines appear with no JavaScript.
+- `mode = "client"` does not re-render the body — instead the
   `<pre>` tag gets `data-linenos="true"`, `data-linenostart="N"` (when
   greater than 1), and/or `data-hl-lines="2-4 7"` attributes, so a
   client-side script or custom CSS can act on them. Hwaro ships no such
@@ -178,6 +187,8 @@ When `use_cdn = false`, assets are loaded from local paths:
 ```
 
 You must provide the local files yourself when using `use_cdn = false`.
+In the default server mode only the theme stylesheet is referenced — the
+`<script>` tags above appear only with `mode = "client"`.
 
 ## Template Integration
 

--- a/docs/content/features/syntax-highlighting.md
+++ b/docs/content/features/syntax-highlighting.md
@@ -110,7 +110,7 @@ def main():
 | `linenos` | `true` / `false` | Show a line-number gutter. Overrides the `[highlight] line_numbers` default for this block. |
 | `hl_lines` | e.g. `"2-4 7"` | Highlight these lines — space/comma-separated line numbers and/or ranges. Always the block's own **physical** 1-based lines, never shifted by `linenostart`. |
 | `linenostart` | e.g. `5` | First displayed line number (default `1`). Only affects the numbers shown — it does not change which physical lines `hl_lines` highlights. |
-| `hide_lines` | e.g. `"1 9-12"` | Omit these lines from the rendered output (server mode). Same syntax and physical-line semantics as `hl_lines`. |
+| `hide_lines` | e.g. `"1 9-12"` | Omit these lines from the rendered output (server mode only — see below). Same syntax and physical-line semantics as `hl_lines`. |
 | `copy` | `true` / `false` | Show a copy-to-clipboard button on this block. Overrides the `[highlight] copy` default. Ignored on `mermaid` fences. |
 | `name` | e.g. `"main.cr"` | Filename/title label rendered above the block (`title=` is accepted as an alias). Ignored on `mermaid` fences. |
 
@@ -141,6 +141,11 @@ unlike Zola, which renumbers the remaining lines. This keeps the
 documented invariant that `hl_lines` and `linenostart` always target the
 block's physical lines, hidden or not (highlighting a hidden line is
 simply a no-op).
+
+Only `mode = "server"` actually removes hidden lines from the HTML. In
+client mode `hide_lines` is presentational-only metadata (an inert
+`data-hide-lines` attribute) — the lines remain in the page source. Do
+**not** use `hide_lines` to redact secrets in client mode.
 
 **Server vs client mode:**
 
@@ -180,10 +185,13 @@ copy = true
 The markup contract: each opted-in block's `<pre>` gets a
 `data-copy="true"` attribute, and `{{ highlight_js }}` injects a small
 inline, dependency-free runtime (works in both server and client mode)
-that wraps each `pre[data-copy]` in a `<div class="code-wrapper">`,
-appends a `<button class="code-copy-btn">`, and copies the code's text
-on click. The inline styles are theme-neutral (currentColor,
-hover-reveal); scaffolded sites override them with token-based styles.
+that wraps each `pre[data-copy]` in a `<div class="code-wrapper">` —
+reusing an existing `.code-block` wrapper (named fences) as the anchor
+instead — appends a `<button class="code-copy-btn">`, and copies the
+code's text on click (server-mode `.ln` line-number gutters are stripped
+from the copied text). The inline styles are theme-neutral
+(currentColor, hover-reveal); scaffolded sites override them with
+token-based styles.
 
 `mermaid` fences never get the attribute — their `<pre>` shape is owned
 by the Mermaid pipeline.

--- a/docs/content/templates/render-hooks.md
+++ b/docs/content/templates/render-hooks.md
@@ -60,6 +60,8 @@ All values are Crinja `Value`s and — like every other hwaro template — **alr
 | `options` | The raw Zola/Pandoc-style `{...}` options block after the language (see [Syntax Highlighting](/features/syntax-highlighting/)), or any trailing info-string text when there's no `{...}` block. Escaped |
 | `code` | The fence body, HTML-escaped |
 | `highlighted` | The server-mode syntax-highlighted body (hljs-class spans), or an empty string when `[highlight] mode` isn't `"server"`, highlighting is off, or the language has no lexer |
+| `name` | The parsed `{name=...}`/`{title=...}` filename label, escaped. Empty string when absent |
+| `copy` | `"true"` when the copy button applies to this block (`[highlight] copy` / per-fence `{copy=...}`, never for mermaid), empty string otherwise. The template decides what markup to emit for it |
 
 ## Default-Equivalent Templates
 

--- a/docs/content/templates/render-hooks.md
+++ b/docs/content/templates/render-hooks.md
@@ -5,7 +5,7 @@ weight = 5
 toc = true
 +++
 
-Render hooks let you override how individual Markdown elements — links, images, headings, and fenced code blocks — turn into HTML, without touching hwaro's Markdown parser. Drop a template in `templates/hooks/`, and every matching element on every page renders through it instead of the built-in markup.
+Render hooks let you override how individual Markdown elements — links, images, headings, fenced code blocks, blockquotes, and tables — turn into HTML, without touching hwaro's Markdown parser. Drop a template in `templates/hooks/`, and every matching element on every page renders through it instead of the built-in markup.
 
 If you don't create any `templates/hooks/render-*` template, nothing changes: hwaro renders exactly as it always has.
 
@@ -14,15 +14,17 @@ If you don't create any `templates/hooks/render-*` template, nothing changes: hw
 ```
 templates/
 └── hooks/
-    ├── render-link.html       # [text](url "title")
-    ├── render-image.html      # ![alt](url "title")
-    ├── render-heading.html    # ## Heading
-    └── render-codeblock.html  # ```lang ... ```
+    ├── render-link.html        # [text](url "title")
+    ├── render-image.html       # ![alt](url "title")
+    ├── render-heading.html     # ## Heading
+    ├── render-codeblock.html   # ```lang ... ```
+    ├── render-blockquote.html  # > quoted
+    └── render-table.html       # | GFM | tables |
 ```
 
 Each file is independent — add only the ones you want to override. A site with just `render-image.html` gets a custom image wrapper and stock rendering for everything else.
 
-`blockquote` and `table` hooks are planned but not implemented yet; a `templates/hooks/render-blockquote.html` or `render-table.html` file is silently ignored today. Any other `hooks/render-*` name is unrecognized and logs a warning at build time.
+Any other `hooks/render-*` name is unrecognized and logs a warning at build time.
 
 ## Context Variables
 
@@ -63,9 +65,25 @@ All values are Crinja `Value`s and — like every other hwaro template — **alr
 | `name` | The parsed `{name=...}`/`{title=...}` filename label, escaped. Empty string when absent |
 | `copy` | `"true"` when the copy button applies to this block (`[highlight] copy` / per-fence `{copy=...}`, never for mermaid), empty string otherwise. The template decides what markup to emit for it |
 
+### `render-blockquote.html`
+
+| Variable | Description |
+|----------|--------------|
+| `text` | The already-rendered inner HTML of the blockquote — block-level content (paragraphs, lists, nested quotes), usually ending with a newline |
+
+### `render-table.html`
+
+| Variable | Description |
+|----------|--------------|
+| `html` | The complete stock `<table>...</table>` markup |
+| `header_html` | The table's `<thead>...</thead>` section |
+| `body_html` | The table's `<tbody>...</tbody>` section — empty string for a header-only table |
+
+All hook templates additionally see the standard `page` (`url`, `title`, `path`, `language`) and `config` (`base_url`, `title`) variables.
+
 ## Default-Equivalent Templates
 
-These four templates reproduce hwaro's stock output exactly — a useful starting point to modify from:
+These templates reproduce hwaro's stock output exactly — a useful starting point to modify from:
 
 ```jinja
 {# templates/hooks/render-link.html #}
@@ -85,6 +103,17 @@ These four templates reproduce hwaro's stock output exactly — a useful startin
 ```jinja
 {# templates/hooks/render-codeblock.html #}
 <pre><code{% if lang is present %} class="language-{{ lang }} hljs"{% endif %}>{% if highlighted is present %}{{ highlighted }}{% else %}{{ code }}{% endif %}</code></pre>
+```
+
+```jinja
+{# templates/hooks/render-blockquote.html #}
+<blockquote>
+{{ text }}</blockquote>
+```
+
+```jinja
+{# templates/hooks/render-table.html #}
+{{ html }}
 ```
 
 Note `{% if title is present %}`, not a bare `{% if title %}` — Crinja's truthiness only treats `false`/`0`/nil as falsy, so a bare `{% if title %}` would render `title=""` even when there's no title. The custom `is present`/`is empty` tests (also used throughout hwaro's own templates) check for that correctly.
@@ -113,8 +142,10 @@ Every `![alt](src "caption")` in your Markdown now renders as a captioned `<figu
 2. **Keep conventional double-quoted `href`/`src` attributes.** Everything downstream — `@/internal-page.md` link resolution, subpath (`base_path`) prefixing of root-relative links, responsive-image `srcset`/`sizes` injection, and `loading="lazy"` — runs as a plain-text pass over the *final* HTML, matching on `href="..."` / `src="..."`. A hook that emits an unquoted or single-quoted attribute, or restructures the destination into something other than a normal attribute value, opts that element out of all of it. An `@/`-prefixed `destination` must land inside `href="..."` for `InternalLinkResolver` to find and resolve it.
 3. **`render-heading.html` must emit an `<hN id="{{ id }}">` element.** The TOC (`{{ toc }}` / `page.toc`) and `insert_anchor_links` both post-process the final HTML looking for `<h1>`–`<h6>` tags with an `id` attribute; a hook that renders something other than a heading tag, or drops `id`, silently falls out of both.
 4. **Don't transform `{{ text }}`.** It's already-rendered HTML, and on pages using shortcodes it may contain an internal placeholder comment (`<!--HWARO-SHORTCODE-PLACEHOLDER-N-->`) that gets swapped for the shortcode's output in a later pass — filtering, truncating, or re-escaping `text` can corrupt or strand that placeholder.
-5. **Mermaid owns its own fence.** With `[markdown] mermaid = true`, a `` ```mermaid `` fence always renders through the existing Mermaid pipeline (`<div class="mermaid">…</div>`), never through `render-codeblock.html` — that's the one config-decided exception to "every hook always applies to every matching element." Set `mermaid = false` to have your codeblock hook render mermaid fences like any other language instead.
-6. **Hooks don't apply inside table cells, footnote bodies, definition lists, or the front-matter `description`/summary text.** Those render through a separate, simpler inline-markdown path that never touches the main Markd parser hooks attach to. This is a known limitation, not a bug.
+5. **Mermaid owns its own fence.** With `[markdown] mermaid = true`, a `` ```mermaid `` fence always renders through the existing Mermaid pipeline (`<div class="mermaid">…</div>`), never through `render-codeblock.html` — a config-decided exception to "every hook always applies to every matching element." Set `mermaid = false` to have your codeblock hook render mermaid fences like any other language instead.
+6. **Admonitions own their blockquotes.** With `[markdown] admonitions = true` (the default), a `> [!NOTE]`-style blockquote keeps rendering through the admonition pipeline (`<div class="admonition admonition-note">…</div>`), never through `render-blockquote.html` — the same config-decided pattern as Mermaid. Set `admonitions = false` to route those quotes through your hook like any other blockquote.
+7. **No blank lines in `render-table.html` output.** Table hook output is spliced into the Markdown *before* the main parse, and an HTML block ends at the first blank line — anything after it would be re-parsed as Markdown. hwaro collapses blank lines out of the output as a safety net, so multi-line templates work, but don't rely on blank-line-sensitive markup.
+8. **Hooks don't apply inside table cells, footnote bodies, definition lists, or the front-matter `description`/summary text.** Those render through a separate, simpler inline-markdown path that never touches the main Markd parser hooks attach to (table *cells* keep that path even when `render-table.html` wraps the table itself). This is a known limitation, not a bug.
 
 ## Incremental Builds
 

--- a/docs/content/writing/taxonomies.md
+++ b/docs/content/writing/taxonomies.md
@@ -31,6 +31,40 @@ name = "authors"
 | `feed` | bool | false | Generate RSS feed for each term |
 | `sitemap` | bool | true | Include taxonomy pages in sitemap |
 | `paginate_by` | int | — | Items per page on term pages |
+| `sort_by` | string | "date" | Order of pages within a term: `"date"`, `"title"`, or `"weight"` (see [Sorting](#sorting)) |
+| `reverse` | bool | false | Flip whichever order `sort_by` produced |
+| `terms_sort_by` | string | "name" | Order of the terms list: `"name"` or `"count"` (see [Sorting](#sorting)) |
+
+## Sorting
+
+`sort_by` controls the order of pages within each term — on the written
+term pages, in `term.pages` from `get_taxonomy()`, and in per-term
+pagination. The semantics match section sorting exactly:
+
+- `"date"` (default) — newest first; `reverse = true` gives oldest first.
+- `"title"` — alphabetical ascending; `reverse = true` descends.
+- `"weight"` — lowest weight first; `reverse = true` descends.
+
+An invalid `sort_by` value logs a warning and keeps the `"date"` default.
+
+`terms_sort_by` controls the order of the terms list — on the taxonomy
+index page and in `get_taxonomy().items`:
+
+- `"name"` (default) — alphabetical ascending.
+- `"count"` — page count descending, name-ascending tiebreak. On a
+  multilingual site, each language's index uses that language's own page
+  counts.
+
+**Term feeds are exempt.** With `feed = true`, each term's RSS feed stays
+reverse-chronological regardless of `sort_by` — RSS consumers assume
+newest-first entries.
+
+```toml
+[[taxonomies]]
+name = "tags"
+sort_by = "title"
+terms_sort_by = "count"
+```
 
 ## Using Taxonomies
 

--- a/spec/functional/build_integration_spec.cr
+++ b/spec/functional/build_integration_spec.cr
@@ -694,7 +694,7 @@ describe "Build Integration: Taxonomy pages" do
     ) do
       # Term page listing honors sort_by = "title" (Alpha before Zulu).
       crystal_html = File.read("public/tags/crystal/index.html")
-      crystal_html.index("Alpha").not_nil!.should be < crystal_html.index("Zulu").not_nil!
+      crystal_html.index!("Alpha").should be < crystal_html.index!("Zulu")
       # get_taxonomy term.pages order matches.
       crystal_html.should contain("PAGES:[Alpha][Zulu]")
       # get_taxonomy items honor terms_sort_by = "count": crystal (2) first.
@@ -702,7 +702,7 @@ describe "Build Integration: Taxonomy pages" do
 
       # Index terms list is count-ordered too.
       idx = File.read("public/tags/index.html")
-      idx.index(">crystal<").not_nil!.should be < idx.index(">web<").not_nil!
+      idx.index!(">crystal<").should be < idx.index!(">web<")
     end
   end
 end

--- a/spec/functional/build_integration_spec.cr
+++ b/spec/functional/build_integration_spec.cr
@@ -976,7 +976,7 @@ end
 # 25. Highlight tags
 # ---------------------------------------------------------------------------
 describe "Build Integration: Highlight tags" do
-  it "renders highlight CSS/JS tags when highlight is enabled" do
+  it "renders the highlight theme CSS tag and no JS in the default server mode" do
     config = <<-TOML
       title = "Test"
       base_url = "http://localhost"
@@ -994,6 +994,29 @@ describe "Build Integration: Highlight tags" do
       html = File.read("public/index.html")
       html.should contain("highlight")
       html.should contain("github-dark")
+      html.should_not contain("hljs.highlightAll()")
+    end
+  end
+
+  it "renders highlight CSS and JS tags in client mode" do
+    config = <<-TOML
+      title = "Test"
+      base_url = "http://localhost"
+
+      [highlight]
+      enabled = true
+      mode = "client"
+      theme = "github-dark"
+      TOML
+
+    build_site(
+      config,
+      content_files: {"index.md" => "---\ntitle: Home\n---\nHome"},
+      template_files: {"page.html" => "{{ highlight_css }}{{ highlight_js }}{{ content }}"},
+    ) do
+      html = File.read("public/index.html")
+      html.should contain("github-dark")
+      html.should contain("hljs.highlightAll()")
     end
   end
 end

--- a/spec/functional/build_integration_spec.cr
+++ b/spec/functional/build_integration_spec.cr
@@ -658,6 +658,53 @@ describe "Build Integration: Taxonomy pages" do
       File.exists?("public/tags/web/index.html").should be_true
     end
   end
+
+  it "honors taxonomy sort_by/reverse/terms_sort_by in templates and written pages" do
+    config = <<-TOML
+      title = "Test"
+      base_url = "http://localhost"
+
+      [[taxonomies]]
+      name = "tags"
+      sort_by = "title"
+      terms_sort_by = "count"
+      TOML
+
+    build_site(
+      config,
+      content_files: {
+        "blog/_index.md" => "---\ntitle: Blog\n---\n",
+        # Date order (Zulu newest) deliberately disagrees with title order.
+        "blog/post1.md" => "---\ntitle: Zulu\ndate: 2024-06-01\ntags:\n  - crystal\n  - web\n---\nZ",
+        "blog/post2.md" => "---\ntitle: Alpha\ndate: 2024-01-01\ntags:\n  - crystal\n---\nA",
+      },
+      template_files: {
+        "page.html"          => "{{ content }}",
+        "section.html"       => "{{ content }}",
+        "taxonomy.html"      => "{{ content }}",
+        "taxonomy_term.html" => <<-JINJA,
+          {{ content }}
+          {% set tax = get_taxonomy(kind=taxonomy_name) %}
+          ITEMS:{% for term in tax.items %}[{{ term.name }}]{% endfor %}
+          {% for term in tax.items if term.name == taxonomy_term %}
+          PAGES:{% for p in term.pages %}[{{ p.title }}]{% endfor %}
+          {% endfor %}
+          JINJA
+      },
+    ) do
+      # Term page listing honors sort_by = "title" (Alpha before Zulu).
+      crystal_html = File.read("public/tags/crystal/index.html")
+      crystal_html.index("Alpha").not_nil!.should be < crystal_html.index("Zulu").not_nil!
+      # get_taxonomy term.pages order matches.
+      crystal_html.should contain("PAGES:[Alpha][Zulu]")
+      # get_taxonomy items honor terms_sort_by = "count": crystal (2) first.
+      crystal_html.should contain("ITEMS:[crystal][web]")
+
+      # Index terms list is count-ordered too.
+      idx = File.read("public/tags/index.html")
+      idx.index(">crystal<").not_nil!.should be < idx.index(">web<").not_nil!
+    end
+  end
 end
 
 # ---------------------------------------------------------------------------

--- a/spec/functional/highlight_assets_spec.cr
+++ b/spec/functional/highlight_assets_spec.cr
@@ -31,11 +31,24 @@ private SELF_HOSTED_HIGHLIGHT_CONFIG = <<-TOML
   theme = "github"
   TOML
 
+# Client mode references the highlight.js script; in the default server mode
+# only the theme CSS is a self-hosted asset, so the JS check is skipped.
+private SELF_HOSTED_CLIENT_HIGHLIGHT_CONFIG = <<-TOML
+  title = "Test"
+  base_url = "http://localhost"
+
+  [highlight]
+  enabled = true
+  mode = "client"
+  use_cdn = false
+  theme = "github"
+  TOML
+
 describe "Highlight: self-hosted asset validation" do
-  it "warns when use_cdn = false but the local highlight assets are missing" do
+  it "warns when use_cdn = false but the local highlight assets are missing (client mode)" do
     logs = capture_build_logs do
       build_site(
-        SELF_HOSTED_HIGHLIGHT_CONFIG,
+        SELF_HOSTED_CLIENT_HIGHLIGHT_CONFIG,
         content_files: {"page.md" => "---\ntitle: P\n---\nBody"},
         template_files: {"page.html" => "{{ highlight_js }}{{ content }}"},
       ) { }
@@ -44,6 +57,21 @@ describe "Highlight: self-hosted asset validation" do
     logs.should contain("use_cdn = false")
     logs.should contain("/assets/js/highlight.min.js")
     logs.should contain("/assets/css/highlight/github.min.css")
+  end
+
+  it "reports only the theme CSS as missing in server mode (no JS is referenced)" do
+    logs = capture_build_logs do
+      build_site(
+        SELF_HOSTED_HIGHLIGHT_CONFIG,
+        content_files: {"page.md" => "---\ntitle: P\n---\nBody"},
+        template_files: {"page.html" => "{{ content }}"},
+      ) { }
+    end
+
+    logs.should contain("use_cdn = false")
+    logs.should contain("missing: /assets/css/highlight/github.min.css.")
+    # The missing list must not include the JS (the advice text still names it).
+    logs.should_not contain(", /assets/js/highlight.min.js")
   end
 
   it "does not warn when the self-hosted highlight assets are present" do

--- a/spec/functional/render_hooks_spec.cr
+++ b/spec/functional/render_hooks_spec.cr
@@ -3,7 +3,7 @@ require "../../src/content/hooks/image_hooks"
 
 # =============================================================================
 # Functional coverage for Hugo-style Markdown render hooks
-# (templates/hooks/render-{link,image,heading,codeblock}.html).
+# (templates/hooks/render-{link,image,heading,codeblock,blockquote,table}.html).
 #
 # These drive the real Builder pipeline end to end (build_site) so the
 # interaction with everything downstream of the raw HTML — internal link
@@ -432,6 +432,83 @@ describe "Render hooks: feeds" do
     ) do
       feed = File.read("public/rss.xml")
       feed.should contain(%(class="hook"))
+    end
+  end
+end
+
+describe "Render hooks: blockquote and table" do
+  it "wraps a blockquote via the blockquote hook end to end" do
+    content = <<-MD
+      +++
+      title = "Home"
+      +++
+      > quoted **bold** text
+      MD
+
+    build_site(
+      BASIC_CONFIG,
+      content_files: {"index.md" => content},
+      template_files: {
+        "page.html"                    => "<body>{{ content }}</body>",
+        "hooks/render-blockquote.html" => %(<aside class="quote">{{ text }}</aside>),
+      },
+    ) do
+      html = File.read("public/index.html")
+      html.should contain(%(<aside class="quote"><p>quoted <strong>bold</strong> text</p>))
+      html.should_not contain("<blockquote>")
+    end
+  end
+
+  it "keeps admonitions on the admonition pipeline while the blockquote hook handles the rest" do
+    content = <<-MD
+      +++
+      title = "Home"
+      +++
+      > plain quote
+
+      > [!NOTE]
+      > Something to note.
+      MD
+
+    build_site(
+      BASIC_CONFIG,
+      content_files: {"index.md" => content},
+      template_files: {
+        "page.html"                    => "<body>{{ content }}</body>",
+        "hooks/render-blockquote.html" => %(<aside class="quote">{{ text }}</aside>),
+      },
+    ) do
+      html = File.read("public/index.html")
+      # admonitions default to true — the [!NOTE] quote became an admonition div…
+      html.should contain(%(class="admonition admonition-note"))
+      # …while the ordinary quote went through the hook.
+      html.should contain(%(<aside class="quote"><p>plain quote</p>))
+    end
+  end
+
+  it "wraps a GFM table via the table hook end to end" do
+    content = <<-MD
+      +++
+      title = "Home"
+      +++
+      | Name | Value |
+      |------|-------|
+      | one  | 1     |
+      MD
+
+    build_site(
+      BASIC_CONFIG,
+      content_files: {"index.md" => content},
+      template_files: {
+        "page.html"               => "<body>{{ content }}</body>",
+        "hooks/render-table.html" => %(<div class="table-wrapper">{{ html }}</div>),
+      },
+    ) do
+      html = File.read("public/index.html")
+      html.should contain(%(<div class="table-wrapper"><table>))
+      html.should contain("<th>Name</th>")
+      html.should contain("<td>one</td>")
+      html.should contain("</table></div>")
     end
   end
 end

--- a/spec/functional/server_highlight_spec.cr
+++ b/spec/functional/server_highlight_spec.cr
@@ -1,11 +1,11 @@
 require "./support/build_helper"
 
 # =============================================================================
-# Build-time syntax highlighting ([highlight] mode = "server")
+# Build-time syntax highlighting ([highlight] mode = "server", the default)
 #
 # Tartrazine lexers tokenize fenced code blocks at build time and emit spans
 # with Highlight.js-compatible classes, so hljs theme CSS keeps working while
-# no JavaScript ships. mode = "client" (default) keeps the previous behavior.
+# no JavaScript ships. mode = "client" opts back into browser-side Highlight.js.
 # =============================================================================
 
 SERVER_HIGHLIGHT_CONFIG = <<-TOML
@@ -116,13 +116,14 @@ describe "Server-side syntax highlighting" do
     reset_highlight_mode
   end
 
-  it "client mode (default) keeps JS injection and emits no spans" do
+  it "client mode keeps JS injection and emits no spans" do
     config = <<-TOML
       title = "Test Site"
       base_url = "http://localhost"
 
       [highlight]
       enabled = true
+      mode = "client"
       TOML
 
     build_site(
@@ -138,7 +139,7 @@ describe "Server-side syntax highlighting" do
     end
   end
 
-  it "warns and falls back to client mode for an unknown mode value" do
+  it "warns and keeps the server default for an unknown mode value" do
     config = <<-TOML
       title = "Test Site"
       base_url = "http://localhost"
@@ -155,9 +156,11 @@ describe "Server-side syntax highlighting" do
       highlight: true,
     ) do
       html = File.read("public/index.html")
-      html.should contain("highlight.min.js")
-      html.should_not contain(%(<span class="hljs-))
+      html.should_not contain("highlight.min.js")
+      html.should contain(%(<span class="hljs-))
     end
+  ensure
+    reset_highlight_mode
   end
 end
 
@@ -290,6 +293,7 @@ describe "Fence options — server mode" do
 
       [highlight]
       enabled = true
+      mode = "client"
       TOML
 
     build_site(

--- a/spec/functional/server_highlight_spec.cr
+++ b/spec/functional/server_highlight_spec.cr
@@ -32,6 +32,7 @@ HIGHLIGHT_TEMPLATE = "<head>{{ highlight_css }}{{ highlight_js }}</head><body>{{
 private def reset_highlight_mode
   Hwaro::Content::Processors::SyntaxHighlighter.server_mode = false
   Hwaro::Content::Processors::SyntaxHighlighter.default_line_numbers = false
+  Hwaro::Content::Processors::SyntaxHighlighter.default_copy = false
 end
 
 describe "Server-side syntax highlighting" do
@@ -310,6 +311,55 @@ describe "Fence options — server mode" do
       # Body stays exactly the plain escaped legacy text — no hljs spans at all
       # (client mode never tokenizes).
       html.should contain(%(<code class="language-python hljs">def main():))
+    end
+  ensure
+    reset_highlight_mode
+  end
+
+  it "[highlight] copy = true marks code blocks, ships the runtime once, and leaves mermaid alone" do
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+
+      [markdown]
+      mermaid = true
+
+      [highlight]
+      enabled = true
+      mode = "server"
+      copy = true
+      TOML
+
+    content = <<-MD
+      +++
+      title = "Code"
+      +++
+      ```python
+      def main():
+          return 42
+      ```
+
+      ```mermaid
+      graph LR
+        A --> B
+      ```
+      MD
+
+    build_site(
+      config,
+      content_files: {"index.md" => content},
+      template_files: {"page.html" => HIGHLIGHT_TEMPLATE},
+      highlight: true,
+    ) do
+      html = File.read("public/index.html")
+      html.should contain(%(<pre data-copy="true">))
+      # The inline runtime rides {{ highlight_js }} — exactly once per page.
+      html.scan("code-copy-btn").size.should be > 0
+      html.scan(%(pre[data-copy])).size.should eq(1)
+      html.should_not contain("highlight.min.js")
+      # Mermaid's <pre> stays bare, so postprocess_mermaid still rewrites it.
+      html.should contain(%(<div class="mermaid">))
+      html.should_not contain("language-mermaid")
     end
   ensure
     reset_highlight_mode

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,6 +4,17 @@ require "../src/hwaro"
 # Suppress Logger output during tests
 Hwaro::Logger.io = IO::Memory.new
 
+# [highlight] settings propagate into SyntaxHighlighter module state during
+# builds (Initialize phase: server_mode / default_line_numbers /
+# default_copy). Reset after every example so one spec's config — e.g. a
+# scaffold build's `mode = "server"` + `copy = true` — never leaks into a
+# later example that renders outside a build.
+Spec.after_each do
+  Hwaro::Content::Processors::SyntaxHighlighter.server_mode = false
+  Hwaro::Content::Processors::SyntaxHighlighter.default_line_numbers = false
+  Hwaro::Content::Processors::SyntaxHighlighter.default_copy = false
+end
+
 # Helper for creating temp directories in tests
 class Dir
   def self.mktmpdir(&)

--- a/spec/unit/config_snippets_spec.cr
+++ b/spec/unit/config_snippets_spec.cr
@@ -46,6 +46,7 @@ describe Hwaro::Services::ConfigSnippets do
       commented.should contain("# [highlight]")
       commented.should contain("# enabled")
       commented.should contain(%(# mode = "server"))
+      commented.should contain("# copy = false")
     end
 
     it "highlight: uncommented version has active values" do
@@ -53,6 +54,7 @@ describe Hwaro::Services::ConfigSnippets do
       uncommented.should contain("[highlight]")
       uncommented.should contain("enabled = true")
       uncommented.should contain(%(mode = "server"))
+      uncommented.should contain("copy = true")
     end
 
     it "sitemap: commented version has all values commented out" do

--- a/spec/unit/config_snippets_spec.cr
+++ b/spec/unit/config_snippets_spec.cr
@@ -45,12 +45,14 @@ describe Hwaro::Services::ConfigSnippets do
       commented = Hwaro::Services::ConfigSnippets.highlight(commented: true)
       commented.should contain("# [highlight]")
       commented.should contain("# enabled")
+      commented.should contain(%(# mode = "server"))
     end
 
     it "highlight: uncommented version has active values" do
       uncommented = Hwaro::Services::ConfigSnippets.highlight(commented: false)
       uncommented.should contain("[highlight]")
       uncommented.should contain("enabled = true")
+      uncommented.should contain(%(mode = "server"))
     end
 
     it "sitemap: commented version has all values commented out" do

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -1050,6 +1050,7 @@ describe Hwaro::Models::Config do
       config.highlight.use_cdn.should be_true
       config.highlight.line_numbers.should be_false
       config.highlight.mode.should eq("server")
+      config.highlight.copy.should be_false
     end
 
     it "can update highlight settings" do
@@ -1113,6 +1114,17 @@ describe Hwaro::Models::Config do
         TOML
 
       config.highlight.line_numbers.should be_false
+    end
+
+    it "loads highlight copy = true from TOML (overrides default false)" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [highlight]
+        copy = true
+        TOML
+
+      config.highlight.copy.should be_true
     end
 
     it "loads highlight mode = \"client\" from TOML (overrides default server)" do

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -1314,6 +1314,43 @@ describe Hwaro::Models::Config do
       config.taxonomies[1].sitemap.should be_false
     end
 
+    it "defaults sorting to date / not reversed / name-ordered terms" do
+      tax = Hwaro::Models::TaxonomyConfig.new("tags")
+      tax.sort_by.should eq("date")
+      tax.reverse.should be_false
+      tax.terms_sort_by.should eq("name")
+    end
+
+    it "loads taxonomy sort_by / reverse / terms_sort_by from TOML" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [[taxonomies]]
+        name = "tags"
+        sort_by = "title"
+        reverse = true
+        terms_sort_by = "count"
+        TOML
+
+      config.taxonomies[0].sort_by.should eq("title")
+      config.taxonomies[0].reverse.should be_true
+      config.taxonomies[0].terms_sort_by.should eq("count")
+    end
+
+    it "warns and keeps the defaults on invalid sort_by / terms_sort_by values" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [[taxonomies]]
+        name = "tags"
+        sort_by = "popularity"
+        terms_sort_by = "size"
+        TOML
+
+      config.taxonomies[0].sort_by.should eq("date")
+      config.taxonomies[0].terms_sort_by.should eq("name")
+    end
+
     it "loads taxonomy feed = true from TOML (overrides default false)" do
       config = load_config(<<-TOML)
         title = "Test"
@@ -2324,6 +2361,9 @@ describe Hwaro::Models::TaxonomyConfig do
     config.feed.should be_false
     config.sitemap.should be_true
     config.paginate_by.should be_nil
+    config.sort_by.should eq("date")
+    config.reverse.should be_false
+    config.terms_sort_by.should eq("name")
   end
 end
 

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -1049,6 +1049,7 @@ describe Hwaro::Models::Config do
       config.highlight.theme.should eq("github")
       config.highlight.use_cdn.should be_true
       config.highlight.line_numbers.should be_false
+      config.highlight.mode.should eq("server")
     end
 
     it "can update highlight settings" do
@@ -1112,6 +1113,28 @@ describe Hwaro::Models::Config do
         TOML
 
       config.highlight.line_numbers.should be_false
+    end
+
+    it "loads highlight mode = \"client\" from TOML (overrides default server)" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [highlight]
+        mode = "client"
+        TOML
+
+      config.highlight.mode.should eq("client")
+    end
+
+    it "keeps the server default on an unknown highlight mode" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [highlight]
+        mode = "browser"
+        TOML
+
+      config.highlight.mode.should eq("server")
     end
   end
 
@@ -2259,16 +2282,23 @@ describe Hwaro::Models::HighlightConfig do
   end
 
   describe "js_tag" do
-    it "returns CDN script when use_cdn is true" do
+    it "returns empty string in the default server mode" do
       config = Hwaro::Models::HighlightConfig.new
+      config.js_tag.should eq("")
+    end
+
+    it "returns CDN script when use_cdn is true (client mode)" do
+      config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       config.js_tag.should contain("cdnjs.cloudflare.com")
       config.js_tag.should contain("highlight.min.js")
     end
   end
 
   describe "tags" do
-    it "returns both CSS and JS tags" do
+    it "returns both CSS and JS tags in client mode" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       config.tags.should contain("stylesheet")
       config.tags.should contain("highlight.min.js")
     end

--- a/spec/unit/content_files_config_spec.cr
+++ b/spec/unit/content_files_config_spec.cr
@@ -311,8 +311,14 @@ describe Hwaro::Models::HighlightConfig do
   end
 
   describe "#js_tag" do
+    it "returns empty string in the default server mode" do
+      config = Hwaro::Models::HighlightConfig.new
+      config.js_tag.should eq("")
+    end
+
     it "returns CDN script when use_cdn is true" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       tag = config.js_tag
       tag.should contain("cdnjs.cloudflare.com")
       tag.should contain("highlight.min.js")
@@ -322,6 +328,7 @@ describe Hwaro::Models::HighlightConfig do
 
     it "returns local script when use_cdn is false" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       config.use_cdn = false
       tag = config.js_tag
       tag.should contain("/assets/js/highlight.min.js")
@@ -332,6 +339,7 @@ describe Hwaro::Models::HighlightConfig do
 
     it "returns empty string when disabled" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       config.enabled = false
       tag = config.js_tag
       tag.should eq("")
@@ -339,6 +347,7 @@ describe Hwaro::Models::HighlightConfig do
 
     it "adds cache bust query parameter to local URL" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       config.use_cdn = false
       tag = config.js_tag("a1b2c3d4")
       tag.should contain("/assets/js/highlight.min.js?v=a1b2c3d4")
@@ -346,14 +355,23 @@ describe Hwaro::Models::HighlightConfig do
 
     it "does not add cache bust to CDN URL" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       tag = config.js_tag("a1b2c3d4")
       tag.should_not contain("?v=")
     end
   end
 
   describe "#tags" do
-    it "returns combined CSS and JS tags" do
+    it "returns only the CSS tag in the default server mode" do
       config = Hwaro::Models::HighlightConfig.new
+      combined = config.tags
+      combined.should contain("<link rel=\"stylesheet\"")
+      combined.should_not contain("<script")
+    end
+
+    it "returns combined CSS and JS tags in client mode" do
+      config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       combined = config.tags
       combined.should contain("<link rel=\"stylesheet\"")
       combined.should contain("<script")
@@ -369,6 +387,7 @@ describe Hwaro::Models::HighlightConfig do
 
     it "contains both css_tag and js_tag output" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       css = config.css_tag
       js = config.js_tag
       combined = config.tags
@@ -377,6 +396,7 @@ describe Hwaro::Models::HighlightConfig do
 
     it "passes cache bust to both css_tag and js_tag" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       config.use_cdn = false
       combined = config.tags("a1b2c3d4")
       combined.should contain("?v=a1b2c3d4")

--- a/spec/unit/design_tokens_spec.cr
+++ b/spec/unit/design_tokens_spec.cr
@@ -74,11 +74,15 @@ describe Hwaro::Services::Scaffolds::DesignTokens do
       css.should_not match(/#[0-9a-f]{3,8}/i)
     end
 
-    it "styles the copy button through tokens (overrides the inline runtime styles)" do
+    it "styles the copy button through tokens, more specific than the inline runtime styles" do
       css = Hwaro::Services::Scaffolds::DesignTokens.highlight_css
       css.should contain(".code-wrapper")
-      css.should contain(".code-copy-btn")
-      css.should contain(".code-copy-btn.copied")
+      # The inline snippet from {{ highlight_js }} ships in-body after this
+      # stylesheet, so equal-specificity rules would lose to it — the doubled
+      # class keeps every scaffold rule strictly more specific.
+      css.should contain(".code-copy-btn.code-copy-btn")
+      css.should contain(".code-block:hover .code-copy-btn.code-copy-btn")
+      css.should contain(".code-copy-btn.code-copy-btn.copied")
       css.should_not match(/#[0-9a-f]{3,8}/i)
     end
   end

--- a/spec/unit/design_tokens_spec.cr
+++ b/spec/unit/design_tokens_spec.cr
@@ -73,6 +73,14 @@ describe Hwaro::Services::Scaffolds::DesignTokens do
       css.should contain("var(--code-string)")
       css.should_not match(/#[0-9a-f]{3,8}/i)
     end
+
+    it "styles the copy button through tokens (overrides the inline runtime styles)" do
+      css = Hwaro::Services::Scaffolds::DesignTokens.highlight_css
+      css.should contain(".code-wrapper")
+      css.should contain(".code-copy-btn")
+      css.should contain(".code-copy-btn.copied")
+      css.should_not match(/#[0-9a-f]{3,8}/i)
+    end
   end
 
   describe ".theme_toggle_css" do

--- a/spec/unit/processors_spec.cr
+++ b/spec/unit/processors_spec.cr
@@ -340,6 +340,20 @@ describe Hwaro::Models::HighlightConfig do
       config.js_tag.should_not contain("highlight.min.js")
     end
 
+    it "copy runtime strips the .ln gutter from copied text and anchors on an existing code-block" do
+      config = Hwaro::Models::HighlightConfig.new
+      config.copy = true
+      tag = config.js_tag
+      # Server-mode linenos bake `<span class="ln">N </span>` into <code> —
+      # the click handler must remove them before reading textContent.
+      tag.should contain(%(querySelectorAll("span.ln")))
+      # A named fence's .code-block wrapper is reused as the positioning
+      # anchor instead of nesting a fresh .code-wrapper inside it (which
+      # would break the scaffold's `.code-block > pre` styling).
+      tag.should contain(%(contains("code-block")))
+      tag.should contain(".code-wrapper,.code-block{position:relative}")
+    end
+
     it "appends the copy runtime after the hljs scripts in client mode" do
       config = Hwaro::Models::HighlightConfig.new
       config.mode = "client"

--- a/spec/unit/processors_spec.cr
+++ b/spec/unit/processors_spec.cr
@@ -347,7 +347,7 @@ describe Hwaro::Models::HighlightConfig do
       tag = config.js_tag
       tag.should contain("hljs.highlightAll()")
       tag.should contain("code-copy-btn")
-      tag.index("hljs.highlightAll()").not_nil!.should be < tag.index("code-copy-btn").not_nil!
+      tag.index!("hljs.highlightAll()").should be < tag.index!("code-copy-btn")
     end
 
     it "omits the copy runtime when highlighting is disabled" do

--- a/spec/unit/processors_spec.cr
+++ b/spec/unit/processors_spec.cr
@@ -301,6 +301,7 @@ describe Hwaro::Models::HighlightConfig do
     config.enabled.should be_true
     config.theme.should eq("github")
     config.use_cdn.should be_true
+    config.mode.should eq("server")
   end
 
   describe "css_tag" do
@@ -325,8 +326,14 @@ describe Hwaro::Models::HighlightConfig do
   end
 
   describe "js_tag" do
+    it "returns empty string in server mode (default)" do
+      config = Hwaro::Models::HighlightConfig.new
+      config.js_tag.should eq("")
+    end
+
     it "returns CDN script when use_cdn is true" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       config.js_tag.should contain("cdnjs.cloudflare.com")
       config.js_tag.should contain("highlight.min.js")
       config.js_tag.should contain("hljs.highlightAll()")
@@ -334,6 +341,7 @@ describe Hwaro::Models::HighlightConfig do
 
     it "returns local script when use_cdn is false" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       config.use_cdn = false
       config.js_tag.should contain("/assets/js/highlight.min.js")
       config.js_tag.should_not contain("cdnjs.cloudflare.com")
@@ -341,14 +349,23 @@ describe Hwaro::Models::HighlightConfig do
 
     it "returns empty string when disabled" do
       config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       config.enabled = false
       config.js_tag.should eq("")
     end
   end
 
   describe "tags" do
-    it "returns combined CSS and JS tags" do
+    it "returns only the CSS tag in server mode (default)" do
       config = Hwaro::Models::HighlightConfig.new
+      tags = config.tags
+      tags.should contain("stylesheet")
+      tags.should_not contain("highlight.min.js")
+    end
+
+    it "returns combined CSS and JS tags in client mode" do
+      config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
       tags = config.tags
       tags.should contain("stylesheet")
       tags.should contain("highlight.min.js")

--- a/spec/unit/processors_spec.cr
+++ b/spec/unit/processors_spec.cr
@@ -302,6 +302,7 @@ describe Hwaro::Models::HighlightConfig do
     config.theme.should eq("github")
     config.use_cdn.should be_true
     config.mode.should eq("server")
+    config.copy.should be_false
   end
 
   describe "css_tag" do
@@ -328,6 +329,31 @@ describe Hwaro::Models::HighlightConfig do
   describe "js_tag" do
     it "returns empty string in server mode (default)" do
       config = Hwaro::Models::HighlightConfig.new
+      config.js_tag.should eq("")
+    end
+
+    it "returns only the copy runtime in server mode when copy is enabled" do
+      config = Hwaro::Models::HighlightConfig.new
+      config.copy = true
+      config.js_tag.should contain("code-copy-btn")
+      config.js_tag.should contain("pre[data-copy]")
+      config.js_tag.should_not contain("highlight.min.js")
+    end
+
+    it "appends the copy runtime after the hljs scripts in client mode" do
+      config = Hwaro::Models::HighlightConfig.new
+      config.mode = "client"
+      config.copy = true
+      tag = config.js_tag
+      tag.should contain("hljs.highlightAll()")
+      tag.should contain("code-copy-btn")
+      tag.index("hljs.highlightAll()").not_nil!.should be < tag.index("code-copy-btn").not_nil!
+    end
+
+    it "omits the copy runtime when highlighting is disabled" do
+      config = Hwaro::Models::HighlightConfig.new
+      config.copy = true
+      config.enabled = false
       config.js_tag.should eq("")
     end
 

--- a/spec/unit/render_hooks_spec.cr
+++ b/spec/unit/render_hooks_spec.cr
@@ -12,16 +12,22 @@ private alias SyntaxHighlighter = Hwaro::Content::Processors::SyntaxHighlighter
 # below. `is present` (not a bare `{% if title %}`) matters: Crinja's
 # value truthiness only treats `false`/`0`/nil as falsy, NOT an empty
 # string, so a bare `{% if title %}` would always render the attribute.
-LINK_TPL      = %(<a href="{{ destination }}"{% if title is present %} title="{{ title }}"{% endif %}>{{ text }}</a>)
-IMAGE_TPL     = %(<img src="{{ destination }}" alt="{{ alt }}"{% if title is present %} title="{{ title }}"{% endif %} />)
-HEADING_TPL   = %(<h{{ level }} id="{{ id }}">{{ text }}</h{{ level }}>)
-CODEBLOCK_TPL = %(<pre><code{% if lang is present %} class="language-{{ lang }}"{% endif %}>{% if highlighted is present %}{{ highlighted }}{% else %}{{ code }}{% endif %}</code></pre>)
+LINK_TPL       = %(<a href="{{ destination }}"{% if title is present %} title="{{ title }}"{% endif %}>{{ text }}</a>)
+IMAGE_TPL      = %(<img src="{{ destination }}" alt="{{ alt }}"{% if title is present %} title="{{ title }}"{% endif %} />)
+HEADING_TPL    = %(<h{{ level }} id="{{ id }}">{{ text }}</h{{ level }}>)
+CODEBLOCK_TPL  = %(<pre><code{% if lang is present %} class="language-{{ lang }}"{% endif %}>{% if highlighted is present %}{{ highlighted }}{% else %}{{ code }}{% endif %}</code></pre>)
+BLOCKQUOTE_TPL = "<blockquote>\n{{ text }}</blockquote>"
+TABLE_TPL      = "{{ html }}"
+
+TABLE_MD = "| A | B |\n|---|---|\n| 1 | 2 |"
 
 private def make_registry(
   link : String? = nil,
   image : String? = nil,
   heading : String? = nil,
   codeblock : String? = nil,
+  blockquote : String? = nil,
+  table : String? = nil,
   fingerprint : String = "test",
 ) : RenderHooks::Registry
   RenderHooks::Registry.new(
@@ -29,6 +35,8 @@ private def make_registry(
     image ? {source: image, disk_path: nil} : nil,
     heading ? {source: heading, disk_path: nil} : nil,
     codeblock ? {source: codeblock, disk_path: nil} : nil,
+    blockquote ? {source: blockquote, disk_path: nil} : nil,
+    table ? {source: table, disk_path: nil} : nil,
     fingerprint,
   )
 end
@@ -40,12 +48,17 @@ private def make_hooks(
   image : String? = nil,
   heading : String? = nil,
   codeblock : String? = nil,
+  blockquote : String? = nil,
+  table : String? = nil,
   mermaid_bypass : Bool = false,
+  admonition_bypass : Bool = false,
 ) : RenderHooks::HookRenderContext
-  registry = make_registry(link: link, image: image, heading: heading, codeblock: codeblock)
+  registry = make_registry(link: link, image: image, heading: heading, codeblock: codeblock,
+    blockquote: blockquote, table: table)
   env = Hwaro::Content::Processors::TemplateEngine.new.env
   cache = {} of UInt64 => Crinja::Template
-  RenderHooks::HookRenderContext.new(registry, env, cache, nil, {} of String => Crinja::Value, mermaid_bypass)
+  RenderHooks::HookRenderContext.new(registry, env, cache, nil, {} of String => Crinja::Value,
+    mermaid_bypass, admonition_bypass)
 end
 
 describe RenderHooks do
@@ -93,17 +106,27 @@ describe RenderHooks do
       fp1.should_not eq(fp2)
     end
 
-    it "warns once about an unrecognized hook name but stays silent about planned ones" do
+    it "recognizes blockquote and table hooks" do
+      RenderHooks.configure(
+        {"hooks/render-blockquote" => "BQ", "hooks/render-table" => "TBL"},
+        {} of String => String,
+      )
+      reg = RenderHooks.registry.not_nil!
+      reg.blockquote.not_nil![:source].should eq("BQ")
+      reg.table.not_nil![:source].should eq("TBL")
+      reg.link.should be_nil
+    end
+
+    it "warns once about an unrecognized hook name" do
       log = with_captured_log do
         RenderHooks.configure(
-          {"hooks/render-foo" => "x", "hooks/render-blockquote" => "y"},
+          {"hooks/render-foo" => "x"},
           {} of String => String,
         )
       end
       log.should contain("unknown render hook 'render-foo'")
-      log.should contain("supported: link, image, heading, codeblock")
-      log.should_not contain("render-blockquote")
-      # Neither "foo" nor "blockquote" is a real hook, so no registry at all.
+      log.should contain("supported: link, image, heading, codeblock, blockquote, table")
+      # "foo" is not a real hook, so no registry at all.
       RenderHooks.registry.should be_nil
     end
 
@@ -252,6 +275,104 @@ describe "HookedRenderer (via SyntaxHighlighter.render with in-memory contexts)"
     end
   end
 
+  describe "blockquote" do
+    it "renders the captured inner HTML, nested inline markup included" do
+      hooks = make_hooks(blockquote: "BQ[{{ text }}]")
+      html = SyntaxHighlighter.render("> quoted **bold** text", hooks: hooks)
+      html.should contain("BQ[<p>quoted <strong>bold</strong> text</p>")
+      html.should_not contain("<blockquote>")
+    end
+
+    it "handles a multi-paragraph blockquote as one hook call" do
+      hooks = make_hooks(blockquote: "BQ[{{ text }}]")
+      html = SyntaxHighlighter.render("> first\n>\n> second", hooks: hooks)
+      html.should contain("BQ[<p>first</p>\n<p>second</p>")
+    end
+
+    it "bypasses the hook for an admonition blockquote when admonitions are enabled" do
+      hooks = make_hooks(blockquote: "BQ[{{ text }}]", admonition_bypass: true)
+      cfg = Hwaro::Models::MarkdownConfig.new
+      cfg.admonitions = true
+      html, _ = Hwaro::Content::Processors::Markdown.new.render("> [!NOTE]\n> Watch out.", markdown_config: cfg, hooks: hooks)
+      html.should_not contain("BQ[")
+      # The stock shape survived to postprocess_admonitions and was rewritten.
+      html.should contain(%(class="admonition admonition-note"))
+    end
+
+    it "runs the hook on an admonition-shaped blockquote when admonitions are disabled" do
+      hooks = make_hooks(blockquote: "BQ[{{ text }}]", admonition_bypass: false)
+      cfg = Hwaro::Models::MarkdownConfig.new
+      cfg.admonitions = false
+      html, _ = Hwaro::Content::Processors::Markdown.new.render("> [!NOTE]\n> Watch out.", markdown_config: cfg, hooks: hooks)
+      html.should contain("BQ[")
+      html.should_not contain("admonition-note")
+    end
+
+    it "leaves ordinary blockquotes on the hook while admonitions bypass it" do
+      hooks = make_hooks(blockquote: "BQ[{{ text }}]", admonition_bypass: true)
+      cfg = Hwaro::Models::MarkdownConfig.new
+      cfg.admonitions = true
+      content = "> plain quote\n\n> [!TIP]\n> A tip."
+      html, _ = Hwaro::Content::Processors::Markdown.new.render(content, markdown_config: cfg, hooks: hooks)
+      html.should contain("BQ[<p>plain quote</p>")
+      html.should contain(%(class="admonition admonition-tip"))
+    end
+
+    it "falls back to the stock <blockquote> shape on a template error" do
+      hooks = make_hooks(blockquote: "{{ text")
+      html = ""
+      log = with_captured_log do
+        html = SyntaxHighlighter.render("> quoted", hooks: hooks)
+      end
+      html.should contain("<blockquote>\n<p>quoted</p>\n</blockquote>")
+      log.should contain("Template error in render hook 'hooks/render-blockquote'")
+    end
+  end
+
+  describe "table" do
+    it "wraps the stock table html via the hook" do
+      hooks = make_hooks(table: %(<div class="tbl">{{ html }}</div>))
+      html = SyntaxHighlighter.render(TABLE_MD, hooks: hooks)
+      html.should contain(%(<div class="tbl"><table>))
+      html.should contain("</table></div>")
+    end
+
+    it "exposes header_html and body_html separately" do
+      hooks = make_hooks(table: "H[{{ header_html }}]B[{{ body_html }}]")
+      html = SyntaxHighlighter.render(TABLE_MD, hooks: hooks)
+      html.should contain("H[<thead>")
+      html.should contain("<th>A</th>")
+      html.should contain("B[<tbody>")
+      html.should contain("<td>1</td>")
+    end
+
+    it "collapses blank lines in the hook output (markd html-block safety)" do
+      hooks = make_hooks(table: "<div>\n\n{{ html }}\n\n\n</div>")
+      html = SyntaxHighlighter.render(TABLE_MD, hooks: hooks)
+      html.should_not match(/\n[ \t]*\n/)
+      html.should contain("<table>")
+      # No escaped leftovers — the whole table stayed one html block.
+      html.should_not contain("&lt;table&gt;")
+    end
+
+    it "falls back to the stock table markup on a template error" do
+      hooks = make_hooks(table: "{{ html")
+      html = ""
+      log = with_captured_log do
+        html = SyntaxHighlighter.render(TABLE_MD, hooks: hooks)
+      end
+      html.should contain("<table>\n<thead>")
+      log.should contain("Template error in render hook 'hooks/render-table'")
+    end
+
+    it "renders the stock table byte-identically when no table hook is configured" do
+      hooks = make_hooks(link: "L[{{ text }}]") # some other hook active
+      stock = SyntaxHighlighter.render(TABLE_MD)
+      hooked = SyntaxHighlighter.render(TABLE_MD, hooks: hooks)
+      hooked.should eq(stock)
+    end
+  end
+
   it "empties the destination in safe mode for an unsafe protocol" do
     hooks = make_hooks(link: "D=[{{ destination }}]")
     html = SyntaxHighlighter.render("[text](javascript:alert(1))", safe: true, hooks: hooks)
@@ -299,6 +420,12 @@ describe "default-equivalent hook templates" do
       "```",
       "plain fence",
       "```",
+      "",
+      "> a quoted *paragraph*",
+      "",
+      "| A | B |",
+      "|---|---|",
+      "| 1 | 2 |",
     ].join("\n")
 
     cfg = Hwaro::Models::MarkdownConfig.new
@@ -306,7 +433,8 @@ describe "default-equivalent hook templates" do
 
     stock_html, _ = processor.render(content, highlight: false, markdown_config: cfg)
 
-    hooks = make_hooks(link: LINK_TPL, image: IMAGE_TPL, heading: HEADING_TPL, codeblock: CODEBLOCK_TPL)
+    hooks = make_hooks(link: LINK_TPL, image: IMAGE_TPL, heading: HEADING_TPL, codeblock: CODEBLOCK_TPL,
+      blockquote: BLOCKQUOTE_TPL, table: TABLE_TPL)
     hook_html, _ = processor.render(content, highlight: false, markdown_config: cfg, hooks: hooks)
 
     hook_html.should eq(stock_html)

--- a/spec/unit/scaffolds_assets_spec.cr
+++ b/spec/unit/scaffolds_assets_spec.cr
@@ -59,20 +59,19 @@ describe "Scaffold embedded assets" do
   end
 
   describe "ember-warm syntax highlighting" do
-    # The default is client-side Highlight.js (`mode = "client"`). The
-    # server/Tartrazine path is multi-thread-safe nowadays (see
-    # ext/tartrazine_mt_fix.cr), so this is a product default — zero
-    # build-time cost and full hljs theme compatibility — rather than a
-    # safety requirement. The warm theme is inlined either way.
-    it "defaults to client-side highlighting (mode = \"client\")" do
+    # The default is build-time highlighting (`mode = "server"`): no
+    # JavaScript ships and the output uses hljs-compatible classes, so the
+    # inlined warm theme keeps working. `mode = "client"` remains the
+    # opt-back for browser-side Highlight.js.
+    it "defaults to build-time highlighting (mode = \"server\")" do
       {
         Hwaro::Services::Scaffolds::Simple.new,
         Hwaro::Services::Scaffolds::Blog.new,
         Hwaro::Services::Scaffolds::Docs.new,
         Hwaro::Services::Scaffolds::Book.new,
       }.each do |scaffold|
-        # The active setting (the explanatory comment may still mention "server").
-        scaffold.config_content.should contain(%(mode = "client"))
+        # The active setting (the explanatory comment may still mention "client").
+        scaffold.config_content.should contain(%(mode = "server"))
       end
     end
 

--- a/spec/unit/scaffolds_assets_spec.cr
+++ b/spec/unit/scaffolds_assets_spec.cr
@@ -75,6 +75,17 @@ describe "Scaffold embedded assets" do
       end
     end
 
+    it "enables the copy button (copy = true)" do
+      {
+        Hwaro::Services::Scaffolds::Simple.new,
+        Hwaro::Services::Scaffolds::Blog.new,
+        Hwaro::Services::Scaffolds::Docs.new,
+        Hwaro::Services::Scaffolds::Book.new,
+      }.each do |scaffold|
+        scaffold.config_content.should contain(%(copy = true))
+      end
+    end
+
     it "inlines the syntax theme into the stylesheet (recolor without a theme link)" do
       css = Hwaro::Services::Scaffolds::Blog.new.static_files["css/style.css"]
       css.should contain(".hljs-keyword")

--- a/spec/unit/syntax_highlighter_spec.cr
+++ b/spec/unit/syntax_highlighter_spec.cr
@@ -340,6 +340,33 @@ describe Hwaro::Content::Processors::FenceOptions do
       _, opts = Hwaro::Content::Processors::FenceOptions.parse(%(crystal {hl_lines="1-100000"}))
       opts.not_nil!.hl_lines.should eq([{1, 100_000}])
     end
+
+    it "parses a single hide_lines value" do
+      lang, opts = Hwaro::Content::Processors::FenceOptions.parse(%(crystal {hide_lines="2"}))
+      lang.should eq("crystal")
+      opts.not_nil!.hide_lines.should eq([{2, 2}])
+    end
+
+    it "parses hide_lines ranges and mixed items" do
+      _, opts = Hwaro::Content::Processors::FenceOptions.parse(%(crystal {hide_lines="1 3-5, 8"}))
+      opts.not_nil!.hide_lines.should eq([{1, 1}, {3, 5}, {8, 8}])
+    end
+
+    it "drops malformed hide_lines items like hl_lines" do
+      _, opts = Hwaro::Content::Processors::FenceOptions.parse(%(crystal {hide_lines="0,x,9-2,3"}))
+      opts.not_nil!.hide_lines.should eq([{3, 3}])
+    end
+
+    it "hide_lines alone activates the options block" do
+      lang, opts = Hwaro::Content::Processors::FenceOptions.parse(%(crystal {hide_lines="2"}))
+      lang.should eq("crystal")
+      opts.should_not be_nil
+    end
+
+    it "returns nil opts when every hide_lines item is malformed" do
+      _, opts = Hwaro::Content::Processors::FenceOptions.parse(%(crystal {hide_lines="0 9-2"}))
+      opts.should be_nil
+    end
   end
 end
 
@@ -394,6 +421,45 @@ describe Hwaro::Content::Processors::LineWrapper do
       result.should contain(%(<span class="line hl"><span class="ln" aria-hidden="true">5 </span>a</span>\n))
       result.should contain(%(<span class="line"><span class="ln" aria-hidden="true">6 </span>b</span>\n))
     end
+
+    it "elides hidden lines but keeps their gutter numbers consumed (gap, not renumber)" do
+      opts = Hwaro::Content::Processors::FenceOptions::Options.new(hide_lines: [{2, 2}])
+      result = Hwaro::Content::Processors::LineWrapper.wrap("a\nb\nc\n", true, 1, opts)
+      result.should contain(%(<span class="ln" aria-hidden="true">1 </span>a</span>\n))
+      result.should_not contain("b")
+      result.should_not contain(%(>2 </span>))
+      result.should contain(%(<span class="ln" aria-hidden="true">3 </span>c</span>\n))
+    end
+
+    it "hides physical lines independent of linenostart" do
+      opts = Hwaro::Content::Processors::FenceOptions::Options.new(hide_lines: [{1, 1}])
+      result = Hwaro::Content::Processors::LineWrapper.wrap("a\nb\n", true, 5, opts)
+      result.should_not contain("a</span>")
+      result.should contain(%(<span class="line"><span class="ln" aria-hidden="true">6 </span>b</span>\n))
+    end
+
+    it "keeps the gutter width computed over the full physical range, hidden tail included" do
+      opts = Hwaro::Content::Processors::FenceOptions::Options.new(hide_lines: [{10, 10}])
+      body = ("a\n" * 10)
+      result = Hwaro::Content::Processors::LineWrapper.wrap(body, true, 1, opts)
+      # 10 physical lines -> width 2, so line 1 is padded even though the
+      # only 2-digit line (10) is hidden.
+      result.should contain(%(<span class="ln" aria-hidden="true"> 1 </span>))
+      result.should_not contain(%(>10 </span>))
+    end
+
+    it "hl_lines on a hidden line is a no-op (the line never renders)" do
+      opts = Hwaro::Content::Processors::FenceOptions::Options.new(hl_lines: [{2, 2}], hide_lines: [{2, 2}])
+      result = Hwaro::Content::Processors::LineWrapper.wrap("a\nb\nc\n", true, 1, opts)
+      result.should_not contain(%(<span class="line hl"))
+      result.should_not contain("b")
+    end
+
+    it "wraps without a gutter when linenos is off but hide_lines is active" do
+      opts = Hwaro::Content::Processors::FenceOptions::Options.new(hide_lines: [{2, 2}])
+      result = Hwaro::Content::Processors::LineWrapper.wrap("a\nb\nc\n", false, 1, opts)
+      result.should eq(%(<span class="line">a</span>\n<span class="line">c</span>\n))
+    end
   end
 end
 
@@ -446,6 +512,51 @@ describe "fence options rendering (server mode)" do
     Hwaro::Content::Processors::SyntaxHighlighter.default_line_numbers = true
     html = Hwaro::Content::Processors::SyntaxHighlighter.render("    indented code\n    more code\n", highlight: true)
     html.should_not contain(%(<span class="line"))
+  ensure
+    reset_fence_options_state
+  end
+
+  it "elides hide_lines lines with gap gutter numbering end-to-end" do
+    Hwaro::Content::Processors::SyntaxHighlighter.server_mode = true
+    content = "```python {linenos=true, hide_lines=\"2\"}\ndef f():\n    secret()\n    pass\n```"
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(content, highlight: true)
+    html.should contain(%(<span class="ln" aria-hidden="true">1 </span>))
+    html.should contain(%(<span class="ln" aria-hidden="true">3 </span>))
+    html.should_not contain(%(>2 </span>))
+    html.should_not contain("secret")
+  ensure
+    reset_fence_options_state
+  end
+
+  it "hide_lines alone (no linenos) activates line wrapping and elides the line" do
+    Hwaro::Content::Processors::SyntaxHighlighter.server_mode = true
+    content = "```python {hide_lines=\"2\"}\ndef f():\n    secret()\n    pass\n```"
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(content, highlight: true)
+    html.should contain(%(<span class="line">))
+    html.should_not contain("secret")
+    html.should_not contain(%(<span class="ln"))
+  ensure
+    reset_fence_options_state
+  end
+
+  it "client mode emits an inert data-hide-lines attribute and keeps the body intact" do
+    content = "```python {hide_lines=\"2\"}\ndef f():\n    secret()\n    pass\n```"
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(content, highlight: true)
+    html.should contain(%(data-hide-lines="2"))
+    html.should contain("secret")
+    html.should_not contain(%(<span class="line))
+  ensure
+    reset_fence_options_state
+  end
+
+  it "leaves mermaid fences untouched by hide_lines" do
+    Hwaro::Content::Processors::SyntaxHighlighter.server_mode = true
+    content = "```mermaid {hide_lines=\"1\"}\ngraph LR\n  A --> B\n```"
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(content, highlight: true)
+    html.should contain("language-mermaid")
+    html.should_not contain("data-hide-lines")
+    html.should_not contain(%(<span class="line"))
+    html.should contain("graph LR")
   ensure
     reset_fence_options_state
   end

--- a/spec/unit/syntax_highlighter_spec.cr
+++ b/spec/unit/syntax_highlighter_spec.cr
@@ -231,6 +231,7 @@ end
 private def reset_fence_options_state
   Hwaro::Content::Processors::SyntaxHighlighter.server_mode = false
   Hwaro::Content::Processors::SyntaxHighlighter.default_line_numbers = false
+  Hwaro::Content::Processors::SyntaxHighlighter.default_copy = false
 end
 
 describe Hwaro::Content::Processors::FenceOptions do
@@ -365,6 +366,23 @@ describe Hwaro::Content::Processors::FenceOptions do
 
     it "returns nil opts when every hide_lines item is malformed" do
       _, opts = Hwaro::Content::Processors::FenceOptions.parse(%(crystal {hide_lines="0 9-2"}))
+      opts.should be_nil
+    end
+
+    it "parses copy=true and copy=false" do
+      _, opts = Hwaro::Content::Processors::FenceOptions.parse("crystal {copy=true}")
+      opts.not_nil!.copy.should be_true
+      _, opts = Hwaro::Content::Processors::FenceOptions.parse("crystal {copy=false}")
+      opts.not_nil!.copy.should be_false
+    end
+
+    it "leaves copy nil when absent" do
+      _, opts = Hwaro::Content::Processors::FenceOptions.parse("crystal {linenos=true}")
+      opts.not_nil!.copy.should be_nil
+    end
+
+    it "ignores a non-boolean copy value (doesn't activate alone)" do
+      _, opts = Hwaro::Content::Processors::FenceOptions.parse("crystal {copy=maybe}")
       opts.should be_nil
     end
   end
@@ -557,6 +575,69 @@ describe "fence options rendering (server mode)" do
     html.should_not contain("data-hide-lines")
     html.should_not contain(%(<span class="line"))
     html.should contain("graph LR")
+  ensure
+    reset_fence_options_state
+  end
+end
+
+describe "copy button marker (data-copy)" do
+  it "marks every fence when the global default is on — in both modes" do
+    content = "```python\npass\n```"
+    Hwaro::Content::Processors::SyntaxHighlighter.default_copy = true
+    client = Hwaro::Content::Processors::SyntaxHighlighter.render(content, highlight: true)
+    client.should contain(%(<pre data-copy="true"><code class="language-python hljs">))
+    Hwaro::Content::Processors::SyntaxHighlighter.server_mode = true
+    server = Hwaro::Content::Processors::SyntaxHighlighter.render(content, highlight: true)
+    server.should contain(%(<pre data-copy="true">))
+  ensure
+    reset_fence_options_state
+  end
+
+  it "a per-fence {copy=false} opts out of the global default" do
+    Hwaro::Content::Processors::SyntaxHighlighter.default_copy = true
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(
+      "```python {copy=false}\npass\n```", highlight: true)
+    html.should_not contain("data-copy")
+  ensure
+    reset_fence_options_state
+  end
+
+  it "a per-fence {copy=true} opts in with the global default off" do
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(
+      "```python {copy=true}\npass\n```", highlight: true)
+    html.should contain(%(data-copy="true"))
+    # copy alone must not activate line wrapping or other data-* attrs.
+    html.should_not contain("data-linenos")
+    html.should_not contain(%(<span class="line))
+  ensure
+    reset_fence_options_state
+  end
+
+  it "never marks mermaid fences (postprocess_mermaid anchors on a bare <pre>)" do
+    Hwaro::Content::Processors::SyntaxHighlighter.default_copy = true
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(
+      "```mermaid\ngraph LR\n  A --> B\n```", highlight: true)
+    html.should contain(%(<pre><code class="language-mermaid))
+    html.should_not contain("data-copy")
+  ensure
+    reset_fence_options_state
+  end
+
+  it "is byte-identical to stock output when the feature is fully off" do
+    content = "```python\npass\n```"
+    baseline = Hwaro::Content::Processors::SyntaxHighlighter.render(content, highlight: true)
+    baseline.should_not contain("data-copy")
+    baseline.should contain("<pre><code")
+  ensure
+    reset_fence_options_state
+  end
+
+  it "composes with client-mode data-* line attributes on the same <pre>" do
+    Hwaro::Content::Processors::SyntaxHighlighter.default_copy = true
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(
+      "```python {linenos=true}\npass\n```", highlight: true)
+    html.should contain(%(data-linenos="true"))
+    html.should contain(%(data-copy="true"))
   ensure
     reset_fence_options_state
   end

--- a/spec/unit/syntax_highlighter_spec.cr
+++ b/spec/unit/syntax_highlighter_spec.cr
@@ -641,6 +641,20 @@ describe "copy button marker (data-copy)" do
   ensure
     reset_fence_options_state
   end
+
+  it "keeps <pre> a direct child of a named block's .code-block wrapper" do
+    # The copy runtime anchors the button on an existing .code-block instead
+    # of inserting a .code-wrapper between it and the <pre>, so the
+    # scaffold's `.code-block > pre` styling must keep matching — the
+    # emitted HTML places the marked <pre> directly inside the wrapper.
+    Hwaro::Content::Processors::SyntaxHighlighter.default_copy = true
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(
+      "```crystal {name=\"main.cr\"}\nputs 1\n```", highlight: true)
+    html.should contain(%(<div class="code-block"><div class="code-filename">main.cr</div>))
+    html.should contain(%(<pre data-copy="true">))
+  ensure
+    reset_fence_options_state
+  end
 end
 
 describe Hwaro::Content::Processors::ServerHighlighter do

--- a/spec/unit/taxonomies_spec.cr
+++ b/spec/unit/taxonomies_spec.cr
@@ -566,6 +566,204 @@ describe Hwaro::Content::Taxonomies do
       end
     end
   end
+
+  describe "configurable sorting" do
+    # Three pages whose title order (Alpha, Bravo, Charlie) deliberately
+    # disagrees with their date order (Charlie newest) and weight order
+    # (Bravo lightest), so each sort mode produces a distinct listing.
+    tagged_pages = -> do
+      a = Hwaro::Models::Page.new("a.md")
+      a.title = "Alpha"
+      a.url = "/blog/alpha/"
+      a.tags = ["crystal"]
+      a.date = Time.utc(2024, 1, 2)
+      a.weight = 2
+
+      b = Hwaro::Models::Page.new("b.md")
+      b.title = "Bravo"
+      b.url = "/blog/bravo/"
+      b.tags = ["crystal"]
+      b.date = Time.utc(2024, 1, 1)
+      b.weight = 1
+
+      c = Hwaro::Models::Page.new("c.md")
+      c.title = "Charlie"
+      c.url = "/blog/charlie/"
+      c.tags = ["crystal"]
+      c.date = Time.utc(2024, 1, 3)
+      c.weight = 3
+
+      [a, b, c] of Hwaro::Models::Page
+    end
+
+    generate_term_html = ->(tax : Hwaro::Models::TaxonomyConfig, pages : Array(Hwaro::Models::Page)) do
+      config = Hwaro::Models::Config.new
+      config.taxonomies = [tax]
+      site = Hwaro::Models::Site.new(config)
+      site.pages = pages
+      html = ""
+      Dir.mktmpdir do |output_dir|
+        templates = {
+          "taxonomy"      => "<html>{{ content }}</html>",
+          "taxonomy_term" => "<html>{{ content }}</html>",
+        }
+        Hwaro::Content::Taxonomies.generate(site, output_dir, templates)
+        html = File.read(File.join(output_dir, "tags", "crystal", "index.html"))
+      end
+      html
+    end
+
+    it "orders a term's pages newest-first by default" do
+      html = generate_term_html.call(Hwaro::Models::TaxonomyConfig.new("tags"), tagged_pages.call)
+      html.index("Charlie").not_nil!.should be < html.index("Alpha").not_nil!
+      html.index("Alpha").not_nil!.should be < html.index("Bravo").not_nil!
+    end
+
+    it "orders a term's pages by title ascending with sort_by = \"title\"" do
+      tax = Hwaro::Models::TaxonomyConfig.new("tags")
+      tax.sort_by = "title"
+      html = generate_term_html.call(tax, tagged_pages.call)
+      html.index("Alpha").not_nil!.should be < html.index("Bravo").not_nil!
+      html.index("Bravo").not_nil!.should be < html.index("Charlie").not_nil!
+    end
+
+    it "reverses the title order with reverse = true" do
+      tax = Hwaro::Models::TaxonomyConfig.new("tags")
+      tax.sort_by = "title"
+      tax.reverse = true
+      html = generate_term_html.call(tax, tagged_pages.call)
+      html.index("Charlie").not_nil!.should be < html.index("Bravo").not_nil!
+      html.index("Bravo").not_nil!.should be < html.index("Alpha").not_nil!
+    end
+
+    it "orders a term's pages by weight ascending with sort_by = \"weight\"" do
+      tax = Hwaro::Models::TaxonomyConfig.new("tags")
+      tax.sort_by = "weight"
+      html = generate_term_html.call(tax, tagged_pages.call)
+      html.index("Bravo").not_nil!.should be < html.index("Alpha").not_nil!
+      html.index("Alpha").not_nil!.should be < html.index("Charlie").not_nil!
+    end
+
+    it "flips date order to oldest-first with reverse = true" do
+      tax = Hwaro::Models::TaxonomyConfig.new("tags")
+      tax.reverse = true
+      html = generate_term_html.call(tax, tagged_pages.call)
+      html.index("Bravo").not_nil!.should be < html.index("Alpha").not_nil!
+      html.index("Alpha").not_nil!.should be < html.index("Charlie").not_nil!
+    end
+
+    it "orders index terms by count desc (name-asc tiebreak) with terms_sort_by = \"count\"" do
+      tax = Hwaro::Models::TaxonomyConfig.new("tags")
+      tax.terms_sort_by = "count"
+      config = Hwaro::Models::Config.new
+      config.taxonomies = [tax]
+      site = Hwaro::Models::Site.new(config)
+
+      pages = [
+        {"p1.md", ["alpha"]},
+        {"p2.md", ["beta", "gamma"]},
+        {"p3.md", ["beta", "gamma"]},
+      ].map do |(path, tags)|
+        p = Hwaro::Models::Page.new(path)
+        p.title = path
+        p.url = "/blog/#{path}/"
+        p.tags = tags
+        p
+      end
+      site.pages = pages
+
+      Dir.mktmpdir do |output_dir|
+        templates = {
+          "taxonomy"      => "<html>{{ content }}</html>",
+          "taxonomy_term" => "<html>{{ content }}</html>",
+        }
+        Hwaro::Content::Taxonomies.generate(site, output_dir, templates)
+        index = File.read(File.join(output_dir, "tags", "index.html"))
+        # count 2 terms first (beta before gamma by name), then alpha (count 1).
+        index.index(">beta<").not_nil!.should be < index.index(">gamma<").not_nil!
+        index.index(">gamma<").not_nil!.should be < index.index(">alpha<").not_nil!
+      end
+    end
+
+    it "keeps the term feed date-desc when sort_by = \"title\"" do
+      tax = Hwaro::Models::TaxonomyConfig.new("tags")
+      tax.sort_by = "title"
+      tax.feed = true
+      config = Hwaro::Models::Config.new
+      config.base_url = "http://localhost"
+      config.taxonomies = [tax]
+      site = Hwaro::Models::Site.new(config)
+
+      older = Hwaro::Models::Page.new("older.md")
+      older.title = "Aardvark (older)"
+      older.url = "/blog/older/"
+      older.tags = ["crystal"]
+      older.date = Time.utc(2024, 1, 1)
+
+      newer = Hwaro::Models::Page.new("newer.md")
+      newer.title = "Zebra (newer)"
+      newer.url = "/blog/newer/"
+      newer.tags = ["crystal"]
+      newer.date = Time.utc(2024, 6, 1)
+
+      site.pages = [older, newer]
+
+      Dir.mktmpdir do |output_dir|
+        templates = {
+          "taxonomy"      => "<html>{{ content }}</html>",
+          "taxonomy_term" => "<html>{{ content }}</html>",
+        }
+        Hwaro::Content::Taxonomies.generate(site, output_dir, templates)
+
+        # The written term page honors sort_by = "title" (Aardvark first)…
+        term_html = File.read(File.join(output_dir, "tags", "crystal", "index.html"))
+        term_html.index("Aardvark").not_nil!.should be < term_html.index("Zebra").not_nil!
+
+        # …but the term FEED stays reverse-chronological (Zebra first).
+        feed = File.read(File.join(output_dir, "tags", "crystal", "rss.xml"))
+        feed.index("Zebra").not_nil!.should be < feed.index("Aardvark").not_nil!
+      end
+    end
+
+    it "exposes get_taxonomy items name-sorted by default and count-sorted when configured" do
+      config = Hwaro::Models::Config.new
+      config.taxonomies = [Hwaro::Models::TaxonomyConfig.new("tags")]
+      site = Hwaro::Models::Site.new(config)
+
+      p1 = Hwaro::Models::Page.new("p1.md")
+      p1.title = "P1"
+      p1.url = "/blog/p1/"
+      p1.tags = ["zeta", "alpha"]
+      p2 = Hwaro::Models::Page.new("p2.md")
+      p2.title = "P2"
+      p2.url = "/blog/p2/"
+      p2.tags = ["zeta"]
+      site.pages = [p1, p2]
+
+      extract_names = ->(vars : Hash(String, Crinja::Value)) do
+        tags = vars["__taxonomies__"].raw.as(Hash(Crinja::Value, Crinja::Value))["tags"]
+        items = tags.raw.as(Hash(Crinja::Value, Crinja::Value))["items"].raw.as(Array(Crinja::Value))
+        items.map { |item| item.raw.as(Hash(Crinja::Value, Crinja::Value))["name"].to_s }
+      end
+
+      Dir.mktmpdir do |output_dir|
+        templates = {
+          "taxonomy"      => "<html>{{ content }}</html>",
+          "taxonomy_term" => "<html>{{ content }}</html>",
+        }
+        Hwaro::Content::Taxonomies.generate(site, output_dir, templates)
+
+        # Default: alphabetical, regardless of page-scan insertion order.
+        vars = Hwaro::Core::Build::Builder.new.global_template_vars(site)
+        extract_names.call(vars).should eq(["alpha", "zeta"])
+
+        # count: zeta (2 pages) first.
+        config.taxonomies[0].terms_sort_by = "count"
+        vars = Hwaro::Core::Build::Builder.new.global_template_vars(site)
+        extract_names.call(vars).should eq(["zeta", "alpha"])
+      end
+    end
+  end
 end
 
 describe Hwaro::Models::TaxonomyConfig do

--- a/spec/unit/taxonomies_spec.cr
+++ b/spec/unit/taxonomies_spec.cr
@@ -615,16 +615,16 @@ describe Hwaro::Content::Taxonomies do
 
     it "orders a term's pages newest-first by default" do
       html = generate_term_html.call(Hwaro::Models::TaxonomyConfig.new("tags"), tagged_pages.call)
-      html.index("Charlie").not_nil!.should be < html.index("Alpha").not_nil!
-      html.index("Alpha").not_nil!.should be < html.index("Bravo").not_nil!
+      html.index!("Charlie").should be < html.index!("Alpha")
+      html.index!("Alpha").should be < html.index!("Bravo")
     end
 
     it "orders a term's pages by title ascending with sort_by = \"title\"" do
       tax = Hwaro::Models::TaxonomyConfig.new("tags")
       tax.sort_by = "title"
       html = generate_term_html.call(tax, tagged_pages.call)
-      html.index("Alpha").not_nil!.should be < html.index("Bravo").not_nil!
-      html.index("Bravo").not_nil!.should be < html.index("Charlie").not_nil!
+      html.index!("Alpha").should be < html.index!("Bravo")
+      html.index!("Bravo").should be < html.index!("Charlie")
     end
 
     it "reverses the title order with reverse = true" do
@@ -632,24 +632,24 @@ describe Hwaro::Content::Taxonomies do
       tax.sort_by = "title"
       tax.reverse = true
       html = generate_term_html.call(tax, tagged_pages.call)
-      html.index("Charlie").not_nil!.should be < html.index("Bravo").not_nil!
-      html.index("Bravo").not_nil!.should be < html.index("Alpha").not_nil!
+      html.index!("Charlie").should be < html.index!("Bravo")
+      html.index!("Bravo").should be < html.index!("Alpha")
     end
 
     it "orders a term's pages by weight ascending with sort_by = \"weight\"" do
       tax = Hwaro::Models::TaxonomyConfig.new("tags")
       tax.sort_by = "weight"
       html = generate_term_html.call(tax, tagged_pages.call)
-      html.index("Bravo").not_nil!.should be < html.index("Alpha").not_nil!
-      html.index("Alpha").not_nil!.should be < html.index("Charlie").not_nil!
+      html.index!("Bravo").should be < html.index!("Alpha")
+      html.index!("Alpha").should be < html.index!("Charlie")
     end
 
     it "flips date order to oldest-first with reverse = true" do
       tax = Hwaro::Models::TaxonomyConfig.new("tags")
       tax.reverse = true
       html = generate_term_html.call(tax, tagged_pages.call)
-      html.index("Bravo").not_nil!.should be < html.index("Alpha").not_nil!
-      html.index("Alpha").not_nil!.should be < html.index("Charlie").not_nil!
+      html.index!("Bravo").should be < html.index!("Alpha")
+      html.index!("Alpha").should be < html.index!("Charlie")
     end
 
     it "orders index terms by count desc (name-asc tiebreak) with terms_sort_by = \"count\"" do
@@ -680,8 +680,8 @@ describe Hwaro::Content::Taxonomies do
         Hwaro::Content::Taxonomies.generate(site, output_dir, templates)
         index = File.read(File.join(output_dir, "tags", "index.html"))
         # count 2 terms first (beta before gamma by name), then alpha (count 1).
-        index.index(">beta<").not_nil!.should be < index.index(">gamma<").not_nil!
-        index.index(">gamma<").not_nil!.should be < index.index(">alpha<").not_nil!
+        index.index!(">beta<").should be < index.index!(">gamma<")
+        index.index!(">gamma<").should be < index.index!(">alpha<")
       end
     end
 
@@ -717,11 +717,11 @@ describe Hwaro::Content::Taxonomies do
 
         # The written term page honors sort_by = "title" (Aardvark first)…
         term_html = File.read(File.join(output_dir, "tags", "crystal", "index.html"))
-        term_html.index("Aardvark").not_nil!.should be < term_html.index("Zebra").not_nil!
+        term_html.index!("Aardvark").should be < term_html.index!("Zebra")
 
         # …but the term FEED stays reverse-chronological (Zebra first).
         feed = File.read(File.join(output_dir, "tags", "crystal", "rss.xml"))
-        feed.index("Zebra").not_nil!.should be < feed.index("Aardvark").not_nil!
+        feed.index!("Zebra").should be < feed.index!("Aardvark")
       end
     end
 

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -156,7 +156,8 @@ module Hwaro
           # sup) into cell rendering, alongside the existing math flag.
           processed = TableParser.process(
             content,
-            flags: markdown_config ? MarkdownExtensions.inline_flags(markdown_config) : InlineMarkdown::Flags.new)
+            flags: markdown_config ? MarkdownExtensions.inline_flags(markdown_config) : InlineMarkdown::Flags.new,
+            hooks: hooks)
 
           # Pre-process markdown extensions (task lists, footnotes, etc.)
           if md_cfg = markdown_config

--- a/src/content/processors/render_hooks.cr
+++ b/src/content/processors/render_hooks.cr
@@ -280,8 +280,10 @@ module Hwaro
           # highlighting didn't apply — templates choose between
           # `{{ highlighted }}` and `{{ code }}`. `name` is the parsed
           # `{name=...}`/`{title=...}` label ("" when absent) so templates
-          # don't have to re-parse `options`.
-          def render_codeblock(lang : String, options : String, code : String, highlighted : String, name : String = "") : String
+          # don't have to re-parse `options`. `copy` is `"true"` when the
+          # copy button applies to this block ("" otherwise) — templates
+          # decide what markup, if any, to emit for it.
+          def render_codeblock(lang : String, options : String, code : String, highlighted : String, name : String = "", copy : String = "") : String
             hook = @registry.codeblock
             return stock_codeblock(lang, code) unless hook
 
@@ -291,6 +293,7 @@ module Hwaro
             vars["code"] = Crinja::Value.new(code)
             vars["highlighted"] = Crinja::Value.new(highlighted)
             vars["name"] = Crinja::Value.new(name)
+            vars["copy"] = Crinja::Value.new(copy)
             render_hook_template("hooks/render-codeblock", hook, SALT_CODEBLOCK, vars) { stock_codeblock(lang, code) }
           end
 

--- a/src/content/processors/render_hooks.cr
+++ b/src/content/processors/render_hooks.cr
@@ -2,8 +2,9 @@
 #
 # User templates under `templates/hooks/` override how individual Markdown
 # elements render: `render-link.html`, `render-image.html`,
-# `render-heading.html`, `render-codeblock.html`. When none of those
-# templates exist, `RenderHooks.registry` is `nil` and the render path is
+# `render-heading.html`, `render-codeblock.html`, `render-blockquote.html`,
+# `render-table.html`. When none of those templates exist,
+# `RenderHooks.registry` is `nil` and the render path is
 # EXACTLY today's — `HighlightingRenderer` (see `syntax_highlighter.cr`)
 # never branches on hooks at all. `HookedRenderer` (a separate subclass)
 # only comes into play once a registry exists.
@@ -26,12 +27,8 @@ module Hwaro
       module RenderHooks
         extend self
 
-        # The four render hooks implemented today.
-        HOOK_NAMES = {"link", "image", "heading", "codeblock"}
-
-        # Recognized but not yet implemented — `configure` stays silent
-        # about these instead of warning "unknown render hook".
-        FUTURE_HOOK_NAMES = {"blockquote", "table"}
+        # The six render hooks implemented today.
+        HOOK_NAMES = {"link", "image", "heading", "codeblock", "blockquote", "table"}
 
         # One hook template's source plus its on-disk path (for Crinja error
         # locations); `disk_path` is nil only for templates not loaded from
@@ -49,6 +46,8 @@ module Hwaro
           getter image : HookEntry?
           getter heading : HookEntry?
           getter codeblock : HookEntry?
+          getter blockquote : HookEntry?
+          getter table : HookEntry?
 
           # MD5 over sorted "name=source" pairs — folded into the per-page
           # template hash (render.cr#page_template_hash) so editing a hook
@@ -56,7 +55,8 @@ module Hwaro
           getter fingerprint : String
 
           def initialize(@link : HookEntry?, @image : HookEntry?, @heading : HookEntry?,
-                         @codeblock : HookEntry?, @fingerprint : String)
+                         @codeblock : HookEntry?, @blockquote : HookEntry?, @table : HookEntry?,
+                         @fingerprint : String)
             @warned = Set(String).new
             @warned_mutex = Mutex.new
           end
@@ -91,6 +91,8 @@ module Hwaro
           image : HookEntry? = nil
           heading : HookEntry? = nil
           codeblock : HookEntry? = nil
+          blockquote : HookEntry? = nil
+          table : HookEntry? = nil
 
           templates.each_key do |key|
             next unless key.starts_with?("hooks/render-")
@@ -100,18 +102,18 @@ module Hwaro
             entry = {source: templates[key], disk_path: template_paths[key]?}
 
             case hook_name
-            when "link"      then link = entry
-            when "image"     then image = entry
-            when "heading"   then heading = entry
-            when "codeblock" then codeblock = entry
+            when "link"       then link = entry
+            when "image"      then image = entry
+            when "heading"    then heading = entry
+            when "codeblock"  then codeblock = entry
+            when "blockquote" then blockquote = entry
+            when "table"      then table = entry
             else
-              unless FUTURE_HOOK_NAMES.includes?(hook_name)
-                Logger.warn "unknown render hook '#{suffix}' — supported: link, image, heading, codeblock; blockquote/table are planned"
-              end
+              Logger.warn "unknown render hook '#{suffix}' — supported: #{HOOK_NAMES.join(", ")}"
             end
           end
 
-          if link.nil? && image.nil? && heading.nil? && codeblock.nil?
+          if link.nil? && image.nil? && heading.nil? && codeblock.nil? && blockquote.nil? && table.nil?
             @@registry = nil
             return
           end
@@ -121,9 +123,11 @@ module Hwaro
           pairs << "image=#{image[:source]}" if image
           pairs << "heading=#{heading[:source]}" if heading
           pairs << "codeblock=#{codeblock[:source]}" if codeblock
+          pairs << "blockquote=#{blockquote[:source]}" if blockquote
+          pairs << "table=#{table[:source]}" if table
           fingerprint = Digest::MD5.hexdigest(pairs.sort!.join(''))
 
-          @@registry = Registry.new(link, image, heading, codeblock, fingerprint)
+          @@registry = Registry.new(link, image, heading, codeblock, blockquote, table, fingerprint)
         end
 
         # --- Fallback rendering context for feeds/search ---
@@ -156,7 +160,8 @@ module Hwaro
             end
           end
 
-          HookRenderContext.new(reg, env, @@fallback_cache, @@fallback_mutex, page_vars(page, config), config.markdown.mermaid)
+          HookRenderContext.new(reg, env, @@fallback_cache, @@fallback_mutex, page_vars(page, config),
+            config.markdown.mermaid, config.markdown.admonitions)
         end
 
         # Shared page/config variable builder — exactly 6 leaf values, used
@@ -189,10 +194,12 @@ module Hwaro
         class HookRenderContext
           # Distinct per-hook salts — arbitrary, just pairwise distinct and
           # unlikely to collide with the shortcode cache's own salt.
-          SALT_LINK      = 0x4C494E4B_484F4F4B_u64
-          SALT_IMAGE     = 0x494D4147_484F4F4B_u64
-          SALT_HEADING   = 0x48454144_484F4F4B_u64
-          SALT_CODEBLOCK = 0x434F4445_484F4F4B_u64
+          SALT_LINK       = 0x4C494E4B_484F4F4B_u64
+          SALT_IMAGE      = 0x494D4147_484F4F4B_u64
+          SALT_HEADING    = 0x48454144_484F4F4B_u64
+          SALT_CODEBLOCK  = 0x434F4445_484F4F4B_u64
+          SALT_BLOCKQUOTE = 0x424C4F43_484F4F4B_u64
+          SALT_TABLE      = 0x5441424C_484F4F4B_u64
 
           def initialize(
             @registry : Registry,
@@ -201,6 +208,7 @@ module Hwaro
             @cache_mutex : Mutex?,
             @page_vars : Hash(String, Crinja::Value),
             @mermaid_bypass : Bool,
+            @admonition_bypass : Bool = false,
           )
           end
 
@@ -220,6 +228,14 @@ module Hwaro
             !@registry.codeblock.nil?
           end
 
+          def blockquote? : Bool
+            !@registry.blockquote.nil?
+          end
+
+          def table? : Bool
+            !@registry.table.nil?
+          end
+
           # Exposed so cache-key builders (e.g. `render_body_cached`) can
           # fold hook-template changes into their memo key without holding
           # a `Registry` reference of their own.
@@ -232,6 +248,14 @@ module Hwaro
           # codeblock hook when `[markdown] mermaid = true`.
           def mermaid_bypass? : Bool
             @mermaid_bypass
+          end
+
+          # Same idea for `> [!NOTE]`-style blockquotes: with `[markdown]
+          # admonitions = true` they keep rendering the stock shape so
+          # `postprocess_admonitions` can rewrite them, instead of going
+          # through the blockquote hook.
+          def admonition_bypass? : Bool
+            @admonition_bypass
           end
 
           # `destination`/`title` arrive already escaped by the caller
@@ -295,6 +319,38 @@ module Hwaro
             vars["name"] = Crinja::Value.new(name)
             vars["copy"] = Crinja::Value.new(copy)
             render_hook_template("hooks/render-codeblock", hook, SALT_CODEBLOCK, vars) { stock_codeblock(lang, code) }
+          end
+
+          # `text` is the captured, already-rendered inner HTML of the
+          # blockquote (block-level: paragraphs, lists, nested quotes...).
+          def render_blockquote(text : String) : String
+            hook = @registry.blockquote
+            return stock_blockquote(text) unless hook
+
+            vars = @page_vars.dup
+            vars["text"] = Crinja::Value.new(text)
+            render_hook_template("hooks/render-blockquote", hook, SALT_BLOCKQUOTE, vars) { stock_blockquote(text) }
+          end
+
+          # `html` is the complete stock `<table>...</table>` markup;
+          # `header_html`/`body_html` are its `<thead>`/`<tbody>` sections
+          # (body_html is "" for a header-only table) so templates can
+          # rebuild the table without re-parsing `html`. Blank lines are
+          # collapsed out of the result: table hooks run in the pre-markd
+          # line stream (TableParser), where markd ends an HTML block at
+          # the first blank line — a blank line in the hook output would
+          # split the table markup into a truncated HTML block plus
+          # escaped-text leftovers.
+          def render_table(html : String, header_html : String, body_html : String) : String
+            hook = @registry.table
+            return html unless hook
+
+            vars = @page_vars.dup
+            vars["html"] = Crinja::Value.new(html)
+            vars["header_html"] = Crinja::Value.new(header_html)
+            vars["body_html"] = Crinja::Value.new(body_html)
+            result = render_hook_template("hooks/render-table", hook, SALT_TABLE, vars) { html }
+            result.gsub(/\n[ \t]*\n(?:[ \t]*\n)*/, "\n")
           end
 
           private def render_hook_template(template_key : String, hook : HookEntry, salt : UInt64, vars : Hash(String, Crinja::Value), & : -> String) : String
@@ -380,6 +436,18 @@ module Hwaro
               "<pre><code class=\"language-#{lang}\">#{code}</code></pre>"
             end
           end
+
+          # Markd emits `<blockquote>\n` + children + `</blockquote>` with
+          # a newline flushed before the close tag; the captured `text`
+          # normally carries that trailing newline already.
+          private def stock_blockquote(text : String) : String
+            inner = text.ends_with?('\n') ? text : "#{text}\n"
+            "<blockquote>\n#{inner}</blockquote>"
+          end
+
+          # The table hook's stock fallback is the assembled `html` itself
+          # (see `render_table`) — TableParser builds it, so there is no
+          # shape to reconstruct here.
         end
       end
     end

--- a/src/content/processors/syntax_highlighter.cr
+++ b/src/content/processors/syntax_highlighter.cr
@@ -234,8 +234,8 @@ module Hwaro
       end
 
       # Parses the Zola/Pandoc-ish `{linenos=true, hl_lines="2-4 7",
-      # linenostart=5}` fence-info suffix that can follow a fenced code
-      # block's language token.
+      # linenostart=5, hide_lines="1 9-12"}` fence-info suffix that can
+      # follow a fenced code block's language token.
       #
       # Grammar: an info string is `LANG`, `LANG {OPTS}`, `LANG{OPTS}`, or
       # `{OPTS}`. It only ACTIVATES the options path when the stripped info
@@ -250,14 +250,19 @@ module Hwaro
         extend self
 
         # A parsed `{...}` fence-options block.
-        # `hl_lines` is stored as (start, end) ranges — NEVER expanded into
-        # a Set of individual line numbers, so a pathological
-        # `hl_lines="1-100000"` costs a handful of bytes, not 100k Int32s.
+        # `hl_lines` and `hide_lines` are stored as (start, end) ranges —
+        # NEVER expanded into a Set of individual line numbers, so a
+        # pathological `hl_lines="1-100000"` costs a handful of bytes, not
+        # 100k Int32s.
         # `name` is the filename/title label (`{name="main.cr"}`, `title=`
         # accepted as an alias) rendered above the code block.
-        record Options, linenos : Bool? = nil, linenostart : Int32 = 1, hl_lines : Array({Int32, Int32}) = [] of {Int32, Int32}, name : String? = nil do
+        record Options, linenos : Bool? = nil, linenostart : Int32 = 1, hl_lines : Array({Int32, Int32}) = [] of {Int32, Int32}, name : String? = nil, hide_lines : Array({Int32, Int32}) = [] of {Int32, Int32} do
           def hl?(physical_line : Int32) : Bool
             hl_lines.any? { |(a, b)| physical_line >= a && physical_line <= b }
+          end
+
+          def hidden?(physical_line : Int32) : Bool
+            hide_lines.any? { |(a, b)| physical_line >= a && physical_line <= b }
           end
         end
 
@@ -306,6 +311,7 @@ module Hwaro
           linenos : Bool? = nil
           linenostart = 1
           hl_lines = [] of {Int32, Int32}
+          hide_lines = [] of {Int32, Int32}
           name : String? = nil
           recognized = 0
 
@@ -340,6 +346,12 @@ module Hwaro
                 hl_lines = ranges
                 recognized += 1
               end
+            when "hide_lines"
+              ranges = parse_hl_lines(value)
+              unless ranges.empty?
+                hide_lines = ranges
+                recognized += 1
+              end
             else
               # Unknown key — ignored, doesn't count toward activation.
             end
@@ -348,7 +360,7 @@ module Hwaro
           return {legacy_lang, nil} if recognized == 0
 
           lang = stripped[0, brace_index].strip.split.first?.try(&.presence)
-          {lang, Options.new(linenos: linenos, linenostart: linenostart, hl_lines: hl_lines, name: name)}
+          {lang, Options.new(linenos: linenos, linenostart: linenostart, hl_lines: hl_lines, name: name, hide_lines: hide_lines)}
         end
 
         # Scans `key=value` pairs from the start of `inner`. Returns the
@@ -469,14 +481,21 @@ module Hwaro
         # Wraps each physical line of already-highlighted `body` in a
         # `<span class="line">` (` hl` appended for highlighted lines),
         # optionally prefixing a `<span class="ln">` gutter number.
-        # `hl_lines` ranges are matched against the PHYSICAL 1-based line
-        # number — never shifted by `linenostart`.
+        # `hl_lines`/`hide_lines` ranges are matched against the PHYSICAL
+        # 1-based line number — never shifted by `linenostart`.
+        #
+        # Hidden lines are elided from the output but KEEP consuming their
+        # physical line numbers, so the gutter shows gaps (unlike Zola,
+        # which renumbers). This preserves the documented invariant that
+        # `hl_lines` and `linenostart` always target physical lines.
         def wrap(body : String, linenos : Bool, start : Int32, opts : FenceOptions::Options) : String
           lines = split_lines(body)
+          # Gutter width spans the full physical range, elided lines included.
           width = (start + lines.size - 1).to_s.size
 
           String.build do |io|
             lines.each_with_index do |line, i|
+              next if opts.hidden?(i + 1)
               hl = opts.hl?(i + 1)
               io << %(<span class="line) << (hl ? " hl" : "") << %(">)
               if linenos
@@ -533,7 +552,7 @@ module Hwaro
 
           if opts
             linenos = effective_linenos(opts)
-            active = linenos || !opts.hl_lines.empty?
+            active = linenos || !opts.hl_lines.empty? || !opts.hide_lines.empty?
 
             if active && @highlight_enabled && @server_mode
               body = highlight_lang && (highlighted = ServerHighlighter.highlight(node.text, highlight_lang)) ? highlighted : escape(node.text)
@@ -574,7 +593,7 @@ module Hwaro
 
           if opts
             linenos = effective_linenos(opts)
-            active = linenos || !opts.hl_lines.empty?
+            active = linenos || !opts.hl_lines.empty? || !opts.hide_lines.empty?
             # Client-side attrs only: server mode bakes line numbers/hl
             # directly into the body, so the <pre> tag stays untouched.
             if active && !@server_mode
@@ -585,6 +604,10 @@ module Hwaro
               end
               unless opts.hl_lines.empty?
                 pre_tag_attrs["data-hl-lines"] = serialize_hl_lines(opts.hl_lines)
+              end
+              # Documented inert: Hwaro ships no client script acting on it.
+              unless opts.hide_lines.empty?
+                pre_tag_attrs["data-hide-lines"] = serialize_hl_lines(opts.hide_lines)
               end
             end
           end

--- a/src/content/processors/syntax_highlighter.cr
+++ b/src/content/processors/syntax_highlighter.cr
@@ -823,6 +823,34 @@ module Hwaro
           end
         end
 
+        # Matches the first paragraph of a rendered admonition blockquote
+        # (`> [!NOTE]` ...). Built from the same type list the postprocess
+        # regex uses, so the two can't drift apart.
+        ADMONITION_START_RE = /\A\s*<p>\[!(#{MarkdownExtensions::ADMONITION_TYPES.join('|')})\]/
+
+        def block_quote(node : Markd::Node, entering : Bool)
+          return super unless @hooks.blockquote?
+          return super if @disable_tag > 0
+
+          if entering
+            newline
+            push_capture
+          else
+            inner = pop_capture
+            # With `[markdown] admonitions = true`, a `> [!TYPE]` blockquote
+            # keeps the stock shape so ADMONITION_BLOCKQUOTE_RE (see
+            # `postprocess_admonitions`) still rewrites it — config decides
+            # who owns that blockquote, not the hook template.
+            if @hooks.admonition_bypass? && ADMONITION_START_RE.matches?(inner)
+              inner += "\n" unless inner.ends_with?('\n')
+              literal("<blockquote>\n#{inner}</blockquote>")
+            else
+              literal(@hooks.render_blockquote(text: inner))
+            end
+            newline
+          end
+        end
+
         # CodeBlock is a leaf — the walker yields exactly one (entering:
         # true) event for it, matching `HighlightingRenderer#code_block`.
         def code_block(node : Markd::Node, entering : Bool)
@@ -960,7 +988,7 @@ module Hwaro
           # extension passes and passes `tables_preprocessed: true` to skip the
           # redundant per-page scan — the default stays for direct callers of
           # SyntaxHighlighter.render.
-          processed_content = tables_preprocessed ? content : TableParser.process(content)
+          processed_content = tables_preprocessed ? content : TableParser.process(content, hooks: hooks)
 
           options = Markd::Options.new(safe: safe, smart: smart)
           document = Markd::Parser.parse(processed_content, options)

--- a/src/content/processors/syntax_highlighter.cr
+++ b/src/content/processors/syntax_highlighter.cr
@@ -256,7 +256,7 @@ module Hwaro
         # 100k Int32s.
         # `name` is the filename/title label (`{name="main.cr"}`, `title=`
         # accepted as an alias) rendered above the code block.
-        record Options, linenos : Bool? = nil, linenostart : Int32 = 1, hl_lines : Array({Int32, Int32}) = [] of {Int32, Int32}, name : String? = nil, hide_lines : Array({Int32, Int32}) = [] of {Int32, Int32} do
+        record Options, linenos : Bool? = nil, linenostart : Int32 = 1, hl_lines : Array({Int32, Int32}) = [] of {Int32, Int32}, name : String? = nil, hide_lines : Array({Int32, Int32}) = [] of {Int32, Int32}, copy : Bool? = nil do
           def hl?(physical_line : Int32) : Bool
             hl_lines.any? { |(a, b)| physical_line >= a && physical_line <= b }
           end
@@ -313,6 +313,7 @@ module Hwaro
           hl_lines = [] of {Int32, Int32}
           hide_lines = [] of {Int32, Int32}
           name : String? = nil
+          copy : Bool? = nil
           recognized = 0
 
           pairs.each do |key, value|
@@ -330,6 +331,14 @@ module Hwaro
                 recognized += 1
               elsif BOOL_FALSE_RE.matches?(value)
                 linenos = false
+                recognized += 1
+              end
+            when "copy"
+              if BOOL_TRUE_RE.matches?(value)
+                copy = true
+                recognized += 1
+              elsif BOOL_FALSE_RE.matches?(value)
+                copy = false
                 recognized += 1
               end
             when "linenostart"
@@ -360,7 +369,7 @@ module Hwaro
           return {legacy_lang, nil} if recognized == 0
 
           lang = stripped[0, brace_index].strip.split.first?.try(&.presence)
-          {lang, Options.new(linenos: linenos, linenostart: linenostart, hl_lines: hl_lines, name: name, hide_lines: hide_lines)}
+          {lang, Options.new(linenos: linenos, linenostart: linenostart, hl_lines: hl_lines, name: name, hide_lines: hide_lines, copy: copy)}
         end
 
         # Scans `key=value` pairs from the start of `inner`. Returns the
@@ -612,6 +621,16 @@ module Hwaro
             end
           end
 
+          # Copy button marker — BOTH modes (the inline runtime from
+          # `js_tag` targets `pre[data-copy]` regardless of who colored the
+          # code). Never on mermaid fences: `postprocess_mermaid`'s regex
+          # anchors on the bare `<pre><code class="language-mermaid...`
+          # shape, so any attribute on <pre> would break the rewrite.
+          if effective_copy(opts) && lang.try(&.downcase) != "mermaid"
+            pre_tag_attrs ||= {} of String => String
+            pre_tag_attrs["data-copy"] = "true"
+          end
+
           # Filename/title label: a structural wrapper around the untouched
           # <pre> so it composes with server-mode line wrapping AND the
           # client-mode data-* attributes alike. Absent a name, the output
@@ -675,6 +694,15 @@ module Hwaro
         private def effective_linenos(opts : FenceOptions::Options) : Bool
           explicit = opts.linenos
           explicit.nil? ? SyntaxHighlighter.default_line_numbers? : explicit
+        end
+
+        # Same override chain for the copy button (`{copy=...}` wins over
+        # `[highlight] copy`). `opts` can be nil here: unlike the line
+        # options, the global default applies to every fence, options
+        # block or not.
+        private def effective_copy(opts : FenceOptions::Options?) : Bool
+          explicit = opts.try(&.copy)
+          explicit.nil? ? SyntaxHighlighter.default_copy? : explicit
         end
       end
 
@@ -821,6 +849,8 @@ module Hwaro
 
           highlighted = (@highlight_enabled && @server_mode && lang) ? (ServerHighlighter.highlight(node.text, lang) || "") : ""
 
+          copy_active = effective_copy(opts) && lang.try(&.downcase) != "mermaid"
+
           newline
           literal(@hooks.render_codeblock(
             lang: lang ? escape(lang) : "",
@@ -828,6 +858,7 @@ module Hwaro
             code: escape(node.text),
             highlighted: highlighted,
             name: opts.try(&.name).try { |n| escape(n) } || "",
+            copy: copy_active ? "true" : "",
           ))
           newline
         end
@@ -891,9 +922,25 @@ module Hwaro
           @@default_line_numbers
         end
 
+        # Global default for the fence-level copy button (`[highlight]
+        # copy`), same lifecycle as `@@default_line_numbers`.
+        @@default_copy = false
+
+        def default_copy=(value : Bool)
+          @@default_copy = value
+        end
+
+        def default_copy? : Bool
+          @@default_copy
+        end
+
         # Fingerprint of module-level state that changes rendered body HTML.
         def body_fingerprint : String
-          String.build(2) { |io| io << (@@server_mode ? '1' : '0') << (@@default_line_numbers ? '1' : '0') }
+          String.build(3) do |io|
+            io << (@@server_mode ? '1' : '0')
+            io << (@@default_line_numbers ? '1' : '0')
+            io << (@@default_copy ? '1' : '0')
+          end
         end
 
         # Render markdown to HTML with syntax highlighting enabled

--- a/src/content/processors/table_parser.cr
+++ b/src/content/processors/table_parser.cr
@@ -24,6 +24,7 @@
 require "html"
 require "./fence_tracker"
 require "./inline_markdown"
+require "./render_hooks"
 
 module Hwaro
   module Content
@@ -49,10 +50,13 @@ module Hwaro
 
           # Convert table to HTML. `math: true` keeps `$…$` spans in cells
           # untransformed for the later math pass (see InlineMarkdown.render).
-          def to_html(math : Bool = false, flags : InlineMarkdown::Flags? = nil) : String
+          # With a `hooks` context whose table hook is configured, the stock
+          # markup (plus its thead/tbody sections) is handed to
+          # `hooks.render_table` instead of returned directly.
+          def to_html(math : Bool = false, flags : InlineMarkdown::Flags? = nil, hooks : RenderHooks::HookRenderContext? = nil) : String
             effective = flags || InlineMarkdown::Flags.new(math: math)
-            html = String.build do |str|
-              str << "<table>\n"
+
+            header_html = String.build do |str|
               str << "<thead>\n<tr>\n"
 
               @headers.each_with_index do |header, i|
@@ -62,30 +66,38 @@ module Hwaro
               end
 
               str << "</tr>\n</thead>\n"
+            end
 
-              if @rows.present?
-                str << "<tbody>\n"
-                @rows.each do |row|
-                  str << "<tr>\n"
-                  row.each_with_index do |cell, i|
-                    alignment = @alignments[i]? || Alignment::Left
-                    align_attr = alignment_attr(alignment)
-                    str << "<td#{align_attr}>#{render_inline_markdown(cell.strip, effective)}</td>\n"
-                  end
-                  # Fill missing cells if row has fewer columns than headers
-                  if row.size < @headers.size
-                    (@headers.size - row.size).times do |j|
-                      alignment = @alignments[row.size + j]? || Alignment::Left
-                      align_attr = alignment_attr(alignment)
-                      str << "<td#{align_attr}></td>\n"
-                    end
-                  end
-                  str << "</tr>\n"
-                end
-                str << "</tbody>\n"
-              end
+            body_html = if @rows.present?
+                          String.build do |str|
+                            str << "<tbody>\n"
+                            @rows.each do |row|
+                              str << "<tr>\n"
+                              row.each_with_index do |cell, i|
+                                alignment = @alignments[i]? || Alignment::Left
+                                align_attr = alignment_attr(alignment)
+                                str << "<td#{align_attr}>#{render_inline_markdown(cell.strip, effective)}</td>\n"
+                              end
+                              # Fill missing cells if row has fewer columns than headers
+                              if row.size < @headers.size
+                                (@headers.size - row.size).times do |j|
+                                  alignment = @alignments[row.size + j]? || Alignment::Left
+                                  align_attr = alignment_attr(alignment)
+                                  str << "<td#{align_attr}></td>\n"
+                                end
+                              end
+                              str << "</tr>\n"
+                            end
+                            str << "</tbody>\n"
+                          end
+                        else
+                          ""
+                        end
 
-              str << "</table>"
+            html = "<table>\n#{header_html}#{body_html}</table>"
+
+            if hooks && hooks.table?
+              return hooks.render_table(html: html, header_html: header_html, body_html: body_html)
             end
             html
           end
@@ -112,8 +124,10 @@ module Hwaro
         # `math: true` keeps `$…$` spans in cells untransformed for the later
         # math pass. `flags` (when given) takes precedence over `math` and
         # also threads the F10 inline markup flags (ins/mark/sub/sup) into
-        # cell rendering.
-        def process(content : String, *, math : Bool = false, flags : InlineMarkdown::Flags? = nil) : String
+        # cell rendering. `hooks` routes each table through the render-table
+        # hook (see `Table#to_html`); nil keeps the stock output.
+        def process(content : String, *, math : Bool = false, flags : InlineMarkdown::Flags? = nil,
+                    hooks : RenderHooks::HookRenderContext? = nil) : String
           return content unless has_table?(content)
 
           effective = flags || InlineMarkdown::Flags.new(math: math)
@@ -138,7 +152,7 @@ module Hwaro
               # Try to parse the table
               table, consumed = parse_table(lines, i)
               if table
-                result << table.to_html(flags: effective)
+                result << table.to_html(flags: effective, hooks: hooks)
                 i += consumed
                 next
               end

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -150,7 +150,7 @@ module Hwaro
                         else
                           terms_map.keys
                         end
-          render_taxonomy_index(index_page, index_terms.sort!, templates, site, output_dir, builder, verbose, global_vars, slug_map)
+          render_taxonomy_index(index_page, sort_terms(taxonomy, index_terms, terms_map, language, site.config.default_language), templates, site, output_dir, builder, verbose, global_vars, slug_map)
           collected << index_page
 
           terms_map.each do |term, pages|
@@ -164,6 +164,35 @@ module Hwaro
 
             collected << render_taxonomy_term(taxonomy, term, filtered_pages, templates, site, output_dir, builder, verbose, global_vars, slug_map[term], lang_prefix: lang_prefix, language: language)
           end
+        end
+      end
+
+      # Order the index page's terms list per the taxonomy's `terms_sort_by`:
+      # "name" (default) is alphabetical ascending; "count" is page count
+      # descending with a name-ascending tiebreak. Counts use the
+      # language-filtered page lists so a per-language index reflects that
+      # language's own term sizes.
+      private def self.sort_terms(
+        taxonomy : Models::TaxonomyConfig,
+        terms : Array(String),
+        terms_map : Hash(String, Array(Models::Page)),
+        language : String?,
+        default_language : String,
+      ) : Array(String)
+        return terms.sort unless taxonomy.terms_sort_by == "count"
+
+        counts = {} of String => Int32
+        terms.each do |term|
+          pages = terms_map[term]? || [] of Models::Page
+          counts[term] = if language
+                           pages.count { |p| (p.language || default_language) == language }
+                         else
+                           pages.size
+                         end
+        end
+        terms.sort do |a, b|
+          cmp = counts[b] <=> counts[a]
+          cmp == 0 ? (a <=> b) : cmp
         end
       end
 
@@ -197,12 +226,9 @@ module Hwaro
           end
         end
 
-        # Sort each term's pages by date (consistent with global behavior)
-        result.each_value do |terms|
-          terms.each_value do |pages|
-            pages.sort! { |a, b| Utils::SortUtils.compare_by_date(a, b) }
-          end
-        end
+        # Sort each term's pages per its taxonomy's configured order
+        # (consistent with global behavior)
+        sort_taxonomy_pages(result, site.config)
 
         result
       end
@@ -239,9 +265,20 @@ module Hwaro
           end
         end
 
-        site.taxonomies.each_value do |terms|
-          terms.each_value do |pages|
-            pages.sort! { |a, b| Utils::SortUtils.compare_by_date(a, b) }
+        sort_taxonomy_pages(site.taxonomies, config)
+      end
+
+      # Sort every term's page list per its taxonomy's sort_by/reverse
+      # (date-desc for taxonomies not in the config, matching the render
+      # phase's rebuild_taxonomies).
+      private def self.sort_taxonomy_pages(taxonomies : Hash(String, Hash(String, Array(Models::Page))), config : Models::Config)
+        tax_configs = config.taxonomies.index_by(&.name)
+        taxonomies.each do |name, terms|
+          cfg = tax_configs[name]?
+          sort_by = cfg.try(&.sort_by) || "date"
+          reverse = cfg.try(&.reverse) || false
+          terms.each_key do |term|
+            terms[term] = Utils::SortUtils.sort_pages(terms[term], sort_by, reverse)
           end
         end
       end

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -58,6 +58,7 @@ module Hwaro::Core::Build::Phases::Initialize
       # build — read-only afterwards, including by parallel render fibers.
       Content::Processors::SyntaxHighlighter.server_mode = config.highlight.server?
       Content::Processors::SyntaxHighlighter.default_line_numbers = config.highlight.line_numbers
+      Content::Processors::SyntaxHighlighter.default_copy = config.highlight.copy
       # Same pattern for the markdown options template filters consult
       # (markdownify honors the site's safe/smart_punctuation settings).
       Processor::Markdown.filter_markdown_config = config.markdown

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -830,7 +830,8 @@ module Hwaro::Core::Build::Phases::Render
     cache = template_cache_override || @compiled_templates_cache
     cache_mutex = template_cache_override ? nil : @crinja_cache_mutex
     page_vars = Content::Processors::RenderHooks.page_vars(page, site.config)
-    Content::Processors::RenderHooks::HookRenderContext.new(registry, env, cache, cache_mutex, page_vars, site.config.markdown.mermaid)
+    Content::Processors::RenderHooks::HookRenderContext.new(registry, env, cache, cache_mutex, page_vars,
+      site.config.markdown.mermaid, site.config.markdown.admonitions)
   end
 
   # Claim a deterministic owner (page.path) for every output URL. Two passes,

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1707,12 +1707,12 @@ module Hwaro::Core::Build::Phases::Render
       # name-ascending tiebreak.
       tax_cfg = config.taxonomies.find { |t| t.name == name }
       sorted_term_names = if tax_cfg.try(&.terms_sort_by) == "count"
-                            terms.keys.sort do |a, b|
+                            terms.keys.sort! do |a, b|
                               cmp = terms[b].size <=> terms[a].size
                               cmp == 0 ? (a <=> b) : cmp
                             end
                           else
-                            terms.keys.sort
+                            terms.keys.sort!
                           end
       terms_array = sorted_term_names.map do |term|
         term_pages = terms[term]

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1701,7 +1701,21 @@ module Hwaro::Core::Build::Phases::Render
       end
       slug_map = Utils::TextUtils.disambiguated_slugs(written_terms)
       term_slug_values = {} of String => Crinja::Value
-      terms_array = terms.map do |term, term_pages|
+      # Term order matches the taxonomy's `terms_sort_by` (same rule the
+      # written index page uses): "name" = alphabetical (also the default
+      # for unconfigured taxonomy names), "count" = page count descending,
+      # name-ascending tiebreak.
+      tax_cfg = config.taxonomies.find { |t| t.name == name }
+      sorted_term_names = if tax_cfg.try(&.terms_sort_by) == "count"
+                            terms.keys.sort do |a, b|
+                              cmp = terms[b].size <=> terms[a].size
+                              cmp == 0 ? (a <=> b) : cmp
+                            end
+                          else
+                            terms.keys.sort
+                          end
+      terms_array = sorted_term_names.map do |term|
+        term_pages = terms[term]
         term_pages_array = term_pages.map do |tp|
           cached_page_crinja_value(tp, default_lang)
         end

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -264,10 +264,15 @@ module Hwaro::Core::Build::Phases::Transform
       end
     end
 
-    # Sort pages in taxonomies in-place (default by date)
-    site.taxonomies.each_value do |terms|
+    # Sort pages in taxonomies in-place (per-taxonomy sort_by/reverse,
+    # default date-desc for unconfigured names)
+    tax_configs = site.config.taxonomies.index_by(&.name)
+    site.taxonomies.each do |name, terms|
+      cfg = tax_configs[name]?
+      sort_by = cfg.try(&.sort_by) || "date"
+      reverse = cfg.try(&.reverse) || false
       terms.each_key do |term|
-        terms[term] = Utils::SortUtils.sort_pages(terms[term], "date", false)
+        terms[term] = Utils::SortUtils.sort_pages(terms[term], sort_by, reverse)
       end
     end
   end
@@ -370,10 +375,12 @@ module Hwaro::Core::Build::Phases::Transform
       end
     end
 
-    # 3. Re-sort only affected terms
+    # 3. Re-sort only affected terms (same per-taxonomy order as the full rebuild)
+    tax_configs = site.config.taxonomies.index_by(&.name)
     affected_tax_keys.each do |(name, term)|
       if pages_list = site.taxonomies[name]?.try(&.[term]?)
-        site.taxonomies[name][term] = Utils::SortUtils.sort_pages(pages_list, "date", false)
+        cfg = tax_configs[name]?
+        site.taxonomies[name][term] = Utils::SortUtils.sort_pages(pages_list, cfg.try(&.sort_by) || "date", cfg.try(&.reverse) || false)
       end
     end
 

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -517,9 +517,10 @@ module Hwaro
       property enabled : Bool
       property theme : String
       property use_cdn : Bool
-      # "client" injects Highlight.js and highlights in the browser;
-      # "server" highlights at build time (Tartrazine lexers, hljs-compatible
-      # CSS classes) so no JavaScript ships — theme CSS keeps working either way.
+      # "server" (default) highlights at build time (Tartrazine lexers,
+      # hljs-compatible CSS classes) so no JavaScript ships; "client" injects
+      # Highlight.js and highlights in the browser — theme CSS keeps working
+      # either way.
       property mode : String
       # Global default for fence-level `linenos` (see FenceOptions): when
       # true, every fenced code block with a language gets line numbers
@@ -531,7 +532,7 @@ module Hwaro
         @enabled = true
         @theme = "github"
         @use_cdn = true
-        @mode = "client"
+        @mode = "server"
         @line_numbers = false
       end
 
@@ -1640,7 +1641,7 @@ module Hwaro
           if mode == "client" || mode == "server"
             config.highlight.mode = mode
           else
-            Logger.warn "Unknown highlight.mode '#{mode}' — expected \"client\" or \"server\". Using \"client\"."
+            Logger.warn "Unknown highlight.mode '#{mode}' — expected \"client\" or \"server\". Using \"server\"."
           end
         end
       end

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -574,13 +574,18 @@ module Hwaro
       end
 
       # Copy-to-clipboard runtime for `pre[data-copy]` blocks: one DOM pass
-      # on DOMContentLoaded wraps each block (position anchor), appends a
-      # button, and copies the code's textContent on click. Theme-neutral —
+      # on DOMContentLoaded, appends a button, and copies the code's text on
+      # click. An existing `.code-block` (named fences) or `.code-wrapper`
+      # parent is reused as the positioning anchor — inserting a new wrapper
+      # inside `.code-block` would break its `.code-block > pre` styling —
+      # otherwise the <pre> is wrapped in a fresh `.code-wrapper`. Copied
+      # text strips the baked-in `.ln` line-number gutter spans (server-mode
+      # `linenos`) so pasted code has no number prefixes. Theme-neutral —
       # currentColor only, revealed on hover/focus — and small enough to
       # inline, so no extra request in either highlight mode.
       COPY_SNIPPET = <<-HTML
-        <style>.code-wrapper{position:relative}.code-copy-btn{position:absolute;top:.4rem;right:.4rem;padding:.25rem .6rem;font:inherit;font-size:.75rem;color:inherit;background:transparent;border:1px solid currentColor;border-radius:.25rem;opacity:0;cursor:pointer;transition:opacity .15s}.code-wrapper:hover .code-copy-btn,.code-copy-btn:focus-visible,.code-copy-btn.copied{opacity:.75}</style>
-        <script>document.addEventListener("DOMContentLoaded",function(){document.querySelectorAll("pre[data-copy]").forEach(function(pre){var w=pre.parentNode;if(!w.classList||!w.classList.contains("code-wrapper")){w=document.createElement("div");w.className="code-wrapper";pre.parentNode.insertBefore(w,pre);w.appendChild(pre);}var b=document.createElement("button");b.type="button";b.className="code-copy-btn";b.textContent="Copy";b.setAttribute("aria-label","Copy code");b.addEventListener("click",function(){var c=pre.querySelector("code");navigator.clipboard.writeText(c?c.textContent:pre.textContent).then(function(){b.classList.add("copied");b.textContent="Copied!";setTimeout(function(){b.classList.remove("copied");b.textContent="Copy";},2000);});});w.appendChild(b);});});</script>
+        <style>.code-wrapper,.code-block{position:relative}.code-copy-btn{position:absolute;top:.4rem;right:.4rem;padding:.25rem .6rem;font:inherit;font-size:.75rem;color:inherit;background:transparent;border:1px solid currentColor;border-radius:.25rem;opacity:0;cursor:pointer;transition:opacity .15s}.code-wrapper:hover .code-copy-btn,.code-block:hover .code-copy-btn,.code-copy-btn:focus-visible,.code-copy-btn.copied{opacity:.75}</style>
+        <script>document.addEventListener("DOMContentLoaded",function(){document.querySelectorAll("pre[data-copy]").forEach(function(pre){var w=pre.parentNode;var l=w.classList;if(!l||!(l.contains("code-wrapper")||l.contains("code-block"))){w=document.createElement("div");w.className="code-wrapper";pre.parentNode.insertBefore(w,pre);w.appendChild(pre);}var b=document.createElement("button");b.type="button";b.className="code-copy-btn";b.textContent="Copy";b.setAttribute("aria-label","Copy code");b.addEventListener("click",function(){var c=pre.querySelector("code");var t;if(c){var k=c.cloneNode(true);k.querySelectorAll("span.ln").forEach(function(n){n.remove();});t=k.textContent;}else{t=pre.textContent;}navigator.clipboard.writeText(t).then(function(){b.classList.add("copied");b.textContent="Copied!";setTimeout(function(){b.classList.remove("copied");b.textContent="Copy";},2000);});});w.appendChild(b);});});</script>
         HTML
 
       # Generate both CSS and JS tags

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -527,6 +527,10 @@ module Hwaro
       # unless it opts out with a per-block `{linenos=false}`. Off by
       # default so existing output is unaffected.
       property line_numbers : Bool
+      # Adds a copy-to-clipboard button to fenced code blocks (per-block
+      # `{copy=false}`/`{copy=true}` overrides). Off by default so existing
+      # output is byte-identical.
+      property copy : Bool
 
       def initialize
         @enabled = true
@@ -534,6 +538,7 @@ module Hwaro
         @use_cdn = true
         @mode = "server"
         @line_numbers = false
+        @copy = false
       end
 
       # True when code is highlighted at build time (no client-side JS).
@@ -554,17 +559,29 @@ module Hwaro
       end
 
       # Generate the JS script tag for highlighting.
-      # Server-side highlighting needs no JavaScript at all.
+      # Server-side highlighting needs no JavaScript at all — unless the
+      # copy button is on, whose (dependency-free) runtime ships either way.
       def js_tag(cache_bust : String = "") : String
         return "" unless @enabled
-        return "" if server?
-        if @use_cdn
-          %(<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>\n<script>hljs.highlightAll();</script>)
-        else
-          suffix = Models.cache_bust_suffix(cache_bust)
-          %(<script src="/assets/js/highlight.min.js#{suffix}"></script>\n<script>hljs.highlightAll();</script>)
-        end
+        return copy ? COPY_SNIPPET : "" if server?
+        hljs = if @use_cdn
+                 %(<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>\n<script>hljs.highlightAll();</script>)
+               else
+                 suffix = Models.cache_bust_suffix(cache_bust)
+                 %(<script src="/assets/js/highlight.min.js#{suffix}"></script>\n<script>hljs.highlightAll();</script>)
+               end
+        copy ? "#{hljs}\n#{COPY_SNIPPET}" : hljs
       end
+
+      # Copy-to-clipboard runtime for `pre[data-copy]` blocks: one DOM pass
+      # on DOMContentLoaded wraps each block (position anchor), appends a
+      # button, and copies the code's textContent on click. Theme-neutral —
+      # currentColor only, revealed on hover/focus — and small enough to
+      # inline, so no extra request in either highlight mode.
+      COPY_SNIPPET = <<-HTML
+        <style>.code-wrapper{position:relative}.code-copy-btn{position:absolute;top:.4rem;right:.4rem;padding:.25rem .6rem;font:inherit;font-size:.75rem;color:inherit;background:transparent;border:1px solid currentColor;border-radius:.25rem;opacity:0;cursor:pointer;transition:opacity .15s}.code-wrapper:hover .code-copy-btn,.code-copy-btn:focus-visible,.code-copy-btn.copied{opacity:.75}</style>
+        <script>document.addEventListener("DOMContentLoaded",function(){document.querySelectorAll("pre[data-copy]").forEach(function(pre){var w=pre.parentNode;if(!w.classList||!w.classList.contains("code-wrapper")){w=document.createElement("div");w.className="code-wrapper";pre.parentNode.insertBefore(w,pre);w.appendChild(pre);}var b=document.createElement("button");b.type="button";b.className="code-copy-btn";b.textContent="Copy";b.setAttribute("aria-label","Copy code");b.addEventListener("click",function(){var c=pre.querySelector("code");navigator.clipboard.writeText(c?c.textContent:pre.textContent).then(function(){b.classList.add("copied");b.textContent="Copied!";setTimeout(function(){b.classList.remove("copied");b.textContent="Copy";},2000);});});w.appendChild(b);});});</script>
+        HTML
 
       # Generate both CSS and JS tags
       def tags(cache_bust : String = "") : String
@@ -1637,6 +1654,7 @@ module Hwaro
         config.highlight.theme = s["theme"]?.try(&.as_s?) || config.highlight.theme
         config.highlight.use_cdn = bool_value(s["use_cdn"]?, config.highlight.use_cdn)
         config.highlight.line_numbers = bool_value(s["line_numbers"]?, config.highlight.line_numbers)
+        config.highlight.copy = bool_value(s["copy"]?, config.highlight.copy)
         if mode = s["mode"]?.try(&.as_s?)
           if mode == "client" || mode == "server"
             config.highlight.mode = mode

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -596,6 +596,17 @@ module Hwaro
       property feed : Bool
       property sitemap : Bool
       property paginate_by : Int32?
+      # Ordering of pages within a term ("date", "title", "weight") —
+      # section semantics: date is newest-first, title/weight ascend, and
+      # `reverse` flips whichever order `sort_by` produced. Term FEEDS are
+      # exempt: RSS consumers assume reverse-chronological, so they stay
+      # date-desc regardless.
+      property sort_by : String = "date"
+      property reverse : Bool = false
+      # Ordering of the terms list (taxonomy index page + `get_taxonomy`
+      # items): "name" = alphabetical, "count" = page count descending
+      # (name-ascending tiebreak).
+      property terms_sort_by : String = "name"
 
       def initialize(@name : String)
         @feed = false
@@ -1780,6 +1791,21 @@ module Hwaro
           taxonomy.feed = bool_value(taxonomy_hash["feed"]?, taxonomy.feed)
           taxonomy.sitemap = bool_value(taxonomy_hash["sitemap"]?, taxonomy.sitemap)
           taxonomy.paginate_by = taxonomy_hash["paginate_by"]?.try { |v| int_or_nil(v) }
+          if sort_by = taxonomy_hash["sort_by"]?.try(&.as_s?)
+            if {"date", "title", "weight"}.includes?(sort_by)
+              taxonomy.sort_by = sort_by
+            else
+              Logger.warn "Unknown taxonomy sort_by '#{sort_by}' for '#{name}' — expected \"date\", \"title\" or \"weight\". Using \"date\"."
+            end
+          end
+          taxonomy.reverse = bool_value(taxonomy_hash["reverse"]?, taxonomy.reverse)
+          if terms_sort_by = taxonomy_hash["terms_sort_by"]?.try(&.as_s?)
+            if {"name", "count"}.includes?(terms_sort_by)
+              taxonomy.terms_sort_by = terms_sort_by
+            else
+              Logger.warn "Unknown taxonomy terms_sort_by '#{terms_sort_by}' for '#{name}' — expected \"name\" or \"count\". Using \"name\"."
+            end
+          end
           taxonomy
         end
       end

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -255,10 +255,12 @@ module Hwaro
             # =============================================================================
             # Syntax Highlighting
             # =============================================================================
-            # Code block syntax highlighting using Highlight.js
+            # Code blocks are highlighted at build time (no JavaScript);
+            # set mode = "client" to highlight in the browser with Highlight.js
 
             # [highlight]
             # enabled = true
+            # mode = "server"
             # theme = "github"
             # use_cdn = true
             # line_numbers = false
@@ -270,15 +272,15 @@ module Hwaro
             # =============================================================================
             # Syntax Highlighting
             # =============================================================================
-            # Code blocks are highlighted in the browser by Highlight.js and themed by
-            # an inlined, ember-warm theme in the scaffold's CSS (so you recolor syntax
-            # by editing that CSS, not the `theme` below). `mode = "server"` can
-            # highlight at build time with no JS, but its Tartrazine backend isn't
-            # multi-thread-safe, so the scaffold default stays "client".
+            # Code blocks are highlighted at build time (hljs-compatible CSS classes,
+            # no JavaScript shipped) and themed by an inlined, ember-warm theme in the
+            # scaffold's CSS (so you recolor syntax by editing that CSS, not the
+            # `theme` below). Set `mode = "client"` to opt back into browser-side
+            # Highlight.js instead.
 
             [highlight]
             enabled = true
-            mode = "client"           # "client" = Highlight.js in the browser; "server" = build-time (no JS)
+            mode = "server"           # "server" = build-time (no JS); "client" = Highlight.js in the browser
             theme = "github"          # Highlight.js theme name; the scaffold's inlined CSS overrides its colors
             use_cdn = true            # true loads Highlight.js from a CDN; false expects a self-hosted build
             line_numbers = false      # true adds line numbers to every fenced code block (override per-block with {linenos=false})

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -264,6 +264,7 @@ module Hwaro
             # theme = "github"
             # use_cdn = true
             # line_numbers = false
+            # copy = false
 
             TOML
         else
@@ -284,6 +285,7 @@ module Hwaro
             theme = "github"          # Highlight.js theme name; the scaffold's inlined CSS overrides its colors
             use_cdn = true            # true loads Highlight.js from a CDN; false expects a self-hosted build
             line_numbers = false      # true adds line numbers to every fenced code block (override per-block with {linenos=false})
+            copy = true               # copy-to-clipboard button on code blocks (default false; override per-block with {copy=...})
 
             TOML
         end

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -440,6 +440,7 @@ module Hwaro
             str << "mode = \"server\"\n"
             str << "theme = \"github\"\n"
             str << "use_cdn = true\n"
+            str << "copy = true\n"
             unless skip_taxonomies
               str << "\n[[taxonomies]]\n"
               str << "name = \"tags\"\n"

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -437,7 +437,7 @@ module Hwaro
             str << "allow_extensions = [\"jpg\", \"jpeg\", \"png\", \"gif\", \"svg\", \"webp\"]\n"
             str << "\n[highlight]\n"
             str << "enabled = true\n"
-            str << "mode = \"client\"\n"
+            str << "mode = \"server\"\n"
             str << "theme = \"github\"\n"
             str << "use_cdn = true\n"
             unless skip_taxonomies

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -1854,7 +1854,7 @@ module Hwaro
             ```toml
             [highlight]
             enabled = true
-            mode = "client"   # Highlight.js in the browser; "server" highlights at build time
+            mode = "server"   # highlights at build time (no JS); "client" uses Highlight.js in the browser
             theme = "github"
             use_cdn = true
             ```

--- a/src/services/scaffolds/design_tokens.cr
+++ b/src/services/scaffolds/design_tokens.cr
@@ -204,15 +204,19 @@ module Hwaro
             pre code .ln { user-select: none; -webkit-user-select: none; opacity: .45; }
 
             /* Fence filename label: {name="main.cr"} / {title="..."} */
-            .code-block { margin: var(--space-md, 1rem) 0; }
+            .code-block { position: relative; margin: var(--space-md, 1rem) 0; }
             .code-block > pre { margin: 0; border-top-left-radius: 0; border-top-right-radius: 0; }
             .code-filename { padding: 0.35rem 0.85rem; font-family: var(--font-mono, monospace); font-size: 0.78rem; color: var(--text-muted); background: color-mix(in srgb, var(--code-bg, var(--surface)) 88%, var(--text-muted)); border: 1px solid var(--border); border-bottom: 0; border-radius: var(--radius-sm) var(--radius-sm) 0 0; }
 
-            /* Copy button: [highlight] copy / {copy=true} — overrides the inline theme-neutral styles from {{ highlight_js }} */
+            /* Copy button: [highlight] copy / {copy=true}. The theme-neutral inline
+               styles from {{ highlight_js }} ship in-body AFTER this stylesheet, so
+               at equal specificity they would win — the doubled .code-copy-btn class
+               keeps every token-based rule here strictly more specific. Named blocks
+               anchor the button on .code-block itself (no extra wrapper). */
             .code-wrapper { position: relative; }
-            .code-copy-btn { position: absolute; top: 0.45rem; right: 0.45rem; padding: 0.25rem 0.6rem; font-family: var(--font-mono, monospace); font-size: 0.72rem; color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); opacity: 0; cursor: pointer; transition: opacity 0.15s ease; }
-            .code-wrapper:hover .code-copy-btn, .code-copy-btn:focus-visible { opacity: 1; }
-            .code-copy-btn.copied { opacity: 1; color: var(--code-string); border-color: var(--code-string); }
+            .code-copy-btn.code-copy-btn { position: absolute; top: 0.45rem; right: 0.45rem; padding: 0.25rem 0.6rem; font-family: var(--font-mono, monospace); font-size: 0.72rem; color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); opacity: 0; cursor: pointer; transition: opacity 0.15s ease; }
+            .code-wrapper:hover .code-copy-btn.code-copy-btn, .code-block:hover .code-copy-btn.code-copy-btn, .code-copy-btn.code-copy-btn:focus-visible { opacity: 1; }
+            .code-copy-btn.code-copy-btn.copied { opacity: 1; color: var(--code-string); border-color: var(--code-string); }
             CSS
         end
 

--- a/src/services/scaffolds/design_tokens.cr
+++ b/src/services/scaffolds/design_tokens.cr
@@ -207,6 +207,12 @@ module Hwaro
             .code-block { margin: var(--space-md, 1rem) 0; }
             .code-block > pre { margin: 0; border-top-left-radius: 0; border-top-right-radius: 0; }
             .code-filename { padding: 0.35rem 0.85rem; font-family: var(--font-mono, monospace); font-size: 0.78rem; color: var(--text-muted); background: color-mix(in srgb, var(--code-bg, var(--surface)) 88%, var(--text-muted)); border: 1px solid var(--border); border-bottom: 0; border-radius: var(--radius-sm) var(--radius-sm) 0 0; }
+
+            /* Copy button: [highlight] copy / {copy=true} — overrides the inline theme-neutral styles from {{ highlight_js }} */
+            .code-wrapper { position: relative; }
+            .code-copy-btn { position: absolute; top: 0.45rem; right: 0.45rem; padding: 0.25rem 0.6rem; font-family: var(--font-mono, monospace); font-size: 0.72rem; color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); opacity: 0; cursor: pointer; transition: opacity 0.15s ease; }
+            .code-wrapper:hover .code-copy-btn, .code-copy-btn:focus-visible { opacity: 1; }
+            .code-copy-btn.copied { opacity: 1; color: var(--code-string); border-color: var(--code-string); }
             CSS
         end
 


### PR DESCRIPTION
## Summary

Workstream ② of the Jekyll/Zola gap-closing effort — five features in commit-per-feature layout.

### 1. `[highlight] mode` defaults to `"server"` (⚠️ breaking)
Code now highlights at build time by default (Tartrazine, 250+ lexers, hljs-compatible classes) and `{{ highlight_js }}` renders empty — no JavaScript ships. Jekyll (Rouge) and Zola both highlight at build time by default; hwaro's client default also left fence options (`linenos`, `hl_lines`) as inert `data-*` attributes with no shipped JS.
- Sites using `{{ highlight_css }}`/`{{ highlight_tags }}` need no changes (theme CSS still emitted, same classes)
- `mode = "client"` restores browser-side Highlight.js (e.g. for hljs plugins or languages Tartrazine lacks)
- Unknown-mode fallback is now `"server"`; scaffolds/config snippets updated (incl. removing the stale "Tartrazine isn't MT-safe" comment); cache invalidation is automatic via the existing body fingerprint

### 2. `hide_lines="2-4 7"` fence option
Elides lines from rendered blocks (server mode). Gutter numbers keep their physical positions (gaps) so `hl_lines`/`linenostart` semantics stay physical-line-based — deliberate difference from Zola's renumbering, documented. Client mode emits `data-hide-lines` for symmetry.

### 3. Copy-to-clipboard button (Zola 0.21 parity)
`[highlight] copy = true` global + per-fence `{copy=true/false}` override. Build-time `data-copy` marker + a small dependency-free inline runtime injected via `{{ highlight_js }}` (works in both modes, theme-neutral, hover-reveal). Mermaid fences are excluded (an attribute on `<pre>` would break the mermaid postprocess regex — spec-guarded). Scaffolds enable it and ship token-based button styles; output is byte-identical when off.

### 4. `render-blockquote.html` + `render-table.html` hooks
Completes the planned render-hook set (was `FUTURE_HOOK_NAMES`).
- Blockquote: markd AST capture (same pattern as heading); GitHub admonition blockquotes (`> [!NOTE]`) bypass the hook so the admonition pipeline keeps working (rule documented)
- Table: tables aren't markd nodes, so the hook is threaded through `TableParser` — context gets `html`, `header_html`, `body_html`; blank lines in hook output are collapsed (html-block splitting hazard, documented)

### 5. Configurable taxonomy sorting
`[[taxonomies]]` gains `sort_by = "date"|"title"|"weight"` + `reverse` (pages within a term; threaded through full/incremental transform, index build, and multilingual paths) and `terms_sort_by = "name"|"count"` (term lists). Term feeds stay newest-first regardless (RSS consumers assume reverse-chronological). Also fixes a latent inconsistency: `get_taxonomy().items` was hash-insertion-ordered while the index page sorted alphabetically — both now honor `terms_sort_by` (Changed entry in CHANGELOG).

## Testing
- Full suite: 6362 examples, 0 failures; `crystal tool format --check` + ameba clean
- New/updated specs across config defaults, fence parsing, LineWrapper elision/gap numbering, copy matrix (incl. mermaid exclusion + byte-identical-off), blockquote/table hooks (admonition bypass, blank-line collapse, error fallback), taxonomy sort orders and feed exemption
- A global spec-side reset for highlighter module state was added — with server as the config default, builds flip module flags that previously leaked across spec files

🤖 Generated with [Claude Code](https://claude.com/claude-code)