### PR TITLE
fix: feature-audit fixes for sass, highlight, and permalinks/links/feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,22 @@
 - Markdown render hooks for blockquotes and tables: `templates/hooks/render-blockquote.html` (`text`) and `templates/hooks/render-table.html` (`html`, `header_html`, `body_html`). GitHub-style `> [!NOTE]` blockquotes keep the admonition pipeline while `[markdown] admonitions = true`; the codeblock hook gains `copy`
 - Taxonomy sorting: per-taxonomy `sort_by` (`date`/`title`/`weight`) and `reverse` order the pages within each term (section semantics — date is newest-first, `reverse` flips), `terms_sort_by` (`name`/`count`) orders the terms list. Term feeds stay reverse-chronological regardless
 
-- Hugo-style token permalinks: `[permalinks]` values may contain `:year`/`:month`/`:day`/`:slug`/`:title`/`:section`/`:filename` segments that rebuild the whole URL for leaf pages (`"posts" = "/:year/:month/:day/:slug/"`); plain values keep the existing directory-remap semantics, unknown tokens fail the config load, and a dateless page under a date-token pattern fails the build with a fix-it hint
+- Hugo-style token permalinks: `[permalinks]` values may contain `:year`/`:month`/`:day`/`:slug`/`:title`/`:section`/`:filename` segments that rebuild the whole URL for leaf pages (`"posts" = "/:year/:month/:day/:slug/"`); plain values keep the existing directory-remap semantics, unknown tokens fail the config load, and a dateless page under a date-token pattern fails the build with a fix-it hint (pages that never publish — filtered drafts, expired/future, `render: false` — are exempt)
 - `[links] broken_internal = "error"` fails the build (exit code 5) with one aggregated list of every unresolved `@/` internal link — `source.md → @/target (reason)` per line; the default `"warn"` keeps today's log-and-continue behavior
 - Custom feed templates: `templates/rss.xml.jinja` / `atom.xml.jinja` override the built-in feed markup for all feed kinds (main, per-section, per-language, per-taxonomy-term) with a precomputed context (absolute encoded URLs, RFC 822/3339 dates, summaries, absolutized HTML); the built-in output remains the fallback when no template exists, and feed-template edits refresh feeds on warm `--cache` builds and `serve` re-renders
 
 ### Changed
 - **Breaking:** `[highlight] mode` now defaults to `"server"` — code blocks are highlighted at build time (Tartrazine, same `hljs-*` classes, theme CSS keeps working) and `{{ highlight_js }}` renders empty by default. Set `mode = "client"` to restore browser-side Highlight.js; all pages re-render once after upgrading
 - `get_taxonomy().items` is now name-sorted (alphabetical) by default instead of unspecified insertion order; set `terms_sort_by = "count"` for count-descending
+
+### Fixed
+- Copy button: per-fence `{copy=true}` with the global `[highlight] copy` default off now works — the runtime is appended to `{{ highlight_js }}` only on pages that contain an opted-in block; `data-copy` is no longer stamped when highlighting is disabled
+- `{hide_lines=…}` is honored on the `render-codeblock` hook path: hidden lines are removed from both `highlighted` and `code` before the template sees them (server mode)
+- Table render hooks saved with CRLF line endings no longer break the emitted HTML block (blank-line collapse handles `\r\n`)
+- Sass: `#{...}` interpolation unquotes string values (dart-sass parity) instead of shipping embedded quotes as invalid CSS; passing a block to a mixin without `@content` is a located error instead of silently dropping the block's styles; a UTF-8 BOM in an imported partial no longer corrupts its first selector; pathological block nesting fails with a located error instead of a process-killing stack overflow; symlink-loop/permission errors during import resolution surface as classified content errors; a `foo.scss`/`foo.css` name collision under `static/` warns instead of silently overwriting
+- Token permalinks: a dateless draft / `render: false` page matching a date-token pattern no longer aborts the build — the error now fires only for pages that actually publish (full builds and serve rebuilds alike)
+- Feeds advertise the same page the build writes when two pages collide on one URL (path-sort-first winner, matching `compute_output_url_winners`)
+- `[links] broken_internal = "error"` now also catches broken `@/` links that ship via `render: false` pages' `<!-- more -->` summaries embedded in listings
 
 ## v0.17.1
 

--- a/docs/content/features/seo.md
+++ b/docs/content/features/seo.md
@@ -145,7 +145,7 @@ To take full control of the feed markup, create a template named after the feed 
 | RSS | `templates/rss.xml.jinja` | `rss.xml` |
 | Atom | `templates/atom.xml.jinja` | `atom.xml` |
 
-Any template extension works (`.jinja`, `.j2`, `.jinja2`, `.html`, `.ecr`) — only the final extension is stripped, so `rss.xml.jinja` loads under the key `rss.xml`. The template file itself is the opt-in: when it's absent, Hwaro emits its built-in feed exactly as before, and deleting the template falls back to the built-in output. The override applies to **all four feed kinds** — the main feed, per-section feeds, per-language feeds, and per-taxonomy-term feeds — and a custom `[feeds] filename` still controls the output path.
+Any template extension works (`.jinja`, `.j2`, `.jinja2`, `.html`) — only the final extension is stripped, so `rss.xml.jinja` loads under the key `rss.xml`. Whatever the extension, the file is always rendered as **Jinja** (an `.ecr` file is picked up too, but ECR `<%= %>` tags pass through as literal text — use Jinja syntax). The template file itself is the opt-in: when it's absent, Hwaro emits its built-in feed exactly as before, and deleting the template falls back to the built-in output. The override applies to **all four feed kinds** — the main feed, per-section feeds, per-language feeds, and per-taxonomy-term feeds — and a custom `[feeds] filename` still controls the output path.
 
 `{% include %}` works inside feed templates, and a broken template fails the build with a template error naming the file.
 

--- a/docs/content/features/syntax-highlighting.md
+++ b/docs/content/features/syntax-highlighting.md
@@ -184,7 +184,11 @@ copy = true
 
 The markup contract: each opted-in block's `<pre>` gets a
 `data-copy="true"` attribute, and `{{ highlight_js }}` injects a small
-inline, dependency-free runtime (works in both server and client mode)
+inline, dependency-free runtime (works in both server and client mode).
+With `copy = true` the runtime ships site-wide; with the global default
+off, pages whose body contains an opted-in block get it appended to
+their own `{{ highlight_js }}` — pages without one stay JavaScript-free.
+The runtime
 that wraps each `pre[data-copy]` in a `<div class="code-wrapper">` —
 reusing an existing `.code-block` wrapper (named fences) as the anchor
 instead — appends a `<button class="code-copy-btn">`, and copies the

--- a/docs/content/start/config.md
+++ b/docs/content/start/config.md
@@ -139,7 +139,7 @@ Notes:
 
 - Tokens must be whole path segments; unknown tokens fail the config load.
 - Patterns apply to leaf pages only. Section `_index` and bundle `index` pages skip pattern rules (they keep their directory URL, or a later plain remap rule).
-- A page without a `date` that matches a pattern using `:year`/`:month`/`:day` fails the build — add a date, set an explicit `path` in front matter, or drop the date tokens.
+- A page without a `date` that matches a pattern using `:year`/`:month`/`:day` fails the build — add a date, set an explicit `path` in front matter, or drop the date tokens. Pages that never publish are exempt: drafts (without `--drafts`), expired/future-dated pages, and headless `render: false` pages don't block the build.
 - An explicit `path` in front matter always wins over any permalink rule.
 - An empty source key (`""` or `"/"`) makes a pattern rule a catch-all for every page — declare it last, since first-match ordering means it would shadow any rule after it.
 - For non-default languages the `/lang/` prefix comes first: `/ko/2026/03/05/hello/`.

--- a/docs/content/templates/render-hooks.md
+++ b/docs/content/templates/render-hooks.md
@@ -61,7 +61,7 @@ All values are Crinja `Value`s and — like every other hwaro template — **alr
 | `lang` | The fence's language token, escaped (`python` in `` ```python ``). Empty string for a fence with no language |
 | `options` | The raw Zola/Pandoc-style `{...}` options block after the language (see [Syntax Highlighting](/features/syntax-highlighting/)), or any trailing info-string text when there's no `{...}` block. Escaped |
 | `code` | The fence body, HTML-escaped |
