### PR TITLE
fix(markdown): only treat `&` as an entity when it starts a well-formed one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- A bare `&` in prose no longer swallows every inline construct up to the next `;` in the same block. `R & D **bold** here; done.` emitted the `**bold**` verbatim; entity references now follow CommonMark — a name from the HTML5 list plus a trailing `;`, anything else is literal text. Also fixes a build-aborting `IndexError` on the input `&;` (#717)
+- `--cache` invalidates when the hwaro binary changes: cached pages were keyed only on their inputs (source, templates, config, cascade), so a rendering fix never reached an incrementally-built site until something else happened to change (#717)
+
 ## v0.18.0
 
 ### Added

--- a/spec/unit/cache_spec.cr
+++ b/spec/unit/cache_spec.cr
@@ -745,7 +745,7 @@ describe Hwaro::Core::Build::Cache do
       end
     end
 
-    it "loads legacy cache format (plain array without metadata)" do
+    it "parses legacy cache format (plain array without metadata) but drops its entries" do
       Dir.mktmpdir do |dir|
         cache_path = File.join(dir, ".hwaro_cache.json")
         test_file = File.join(dir, "test.md")
@@ -756,8 +756,12 @@ describe Hwaro::Core::Build::Cache do
         File.write(cache_path, legacy_json)
 
         cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
-        cache.stats[:total].should eq(1)
-        cache.changed?(test_file).should be_false
+        # Parsed, not rejected as corrupt — the file survives the load.
+        File.exists?(cache_path).should be_true
+        # But a legacy array carries no generator_version, so the hwaro that
+        # wrote those entries is unknown and they cannot be trusted to match
+        # this renderer's output.
+        cache.stats[:total].should eq(0)
       end
     end
 
@@ -770,7 +774,7 @@ describe Hwaro::Core::Build::Cache do
 
         new_json = <<-JSON
           {
-            "metadata":{"template_hash":"abc","config_hash":"def"},
+            "metadata":{"template_hash":"abc","config_hash":"def","generator_version":"#{Hwaro::VERSION}"},
             "entries":[{"path":"#{test_file}","mtime":#{mtime},"hash":"","output_path":""}]
           }
           JSON
@@ -821,7 +825,7 @@ describe Hwaro::Core::Build::Cache do
 
         json_with_extra = <<-JSON
           {
-            "metadata":{"template_hash":"","config_hash":""},
+            "metadata":{"template_hash":"","config_hash":"","generator_version":"#{Hwaro::VERSION}"},
             "entries":[{"path":"#{test_file}","mtime":#{mtime},"hash":"","output_path":"","unknown_field":"value"}]
           }
           JSON
@@ -914,14 +918,19 @@ describe Hwaro::Core::Build::Cache do
       end
     end
 
-    it "loads legacy cache JSON without an output_paths key as an empty array" do
+    it "loads cache JSON without an output_paths key as an empty array" do
       Dir.mktmpdir do |dir|
         cache_path = File.join(dir, ".hwaro_cache.json")
         test_file = File.join(dir, "test.md")
         File.write(test_file, "content")
         mtime = File.info(test_file).modification_time.to_unix_ms
 
-        legacy_json = %([{"path":"#{test_file}","mtime":#{mtime},"hash":"","output_path":""}])
+        legacy_json = <<-JSON
+          {
+            "metadata":{"template_hash":"","config_hash":"","generator_version":"#{Hwaro::VERSION}"},
+            "entries":[{"path":"#{test_file}","mtime":#{mtime},"hash":"","output_path":""}]
+          }
+          JSON
         File.write(cache_path, legacy_json)
 
         cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
@@ -1037,13 +1046,70 @@ describe Hwaro::Core::Build::Cache do
         File.write(cache_path, legacy_json)
 
         # Legacy load marks @dirty=true so the first save upgrades the format
-        # even on an otherwise no-op build.
+        # even on an otherwise no-op build. Its entries are dropped (unknown
+        # writer version), so re-register the file to have something to write.
         cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        cache.update(test_file)
         cache.save
 
         data = Hwaro::Core::Build::CacheData.from_json(File.read(cache_path))
         data.entries.size.should eq(1)
         data.metadata.should be_a(Hwaro::Core::Build::CacheMetadata)
+        data.metadata.generator_version.should eq(Hwaro::VERSION)
+      end
+    end
+
+    it "stamps the running hwaro version on every saved cache file" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+
+        cache = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        cache.update(test_file)
+        cache.save
+
+        data = Hwaro::Core::Build::CacheData.from_json(File.read(cache_path))
+        data.metadata.generator_version.should eq(Hwaro::VERSION)
+      end
+    end
+
+    it "reuses entries written by the same hwaro version" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+
+        c1 = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        c1.update(test_file)
+        c1.save
+
+        c2 = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        c2.stats[:total].should eq(1)
+        c2.changed?(test_file).should be_false
+      end
+    end
+
+    it "invalidates entries written by a different hwaro version" do
+      Dir.mktmpdir do |dir|
+        cache_path = File.join(dir, ".hwaro_cache.json")
+        test_file = File.join(dir, "test.md")
+        File.write(test_file, "content")
+
+        c1 = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        c1.update(test_file)
+        c1.save
+
+        # Same sources, same templates, same config — only the renderer moved.
+        # Nothing else in the entry can detect that, so without the version
+        # stamp a rendering fix would never reach an incrementally-built site.
+        data = Hwaro::Core::Build::CacheData.from_json(File.read(cache_path))
+        data.metadata.generator_version = "0.0.0-not-this-build"
+        File.write(cache_path, data.to_json)
+
+        c2 = Hwaro::Core::Build::Cache.new(enabled: true, cache_path: cache_path)
+        c2.stats[:total].should eq(0)
+        c2.changed?(test_file).should be_true
       end
     end
   end

--- a/spec/unit/markdown_entities_spec.cr
+++ b/spec/unit/markdown_entities_spec.cr
@@ -1,0 +1,103 @@
+require "../spec_helper"
+
+# Regression coverage for ext/markd_entity_fix.cr — a bare `&` used to be
+# treated as the opening of a named entity, and the scanner then ran forward
+# without a bound to the next `;`, swallowing every inline construct in
+# between (hwaro#717). Both characters are ordinary English punctuation, so
+# this silently broke prose on successful builds.
+private def render(content : String) : String
+  html, _ = Hwaro::Content::Processors::Markdown.new.render(content, highlight: false)
+  html.strip
+end
+
+describe "markdown entity scanning" do
+  describe "a bare ampersand is literal text" do
+    it "keeps parsing emphasis before a later semicolon" do
+      render("R & D **bold** here; done.")
+        .should eq("<p>R &amp; D <strong>bold</strong> here; done.</p>")
+    end
+
+    it "keeps parsing code spans before a later semicolon" do
+      render("R & D `code` here; done.")
+        .should eq("<p>R &amp; D <code>code</code> here; done.</p>")
+    end
+
+    it "keeps parsing links before a later semicolon" do
+      render("R & D [link](/) here; done.")
+        .should eq(%(<p>R &amp; D <a href="/">link</a> here; done.</p>))
+    end
+
+    it "handles the ampersand-then-semicolon run spanning many words" do
+      render("Preferences → **Network & Tabs** → **Network**. It is not a per-project lock; done.")
+        .should eq("<p>Preferences → <strong>Network &amp; Tabs</strong> → " \
+                   "<strong>Network</strong>. It is not a per-project lock; done.</p>")
+    end
+
+    it "keeps parsing when the ampersand and semicolon are on different lines" do
+      # How the bug actually showed up in the wild: a soft line break sits
+      # between the two characters, so the run crosses lines inside one block.
+      render("**Cards & containers:** a soft-wrapped sentence\nwith an inset highlight; done.")
+        .should eq("<p><strong>Cards &amp; containers:</strong> a soft-wrapped sentence\n" \
+                   "with an inset highlight; done.</p>")
+    end
+
+    it "is unaffected by a semicolon that precedes the ampersand" do
+      render("a; b & c **bold**.")
+        .should eq("<p>a; b &amp; c <strong>bold</strong>.</p>")
+    end
+
+    it "handles an ampersand with no semicolon at all" do
+      render("R & D **bold** here. done.")
+        .should eq("<p>R &amp; D <strong>bold</strong> here. done.</p>")
+    end
+  end
+
+  describe "well-formed references still decode" do
+    it "decodes named references" do
+      render("&amp; &copy; &nbsp; &frac34; &AMP;")
+        .should eq("<p>&amp; © \u{00A0} ¾ &amp;</p>")
+    end
+
+    it "decodes the longest name in the HTML5 list" do
+      render("&CounterClockwiseContourIntegral;").should eq("<p>∳</p>")
+    end
+
+    it "decodes decimal and hexadecimal references" do
+      render("&#38; &#x26; &#8212;").should eq("<p>&amp; &amp; —</p>")
+    end
+
+    it "maps out-of-range codepoints to the replacement character" do
+      render("&#0; &#xD800;").should eq("<p>\u{FFFD} \u{FFFD}</p>")
+    end
+  end
+
+  describe "malformed references stay literal" do
+    it "leaves an unknown name alone and keeps parsing after it" do
+      render("&notanentity; **bold**")
+        .should eq("<p>&amp;notanentity; <strong>bold</strong></p>")
+    end
+
+    it "leaves an over-long name alone" do
+      render("&ThisNameIsWayTooLongToEverBeAnEntityName; **bold**")
+        .should eq("<p>&amp;ThisNameIsWayTooLongToEverBeAnEntityName; <strong>bold</strong></p>")
+    end
+
+    it "leaves malformed numeric references alone" do
+      render("&#xZZ; &#99999999; &#; **bold**")
+        .should eq("<p>&amp;#xZZ; &amp;#99999999; &amp;#; <strong>bold</strong></p>")
+    end
+
+    it "does not crash on an empty entity name" do
+      # Upstream indexed byte 0 of the empty name and raised IndexError,
+      # aborting the whole build.
+      render("&; **bold**").should eq("<p>&amp;; <strong>bold</strong></p>")
+    end
+  end
+
+  describe "surrounding constructs are untouched" do
+    it "leaves ampersands inside code spans and links escaped" do
+      render("`a & b;` and [a & b](/x?y=1&z=2)")
+        .should eq(%(<p><code>a &amp; b;</code> and <a href="/x?y=1&amp;z=2">a &amp; b</a></p>))
+    end
+  end
+end

--- a/src/core/build/cache.cr
+++ b/src/core/build/cache.cr
@@ -103,6 +103,21 @@ module Hwaro
         @[JSON::Field(key: "section_set_hash", emit_null: false)]
         property section_set_hash : String = ""
 
+        # hwaro version that wrote this cache. Every hash above fingerprints
+        # the *inputs* (sources, templates, config, cascade) — none of them
+        # move when only the renderer changes, so a build that fixes how
+        # markdown becomes HTML would otherwise never reach a `--cache` site:
+        # its pages are unedited, so they stay skipped indefinitely. Treating
+        # a version change as a full invalidation costs one cold build per
+        # upgrade and makes every future rendering fix actually land.
+        #
+        # Written by Cache#save (which always stamps the running version, so
+        # the in-memory rebuilds in set_global_checksums/set_set_fingerprints
+        # cannot drop it) and compared by Cache#load. Default "" so caches
+        # written before this field existed invalidate once on upgrade.
+        @[JSON::Field(key: "generator_version", emit_null: false)]
+        property generator_version : String = ""
+
         def initialize(@template_hash : String = "", @config_hash : String = "",
                        @page_set_hash : String = "", @section_set_hash : String = "")
         end
@@ -364,7 +379,13 @@ module Hwaro
             # be writing @entries via #update, and iterating a Hash mid-mutation
             # is undefined behavior under -Dpreview_mt.
             data = @mutex.synchronize do
-              CacheData.new(metadata: @metadata, entries: @entries.values)
+              # Stamp the running version on the copy that goes to disk, so the
+              # next build can tell the renderer changed even though every input
+              # hash matches (see CacheMetadata#generator_version). CacheMetadata
+              # is a struct, so this leaves @metadata itself untouched.
+              stamped = @metadata
+              stamped.generator_version = Hwaro::VERSION
+              CacheData.new(metadata: stamped, entries: @entries.values)
             end
             File.write(tmp_path, data.to_json)
             File.rename(tmp_path, @cache_path)
@@ -411,6 +432,19 @@ module Hwaro
               @metadata = CacheMetadata.new
               delete_corrupt_cache
             end
+          end
+
+          # A different hwaro wrote this cache: its entries were rendered by a
+          # different renderer, and no input hash can detect that. Drop them so
+          # renderer fixes reach incrementally-built sites (see
+          # CacheMetadata#generator_version).
+          if @metadata.generator_version != Hwaro::VERSION
+            unless @entries.empty?
+              Logger.info "  Cache: hwaro version changed — invalidating all entries."
+              @entries.clear
+            end
+            @metadata = CacheMetadata.new
+            @dirty = true
           end
         end
 

--- a/src/ext/markd_entity_fix.cr
+++ b/src/ext/markd_entity_fix.cr
@@ -1,0 +1,78 @@
+# Monkey-patch for Markd's inline entity scanner — kept here so we don't
+# fork the vendored library, mirroring ext/crinja_resolve_fix.cr and
+# ext/tartrazine_mt_fix.cr.
+#
+# Upstream `Markd::Parser::Inline#entity` treats ANY `&` as the start of a
+# named entity and then scans forward without a bound for the next `;`,
+# consuming everything in between as one text node. A bare ampersand in
+# prose therefore swallowed every inline construct up to the next
+# semicolon in the same block:
+#
+#   `R & D **bold** here; done.` => `R &amp; D **bold** here; done.`
+#
+# The `**bold**`, `` `code` ``, `[link](/)` between the two characters were
+# never parsed — they were emitted verbatim, silently, on a successful
+# build. Both `&` and `;` are ordinary English punctuation, so any
+# paragraph pairing them was at risk (hwaro#717).
+#
+# CommonMark 0.31.2 "Entity and numeric character references" specifies the
+# bounded grammar we implement instead: a named reference is `&`, a name
+# from the HTML5 named-character-reference list, and a trailing `;` — with
+# no lenient semicolon-less forms, "because it makes the grammar too
+# ambiguous". Anything else is literal text. Markd's own
+# ENTITIES_MAPPINGS is exactly that list (2125 names), so membership in it
+# is the authority on whether a run is an entity.
+#
+# Falling through with `false` is the correct literal path: the caller
+# (`process_line`) emits the `&` as a one-char text node, bumps the
+# position by one, and resumes normal inline parsing on the rest — so the
+# markup after the ampersand is parsed, and the renderer escapes the `&`
+# to `&amp;` on output.
+#
+# This also fixes a hard crash: `&;` gave upstream an empty entity name and
+# `decode_entity` indexed byte 0 of it, raising IndexError and aborting the
+# build. An empty name cannot match the bounded grammar, so it never
+# reaches the decoder now.
+#
+# The numeric branch is left untouched — `Rule::NUMERIC_HTML_ENTITY` is
+# already anchored and bounded per the same spec section.
+#
+# No upstream issue is filed yet (as of 2026-07). Remove when: upstream
+# requires a well-formed, list-backed name before consuming the run.
+
+require "markd"
+
+module Markd
+  module Rule
+    # `&` + HTML5 name + `;`. The length cap covers the longest name in the
+    # list ("CounterClockwiseContourIntegral", 31 chars); the mapping lookup
+    # below is what actually decides validity.
+    NAMED_HTML_ENTITY = /^&[a-zA-Z][a-zA-Z0-9]{1,31};/
+  end
+end
+
+module Markd::Parser
+  class Inline
+    private def entity(node : Node)
+      return false unless char_at?(@pos) == '&'
+
+      if char_at?(@pos + 1) == '#'
+        matched = match(Rule::NUMERIC_HTML_ENTITY) || return false
+        body = matched.byte_slice(1, matched.bytesize - 2)
+      else
+        start_pos = @pos
+        matched = match(Rule::NAMED_HTML_ENTITY) || return false
+        body = matched.byte_slice(1, matched.bytesize - 2)
+        # Not a real HTML5 name: rewind so the `&` is re-emitted as literal
+        # text and the rest of the run goes back through inline parsing.
+        unless Markd::HTMLEntities::ENTITIES_MAPPINGS.has_key?(body)
+          @pos = start_pos
+          return false
+        end
+      end
+
+      node.append_child(text(HTML.decode_entity(body)))
+      true
+    end
+  end
+end

--- a/src/hwaro.cr
+++ b/src/hwaro.cr
@@ -22,6 +22,7 @@ require "crinja"
 require "./ext/crinja_resolve_fix"
 require "http/server"
 require "markd"
+require "./ext/markd_entity_fix"
 require "toml"
 require "emoji"
 


### PR DESCRIPTION
Closes #717

## Problem

A bare `&` in body text made the renderer drop every inline construct between it and the next `;` in the same block, emitting the markup verbatim on a successful build:

```html
<p>A: R &amp; D **bold** here; done.</p>   <!-- BROKEN -->
<p>D: R &amp; D `code` here; done.</p>     <!-- BROKEN -->
<p>E: R &amp; D [link](/) here; done.</p>  <!-- BROKEN -->
```

## Root cause

`Markd::Parser::Inline#entity` (`lib/markd/src/markd/parsers/inline.cr:426`) treats **any** `&` as the start of a named entity, then scans forward with no bound for the next `;`:

```crystal
pos = @pos + 1
loop do
  char = char_at?(pos); pos += 1
  case char
  when ';'             then break        # <-- any `;`, however distant
  when Char::ZERO, nil then return false
  end
end
```

`HTML.decode_entity` finds no match and hands the whole run back verbatim as one text node, so the markup inside it is never parsed. Both `&` and `;` are ordinary English punctuation, so any prose pairing them was at risk. This hit 7 pages on a published site before anyone noticed.

## Fix

New `src/ext/markd_entity_fix.cr` patches the method in place — same approach as the existing `crinja_resolve_fix.cr` / `tartrazine_mt_fix.cr`, so the shard is not forked. It implements the CommonMark 0.31.2 [grammar](https://spec.commonmark.org/0.31.2/#entity-and-numeric-character-references): a named reference is `&`, a name from the HTML5 named-character-reference list, and a trailing `;`. Anything else rewinds and returns `false`, which is already the correct literal path upstream — the caller emits `&` as a one-char text node and resumes inline parsing on the rest. The numeric branch is untouched (`Rule::NUMERIC_HTML_ENTITY` was already anchored and bounded).

Validity is decided by membership in markd's own `ENTITIES_MAPPINGS`, which is exactly the CommonMark list — all 2125 keys match the regex bound `[a-zA-Z][a-zA-Z0-9]{1,31}`, so it neither over- nor under-matches.

**Bonus crash:** `&;` in any content gave upstream an empty entity name, and `decode_entity` indexed byte 0 of it — `IndexError`, build aborted. An empty name can't match the bounded grammar, so it never reaches the decoder.

## Second fix: cache invalidation on renderer change

The build cache keys entries on source mtime/hash, `template_hash`, `config_hash`, and `cascade_hash` — none of which move when only the hwaro binary changes. A `--cache` site upgrading to this build would have kept serving the broken HTML indefinitely, since the pages themselves are unedited. `CacheMetadata` now records the hwaro version that wrote the cache (stamped in `#save`, so the in-memory metadata rebuilds in `set_global_checksums` / `set_set_fingerprints` can't drop it) and `#load` invalidates on mismatch.

Verified end to end — old binary builds with `--cache`, then upgrade:

```
--- old binary, --cache (pre-fix output):
<p>A: R &amp; D **bold** here; done.</p>
--- upgrade: new binary, --cache, nothing else touched:
  Cache: hwaro version changed — invalidating all entries.
render: 1 pages
<p>A: R &amp; D <strong>bold</strong> here; done.</p>
--- second run of the new binary:
render: 0 pages, 1 cached
```

One cold build per version upgrade; steady state is unchanged.

## Verification

- All six repro cases from the issue plus the real-world 14-word paragraph, through an actual `hwaro build`.
- **CommonMark conformance unchanged**: markd's own fixtures with and without the patch — `spec.txt` 649/649, `regression.txt` 14/14, `smart_punct.txt` 15/15.
- **Corpus differential**: all 189 `.md` files in this repo rendered both ways. Exactly one file differs (`skills/hwaro-design/SKILL.md`) and all three diffs are the intended fix. Zero unintended changes.
- **Build determinism**: `docs/` built with both binaries — 476 files, byte-identical.
- New `spec/unit/markdown_entities_spec.cr` (16 examples): the six repro cases, the newline-crossing shape the bug actually took in the wild, valid named/decimal/hex refs (`&copy;` `&AMP;` `&CounterClockwiseContourIntegral;` `&#38;` `&#x26;`), out-of-range codepoints → U+FFFD, malformed refs staying literal (`&notanentity;`, over-long names, `&#xZZ;`, `&#99999999;`, `&;`), and code spans / link destinations unaffected.
- Cache specs updated for the new contract, plus coverage for same-version reuse, different-version invalidation, and version stamping on save.
- Full suite 6701/6701, `crystal tool format --check` and ameba (436 files) clean.

Heading anchor IDs are unchanged, so there is no deep-link churn.

## Upstream

Not yet filed against [icyleaf/markd](https://github.com/icyleaf/markd); the patch header documents the removal criteria for when it is fixed upstream.
