### PR TITLE
ci(homebrew): auto-publish the tap formula after a release build

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,8 +1,9 @@
 ---
 name: Homebrew tap Publish
-# Manual-only: publish the prebuilt formula to the Homebrew tap on demand.
-# The release binaries must already exist on the GitHub release for the given
-# version. Trigger this after "Build and Release Binaries" has finished.
+# Publishes the prebuilt formula to the Homebrew tap. Runs automatically once
+# "Build and Release Binaries" succeeds for a release (that workflow produces
+# the assets this one checksums), and can also be dispatched manually to
+# re-publish or backfill a version.
 on:
   workflow_dispatch:
     inputs:
@@ -10,22 +11,35 @@ on:
         description: "Version to publish (e.g. 0.17.0)"
         required: true
         type: string
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
 permissions:
   contents: read
 jobs:
   publish-formula:
     name: Publish prebuilt formula to tap
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
     runs-on: ubuntu-latest
     steps:
       - name: Resolve version
         id: ver
         # Pass event data via env (never interpolate ${{ }} straight into the
-        # script body) so a crafted input can't inject shell.
+        # script body) so a crafted input can't inject shell. On workflow_run
+        # the release tag arrives as head_branch (e.g. "v0.18.0").
         env:
           DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RUN_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           # Strip a leading 'v' if present.
-          VERSION="${DISPATCH_VERSION#v}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${DISPATCH_VERSION#v}"
+          else
+            VERSION="${RUN_TAG#v}"
+          fi
           if [ -z "$VERSION" ]; then
             echo "::error::version input is empty"; exit 1
           fi


### PR DESCRIPTION
## 문제

`publish-homebrew.yml`이 `51e4bf11`에서 macOS tarball 에셋 이름 불일치를 고치면서 함께 **manual-only**로 바뀌었습니다. 그 결과 v0.15.2 이후 어떤 릴리스도 tap에 자동 반영되지 않았고, v0.17.1과 v0.18.0 모두 tap이 0.17.0에 머문 채로 배포됐습니다.

패키지 워크플로우 중 자동 트리거가 없는 건 homebrew 하나뿐이었습니다:

| workflow | trigger |
|---|---|
| release-binary / snapcraft / ghcr | `release: [published]` |
| aur / deb / rpm / apk | `workflow_run: ["Build and Release Binaries"]` |
| **publish-homebrew** | **`workflow_dispatch` 뿐** |

## 변경

manual 전환의 원인이던 에셋 이름 불일치는 같은 커밋에서 이미 해결됐으므로, aur/deb/rpm과 동일한 패턴으로 자동 트리거를 복구합니다.

- `workflow_run` on `"Build and Release Binaries"`, `conclusion == 'success' && event == 'release'`로 게이트
- `workflow_dispatch`는 재발행·백필용으로 유지
- `workflow_run`에서는 태그가 `head_branch`로 오므로, 기존 dispatch 입력과 동일하게 `${{ }}`를 스크립트 본문에 직접 넣지 않고 env(`RUN_TAG`)를 경유

## 검증

v0.18.0을 수동 dispatch해 경로 전체를 확인했습니다 ([run 29684529811](https://github.com/hahwul/hwaro/actions/runs/29684529811), 전 스텝 성공). tap의 `Formula/hwaro.rb`는 0.18.0으로 갱신됐고, 발행된 sha256이 실제 릴리스 에셋과 일치함을 독립적으로 확인했습니다:

```
hwaro-v0.18.0-osx-arm64.tar.gz  16135a06bcd75408f15d695e435e743da154f57a8c58b33a153e1c6400993b68
hwaro-v0.18.0-linux-x86_64      530fea168771503a4f4a4bd1f3c440a98434ba56ca78f681202d6ebda5efd410
```

자동 트리거 자체는 다음 릴리스에서 처음 실행됩니다.