### PR TITLE
chore: switch contributors wall to crystal-actions/hall-of-fame

### DIFF
--- a/.github/hall-of-fame.yml
+++ b/.github/hall-of-fame.yml
@@ -1,0 +1,10 @@
+# https://github.com/crystal-actions/hall-of-fame
+contributors:
+
+output: docs/static/CONTRIBUTORS.svg
+
+grid:
+  columns: 12
+  avatar_size: 56
+  shape: circle
+  show_names: false

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crystal-actions/hall-of-fame@main
+      - uses: crystal-actions/hall-of-fame@v1
         with:
           no_commit: "true"
       - uses: peter-evans/create-pull-request@v8.1.1

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -17,13 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: wow-actions/contributors-list@v1.2.1
+      - uses: crystal-actions/hall-of-fame@main
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          round: false
-          includeBots: false
-          svgPath: docs/static/CONTRIBUTORS.svg
-          noCommit: true
+          no_commit: "true"
       - uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces `wow-actions/contributors-list` with [crystal-actions/hall-of-fame](https://github.com/crystal-actions/hall-of-fame).

Configuration moves out of the workflow and into `.github/hall-of-fame.yml`; the workflow keeps doing what it did before — generate `docs/static/CONTRIBUTORS.svg` and open a PR with it, so the README embed is unchanged.

Verified by dispatching the workflow on this branch twice: once against `@main` and once against the released `@v1`. Both produced the same six-contributor wall (bots filtered), and the second run opened #713 with the result.

One difference worth knowing: the generated SVG now carries both light and dark palettes with a `prefers-color-scheme` media query, so the labels follow the reader's GitHub theme. This wall has labels off, so in practice only the avatars show either way.