-| `highlighted` | The server-mode syntax-highlighted body (hljs-class spans), or an empty string when `[highlight] mode` isn't `"server"`, highlighting is off, or the language has no lexer |
+| `highlighted` | The server-mode syntax-highlighted body (hljs-class spans), or an empty string when `[highlight] mode` isn't `"server"`, highlighting is off, or the language has no lexer. A `{hide_lines=…}` fence option is already applied — hidden lines never reach the template (nor `code`) in server mode |
 | `name` | The parsed `{name=...}`/`{title=...}` filename label, escaped. Empty string when absent |
 | `copy` | `"true"` when the copy button applies to this block (`[highlight] copy` / per-fence `{copy=...}`, never for mermaid), empty string otherwise. The template decides what markup to emit for it |
 

--- a/spec/functional/build_integration_spec.cr
+++ b/spec/functional/build_integration_spec.cr
@@ -90,6 +90,47 @@ describe "Build Integration: URL generation" do
       body.should contain("Body A")
     end
   end
+
+  it "a dateless draft or headless page under a date-token pattern does not abort the build" do
+    config = <<-TOML
+      title = "Test"
+      base_url = "http://localhost"
+
+      [permalinks]
+      "posts" = "/:year/:slug/"
+      TOML
+
+    build_site(
+      config,
+      content_files: {
+        "posts/wip.md"    => "---\ntitle: WIP\ndraft: true\n---\nDraft, no date",
+        "posts/data.md"   => "---\ntitle: Data\nrender: false\n---\nHeadless, no date",
+        "posts/public.md" => "---\ntitle: Public\ndate: 2026-03-05\n---\nDated",
+      },
+      template_files: {"page.html" => "{{ content }}", "section.html" => "{{ content }}"},
+    ) do
+      File.exists?("public/2026/public/index.html").should be_true
+    end
+  end
+
+  it "a dateless PUBLISHED page under a date-token pattern still fails the build" do
+    config = <<-TOML
+      title = "Test"
+      base_url = "http://localhost"
+
+      [permalinks]
+      "posts" = "/:year/:slug/"
+      TOML
+
+    ex = expect_raises(Hwaro::HwaroError, /requires a date, but the page has none/) do
+      build_site(
+        config,
+        content_files: {"posts/undated.md" => "---\ntitle: Undated\n---\nNo date"},
+        template_files: {"page.html" => "{{ content }}"},
+      ) { }
+    end
+    ex.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+  end
 end
 
 # ---------------------------------------------------------------------------

--- a/spec/functional/server_highlight_spec.cr
+++ b/spec/functional/server_highlight_spec.cr
@@ -365,6 +365,55 @@ describe "Fence options — server mode" do
     reset_highlight_mode
   end
 
+  it "per-fence {copy=true} with the global default off ships the runtime only on opted-in pages" do
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+
+      [highlight]
+      enabled = true
+      mode = "server"
+      TOML
+
+    opted = <<-MD
+      +++
+      title = "Opted"
+      +++
+      ```python {copy=true}
+      pass
+      ```
+      MD
+
+    plain = <<-MD
+      +++
+      title = "Plain"
+      +++
+      ```python
+      pass
+      ```
+      MD
+
+    build_site(
+      config,
+      content_files: {"opted.md" => opted, "plain.md" => plain},
+      template_files: {"page.html" => HIGHLIGHT_TEMPLATE},
+      highlight: true,
+    ) do
+      # The opted-in page gets the runtime appended to its own
+      # {{ highlight_js }} — the site-wide value ships nothing.
+      opted_html = File.read("public/opted/index.html")
+      opted_html.should contain(%(<pre data-copy="true">))
+      opted_html.scan("code-copy-btn").size.should be > 0
+
+      # Pages without an opted-in fence stay JavaScript-free.
+      plain_html = File.read("public/plain/index.html")
+      plain_html.should_not contain("data-copy")
+      plain_html.should_not contain("code-copy-btn")
+    end
+  ensure
+    reset_highlight_mode
+  end
+
   it "the global [highlight] line_numbers default wraps a bare fence, and a per-block override opts out" do
     config = <<-TOML
       title = "Test Site"

--- a/spec/functional/strict_internal_links_spec.cr
+++ b/spec/functional/strict_internal_links_spec.cr
@@ -54,6 +54,38 @@ describe "Strict internal links: error mode" do
     message.scan("page.md → @/nonexistent.md (page not found)").size.should eq(1)
   end
 
+  it "catches a broken link that only ships via a render:false page's summary" do
+    # The headless page never enters the render fan-out, but its
+    # <!-- more --> summary is embedded by listings — the strict pass must
+    # see the summary render too.
+    ex = expect_raises(Hwaro::HwaroError) do
+      build_site(
+        STRICT_LINKS_CONFIG,
+        content_files: {
+          "posts/data.md" => "---\ntitle: Data\nrender: false\n---\nIntro [x](@/gone.md)\n<!-- more -->\nrest",
+        },
+        template_files: {"page.html" => "{{ content }}"},
+      ) { }
+    end
+    ex.message.not_nil!.should contain("posts/data.md → @/gone.md (page not found)")
+  end
+
+  it "reports a broken summary link once for pages that also render" do
+    ex = expect_raises(Hwaro::HwaroError) do
+      build_site(
+        STRICT_LINKS_CONFIG,
+        content_files: {
+          "page.md" => "---\ntitle: Page\n---\nIntro [x](@/gone.md)\n<!-- more -->\nbody",
+        },
+        template_files: {"page.html" => "{{ content }}"},
+      ) { }
+    end
+
+    message = ex.message.not_nil!
+    message.should contain("1 broken internal link")
+    message.scan("page.md → @/gone.md (page not found)").size.should eq(1)
+  end
+
   # The fast-start deferred fan-out is the one render pass that runs outside
   # the Render phase — it must surface strict-mode offenders too, or a
   # broken link in a non-priority page silently ships during `serve

--- a/spec/unit/calculate_page_url_spec.cr
+++ b/spec/unit/calculate_page_url_spec.cr
@@ -8,6 +8,10 @@ module Hwaro::Core::Build
       calculate_page_url(page)
     end
 
+    def test_raise_on_permalink_errors(pages : Array(Models::Page))
+      raise_on_permalink_errors!(pages)
+    end
+
     def test_set_config(config : Models::Config)
       @config = config
     end
@@ -403,17 +407,46 @@ describe Hwaro::Core::Build::Builder do
         page.url.should eq("/posts/")
       end
 
-      it "raises a classified content error for a dateless page under a date pattern" do
+      it "defers the dateless-page error: fallback URL at parse, raise only for publishing pages" do
+        builder = Hwaro::Core::Build::Builder.new
+        config = Hwaro::Models::Config.new
+        config.permalinks = {"posts" => ":year/:slug"}
+        builder.test_set_config(config)
+
+        # The parse fan-out runs before cascades/draft filtering, so URL
+        # calculation must not abort the build — it parks the error and
+        # falls back to the directory URL.
+        page = Hwaro::Models::Page.new("posts/undated.md")
+        builder.test_calculate_page_url(page)
+        page.url.should eq("/posts/undated/")
+        page.permalink_error.not_nil!.should contain("requires a date, but the page has none")
+
+        # A page that publishes still fails the build, classified.
+        ex = expect_raises(Hwaro::HwaroError, /requires a date, but the page has none/) do
+          builder.test_raise_on_permalink_errors([page])
+        end
+        ex.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+
+        # A headless page never publishes the URL — no error.
+        page.render = false
+        builder.test_raise_on_permalink_errors([page])
+      end
+
+      it "clears a stale permalink error once the page gains a date" do
         builder = Hwaro::Core::Build::Builder.new
         config = Hwaro::Models::Config.new
         config.permalinks = {"posts" => ":year/:slug"}
         builder.test_set_config(config)
 
         page = Hwaro::Models::Page.new("posts/undated.md")
-        ex = expect_raises(Hwaro::HwaroError, /requires a date, but the page has none/) do
-          builder.test_calculate_page_url(page)
-        end
-        ex.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+        builder.test_calculate_page_url(page)
+        page.permalink_error.should_not be_nil
+
+        page.date = Time.utc(2026, 3, 5)
+        builder.test_calculate_page_url(page)
+        page.permalink_error.should be_nil
+        page.url.should eq("/2026/undated/")
+        builder.test_raise_on_permalink_errors([page])
       end
     end
 

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -2535,50 +2535,10 @@ describe Hwaro::Models::OpenGraphConfig do
   end
 end
 
