### PR TITLE
chore: follow the contributor-mural rename

### DIFF
--- a/.github/contributor-mural.yml
+++ b/.github/contributor-mural.yml
@@ -1,4 +1,4 @@
-# https://github.com/crystal-actions/hall-of-fame
+# https://github.com/crystal-actions/contributor-mural
 contributors:
 
 output: docs/static/CONTRIBUTORS.svg

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crystal-actions/hall-of-fame@v1
+      - uses: crystal-actions/contributor-mural@v1
         with:
           no_commit: "true"
       - uses: peter-evans/create-pull-request@v8.1.1


### PR DESCRIPTION
The action `crystal-actions/hall-of-fame` has been renamed to `crystal-actions/contributor-mural`.

The old `uses:` reference still resolves through the GitHub repository redirect, but the old image stops receiving updates, so this points at the new name.

The config file is renamed in the same commit: this workflow does not pass `config:`, so it depends on the action's default path, which moved from `.github/hall-of-fame.yml` to `.github/contributor-mural.yml`. Renaming only the `uses:` line would leave the run failing with a missing config.

No change to the output — still `docs/static/CONTRIBUTORS.svg`.