### PR TITLE
feat(cli): support -v flag for version output

### DIFF
--- a/skills/hwaro/SKILL.md
+++ b/skills/hwaro/SKILL.md
@@ -35,7 +35,7 @@ Trigger this skill when the user asks to:
 
 Confirm you are in a Hwaro project before acting: a project root has a
 `config.toml`, usually alongside `content/` and `templates/`. Run
-`hwaro --version` (also `hwaro -V` or `hwaro version`) to confirm the binary is
+`hwaro --version` (also `hwaro -v`, `hwaro -V`, or `hwaro version`) to confirm the binary is
 installed and which version you are targeting. This skill is written against
 **Hwaro 0.16.x**.
 

--- a/spec/unit/cli_runner_spec.cr
+++ b/spec/unit/cli_runner_spec.cr
@@ -213,4 +213,30 @@ describe Hwaro::CLI::Runner do
       end
     end
   end
+
+  describe "#run" do
+    it "prints version with -v, -V, and --version flags" do
+      ["-v", "-V", "--version"].each do |flag|
+        previous_io = Hwaro::Logger.io
+        previous_level = Hwaro::Logger.level
+        sink = IO::Memory.new
+        Hwaro::Logger.io = sink
+        Hwaro::Logger.level = Hwaro::Logger::Level::Info
+
+        old_argv = ARGV.dup
+        ARGV.clear
+        ARGV.push(flag)
+
+        begin
+          Hwaro::CLI::Runner.new.run
+          sink.to_s.should contain(Hwaro::VERSION)
+        ensure
+          ARGV.clear
+          ARGV.concat(old_argv)
+          Hwaro::Logger.io = previous_io
+          Hwaro::Logger.level = previous_level
+        end
+      end
+    end
+  end
 end

--- a/src/cli/runner.cr
+++ b/src/cli/runner.cr
@@ -84,7 +84,7 @@ module Hwaro
         args = ARGV.dup
 
         case command
-        when "-V", "--version"
+        when "-v", "-V", "--version"
           Logger.info "#{Hwaro::VERSION}"
         when "-h", "--help"
           Runner.print_help


### PR DESCRIPTION
## Summary
- Added `-v` flag to print version info alongside `-V` and `--version`.
- Added unit tests for `-v`, `-V`, and `--version` flags in `spec/unit/cli_runner_spec.cr`.
- Updated SKILL.md documentation.