-private def config_with(permalinks : Hash(String, String)) : Hwaro::Models::Config
-  config = Hwaro::Models::Config.new
-  config.permalinks = permalinks
-  config
-end
-
-describe "Hwaro::Models::Config#resolve_permalink_dir" do
-  it "returns the directory unchanged when no rules are configured" do
-    config_with({} of String => String).resolve_permalink_dir("blog/posts").should eq("blog/posts")
-  end
-
-  it "returns the directory unchanged when no rule matches" do
-    config_with({"old/posts" => "posts"}).resolve_permalink_dir("blog").should eq("blog")
-  end
-
-  it "remaps an exact directory match to the target" do
-    config_with({"old/posts" => "posts"}).resolve_permalink_dir("old/posts").should eq("posts")
-  end
-
-  it "remaps an exact match with an empty target to the root" do
-    config_with({"pages" => ""}).resolve_permalink_dir("pages").should eq("")
-  end
-
-  it "remaps a nested subdirectory and preserves the deeper path" do
-    config_with({"old/posts" => "archive"}).resolve_permalink_dir("old/posts/2024").should eq("archive/2024")
-  end
-
-  it "maps a nested subdirectory to the root without a leading slash for an empty target" do
-    config_with({"pages" => ""}).resolve_permalink_dir("pages/contact").should eq("contact")
-  end
-
-  it "honors the first matching rule" do
-    permalinks = {
-      "2023/drafts" => "archive/2023",
-      "old/posts"   => "posts",
-    }
-    config_with(permalinks).resolve_permalink_dir("2023/drafts/wip").should eq("archive/2023/wip")
-  end
-
-  it "matches the source literally rather than as a regular expression" do
-    config_with({"a.b" => "x"}).resolve_permalink_dir("a.b/c").should eq("x/c")
-    config_with({"a.b" => "x"}).resolve_permalink_dir("axb/c").should eq("axb/c")
-  end
-
+# Directory-remap [permalinks] semantics live in Utils::PermalinkResolver
+# (spec/unit/permalink_resolver_spec.cr) — Config#resolve_permalink_dir was
+# deleted once the shared resolver became the single source of truth.
+describe "Hwaro::Models::Config" do
   describe "related config" do
     it "clamps a negative limit to zero" do
       # A negative limit reaches Array#first(limit) in the incremental

--- a/spec/unit/feeds_spec.cr
+++ b/spec/unit/feeds_spec.cr
@@ -917,6 +917,37 @@ describe Hwaro::Content::Seo::Feeds do
       end
     end
 
+    it "keeps the path-sort-first page when two pages collide on one URL (matches the written output)" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+
+      winner = Hwaro::Models::Page.new("posts/2025/foo.md")
+      winner.title = "Winner (written to disk)"
+      winner.url = "/foo/"
+      winner.render = true
+      winner.raw_content = "a"
+
+      loser = Hwaro::Models::Page.new("posts/2026/foo.md")
+      loser.title = "Loser (suppressed on disk)"
+      loser.url = "/foo/"
+      loser.render = true
+      loser.raw_content = "b"
+
+      Dir.mktmpdir do |output_dir|
+        # Later-path page listed FIRST: the dedupe must pick by path sort
+        # (compute_output_url_winners' rule), not by input order.
+        Hwaro::Content::Seo::Feeds.generate([loser, winner], config, output_dir)
+
+        content = File.read(File.join(output_dir, "rss.xml"))
+        content.should contain("Winner (written to disk)")
+        content.should_not contain("Loser (suppressed on disk)")
+      end
+    end
+
     it "generates Atom feed when type is atom" do
       config = Hwaro::Models::Config.new
       config.feeds.enabled = true

--- a/spec/unit/permalink_resolver_spec.cr
+++ b/spec/unit/permalink_resolver_spec.cr
@@ -180,6 +180,38 @@ describe Hwaro::Utils::PermalinkResolver do
     end
   end
 
+  describe ".resolve_url_lenient" do
+    it "falls back to the directory URL and reports when a date token has no date" do
+      config = config_with({"posts" => ":year/:month/:slug"})
+      url, error = Hwaro::Utils::PermalinkResolver.resolve_url_lenient(
+        "posts/undated.md", config,
+        slug: nil, custom_path: nil, language: nil, date: nil, title: "",
+      )
+      url.should eq("/posts/undated/")
+      error.not_nil!.should contain("requires a date, but the page has none")
+    end
+
+    it "returns no error when the date is present" do
+      config = config_with({"posts" => ":year/:slug"})
+      url, error = Hwaro::Utils::PermalinkResolver.resolve_url_lenient(
+        "posts/x.md", config,
+        slug: nil, custom_path: nil, language: nil, date: Time.utc(2026, 3, 5), title: "",
+      )
+      url.should eq("/2026/x/")
+      error.should be_nil
+    end
+
+    it "still raises for unknown tokens (config errors are never deferred)" do
+      config = config_with({"posts" => ":bogus/:slug"})
+      expect_raises(Hwaro::HwaroError, /Unknown token ':bogus'/) do
+        Hwaro::Utils::PermalinkResolver.resolve_url_lenient(
+          "posts/x.md", config,
+          slug: nil, custom_path: nil, language: nil, date: nil, title: "",
+        )
+      end
+    end
+  end
+
   describe ".resolve_url with plain remaps" do
     it "keeps directory-remap semantics for plain targets" do
       config = config_with({"old/posts" => "archive"})

--- a/spec/unit/render_hooks_spec.cr
+++ b/spec/unit/render_hooks_spec.cr
@@ -261,6 +261,29 @@ describe "HookedRenderer (via SyntaxHighlighter.render with in-memory contexts)"
       end
     end
 
+    it "applies hide_lines to highlighted AND code under server mode" do
+      previous = SyntaxHighlighter.server_mode?
+      SyntaxHighlighter.server_mode = true
+      begin
+        hooks = make_hooks(codeblock: "H=<<<{{ highlighted }}>>> C=<<<{{ code }}>>>")
+        html = SyntaxHighlighter.render(
+          "```python {hide_lines=\"2\"}\nkeep_one()\nsecret()\nkeep_two()\n```",
+          highlight: true, hooks: hooks)
+        html.should_not contain("secret")
+        html.should contain("keep_one")
+        html.should contain("keep_two")
+      ensure
+        SyntaxHighlighter.server_mode = previous
+      end
+    end
+
+    it "keeps hidden lines in client mode (hide_lines is server-only, matching the stock path)" do
+      hooks = make_hooks(codeblock: "C=<<<{{ code }}>>>")
+      html = SyntaxHighlighter.render(
+        "```python {hide_lines=\"2\"}\na()\nsecret()\n```", highlight: true, hooks: hooks)
+      html.should contain("secret")
+    end
+
     it "bypasses the hook for a mermaid fence when mermaid is enabled" do
       hooks = make_hooks(codeblock: "CB[{{ lang }}]", mermaid_bypass: true)
       html = SyntaxHighlighter.render("```mermaid\ngraph TD;\n```", hooks: hooks)
@@ -352,6 +375,14 @@ describe "HookedRenderer (via SyntaxHighlighter.render with in-memory contexts)"
       html.should_not match(/\n[ \t]*\n/)
       html.should contain("<table>")
       # No escaped leftovers — the whole table stayed one html block.
+      html.should_not contain("&lt;table&gt;")
+    end
+
+    it "collapses blank lines in a CRLF-saved hook template too" do
+      hooks = make_hooks(table: "<div>\r\n\r\n{{ html }}\r\n\r\n\r\n</div>")
+      html = SyntaxHighlighter.render(TABLE_MD, hooks: hooks)
+      html.should_not match(/\r?\n[ \t\r]*\r?\n/)
+      html.should contain("<table>")
       html.should_not contain("&lt;table&gt;")
     end
 

--- a/spec/unit/sass/compile_spec.cr
+++ b/spec/unit/sass/compile_spec.cr
@@ -129,6 +129,40 @@ describe Hwaro::Assets::Sass do
       end
     end
 
