### PR TITLE
fix(markdown): correct three defects in markd's entity decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 - A bare `&` in prose no longer swallows every inline construct up to the next `;` in the same block. `R & D **bold** here; done.` emitted the `**bold**` verbatim; entity references now follow CommonMark — a name from the HTML5 list plus a trailing `;`, anything else is literal text. Also fixes a build-aborting `IndexError` on the input `&;` (#717)
 - `--cache` invalidates when the hwaro binary changes: cached pages were keyed only on their inputs (source, templates, config, cascade), so a rendering fix never reached an incrementally-built site until something else happened to change (#717)
+- Numeric character references above U+10FFF decode correctly instead of becoming `�` — this covered every emoji (`&#x1F600;`, `&#128512;`), CJK Ext B and beyond, and math alphanumerics (#719)
+- A long numeric character reference in a link destination, link title, or fence info string no longer aborts the build with `ArgumentError`, and a semicolon-less one (`&#38`) stays literal instead of silently decoding to a control character (#719)
 
 ## v0.18.0
 

--- a/spec/unit/markdown_entities_spec.cr
+++ b/spec/unit/markdown_entities_spec.cr
@@ -100,4 +100,81 @@ describe "markdown entity scanning" do
         .should eq(%(<p><code>a &amp; b;</code> and <a href="/x?y=1&amp;z=2">a &amp; b</a></p>))
     end
   end
+
+  # Link destinations, link titles and fence info strings bypass the inline
+  # scanner and are decoded wholesale by Markd::HTMLEntities::Decoder, which
+  # had three defects of its own. See ext/markd_entity_fix.cr.
+  describe "astral-plane numeric references" do
+    it "decodes emoji rather than the replacement character" do
+      # decode_codepoint range-checked against 0x10FFF instead of 0x10FFFF,
+      # so every codepoint above U+10FFF came back as U+FFFD.
+      render("&#x1F600; &#128512;").should eq("<p>😀 😀</p>")
+    end
+
+    it "decodes other planes above U+10FFF" do
+      render("&#x1D54F; &#x20000; &#x10FFFF;").should eq("<p>𝕏 𠀀 \u{10FFFF}</p>")
+    end
+
+    it "still rejects genuinely out-of-range codepoints and surrogates" do
+      render("&#x110000; &#xD800;").should eq("<p>\u{FFFD} \u{FFFD}</p>")
+    end
+
+    it "decodes astral references in link destinations, titles and fence info" do
+      render("[t](/a?e=&#x1F600;)").should eq(%(<p><a href="/a?e=%F0%9F%98%80">t</a></p>))
+      render(%([t](/a "smile &#x1F600;"))).should eq(%(<p><a href="/a" title="smile 😀">t</a></p>))
+      render("```&#x1F600;\ncode\n```")
+        .should eq(%(<pre><code class="language-😀">code\n</code></pre>))
+    end
+  end
+
+  describe "oversized numeric references outside body text" do
+    # The decoder's pattern put no bound on the digit run and then called
+    # .to_i on it, so these raised ArgumentError and aborted the build.
+    it "does not crash in a link destination" do
+      render("[t](/a?x=&#99999999999999999999;)")
+        .should eq(%(<p><a href="/a?x=&amp;#99999999999999999999;">t</a></p>))
+    end
+
+    it "does not crash in a link title" do
+      render(%([t](/a "&#99999999999999999999;")))
+        .should eq(%(<p><a href="/a" title="&amp;#99999999999999999999;">t</a></p>))
+    end
+
+    it "does not crash in a fence info string" do
+      render("```&#99999999999999999999;\ncode\n```")
+        .should eq(%(<pre><code class="language-&amp;#99999999999999999999;">code\n</code></pre>))
+    end
+  end
+
+  describe "semicolon-less numeric references outside body text" do
+    # The decoder stripped the first AND last character unconditionally, so a
+    # reference with no `;` lost its final digit and decoded the wrong
+    # codepoint — `&#38` became U+0003, `&#100` became a newline.
+    it "leaves them literal in a link destination" do
+      render("[t](/a?x=1&#38y=2)").should eq(%(<p><a href="/a?x=1&amp;#38y=2">t</a></p>))
+      render("[t](/a?x=1&#100y=2)").should eq(%(<p><a href="/a?x=1&amp;#100y=2">t</a></p>))
+    end
+
+    it "leaves them literal in a link title" do
+      render(%([t](/a "q &#38 r"))).should eq(%(<p><a href="/a" title="q &amp;#38 r">t</a></p>))
+    end
+
+    it "leaves them literal in a fence info string" do
+      render("```rb&#38\ncode\n```")
+        .should eq(%(<pre><code class="language-rb&amp;#38">code\n</code></pre>))
+    end
+  end
+
+  describe "well-formed references outside body text still decode" do
+    it "decodes named and numeric references in destinations and titles" do
+      render("[t](/a?x=&#38;y=2)").should eq(%(<p><a href="/a?x=&amp;y=2">t</a></p>))
+      render("[t](/a?x=&amp;y=2)").should eq(%(<p><a href="/a?x=&amp;y=2">t</a></p>))
+      render(%([t](/a "q &amp; r"))).should eq(%(<p><a href="/a" title="q &amp; r">t</a></p>))
+    end
+
+    it "decodes references in a fence info string" do
+      render("```C&#43;&#43;\ncode\n```")
+        .should eq(%(<pre><code class="language-C++">code\n</code></pre>))
+    end
+  end
 end

--- a/src/ext/markd_entity_fix.cr
+++ b/src/ext/markd_entity_fix.cr
@@ -76,3 +76,88 @@ module Markd::Parser
     end
   end
 end
+
+# === Decoder: the entity path used OUTSIDE inline body text ================
+#
+# Link destinations, link titles, and fence info strings do not go through
+# the scanner above — they are decoded wholesale by
+# `Markd::HTMLEntities::Decoder.decode` (via `Markd::Utils
+# .decode_entities_string`). That decoder has three defects of its own,
+# found while auditing the neighbourhood of hwaro#717. All three are fixed
+# by overriding the three methods below; `Decoder::REGEX` itself cannot be
+# reassigned from a reopened module, so `decode` switches to the strict
+# pattern defined here and the old constant simply goes unused.
+#
+# 1. CRASH. `REGEX` accepts `#\d+;?` with no digit bound and `decode_entity`
+#    then calls `.to_i` on the run, so a long enough reference raises
+#    `ArgumentError: Invalid Int32` and aborts the build:
+#      `[t](/a?x=&#99999999999999999999;)` — link destination
+#      `[t](/a "&#99999999999999999999;")` — link title
+#      "```&#99999999999999999999;"       — fence info string
+#    hwaro's own importer already guards this with `to_i?` (see
+#    html_to_markdown.cr); the vendored decoder does not.
+#
+# 2. MIS-DECODE. `REGEX` makes the trailing `;` optional, but `decode`
+#    unconditionally strips the FIRST AND LAST character before decoding.
+#    A semicolon-less reference therefore loses its final digit and decodes
+#    the wrong codepoint entirely: `&#38` -> U+0003, `&#100` -> newline.
+#    CommonMark does not recognize semicolon-less references at all, so the
+#    strict pattern leaves them as literal text.
+#
+# 3. ASTRAL PLANE. `decode_codepoint` range-checks against `0x10FFF`
+#    (69_631) where Unicode's maximum is `0x10FFFF` (1_114_111) — one hex
+#    digit short. EVERY reference above U+10FFF decoded to U+FFFD: all
+#    emoji (`&#x1F600;`, `&#128512;`), CJK Ext B and beyond, math
+#    alphanumerics, musical symbols. This one also reaches ordinary body
+#    text through the scanner above.
+#
+# Remove when: upstream requires `;`, bounds the digit run, parses with
+# `to_i?`, and range-checks against 0x10FFFF.
+
+module Markd::HTMLEntities
+  module Decoder
+    # The CommonMark 0.31.2 grammar, matching Rule::NAMED_HTML_ENTITY and
+    # Rule::NUMERIC_HTML_ENTITY above: `;` required, digits bounded.
+    STRICT_REGEX = /&(?:[a-zA-Z][a-zA-Z0-9]{1,31}|#[Xx][0-9a-fA-F]{1,6}|#[0-9]{1,7});/
+
+    def self.decode(source)
+      source.gsub(STRICT_REGEX) do |chars|
+        # Safe now that the pattern guarantees a leading `&` and trailing `;`
+        # with a non-empty body between them.
+        decode_entity(chars[1..-2])
+      end
+    end
+
+    def self.decode_entity(chars)
+      return "&;" if chars.empty?
+
+      if chars[0] == '#'
+        if chars.size > 2 && chars[1].downcase == 'x'
+          # to_i?, not to_i: never raise on a caller that skipped the pattern.
+          if codepoint = chars[2..-1].to_i?(16)
+            return decode_codepoint(codepoint)
+          end
+        elsif chars.size > 1
+          if codepoint = chars[1..-1].to_i?(10)
+            return decode_codepoint(codepoint)
+          end
+        end
+      elsif resolved_entity = Markd::HTMLEntities::ENTITIES_MAPPINGS[chars]?
+        return resolved_entity
+      end
+
+      "&#{chars};"
+    end
+
+    def self.decode_codepoint(codepoint)
+      # 0x10FFFF, not 0x10FFF — see defect 3 above.
+      return "�" if (0xD800 <= codepoint <= 0xDFFF) || codepoint > 0x10FFFF
+
+      if decoded = Markd::HTMLEntities::DECODE_MAPPINGS[codepoint]?
+        codepoint = decoded
+      end
+
+      codepoint.unsafe_chr
+    end
+  end
+end


### PR DESCRIPTION
Follow-up audit of the neighbourhood of #717 / #718.

The scanner patched in #718 covers inline body text. Link destinations, link titles, and fence info strings never reach it — they are decoded wholesale by `Markd::HTMLEntities::Decoder`, which has three defects of its own. All are reachable from ordinary content.

## 1. Every astral-plane reference became U+FFFD

`decode_codepoint` range-checks against `0x10FFF` (69,631). Unicode's maximum is `0x10FFFF` (1,114,111) — one hex digit short. So **every** numeric character reference above U+10FFF decoded to the replacement character:

| input | before | after |
|---|---|---|
| `&#x1F600;` | U+FFFD | grinning face |
| `&#128512;` | U+FFFD | grinning face |
| `&#x1D54F;` | U+FFFD | math double-struck X |
| `&#x20000;` | U+FFFD | CJK Ext B |
| `&#x10FFFF;` | U+FFFD | U+10FFFF |
| `&#x110000;` | U+FFFD | U+FFFD (correct — out of range) |
| `&#xD800;` | U+FFFD | U+FFFD (correct — surrogate) |

This one reaches ordinary body text as well as the three surfaces below. hwaro's own importer already uses the correct bound (`html_to_markdown.cr`), which is what made the vendored decoder's value look wrong.

## 2. Build-aborting crash

The decoder's pattern allows an unbounded digit run and `decode_entity` then calls `.to_i` on it. All three of these raise `ArgumentError: Invalid Int32` and kill the build:

- link destination — `[t](/a?x=&#99999999999999999999;)`
- link title — `[t](/a "&#99999999999999999999;")`
- fence info string — a fence opened with `&#99999999999999999999;` as its language

Same family as the `&;` `IndexError` fixed in #718. Body text was already safe after that PR; these three surfaces were not.

## 3. Semicolon-less references mis-decoded

The pattern makes the trailing `;` optional, but `decode` strips the **first and last** character unconditionally before decoding. A reference without `;` therefore loses its final digit and decodes something else entirely:

- `&#38` decoded to U+0003 (not `&`), and `&#100` to a newline (not `d`)
- `[t](/a?x=1&#38y=2)` produced `href="/a?x=1%03y=2"`
- a fence opened with `rb&#38` produced `class="language-rb"` plus a control character

CommonMark does not recognize semicolon-less references at all, so they now stay literal.

## Fix

Overrides `decode` / `decode_entity` / `decode_codepoint` in the existing `src/ext/markd_entity_fix.cr`: the CommonMark grammar (`;` required, digits bounded to 7 decimal / 6 hex, matching `Rule::NUMERIC_HTML_ENTITY`), `to_i?` instead of `to_i` so no caller can crash the decoder regardless of pattern, and the correct `0x10FFFF` bound. `Decoder::REGEX` cannot be reassigned from a reopened module, so `decode` switches to a strict pattern defined in the ext and the old constant goes unused.

## Verification

- **CommonMark conformance identical** with and without the patch: `spec.txt` 649/649, `regression.txt` 14/14, `smart_punct.txt` 15/15.
- **Corpus differential vs `main`**: the repo's 146 markdown files render byte-identically.
- **Build determinism**: `docs/` built with both binaries — 476 files, byte-identical.
- 12 new examples (28 total in the file) covering all three defects on each affected surface, plus regression guards that `&#38;`, `&amp;`, `&copy;` and `&#43;` still decode normally in destinations, titles and fence info.
- Full suite 6713/6713, format + ameba clean.

## How I looked for more

The oracle from #717 generalized: wrap a known-good construct in every pair of punctuation tokens and check it still renders.

- **Inline axis** — 6 constructs (bold, code span, link, emphasis, image, strikethrough) x 53² token pairs x 2 configs (defaults / all extensions on). Every hit was a legitimate consumer (backtick code span, `$$...$$` math, HTML comment). Zero unexplained.
- **Container axis** — 13 block containers (paragraph, soft-wrapped paragraph, heading, list item, ordered item, blockquote, nested list, table cell, admonition, definition list, footnote, `:::` container, task item) x 47² token pairs. Zero swallowing, zero crashes.

So #717 was isolated in the scanner, and the remaining defects were all in the decoder the scanner does not cover.

## Upstream

Still not filed against [icyleaf/markd](https://github.com/icyleaf/markd) — all four defects (#718's plus these three) are upstream bugs. The patch header documents removal criteria for each.