+    it "unquotes quoted string values inside interpolation (dart-sass parity)" do
+      css = compile(<<-'SCSS')
+        $q: "x";
+        .a { content: "say #{$q} suffix"; }
+        SCSS
+      css.should contain(%q(content: "say x suffix";))
+    end
+
+    it "unquotes a quoted selector string interpolated as a selector" do
+      css = compile(<<-'SCSS')
+        $s: ".a, .b";
+        #{$s} { color: red; }
+        SCSS
+      css.should_not contain(%q("))
+      css.should contain("color: red;")
+    end
+
+    it "does not unquote multi-token interpolation results" do
+      # Only ONE complete quoted string unquotes; a space-separated list of
+      # strings passes through verbatim (the subset boundary).
+      css = compile(<<-'SCSS')
+        $pair: "a" "b";
+        .x { font-family: #{$pair}; }
+        SCSS
+      css.should contain(%q(font-family: "a" "b";))
+    end
+
+    it "errors on pathological block nesting instead of overflowing the stack" do
+      scss = ".a{" * 300 + "color:red;" + "}" * 300
+      expect_raises(Hwaro::Assets::Sass::SyntaxError, /nested more than/) do
+        compile(scss)
+      end
+    end
+
     # =========================================================================
     # At-rule bubbling
     # =========================================================================

--- a/spec/unit/sass/importer_spec.cr
+++ b/spec/unit/sass/importer_spec.cr
@@ -148,4 +148,25 @@ describe "Hwaro::Assets::Sass imports" do
       css.should contain(".a {")
     end
   end
+
+  describe "byte-order marks" do
+    it "strips a UTF-8 BOM from imported partials" do
+      # Without the strip, U+FEFF counts as an identifier char and embeds
+      # invisibly into the partial's first selector (`\u{FEFF}.from-bom`),
+      # which then never matches in any browser.
+      css = compile_with({
+        "sass/_bom.scss" => "\u{FEFF}.from-bom { color: red; }",
+        "sass/main.scss" => ".before { margin: 0; }\n@import \"bom\";",
+      }, "sass/main.scss")
+      css.should contain("\n.from-bom {")
+      css.should_not contain('\u{FEFF}')
+    end
+
+    it "strips a UTF-8 BOM from the entry file" do
+      css = compile_with({
+        "sass/main.scss" => "\u{FEFF}.a { color: red; }",
+      }, "sass/main.scss")
+      css.should start_with(".a {")
+    end
+  end
 end

--- a/spec/unit/sass/mixins_spec.cr
+++ b/spec/unit/sass/mixins_spec.cr
@@ -72,6 +72,33 @@ describe "Hwaro::Assets::Sass mixins" do
     css.should contain(".a {\n  color: red;\n}")
   end
 
+  it "errors when a block is passed to a mixin without @content (dart-sass parity)" do
+    ex = expect_raises(Hwaro::Assets::Sass::SyntaxError, /doesn't accept a content block/) do
+      compile(<<-SCSS)
+        @mixin m { color: red; }
+        .x { @include m { border: 1px; } }
+        SCSS
+    end
+    ex.message.to_s.should contain("mixin m")
+  end
+
+  it "accepts a block when @content sits behind a nested include" do
+    css = compile(<<-SCSS)
+      @mixin inner { @content; }
+      @mixin outer { @include inner { @content; } }
+      .x { @include outer { color: red; } }
+      SCSS
+    css.should contain(".x {\n  color: red;")
+  end
+
+  it "accepts a block when @content is nested inside rules and at-rules" do
+    css = compile(<<-SCSS)
+      @mixin respond { @media (min-width: 600px) { .wrap { @content; } } }
+      .x { @include respond { color: red; } }
+      SCSS
+    css.should contain("color: red;")
+  end
+
   it "closes over the definition environment" do
     css = compile(<<-'SCSS')
       $theme: dark;

--- a/spec/unit/syntax_highlighter_spec.cr
+++ b/spec/unit/syntax_highlighter_spec.cr
@@ -623,6 +623,18 @@ describe "copy button marker (data-copy)" do
     reset_fence_options_state
   end
 
+  it "never marks fences when highlighting is disabled (no runtime ever ships)" do
+    Hwaro::Content::Processors::SyntaxHighlighter.default_copy = true
+    html = Hwaro::Content::Processors::SyntaxHighlighter.render(
+      "```python\npass\n```", highlight: false)
+    html.should_not contain("data-copy")
+    per_fence = Hwaro::Content::Processors::SyntaxHighlighter.render(
+      "```python {copy=true}\npass\n```", highlight: false)
+    per_fence.should_not contain("data-copy")
+  ensure
+    reset_fence_options_state
+  end
+
   it "is byte-identical to stock output when the feature is fully off" do
     content = "```python\npass\n```"
     baseline = Hwaro::Content::Processors::SyntaxHighlighter.render(content, highlight: true)

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -332,6 +332,14 @@ module Hwaro
 
           content =
             if body = node.body
+              # dart-sass parity: passing a block to a mixin whose body never
+              # reaches `@content` is an error — silently discarding the
+              # block's styles (the alternative) loses user CSS on a typo'd
+              # or refactored mixin with no signal at all.
+              unless accepts_content?(closure.node.body)
+                error_at(node.line, node.column,
+                  "mixin #{node.name} doesn't accept a content block (no @content in its body)")
+              end
               ContentBlock.new(body, @env, @content, @path)
             end
 
@@ -416,6 +424,28 @@ module Hwaro
                 error_at(node.line, node.column, "missing argument $#{param.name} for mixin #{node.name}")
               end
             call_env.variables[param_name] = value
+          end
+        end
+
+        # True when the mixin body can reach `@content`: a lexically nested
+        # `@content` anywhere except inside a nested `@mixin` definition
+        # (whose `@content` belongs to that inner mixin — dart-sass scoping).
+        # Include bodies DO count: `@mixin a { @include b { @content } }`
+        # passes a's content through b.
+        private def accepts_content?(nodes : Array(Ast::Node)) : Bool
+          nodes.any? do |node|
+            case node
+            when Ast::ContentNode
+              true
+            when Ast::RuleNode
+              accepts_content?(node.children)
+            when Ast::IncludeNode
+              node.body.try { |b| accepts_content?(b) } || false
+            when Ast::RawAtRuleNode
+              node.children.try { |c| accepts_content?(c) } || false
+            else
+              false
+            end
           end
         end
 
@@ -567,10 +597,37 @@ module Hwaro
                 end
                 io << lookup_var_ref(piece)
               in Ast::Interp
-                io << resolve_template(piece.inner, allow_vars: true)
+                io << unquote_interp(resolve_template(piece.inner, allow_vars: true))
               end
             end
           end
+        end
+
+        # dart-sass semantics: `#{...}` substitutes the UNQUOTED value of a
+        # string — `$q: "x"` interpolates as `x`, never `"x"` (a quoted
+        # substitution terminates the surrounding string early and ships
+        # invalid CSS, e.g. `content: "say "x""`). Only a result that is one
+        # complete quoted string unquotes; anything else — already unquoted,
+        # or multiple tokens like `"a" "b"` — passes through verbatim.
+        private def unquote_interp(text : String) : String
+          return text if text.size < 2
+          quote = text[0]
+          return text unless quote == '"' || quote == '\''
+          return text unless text[-1] == quote
+          inner = text[1..-2]
+          i = 0
+          while i < inner.size
+            c = inner[i]
+            if c == '\\'
+              i += 2
+              next
+            end
+            # An unescaped same-quote char inside means this is not ONE
+            # quoted string ("a" + "b" territory) — leave it alone.
+            return text if c == quote
+            i += 1
+          end
+          inner
         end
 
         private def lookup_var_ref(ref : Ast::VarRef) : String

--- a/src/assets/sass/parser.cr
+++ b/src/assets/sass/parser.cr
@@ -63,6 +63,7 @@ module Hwaro
 
         def initialize(source : String, path : String)
           @s = Scanner.new(source, path)
+          @block_depth = 0
         end
 
         def self.parse(source : String, path : String) : Ast::Stylesheet
@@ -144,15 +145,26 @@ module Hwaro
           nodes
         end
 
+        # Far beyond any real stylesheet's nesting; parse recursion past this
+        # must error instead of overflowing the stack — a stack overflow is
+        # unrescuable and would kill `hwaro serve` outright.
+        MAX_BLOCK_DEPTH = 256
+
         # Consumes "{ ... }" (cursor on the opening brace).
         private def parse_block : Array(Ast::Node)
           open_line = @s.line
           open_col = @s.column
+          @block_depth += 1
+          if @block_depth > MAX_BLOCK_DEPTH
+            @s.error("blocks nested more than #{MAX_BLOCK_DEPTH} levels deep", open_line, open_col)
+          end
           @s.advance # '{'
           nodes = parse_statements(top_level: false)
           @s.error("unterminated block", open_line, open_col) if @s.eof?
           @s.advance # '}'
           nodes
+        ensure
+          @block_depth -= 1
         end
 
         private def parse_var_decl : Ast::Node
@@ -324,7 +336,7 @@ module Hwaro
             default = nil
             if @s.peek == ':'
               @s.advance
-              scan = read_template(stops: ",)", value_vars: true, depth_relative_stops: true)
+              scan = read_template(stops: ",)", value_vars: true)
               default = trim_template(scan.template)
             end
             params << Ast::Param.new(name, default)
@@ -395,7 +407,7 @@ module Hwaro
                 @s.advance # ':'
               end
             end
-            scan = read_template(stops: ",)", value_vars: true, depth_relative_stops: true)
+            scan = read_template(stops: ",)", value_vars: true)
             value = trim_template(scan.template)
             @s.error("expected argument value") if value.empty?
             args << Ast::Arg.new(kwarg, value)
@@ -466,10 +478,10 @@ module Hwaro
         # terminator is not consumed; nil terminator = EOF). Handles quoted
         # strings, url(...) spans, comments (dropped, replaced by a space),
         # `#{...}` interpolation, and — when `value_vars` — `$var` and
-        # `ns.$var` references. With `depth_relative_stops` the caller has
-        # already consumed an opening paren, so a `)` stop is expected at
-        # depth 0 rather than being an unmatched-paren error.
-        private def read_template(stops : String, value_vars : Bool, depth_relative_stops : Bool = false) : TemplateScan
+        # `ns.$var` references. A `)` listed in `stops` terminates at depth 0
+        # before the unmatched-paren check, so callers that already consumed
+        # an opening paren (arg/param lists) need no special casing.
+        private def read_template(stops : String, value_vars : Bool) : TemplateScan
           start_line = @s.line
           start_col = @s.column
           pieces = [] of Ast::Piece

--- a/src/assets/sass/scanner.cr
+++ b/src/assets/sass/scanner.cr
@@ -20,7 +20,11 @@ module Hwaro
         getter column : Int32
 
         def initialize(source : String, @path : String)
-          @chars = source.chars
+          # A UTF-8 BOM is not content (dart-sass strips it too). Without
+          # this, U+FEFF falls into the `ord > 0x7F` ident charset below and
+          # a BOM'd partial embeds an invisible char into the first selector
+          # it contributes mid-sheet.
+          @chars = source.lchop('\u{FEFF}').chars
           @pos = 0
           @line = 1
           @column = 1

--- a/src/assets/sass_compiler.cr
+++ b/src/assets/sass_compiler.cr
@@ -36,6 +36,15 @@ module Hwaro
           relative = Path[src_path].relative_to(@source_dir).to_s
           next if @static_config.excluded?(relative)
 
+          # A hand-written sibling `.css` and this compiled output land on
+          # the same path: full builds copy the raw file first and clobber it
+          # here, while a serve session re-copies the raw file OVER the
+          # compiled one on edit — warn so the mixed state isn't silent.
+          raw_sibling = src_path.sub(/\.scss\z/i, ".css")
+          if File.exists?(raw_sibling)
+            Logger.warn "  Sass: #{relative} compiles to #{relative.sub(/\.scss\z/i, ".css")}, which also exists as a static source — remove one of the two."
+          end
+
           css = SassCompiler.compile_source(File.read(src_path), src_path)
           css = Utils::CssMinifier.minify(css) if @config.minify
 
@@ -58,6 +67,16 @@ module Hwaro
           Hwaro::Errors::HWARO_E_CONTENT,
           "Sass: #{ex.location}: #{ex.message}",
           hint: "Fix the SCSS source at the location above. The supported subset and its limits are documented in features/sass."
+        )
+      rescue ex : File::Error
+        # Import resolution stats/reads real files; anything the OS refuses
+        # beyond "missing" (symlink loops → ELOOP, permissions) must still
+        # come out classified, not as a bare File::Error the hook manager
+        # downgrades to a generic abort.
+        raise Hwaro::HwaroError.new(
+          Hwaro::Errors::HWARO_E_CONTENT,
+          "Sass: #{path}: filesystem error while resolving imports: #{ex.message}",
+          hint: "Check for broken or looping symlinks and unreadable files under the imported paths."
         )
       end
     end

--- a/src/content/processors/render_hooks.cr
+++ b/src/content/processors/render_hooks.cr
@@ -40,7 +40,7 @@ module Hwaro
         # build. Constructed once per `load_templates` call (Initialize
         # phase, and again on every `serve` template reload) and read-only
         # for the rest of the build — parallel render workers only ever
-        # read `link`/`image`/`heading`/`codeblock`/`fingerprint`.
+        # read the per-hook entries (HOOK_NAMES) and `fingerprint`.
         class Registry
           getter link : HookEntry?
           getter image : HookEntry?
@@ -350,7 +350,10 @@ module Hwaro
             vars["header_html"] = Crinja::Value.new(header_html)
             vars["body_html"] = Crinja::Value.new(body_html)
             result = render_hook_template("hooks/render-table", hook, SALT_TABLE, vars) { html }
-            result.gsub(/\n[ \t]*\n(?:[ \t]*\n)*/, "\n")
+            # `\r?` so a hook template saved with CRLF line endings still has
+            # its blank lines collapsed — markd treats a stray `\r\n\r\n`
+            # exactly like `\n\n` (HTML block ends, remainder re-escapes).
+            result.gsub(/\r?\n(?:[ \t]*\r?\n)+/, "\n")
           end
 
           private def render_hook_template(template_key : String, hook : HookEntry, salt : UInt64, vars : Hash(String, Crinja::Value), & : -> String) : String

--- a/src/content/processors/syntax_highlighter.cr
+++ b/src/content/processors/syntax_highlighter.cr
@@ -515,6 +515,24 @@ module Hwaro
           end
         end
 
+        # Removes `hide_lines` lines from an already highlighted (or escaped)
+        # body WITHOUT adding the per-line wrapper spans — the render-hook
+        # path hands templates plain `highlighted`/`code` strings, but the
+        # redaction promise ("hidden lines are removed from the output")
+        # must hold before the text reaches any template. split_lines
+        # re-opens token spans across line boundaries, so dropping whole
+        # lines keeps the remaining markup balanced.
+        def drop_hidden(body : String, opts : FenceOptions::Options) : String
+          return body if opts.hide_lines.empty?
+          lines = split_lines(body)
+          String.build do |io|
+            lines.each_with_index do |line, i|
+              next if opts.hidden?(i + 1)
+              io << line << '\n'
+            end
+          end
+        end
+
         # True when `bytes[pos...]` starts with the literal ASCII `needle`.
         private def match_at?(bytes : Bytes, pos : Int32, needle : String) : Bool
           needle_bytes = needle.to_slice
@@ -625,8 +643,10 @@ module Hwaro
           # `js_tag` targets `pre[data-copy]` regardless of who colored the
           # code). Never on mermaid fences: `postprocess_mermaid`'s regex
           # anchors on the bare `<pre><code class="language-mermaid...`
-          # shape, so any attribute on <pre> would break the rewrite.
-          if effective_copy(opts) && lang.try(&.downcase) != "mermaid"
+          # shape, so any attribute on <pre> would break the rewrite. Gated
+          # on `[highlight] enabled` like `js_tag` is — a disabled section
+          # must not stamp attributes no runtime will ever act on.
+          if @highlight_enabled && effective_copy(opts) && lang.try(&.downcase) != "mermaid"
             pre_tag_attrs ||= {} of String => String
             pre_tag_attrs["data-copy"] = "true"
           end
@@ -877,13 +897,27 @@ module Hwaro
 
           highlighted = (@highlight_enabled && @server_mode && lang) ? (ServerHighlighter.highlight(node.text, lang) || "") : ""
 
-          copy_active = effective_copy(opts) && lang.try(&.downcase) != "mermaid"
+          # `hide_lines` redaction (server mode only, matching the stock
+          # path): both the highlighted body AND the raw `code` fallback the
+          # template receives must drop the hidden lines — a hook template
+          # must never be handed content the fence asked to omit.
+          code_text = node.text
+          if @highlight_enabled && @server_mode && (o = opts) && !o.hide_lines.empty?
+            highlighted = LineWrapper.drop_hidden(highlighted, o) unless highlighted.empty?
+            code_text = String.build do |io|
+              node.text.each_line(chomp: false).with_index do |line, i|
+                io << line unless o.hidden?(i + 1)
+              end
+            end
+          end
+
+          copy_active = @highlight_enabled && effective_copy(opts) && lang.try(&.downcase) != "mermaid"
 
           newline
           literal(@hooks.render_codeblock(
             lang: lang ? escape(lang) : "",
             options: escape(options_str),
-            code: escape(node.text),
+            code: escape(code_text),
             highlighted: highlighted,
             name: opts.try(&.name).try { |n| escape(n) } || "",
             copy: copy_active ? "true" : "",

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -40,9 +40,20 @@ module Hwaro
           if config.feeds.enabled
             site_pages = pages.reject { |p| p.draft || p.unpublished || !p.render || p.is_a?(Models::Section) }
 
-            # Deduplicate by URL (keep last occurrence, matching build behavior)
-            seen_urls = Set(String).new
-            site_pages = site_pages.reverse.select { |p| seen_urls.add?(p.url) }.reverse!
+            # Deduplicate by URL, keeping the page the build actually wrote:
+            # output collisions resolve to the source-path-sort-first page
+            # (render.cr#compute_output_url_winners), so the feed must
+            # advertise that page's content — not whichever colliding page
+            # happened to come last.
+            url_winners = {} of String => Models::Page
+            site_pages.each do |p|
+              if prev = url_winners[p.url]?
+                url_winners[p.url] = p if p.path < prev.path
+              else
+                url_winners[p.url] = p
+              end
+            end
+            site_pages = site_pages.select { |p| url_winners[p.url].same?(p) }
 
             # Filter by section if configured for main feed
             if !config.feeds.sections.empty?

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -269,9 +269,12 @@ module Hwaro
       end
 
       # Sort every term's page list per its taxonomy's sort_by/reverse
-      # (date-desc for taxonomies not in the config, matching the render
-      # phase's rebuild_taxonomies).
-      private def self.sort_taxonomy_pages(taxonomies : Hash(String, Hash(String, Array(Models::Page))), config : Models::Config)
+      # (date-desc for taxonomies not in the config). ONE implementation
+      # serves both the generator (populate_taxonomies) and the render
+      # phase's rebuild_taxonomies (transform.cr) — per-term ordering
+      # drifting between the written pages and get_taxonomy is exactly the
+      # bug class this shared helper prevents.
+      def self.sort_taxonomy_pages(taxonomies : Hash(String, Hash(String, Array(Models::Page))), config : Models::Config)
         tax_configs = config.taxonomies.index_by(&.name)
         taxonomies.each do |name, terms|
           cfg = tax_configs[name]?
@@ -497,14 +500,10 @@ module Hwaro
         Hwaro::Utils::FileSafe.mkdir_p(feed_output_dir)
         feed_title = "#{site.config.title} - #{taxonomy.name.capitalize}: #{term}"
 
-        feed_pages = pages.sort { |a, b| Utils::SortUtils.compare_by_date(a, b) }
-
-        if site.config.feeds.limit > 0
-          feed_pages = feed_pages.first(site.config.feeds.limit)
-        end
-
+        # No caller-side sort/limit: process_feed itself sorts date-desc
+        # (SortUtils.compare_by_date) and applies feeds.limit.
         Content::Seo::Feeds.process_feed(
-          feed_pages,
+          pages,
           site.config,
           feed_output_dir,
           "",

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -469,12 +469,6 @@ module Hwaro
             return true
           end
 
-          # Re-render <!-- more --> summaries for the re-parsed pages with the
-          # body pipeline (parse_single_page reset summary_html to nil); the
-          # listing pages re-rendered below read it.
-          render_page_summaries(changed_pages, site, templates, highlight,
-            link_targets: (site.pages + site.sections).as(Array(Models::Page)))
-
           # Re-claim output URLs: the edit may have introduced or resolved a
           # slug/alias collision, and a stale winner map would keep
           # suppressing (or racing) writes for the rest of the serve session.
@@ -505,6 +499,23 @@ module Hwaro
             changed_pages.reject! { |p| p.date.try { |d| d > now } || false }
           end
           excluded_paths = excluded_pages.map(&.path).to_set
+
+          # Date-token permalink errors deferred by the lenient parse (see
+          # ParseContent#calculate_page_url): now that cascades and the
+          # exclusion pass ran, a surviving renderable page must fail the
+          # rebuild — same contract as the full parse phase. The serve
+          # watcher surfaces this via the overlay and escalates the next
+          # rebuild through @rebuild_failed.
+          raise_on_permalink_errors!(changed_pages)
+
+          # Re-render <!-- more --> summaries for the re-parsed pages with the
+          # body pipeline (parse_single_page reset summary_html to nil); the
+          # listing pages re-rendered below read it. Runs AFTER the exclusion
+          # pass so a page just flipped to draft can't feed its summary's
+          # broken @/ links into the strict-mode accumulator (the full build
+          # renders summaries post-filter too).
+          render_page_summaries(changed_pages, site, templates, highlight,
+            link_targets: (site.pages + site.sections).as(Array(Models::Page)))
 
           # Run taxonomy update on ALL re-parsed pages (including the excluded
           # ones — their OLD entries must be removed; excluded_paths keeps
@@ -772,6 +783,9 @@ module Hwaro
             changed_pages.reject! { |p| p.date.try { |d| d > now } || false }
           end
           excluded_paths = excluded_pages.map(&.path).to_set
+
+          # Deferred permalink errors — mirrors run_incremental.
+          raise_on_permalink_errors!(changed_pages)
 
           # Update all derived relationships before full re-render (removal
           # runs for every re-parsed page; excluded pages' new terms are not
@@ -1107,11 +1121,14 @@ module Hwaro
                     process_files_sequential(renderable, site, templates, output_dir, minify, cache, highlight, verbose, global_vars, error_overlay: options.error_overlay, profiler: active_profiler)
                   end
           # Strict [links] broken_internal = "error": this pass continues the
-          # initial fast-start build (whose priority fan-out already raised
-          # for its own subset and left the accumulator empty), so don't
-          # clear here — just surface what the deferred pages collected. The
-          # server's fast-start fiber rescues this and routes it into the
-          # error overlay via notify_build_error; the server keeps running.
+          # initial fast-start build, so don't clear here. If the priority
+          # fan-out already raised, its entries are still in the accumulator
+          # (raising never clears) and get re-reported alongside whatever the
+          # deferred pages collected — acceptable: those links are still
+          # broken, and @rebuild_failed escalates the next watch rebuild to a
+          # full build, which clears at entry. The server's fast-start fiber
+          # rescues this and routes it into the error overlay via
+          # notify_build_error; the server keeps running.
           raise_on_broken_internal_links!
 
           # Refresh feeds / sitemap / search now that every page has rendered

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -101,7 +101,22 @@ module Hwaro::Core::Build::Phases::ParseContent
         link_targets.each { |p| map[p.path] ||= p }
         map
       end)
-      html = Content::Processors::InternalLinkResolver.resolve(html, pbp, page.path, site.config.base_url)
+      if site.config.links.broken_internal == "error"
+        # Strict mode must see summary links too: a `render: false` page
+        # never reaches the body render pass, yet its summary ships inside
+        # every listing that embeds `{{ p.summary }}`. Entries use the same
+        # "path → @/target (reason)" shape as the body pass, so pages that
+        # DO render report each link once (raise_… sort-uniqs).
+        misses = [] of {String, String}
+        html = Content::Processors::InternalLinkResolver.resolve(html, pbp, page.path, site.config.base_url, misses: misses)
+        unless misses.empty?
+          @broken_links_mutex.synchronize do
+            misses.each { |target, reason| @broken_internal_links << "#{page.path} → @/#{target} (#{reason})" }
+          end
+        end
+      else
+        html = Content::Processors::InternalLinkResolver.resolve(html, pbp, page.path, site.config.base_url)
+      end
       html = Content::Processors::InternalLinkResolver.prefix_root_relative_links(html, site.config.base_url)
 
       page.summary_html = html
@@ -210,6 +225,10 @@ module Hwaro::Core::Build::Phases::ParseContent
     if total_removed > 0
       ctx.invalidate_all_pages_cache
     end
+
+    # Deferred date-token permalink errors: only pages that survived the
+    # filters above can publish a URL, so only they can fail the build.
+    raise_on_permalink_errors!(ctx.pages)
 
     # The skipped total feeds the receipt's "parse … N skipped" emphasis; the
     # per-reason breakdown stays available under --verbose. Parse errors remain
@@ -607,8 +626,15 @@ module Hwaro::Core::Build::Phases::ParseContent
   # Canonical URL computation is shared with PlatformConfig alias generation
   # via Utils::PermalinkResolver so build URLs and generated platform
   # redirects can never drift apart.
+  #
+  # Lenient on missing dates: this runs inside the parse fan-out, BEFORE
+  # cascades apply and draft/expiry filtering runs, so whether the page
+  # will publish at all isn't knowable yet. The error is parked on the
+  # page and raised after filtering (raise_on_permalink_errors!) — a WIP
+  # draft or headless data page must not abort every build over a URL it
+  # never publishes.
   private def calculate_page_url(page : Models::Page)
-    page.url = Utils::PermalinkResolver.resolve_url(
+    url, error = Utils::PermalinkResolver.resolve_url_lenient(
       page.path,
       @config,
       slug: page.slug,
@@ -616,6 +642,26 @@ module Hwaro::Core::Build::Phases::ParseContent
       language: page.language,
       date: page.date,
       title: page.title,
+    )
+    page.url = url
+    page.permalink_error = error
+  end
+
+  # Fails the build for every SURVIVING page whose permalink couldn't be
+  # resolved (see calculate_page_url): filtered-out drafts/expired/future
+  # pages and headless `render: false` pages write no output, so their
+  # fallback URL is harmless; anything else would publish a URL that
+  # ignores the configured pattern — that stays a hard error, aggregated
+  # so one build surfaces every offender.
+  private def raise_on_permalink_errors!(pages : Array(Models::Page))
+    offenders = pages.compact_map { |p| p.permalink_error if p.render }
+    return if offenders.empty?
+
+    offenders.sort!.uniq!
+    raise Hwaro::HwaroError.new(
+      code: Hwaro::Errors::HWARO_E_CONTENT,
+      message: offenders.join("\n"),
+      hint: Utils::PermalinkResolver::DATE_TOKEN_HINT,
     )
   end
 end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1721,10 +1721,13 @@ module Hwaro::Core::Build::Phases::Render
       end
       slug_map = Utils::TextUtils.disambiguated_slugs(written_terms)
       term_slug_values = {} of String => Crinja::Value
-      # Term order matches the taxonomy's `terms_sort_by` (same rule the
-      # written index page uses): "name" = alphabetical (also the default
-      # for unconfigured taxonomy names), "count" = page count descending,
-      # name-ascending tiebreak.
+      # Term order matches the taxonomy's `terms_sort_by` as the ROOT index
+      # page applies it: "name" = alphabetical (also the default for
+      # unconfigured taxonomy names), "count" = page count descending,
+      # name-ascending tiebreak. Counts here are site-wide (all languages,
+      # like the root index); per-language index pages sort by their own
+      # language-filtered counts and may order differently — get_taxonomy
+      # is a site-wide view, so the root rule is the right parity target.
       tax_cfg = config.taxonomies.find { |t| t.name == name }
       sorted_term_names = if tax_cfg.try(&.terms_sort_by) == "count"
                             terms.keys.sort! do |a, b|
@@ -2409,6 +2412,22 @@ module Hwaro::Core::Build::Phases::Render
     # that don't already exist when we reverse the direction below.
     gv = global_vars || build_global_vars(site)
     gv.each { |k, v| vars[k] = v unless vars.has_key?(k) }
+
+    # Per-fence copy opt-in (`{copy=true}`) with the global `[highlight]
+    # copy` default off: the site-wide `highlight_js` (computed once in
+    # build_global_vars) ships no copy runtime, so a page whose rendered
+    # body carries an opted-in block appends it here — after the merge, so
+    # the page-level value wins. The probe can't false-positive on fenced
+    # documentation examples: the escape pipeline turns their `"` into
+    # `&quot;`. With the global flag ON the runtime is already in `gv`.
+    if config.highlight.enabled && !config.highlight.copy && content.includes?(%(data-copy="true"))
+      snippet = Models::HighlightConfig::COPY_SNIPPET
+      base_js = vars["highlight_js"]?.try(&.raw).as?(String) || ""
+      js = base_js.empty? ? snippet : "#{base_js}\n#{snippet}"
+      vars["highlight_js"] = Crinja::Value.new(js)
+      base_css = vars["highlight_css"]?.try(&.raw).as?(String) || ""
+      vars["highlight_tags"] = Crinja::Value.new(base_css.empty? ? js : "#{base_css}\n#{js}")
+    end
 
     vars
   end

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -264,17 +264,10 @@ module Hwaro::Core::Build::Phases::Transform
       end
     end
 
-    # Sort pages in taxonomies in-place (per-taxonomy sort_by/reverse,
-    # default date-desc for unconfigured names)
-    tax_configs = site.config.taxonomies.index_by(&.name)
-    site.taxonomies.each do |name, terms|
-      cfg = tax_configs[name]?
-      sort_by = cfg.try(&.sort_by) || "date"
-      reverse = cfg.try(&.reverse) || false
-      terms.each_key do |term|
-        terms[term] = Utils::SortUtils.sort_pages(terms[term], sort_by, reverse)
-      end
-    end
+    # Sort pages in taxonomies in-place — the same helper the generator
+    # uses, so per-term ordering can't drift between the written pages
+    # and the render phase's get_taxonomy view.
+    Content::Taxonomies.sort_taxonomy_pages(site.taxonomies, site.config)
   end
 
   # Yield each {name, term} a page carries via a taxonomy whose terms live on

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1248,26 +1248,6 @@ module Hwaro
         @languages.values.sort_by!(&.weight)
       end
 
-      # Resolve a content directory through the configured `permalinks` rules.
-      #
-      # Returns the remapped directory (relative to the site root) for the first
-      # rule whose source matches `directory_path` exactly or as a parent prefix;
-      # the matched prefix is replaced and any deeper path is preserved. An empty
-      # target maps the matched tree to the site root (so `pages/contact` under
-      # `"pages" => ""` becomes `contact`, not `/contact`). Returns
-      # `directory_path` unchanged when no rule matches.
-      def resolve_permalink_dir(directory_path : String) : String
-        permalinks.each do |source, target|
-          if directory_path == source
-            return target
-          elsif directory_path.starts_with?("#{source}/")
-            rest = directory_path[(source.size + 1)..]
-            return target.empty? ? rest : "#{target}/#{rest}"
-          end
-        end
-        directory_path
-      end
-
       # Load and parse a `config.toml` into a populated `Config`.
       #
       # Raises `Hwaro::HwaroError(HWARO_E_CONFIG)` directly at the source for
@@ -1978,23 +1958,20 @@ module Hwaro
 
         s.each do |k, v|
           if target = v.as_s?
-            if Utils::PermalinkResolver.pattern?(target)
-              # Token patterns (e.g. "/:year/:month/:slug/") rebuild whole
-              # URLs at resolve time. Validate tokens up front so a typo'd
-              # `:tokne` fails the config load instead of emitting literal
-              # `:tokne` path segments, and only normalize the OUTER slashes
-              # — the interior pattern structure must survive verbatim.
-              Utils::PermalinkResolver.validate_pattern!(k, target)
-              config.permalinks[k.strip("/")] = target.strip("/")
-            else
-              # Strip surrounding slashes from BOTH the source key and the target.
-              # resolve_permalink_dir matches against slash-free directory paths
-              # and interpolates the target as `/#{effective_dir}/`, so a key or
-              # target written with leading/trailing slashes (e.g. `"/blog/"`)
-              # would otherwise silently never match (source) or produce
-              # double-slash URLs like `http://host//blog//p/` (target).
-              config.permalinks[k.strip("/")] = target.strip("/")
-            end
+            # Token patterns (e.g. "/:year/:month/:slug/") rebuild whole
+            # URLs at resolve time. Validate tokens up front so a typo'd
+            # `:tokne` fails the config load instead of emitting literal
+            # `:tokne` path segments.
+            Utils::PermalinkResolver.validate_pattern!(k, target) if Utils::PermalinkResolver.pattern?(target)
+            # Strip surrounding slashes from BOTH the source key and the
+            # target — only the OUTER slashes; interior structure (pattern
+            # or remap) must survive verbatim. The resolver matches against
+            # slash-free directory paths and interpolates the target as
+            # `/#{effective_dir}/`, so a key or target written with
+            # leading/trailing slashes (e.g. `"/blog/"`) would otherwise
+            # silently never match (source) or produce double-slash URLs
+            # like `http://host//blog//p/` (target).
+            config.permalinks[k.strip("/")] = target.strip("/")
           end
         end
       end

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -105,6 +105,14 @@ module Hwaro
       # Whether parsing (front-matter / markdown) failed for this page
       property parse_failed : Bool
 
+      # Deferred [permalinks] error from the parse fan-out (a date-token
+      # pattern matched a dateless page). Whether it's fatal isn't knowable
+      # until cascades and draft/expiry filtering ran: a page filtered out
+      # of the build (or a headless `render: false` page) never publishes
+      # the URL, so only surviving renderable pages raise — see
+      # ParseContent#raise_on_permalink_errors!.
+      property permalink_error : String?
+
       # True when the page is outside its publication window at build time
       # (future `date` or past `expires`). Such pages only survive the parse
       # filter under --include-future / --include-expired — preview flags —

--- a/src/utils/permalink_resolver.cr
+++ b/src/utils/permalink_resolver.cr
@@ -50,6 +50,8 @@ module Hwaro
         end
       end
 
+      DATE_TOKEN_HINT = "Add a date to the page's front matter, set an explicit `path`, or remove date tokens from the pattern."
+
       # Compute the canonical site-relative URL for a content file.
       #
       # Precedence: explicit `path` front matter (custom_path) wins outright;
@@ -58,6 +60,11 @@ module Hwaro
       # matching `[permalinks]` rule applies (pattern expansion for leaf
       # pages, directory remap otherwise), and the result is normalized to a
       # leading- and trailing-slash directory URL.
+      #
+      # A date-token pattern on a dateless page raises HWARO_E_CONTENT.
+      # Callers that can't yet know whether the page will publish (the parse
+      # fan-out runs before cascades and draft/expiry filtering) use
+      # `resolve_url_lenient` and defer the error to after filtering.
       def resolve_url(
         relative_path : String,
         config : Models::Config?,
@@ -68,6 +75,33 @@ module Hwaro
         date : Time?,
         title : String,
       ) : String
+        url, error = resolve_url_lenient(relative_path, config,
+          slug: slug, custom_path: custom_path, language: language, date: date, title: title)
+        if error
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_CONTENT,
+            message: error,
+            hint: DATE_TOKEN_HINT,
+          )
+        end
+        url
+      end
+
+      # Like `resolve_url`, but a date-token pattern on a dateless page
+      # falls back to the default directory URL and REPORTS the problem in
+      # the second tuple slot instead of raising — so a draft or headless
+      # page the build is about to discard can't abort the whole build over
+      # a URL it never publishes.
+      def resolve_url_lenient(
+        relative_path : String,
+        config : Models::Config?,
+        *,
+        slug : String?,
+        custom_path : String?,
+        language : String?,
+        date : Time?,
+        title : String,
+      ) : {String, String?}
         stem = Path[relative_path].stem
 
         # Remove language suffix from stem (e.g. "hello-world.ko" -> "hello-world")
@@ -90,9 +124,10 @@ module Hwaro
         if custom_path
           url = "#{lang_prefix}/#{custom_path.lchop("/")}"
           url += "/" unless url.ends_with?("/")
-          return url
+          return {url, nil}
         end
 
+        error = nil
         rule = match_permalink_rule(config, directory_path, is_index)
 
         if rule && pattern?(rule[:target])
@@ -100,25 +135,32 @@ module Hwaro
             rule[:key], rule[:target], relative_path, directory_path, clean_stem,
             slug: slug, date: date, title: title,
           )
-          return path.empty? ? "#{lang_prefix}/" : "#{lang_prefix}/#{path}/"
+          if path
+            return {path.empty? ? "#{lang_prefix}/" : "#{lang_prefix}/#{path}/", nil}
+          end
+          # Date token, no date: report and fall back to the un-remapped
+          # directory URL (the pattern target has no directory to remap to).
+          error = "#{relative_path} matches [permalinks] rule \"#{rule[:key]}\" (pattern '#{rule[:target]}') which requires a date, but the page has none."
+          rule = nil
         end
 
         effective_dir = rule ? remap_directory(rule[:target], rule[:rest]) : directory_path
 
-        if is_index
-          if effective_dir == "." || effective_dir.empty?
-            lang_prefix.empty? ? "/" : "#{lang_prefix}/"
-          else
-            "#{lang_prefix}/#{effective_dir}/"
-          end
-        else
-          leaf = slug || clean_stem
-          if effective_dir == "." || effective_dir.empty?
-            "#{lang_prefix}/#{leaf}/"
-          else
-            "#{lang_prefix}/#{effective_dir}/#{leaf}/"
-          end
-        end
+        url = if is_index
+                if effective_dir == "." || effective_dir.empty?
+                  lang_prefix.empty? ? "/" : "#{lang_prefix}/"
+                else
+                  "#{lang_prefix}/#{effective_dir}/"
+                end
+              else
+                leaf = slug || clean_stem
+                if effective_dir == "." || effective_dir.empty?
+                  "#{lang_prefix}/#{leaf}/"
+                else
+                  "#{lang_prefix}/#{effective_dir}/#{leaf}/"
+                end
+              end
+        {url, error}
       end
 
       # First `[permalinks]` rule whose source matches `directory_path`
@@ -130,7 +172,7 @@ module Hwaro
       # An empty source (`""` or `"/"` in config.toml) acts as a catch-all
       # for PATTERN rules only — it matches every page, including root-level
       # ones. Empty-source plain remaps stay inert as they always have been
-      # (`resolve_permalink_dir` never matched them), so no legacy config
+      # (the pre-resolver remap logic never matched them), so no legacy config
       # changes meaning.
       private def match_permalink_rule(config : Models::Config?, directory_path : String, is_index : Bool)
         return unless config
@@ -153,15 +195,16 @@ module Hwaro
       end
 
       # Replace the matched source prefix with the remap target, preserving
-      # any deeper path (mirrors Config#resolve_permalink_dir semantics).
+      # any deeper path (the original directory-remap semantics).
       private def remap_directory(target : String, rest : String) : String
         return target if rest.empty?
         target.empty? ? rest : "#{target}/#{rest}"
       end
 
       # Expand a token pattern into a slash-joined URL path (no surrounding
-      # slashes). An empty `:section` (root-level page) collapses instead of
-      # emitting a `//` segment.
+      # slashes), or nil when the pattern needs a date the page doesn't have
+      # (the caller owns whether that's an error). An empty `:section`
+      # (root-level page) collapses instead of emitting a `//` segment.
       private def expand_pattern(
         rule_key : String,
         pattern : String,
@@ -172,7 +215,7 @@ module Hwaro
         slug : String?,
         date : Time?,
         title : String,
-      ) : String
+      ) : String?
         segments = [] of String
 
         pattern.split('/').each do |segment|
@@ -185,11 +228,7 @@ module Hwaro
 
           case token = segment.lchop(':')
           when "year", "month", "day"
-            page_date = date || raise Hwaro::HwaroError.new(
-              code: Hwaro::Errors::HWARO_E_CONTENT,
-              message: "#{relative_path} matches [permalinks] rule \"#{rule_key}\" (pattern '#{pattern}') which requires a date, but the page has none.",
-              hint: "Add a date to the page's front matter, set an explicit `path`, or remove date tokens from the pattern.",
-            )
+            page_date = date || return
             segments << case token
             when "year"  then page_date.to_s("%Y")
             when "month" then page_date.to_s("%m")


### PR DESCRIPTION
Deep audit of the three recent feature PRs (#700 sass, #702 highlight/render-hooks/taxonomies, #701 permalinks/links/feeds): 17 verified findings, 15 fixed, 23 new spec examples.

## Sass (713def33)
- `#{...}` interpolation unquotes a complete quoted string (dart-sass parity) instead of shipping embedded quotes as invalid CSS
- Passing a block to a mixin without `@content` is a located error instead of silently dropping the block's styles
- UTF-8 BOM stripped per file — a BOM'd partial no longer embeds U+FEFF into its first selector
- Block nesting capped (256) with a located error instead of an unrescuable stack overflow that killed `hwaro serve`
- Symlink-loop/permission errors during import resolution surface as classified `HWARO_E_CONTENT`
- `foo.scss`/`foo.css` collision under `static/` warns; removed the never-read `depth_relative_stops` parameter

## Highlight / render hooks (7f614969)
- Per-fence `{copy=true}` with the global `[highlight] copy` default off now works: the runtime is appended to the opted-in page's own `{{ highlight_js }}`; other pages stay JavaScript-free
- `data-copy` is no longer stamped when highlighting is disabled
- The `render-codeblock` hook path applies `{hide_lines=…}` to both `highlighted` and `code` — hook templates are never handed redacted lines
- `render-table` blank-line collapse handles CRLF-saved templates

## Permalinks / links / feeds (052119c3)
- A dateless page matching a date-token pattern no longer aborts the build from the parse fan-out: the error defers past cascades + draft/expiry filtering, so WIP drafts and headless `render: false` pages can't block builds — publishable pages still fail, aggregated, on full builds and serve rebuilds alike
- Strict `[links] broken_internal = "error"` now sees `<!-- more -->` summary renders, catching broken `@/` links that only ship via `render: false` pages' summaries
- Feed URL-dedupe keeps the page the build actually writes (path-sort-first, matching `compute_output_url_winners`) instead of the last occurrence
- Dedup: `Config#resolve_permalink_dir` deleted (resolver is the SoT), `load_permalinks` branches hoisted, taxonomy per-term sort shares one helper between generator and rebuild

## Verification
- `crystal spec`: 6530 examples, 0 failures — ameba: 425 files, 0 failures
- docs/ site builds clean with the patched binary; double-build `diff -r` identical (determinism)
- Old (main) vs patched binary `diff -r` on docs/ output: **byte-identical** — the refactor-only changes are proven inert