### PR TITLE
fix: 24 defects from a ten-round source-wide audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.19.0, 1.20.0, 1.21.0]
+        crystal-version: [1.21.0]
     steps:
       - uses: actions/checkout@v6
       - uses: crystal-lang/install-crystal@v1
@@ -31,9 +31,7 @@ jobs:
       - name: Install dependencies
         run: shards install
       - name: Build
-        # `-Dpreview_mt` mirrors release builds so CI surfaces fiber-race
-        # regressions before they ship.
-        run: shards build -Dpreview_mt
+        run: shards build
   build-docker:
     strategy:
       fail-fast: false
@@ -76,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.19.0, 1.20.0, 1.21.0]
+        crystal-version: [1.21.0]
     steps:
       - uses: actions/checkout@v6
       - uses: crystal-lang/install-crystal@v1
@@ -85,9 +83,7 @@ jobs:
       - name: Install dependencies
         run: shards install
       - name: Build binary
-        # `-Dpreview_mt` mirrors release builds so CI surfaces fiber-race
-        # regressions before they ship.
-        run: shards build -Dpreview_mt
+        run: shards build
       - name: Run tests
         run: crystal spec
   build-snapcraft:

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -45,14 +45,14 @@ jobs:
         run: |
           mkdir -p build
           # Use Alpine/musl-based Crystal container for proper static binary.
-          # `-Dpreview_mt` enables Crystal's multi-threaded runtime; without
-          # it, `hwaro build` runs all fibers on a single OS thread and big
-          # sites are bottlenecked on one core.
-          docker run --rm -v $(pwd):/hwaro -w /hwaro --entrypoint="" crystallang/crystal:1.20.0-alpine sh -c "
+          # Parallelism comes from Crystal's execution contexts, sized in
+          # src/main.cr — the old `-Dpreview_mt` flag is deprecated and its
+          # legacy MT scheduler can spin forever at process exit.
+          docker run --rm -v $(pwd):/hwaro -w /hwaro --entrypoint="" crystallang/crystal:1.21.0-alpine sh -c "
             apk add --no-cache yaml-dev git curl &&
             shards install --release --no-debug --production &&
             mkdir -p build &&
-            crystal build src/main.cr -o build/hwaro-${GITHUB_REF_SLUG}-linux-${ARCH} --release --no-debug --static -Dpreview_mt
+            crystal build src/main.cr -o build/hwaro-${GITHUB_REF_SLUG}-linux-${ARCH} --release --no-debug --static
           "
       - if: matrix.platform == 'macos'
         name: Install macOS build dependencies
@@ -64,7 +64,7 @@ jobs:
           OPENSSL_PREFIX="$(brew --prefix openssl@3)"
           export PKG_CONFIG_PATH="${OPENSSL_PREFIX}/lib/pkgconfig"
           BIN="build/hwaro-${GITHUB_REF_SLUG}-osx-${ARCH}"
-          crystal build src/main.cr -o "$BIN" --no-debug --release -Dpreview_mt
+          crystal build src/main.cr -o "$BIN" --no-debug --release
           chmod +x scripts/package-macos.sh
           scripts/package-macos.sh "$BIN" "build/hwaro-${GITHUB_REF_SLUG}-osx-${ARCH}.tar.gz" hwaro
           rm -f "$BIN"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Hwaro is a fast, lifecycle-driven static site generator written in Crystal. Feat
 
 ## Build & Run
 ```bash
-just build          # shards install && shards build -Dpreview_mt → bin/hwaro
+just build          # shards install && shards build → bin/hwaro
 just test           # crystal spec (unit + functional + content)
 just fix            # crystal tool format
 just dev            # Serve docs site locally (bin/hwaro serve -i docs)
@@ -13,7 +13,7 @@ just clean          # Remove bin/, lib/, stb_impl.o
 ```
 Dependencies (shard.yml): `markd` (Markdown), `toml` (TOML parsing), `crinja` (Jinja2 templates), `emoji`.
 
-All build paths (dev, CI, docker, snap, homebrew, release-binary) pass `-Dpreview_mt` so the multi-threaded Crystal runtime is enabled. Set `CRYSTAL_WORKERS=N` to override the worker count (default 4). New code that mutates shared state from worker fibers must guard with a `Mutex` or use the existing `@crinja_cache_mutex`; new directory creation must go through `Hwaro::Utils::FileSafe.mkdir_p` rather than `FileUtils.mkdir_p` (the latter has a check-then-create race that fires under MT).
+Hwaro requires Crystal >= 1.21 and gets its parallelism from Crystal's **execution contexts**: `src/main.cr` resizes the default `Fiber::ExecutionContext::Parallel` to `default_workers_count` (which honours `CRYSTAL_WORKERS`, defaulting to the CPU count). Do NOT reintroduce `-Dpreview_mt` — Crystal 1.21 deprecated it, and its legacy MT scheduler can spin forever at process exit (all `CRYSTAL-MT-*` threads stuck in `Crystal::SpinLock#lock` inside the event loop), so `hwaro build` never returns. Every `spawn` lands in the default context, so the build still runs fibers across cores: new code that mutates shared state from worker fibers must guard with a `Mutex` or use the existing `@crinja_cache_mutex`; new directory creation must go through `Hwaro::Utils::FileSafe.mkdir_p` rather than `FileUtils.mkdir_p` (the latter has a check-then-create race that fires under parallelism).
 
 ## Directory Structure
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- HTML minifier no longer deletes rendered `&nbsp;`: Crystal's `\s` (UCP) matched U+00A0/U+3000, so a non-breaking space between two tags was downgraded to a breakable space or dropped outright
+- CSS minifier no longer mangles descendant combinators inside at-rule blocks (`@media screen{.card :hover{…}}` became the compound `.card:hover`), and a comment containing an apostrophe (`/* don't */`) no longer swallows the rules after it
+- `slugify()` treats the ideographic space U+3000 and U+00A0 as word separators instead of dropping them — CJK titles no longer weld into one slug segment
+- Block shortcodes whose name starts with a Jinja keyword (`callout`, `iframe`, `setup`, `format`, `blockquote`, …) expand again when closed with the named form `{% endcallout %}`; previously the raw shortcode source leaked into the published page. Hyphenated names (`include-code`) work too
+- `absolute_url`/`relative_url`/`url_for`/`get_url` leave `mailto:`, `tel:`, `data:` and protocol-relative `//host` URLs alone instead of prefixing base_url onto them
+- `resize_image(width="800")` and `truncate_words(length="20")` accept quoted numbers — every shortcode argument is a String, and these used to raise and abort the page render
+- `og:image`, `twitter:image` and JSON-LD `image` handle protocol-relative and `data:` values, and absolutize a relative path that merely starts with the letters "http"
+- `robots.txt` advertises the sitemap at the path the sitemap generator actually writes (a `filename` with a directory component pointed crawlers at a 404)
+- `get_taxonomy_url` on a multilingual site links to that language's term page (`/ko/tags/foo/`) when one exists — a term appearing only in non-default-language content previously linked to a root page that was never written
+- **Release binaries could hang forever at exit.** `-Dpreview_mt` is deprecated in Crystal 1.21 and its legacy MT scheduler spins in the event loop's spin lock at process exit, so `hwaro build` never returned (measured 4/120 short-lived runs under CPU oversubscription). Parallelism now comes from Crystal's execution contexts, sized in `src/main.cr`
+- Sass grouping parentheses no longer leak into declaration values (`width: (10px / 2)`, `margin: (1px 2px)`); a failing namespaced reference (`math.div(…)`) now warns with a `path:line:col` location instead of silently emitting invalid CSS
+- GFM tables with short alignment delimiters (`|:--|--:|`, `|:-:|`, `| - |`) render as tables; the delimiter cell now matches GFM's `:?-+:?` instead of requiring three hyphens
+- `hwaro tool check-links` stops reporting valid links as dead: angle-bracket destinations (`[t](</about/>)`, including ones containing spaces) and destinations with balanced parentheses (`/docs/foo_(bar)`)
+- An oversized `[image_processing] widths` entry no longer aborts the build with a bare `OverflowError`; the variant is declined by the existing pixel-count guard instead
+
+### Changed
+- **Breaking (packagers):** minimum Crystal is now 1.21, and no build path passes `-Dpreview_mt` any more. Worker count still honours `CRYSTAL_WORKERS` (now defaulting to the CPU count)
+
 ## v0.18.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Hwaro processes Markdown content with TOML, YAML, or JSON front matter and Jinja
 - Page weight and custom sorting (by date, weight, title)
 
 ### Build & Performance
-- Multi-threaded parallel processing (Crystal `preview_mt`) — tune with `CRYSTAL_WORKERS` (default 4)
+- Multi-threaded parallel processing (Crystal execution contexts) — tune with `CRYSTAL_WORKERS` (defaults to the CPU count)
 - Incremental build caching
 - Streaming build mode with memory limits
 - Pre/post build hooks
@@ -104,9 +104,9 @@ cd hwaro
 shards install
 
 # Build
-# -Dpreview_mt enables the multi-threaded runtime (how official binaries
-# ship) — without it, builds render on a single thread.
-shards build --release --no-debug --production -Dpreview_mt
+# Parallelism comes from Crystal's execution contexts, sized in src/main.cr
+# (same as the official binaries). Requires Crystal >= 1.21.
+shards build --release --no-debug --production
 ```
 
 > For more installation options including Docker and pre-built binaries, see the [Installation Guide](https://hwaro.hahwul.com/start/installation/).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ##= BUILDER =##
-FROM crystallang/crystal:1.20.0 AS builder
+FROM crystallang/crystal:1.21.0 AS builder
 WORKDIR /hwaro
 
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,10 +10,10 @@ COPY shard.yml shard.lock ./
 RUN shards install --production
 
 COPY . .
-# `-Dpreview_mt` enables Crystal's multi-threaded runtime so `hwaro build`
+# Parallelism comes from Crystal's execution contexts (see src/main.cr) so `hwaro build`
 # can use multiple cores on big sites. Default workers = 4; override with
 # CRYSTAL_WORKERS at run time.
-RUN shards build --release --no-debug --production -Dpreview_mt && \
+RUN shards build --release --no-debug --production && \
     strip /hwaro/bin/hwaro
 
 ##= RUNNER =##

--- a/docs/content/start/installation.ko.md
+++ b/docs/content/start/installation.ko.md
@@ -96,15 +96,16 @@ sudo mv hwaro-v*-linux-x86_64 /usr/local/bin/hwaro
 git clone https://github.com/hahwul/hwaro
 cd hwaro
 shards install
-shards build --release --no-debug -Dpreview_mt
+shards build --release --no-debug
 ```
 
 바이너리는 `./bin/hwaro`에 생성됩니다.
 
-> `-Dpreview_mt`는 Crystal의 멀티스레드 런타임을 켭니다. 공식 바이너리와
-> Docker 이미지가 이 방식으로 빌드되며, `hwaro build`의 병렬 페이지 렌더링도
-> 이 플래그가 있어야 동작합니다. 패키저는 항상 이 플래그를 넣어야 합니다.
-> 없으면 빌드가 단일 스레드로 실행됩니다.
+> Crystal **1.21 이상**이 필요합니다. 병렬 페이지 렌더링은 `src/main.cr`에서
+> Crystal 기본 실행 컨텍스트 크기를 조정해 켜지므로 별도 빌드 플래그가
+> 필요 없습니다. 워커 수는 `CRYSTAL_WORKERS=N`으로 조정할 수 있습니다(기본값은
+> CPU 코어 수). 예전 `-Dpreview_mt` 플래그는 넣지 마세요. Crystal 1.21에서
+> deprecated 되었고, 해당 스케줄러는 프로세스 종료 시 멈출 수 있습니다.
 
 ### PATH 등록 (선택)
 

--- a/docs/content/start/installation.md
+++ b/docs/content/start/installation.md
@@ -96,15 +96,16 @@ sudo mv hwaro-v*-linux-x86_64 /usr/local/bin/hwaro
 git clone https://github.com/hahwul/hwaro
 cd hwaro
 shards install
-shards build --release --no-debug -Dpreview_mt
+shards build --release --no-debug
 ```
 
 The binary is created at `./bin/hwaro`.
 
-> `-Dpreview_mt` enables Crystal's multi-threaded runtime — it is how the
-> official binaries and Docker image are built, and `hwaro build` renders
-> pages in parallel only with it. Packagers should always pass this flag;
-> without it, builds run on a single thread.
+> Requires Crystal **1.21 or newer**. Parallel page rendering is enabled in
+> `src/main.cr`, which resizes Crystal's default execution context — no build
+> flag needed. Set `CRYSTAL_WORKERS=N` to override the worker count (it
+> defaults to the CPU count). Do not pass the old `-Dpreview_mt` flag:
+> Crystal 1.21 deprecated it and its scheduler can hang at process exit.
 
 ### Add to PATH (Optional)
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
 
           buildPhase = ''
             runHook preBuild
-            shards build --release -Dpreview_mt
+            shards build --release
             runHook postBuild
           '';
 

--- a/justfile
+++ b/justfile
@@ -9,13 +9,13 @@ default:
 
 # Build hwaro binary.
 #
-# Always passes `-Dpreview_mt` so dev/CI builds exercise the same
-# multi-threaded runtime that release binaries ship with. Without this,
-# fiber races stay hidden in dev and only surface for end users.
+# Parallelism comes from Crystal's execution contexts (see src/main.cr),
+# not the deprecated `-Dpreview_mt` flag: its legacy MT scheduler spins
+# forever at exit under CPU oversubscription and the process never quits.
 [group('build')]
 build:
     shards install
-    shards build -Dpreview_mt
+    shards build
 
 # Update shards.nix.
 [group('build')]

--- a/scripts/benchmark_run.cr
+++ b/scripts/benchmark_run.cr
@@ -408,7 +408,7 @@ def compile_hwaro
   puts "Building hwaro (release, parity with shipped binaries)..."
   # Same flags as .github/workflows/release-binary.yml so measurements
   # reflect what users actually run.
-  status = Process.run("shards", ["build", "--release", "--no-debug", "-Dpreview_mt"],
+  status = Process.run("shards", ["build", "--release", "--no-debug"],
     output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
   unless status.success?
     puts "Build failed"

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.18.1
 authors:
   - HAHWUL <hahwul@gmail.com>
 
-crystal: ">= 1.19.0"
+crystal: ">= 1.21.0"
 
 license: MIT
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ parts:
     override-build: |
       curl -fsSL https://crystal-lang.org/install.sh | bash
       shards install --production
-      shards build --release --no-debug --production -Dpreview_mt
+      shards build --release --no-debug --production
       cp ./bin/hwaro $CRAFT_PART_INSTALL/
     build-packages:
       - git

--- a/spec/functional/fast_start_serve_spec.cr
+++ b/spec/functional/fast_start_serve_spec.cr
@@ -75,7 +75,7 @@ end
 
 describe "hwaro serve --fast-start" do
   it "answers HTTP requests immediately after emitting the ready signal" do
-    pending! "bin/hwaro not built — run `shards build -Dpreview_mt` first" unless fast_start_serve_available?
+    pending! "bin/hwaro not built — run `shards build` first" unless fast_start_serve_available?
 
     Dir.mktmpdir do |dir|
       make_fast_start_site(dir)

--- a/spec/functional/multilingual_spec.cr
+++ b/spec/functional/multilingual_spec.cr
@@ -518,3 +518,102 @@ describe "Multilingual: Taxonomy output" do
     end
   end
 end
+
+# =============================================================================
+# Multilingual: taxonomy term links
+#
+# `get_taxonomy_url` used to always emit the ROOT term URL (`/tags/foo/`).
+# On a multilingual site the taxonomy generator writes `/<lang>/tags/<slug>/`
+# for every non-default language that enables the taxonomy, so a term that
+# exists only in that language had NO root page — the link was a hard 404 —
+# and a shared term pointed the reader at the default language's listing.
+# =============================================================================
+
+MULTILINGUAL_TAXONOMY_CONFIG = <<-TOML
+  title = "Test Site"
+  base_url = "http://localhost"
+  default_language = "en"
+  taxonomies = [{ name = "tags" }]
+
+  [languages.en]
+  taxonomies = ["tags"]
+
+  [languages.ko]
+  language_name = "한국어"
+  taxonomies = ["tags"]
+  TOML
+
+TAXONOMY_LINK_FILES = {
+  "posts/a.md"    => "---\ntitle: English post\ntags: [shared, onlyen]\n---\nHello",
+  "posts/a.ko.md" => "---\ntitle: 한국어 글\ntags: [shared, onlyko]\n---\n안녕",
+}
+
+TAXONOMY_LINK_TEMPLATES = {
+  "page.html" => "{% for t in page.tags %}<a href=\"{{ get_taxonomy_url(kind='tags', term=t) }}\"></a>{% endfor %}",
+}
+
+describe "Multilingual: taxonomy term links" do
+  it "links a non-default-language page at that language's term pages" do
+    build_site(
+      MULTILINGUAL_TAXONOMY_CONFIG,
+      content_files: TAXONOMY_LINK_FILES,
+      template_files: TAXONOMY_LINK_TEMPLATES,
+    ) do
+      ko_html = File.read("public/ko/posts/a/index.html")
+      ko_html.should contain("http://localhost/ko/tags/onlyko/")
+      ko_html.should contain("http://localhost/ko/tags/shared/")
+
+      # Every emitted link must be a page that was actually written.
+      File.exists?("public/ko/tags/onlyko/index.html").should be_true
+      File.exists?("public/ko/tags/shared/index.html").should be_true
+    end
+  end
+
+  it "leaves default-language pages on the root term URLs" do
+    build_site(
+      MULTILINGUAL_TAXONOMY_CONFIG,
+      content_files: TAXONOMY_LINK_FILES,
+      template_files: TAXONOMY_LINK_TEMPLATES,
+    ) do
+      en_html = File.read("public/posts/a/index.html")
+      en_html.should contain("http://localhost/tags/onlyen/")
+      en_html.should contain("http://localhost/tags/shared/")
+      en_html.should_not contain("/ko/tags/")
+
+      File.exists?("public/tags/onlyen/index.html").should be_true
+      File.exists?("public/tags/shared/index.html").should be_true
+    end
+  end
+
+  it "falls back to the root term URL when the language does not enable the taxonomy" do
+    build_site(
+      <<-TOML,
+        title = "Test Site"
+        base_url = "http://localhost"
+        default_language = "en"
+        taxonomies = [{ name = "topics" }]
+
+        [languages.en]
+        taxonomies = ["topics"]
+
+        [languages.ko]
+        language_name = "한국어"
+        taxonomies = []
+        TOML
+      content_files: {
+        "posts/a.md"    => "---\ntitle: English post\ntopics: [shared]\n---\nHello",
+        "posts/a.ko.md" => "---\ntitle: 한국어 글\ntopics: [shared]\n---\n안녕",
+      },
+      template_files: {
+        "page.html" => "{% for t in page.taxonomies['topics'] %}<a href=\"{{ get_taxonomy_url(kind='topics', term=t) }}\"></a>{% endfor %}",
+      },
+    ) do
+      # `[languages.ko].taxonomies = []` means no /ko/topics/ pages exist — the
+      # link must stay on the root URL rather than inventing one.
+      ko_html = File.read("public/ko/posts/a/index.html")
+      ko_html.should_not contain("/ko/topics/")
+      ko_html.should contain("http://localhost/topics/shared/")
+      Dir.exists?("public/ko/topics").should be_false
+    end
+  end
+end

--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -138,12 +138,58 @@ describe Hwaro::Core::Build::Builder do
       templates = {"shortcodes/note" => "<div class=\"note\">{{ body }}</div>"}
       context = {} of String => Crinja::Value
 
-      # Named closers are supported (the parser's BLOCK_CLOSE_RE recognizes them).
-      # For the test we normalize once so the existing depth logic consumes it.
       content = "{% note(type=\"info\") %}Named closer works{% endnote %}"
-        .gsub(/\{\%\s*end\s*[a-zA-Z_][\w\-]*\s*\%\}/i, "{% end %}")
       result = builder.test_process_shortcodes_jinja(content, templates, context, crinja_env_override: env)
       result.should contain("<div class=\"note\">Named closer works</div>")
+    end
+
+    # The named-closer normalizer used a keyword lookahead with no word
+    # boundary, so `{% endcallout %}` was read as the Jinja `call` closer and
+    # left alone. The block parser then never found a `{% end %}` and the raw
+    # shortcode source leaked verbatim into the published page.
+    %w[callout iframe setup format blockquote rawdata withdraw commentary doable fromage].each do |name|
+      it "expands a block shortcode named '#{name}' closed by {% end#{name} %}" do
+        builder = Hwaro::Core::Build::Builder.new
+        env = Crinja.new
+        templates = {"shortcodes/#{name}" => "<div class=\"x\">{{ body }}</div>"}
+        context = {} of String => Crinja::Value
+
+        content = "{% #{name}(type=\"info\") %}Body{% end#{name} %}"
+        result = builder.test_process_shortcodes_jinja(content, templates, context, crinja_env_override: env)
+        result.should eq("<div class=\"x\">Body</div>")
+      end
+    end
+
+    %w[include-code if-banner do-not-translate].each do |name|
+      it "expands a hyphenated block shortcode named '#{name}'" do
+        builder = Hwaro::Core::Build::Builder.new
+        env = Crinja.new
+        templates = {"shortcodes/#{name}" => "<div>{{ body }}</div>"}
+        context = {} of String => Crinja::Value
+
+        content = "{% #{name}(type=\"i\") %}Body{% end#{name} %}"
+        result = builder.test_process_shortcodes_jinja(content, templates, context, crinja_env_override: env)
+        result.should eq("<div>Body</div>")
+      end
+    end
+
+    it "leaves Jinja control closers untouched while normalizing shortcode closers" do
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      templates = {"shortcodes/note" => "<div>{{ body }}</div>"}
+      context = {} of String => Crinja::Value
+
+      content = "{% note() %}{% if x %}A{% endif %}{% for i in y %}B{% endfor %}{% endnote %}"
+      result = builder.test_process_shortcodes_jinja(content, templates, context, crinja_env_override: env)
+      result.should eq("<div>{% if x %}A{% endif %}{% for i in y %}B{% endfor %}</div>")
+    end
+
+    it "leaves a bare {% raw %} block untouched" do
+      builder = Hwaro::Core::Build::Builder.new
+      env = Crinja.new
+      content = "{% raw %}{{ x }}{% endraw %}"
+      result = builder.test_process_shortcodes_jinja(content, {} of String => String, {} of String => Crinja::Value, crinja_env_override: env)
+      result.should eq(content)
     end
 
     it "processes explicit shortcode calls" do

--- a/spec/unit/css_minifier_spec.cr
+++ b/spec/unit/css_minifier_spec.cr
@@ -713,6 +713,75 @@ describe Hwaro::Utils::CssMinifier do
       result.should contain("color:red")
     end
 
+    # =========================================================================
+    # Descendant combinator inside at-rule blocks (BUG FIX verification)
+    # =========================================================================
+    it "preserves descendant combinator before pseudo-class inside @media" do
+      css = "@media screen {\n  .card :hover { color: red; }\n}"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should eq("@media screen{.card :hover{color:red}}")
+    end
+
+    it "preserves descendant combinator before pseudo-class inside @supports" do
+      css = "@supports (display: grid) { .grid :focus { outline: 0; } }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should contain(".grid :focus")
+      result.should contain("display:grid")
+    end
+
+    it "preserves descendant combinator in a nested rule inside @media" do
+      css = "@media print { .a .b :first-child { margin : 0 ; } }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should contain(".a .b :first-child")
+      result.should contain("margin:0")
+    end
+
+    it "still tightens declaration colons inside nested at-rule blocks" do
+      css = "@media screen { .x { color : red ; font-size : 2px ; } }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should eq("@media screen{.x{color:red;font-size:2px}}")
+    end
+
+    # =========================================================================
+    # Quotes inside comments (BUG FIX verification)
+    # =========================================================================
+    it "removes a comment containing an apostrophe" do
+      css = "/* don't */ .a { color: red; } .b { content: 'x'; }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should_not contain("don't")
+      result.should eq(".a{color:red}.b{content:'x'}")
+    end
+
+    it "removes a comment containing an unbalanced double quote" do
+      css = %(/* say " hi */ .a { color: red; })
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should eq(".a{color:red}")
+    end
+
+    it "keeps a quote inside a comment from swallowing later rules" do
+      css = "/* it's */ .a { color: red; } /* fine */ .b { color: blue; }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should eq(".a{color:red}.b{color:blue}")
+    end
+
+    it "preserves an apostrophe inside a string even after a comment" do
+      css = "/* c */ p::before { content: \"it's\"; }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should eq("p::before{content:\"it's\"}")
+    end
+
+    it "drops an unterminated comment through end of file" do
+      css = ".a { color: red; } /* trailing"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should eq(".a{color:red}")
+    end
+
+    it "preserves uppercase URL() contents" do
+      css = "body { background: URL( 'a b.png' ); }"
+      result = Hwaro::Utils::CssMinifier.minify(css)
+      result.should contain("URL('a b.png')")
+    end
+
     it "leaves a counterfeit out-of-range PRESERVE placeholder token intact" do
       # The counterfeit token sits inside a real string literal so Step 2 stashes
       # the surrounding string; Step 7's restore regex then re-matches the embedded

--- a/spec/unit/deadlink_command_spec.cr
+++ b/spec/unit/deadlink_command_spec.cr
@@ -172,6 +172,50 @@ describe Hwaro::CLI::Commands::Tool::DeadlinkCommand do
       end
     end
 
+    it "unwraps an angle-bracket destination" do
+      # Regression: `[t](</about/>)` is a plain CommonMark destination that the
+      # build resolves fine, but the extractor kept the angle brackets (and the
+      # whitespace split turned `</my page.md>` into `</my`), so every one was
+      # reported dead — a false positive that fails a CI link gate.
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "test.md"),
+          %([Angle](</about/>)\n[AngleTitle](</posts/b/> "T")\n![AngleImg](</img/a.png>)))
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        urls = cmd.find_internal_links_for_test(dir).map(&.url)
+
+        urls.should contain("/about/")
+        urls.should contain("/posts/b/")
+        urls.should contain("/img/a.png")
+        urls.none?(&.includes?("<")).should be_true
+        urls.none?(&.includes?(">")).should be_true
+      end
+    end
+
+    it "unwraps an angle-bracket destination containing spaces" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "test.md"), %([Spaced](</my page/>)))
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        cmd.find_internal_links_for_test(dir).map(&.url).should eq(["/my page/"])
+      end
+    end
+
+    it "keeps balanced parentheses inside a destination" do
+      # `[^\)]+` stopped at the first `)`, so `/docs/foo_(bar)` was scanned as
+      # `/docs/foo_(bar` — a link the build resolves, reported dead.
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "test.md"),
+          %([Paren](/docs/foo_(bar))\n![ParenImg](/img/a_(1).png)))
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        urls = cmd.find_internal_links_for_test(dir).map(&.url)
+
+        urls.should contain("/docs/foo_(bar)")
+        urls.should contain("/img/a_(1).png")
+      end
+    end
+
     it "strips an optional CommonMark title from the destination" do
       # Regression: `[t](/url "title")` captured `/url "title"`, which never
       # resolves on disk — every titled internal link was falsely flagged dead.

--- a/spec/unit/filters_spec.cr
+++ b/spec/unit/filters_spec.cr
@@ -791,6 +791,123 @@ describe "UrlFilters" do
     end
   end
 
+  describe "values that already carry their own origin" do
+    # `absolute_url`/`relative_url` only special-cased http(s)://, so a
+    # `mailto:` link came back as https://example.com/mailto:a@b.com and a
+    # protocol-relative CDN URL (which starts with "/") became
+    # https://example.com//cdn.example.com/x.js.
+    {
+      "mailto:hello@example.com",
+      "tel:+15551234",
+      "data:image/png;base64,AAAA",
+      "//cdn.example.com/lib.js",
+      "ftp://files.example.com/x.zip",
+    }.each do |url|
+      it "absolute_url passes #{url} through unchanged" do
+        page = Hwaro::Models::Page.new("test.md")
+        config = Hwaro::Models::Config.new
+        config.base_url = "https://example.com"
+
+        context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+        context.add("my_url", url)
+
+        result = Hwaro::Content::Processors::Template.process("{{ my_url | absolute_url }}", context).strip
+        result.should eq(url)
+      end
+
+      it "relative_url passes #{url} through unchanged" do
+        page = Hwaro::Models::Page.new("test.md")
+        config = Hwaro::Models::Config.new
+        config.base_url = "https://example.com/sub/"
+
+        context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+        context.add("my_url", url)
+
+        result = Hwaro::Content::Processors::Template.process("{{ my_url | relative_url }}", context).strip
+        result.should eq(url)
+      end
+
+      it "url_for passes #{url} through unchanged" do
+        page = Hwaro::Models::Page.new("test.md")
+        config = Hwaro::Models::Config.new
+        config.base_url = "https://example.com"
+
+        context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+        context.add("my_url", url)
+
+        result = Hwaro::Content::Processors::Template.process("{{ url_for(path=my_url) }}", context).strip
+        result.should eq(url)
+      end
+    end
+
+    it "relative_url survives a malformed base_url instead of aborting the build" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+      config.base_url = "http://[bad"
+
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+      context.add("my_url", "/about/")
+
+      result = Hwaro::Content::Processors::Template.process("{{ my_url | relative_url }}", context).strip
+      result.should eq("/about/")
+    end
+  end
+
+  describe "numeric arguments given as strings" do
+    # Every shortcode argument is parsed into a String, so a numeric argument
+    # forwarded from a shortcode always arrives quoted. `as_number` raised
+    # Crinja::TypeError on those and the raise aborted the whole page render.
+    it "truncate_words accepts a quoted length" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+      context.add("text", "one two three four five")
+
+      result = Hwaro::Content::Processors::Template.process(%({{ text | truncate_words(length="2", end="…") }}), context).strip
+      result.should eq("one two…")
+    end
+
+    it "truncate_words falls back to the default for a non-numeric length" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+      context.add("text", "one two three")
+
+      result = Hwaro::Content::Processors::Template.process(%({{ text | truncate_words(length="wat") }}), context).strip
+      result.should eq("one two three")
+    end
+
+    it "truncate_words does not drop trailing words for a negative length" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+      context.add("text", "one two three")
+
+      result = Hwaro::Content::Processors::Template.process(%({{ text | truncate_words(length=-5, end="…") }}), context).strip
+      result.should eq("…")
+    end
+
+    it "resize_image accepts a quoted width instead of aborting the render" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+
+      result = Hwaro::Content::Processors::Template.process(%({{ resize_image(path="/img/a.png", width="800").width }}), context).strip
+      result.should eq("800")
+    end
+
+    it "resize_image clamps an out-of-range width instead of raising" do
+      page = Hwaro::Models::Page.new("test.md")
+      config = Hwaro::Models::Config.new
+      config.base_url = "https://example.com"
+      context = Hwaro::Content::Processors::TemplateContext.new(page, config)
+
+      result = Hwaro::Content::Processors::Template.process(%({{ resize_image(path="/img/a.png", width="999999999999").width }}), context).strip
+      result.should eq(Int32::MAX.to_s)
+    end
+  end
+
   describe "empty base_url (pre-deploy state)" do
     it "absolute_url returns the path unchanged and never emits a // prefix" do
       page = Hwaro::Models::Page.new("test.md")

--- a/spec/unit/html_minifier_spec.cr
+++ b/spec/unit/html_minifier_spec.cr
@@ -368,6 +368,31 @@ describe Hwaro::Utils::HtmlMinifier do
       end
     end
 
+    describe "non-breaking and other Unicode spaces" do
+      # `\s` under PCRE2's UCP flag (which Crystal enables) matches U+00A0
+      # and friends, so the inter-token pass used to treat rendered `&nbsp;`
+      # text as collapsible layout whitespace.
+      it "keeps a non-breaking space between inline siblings" do
+        html = "<em>a</em>\u{00A0}<em>b</em>"
+        Hwaro::Utils::HtmlMinifier.minify(html).should eq(html)
+      end
+
+      it "keeps a non-breaking space between block siblings" do
+        html = "<p>a</p>\u{00A0}<p>b</p>"
+        Hwaro::Utils::HtmlMinifier.minify(html).should eq(html)
+      end
+
+      it "keeps an ideographic space between tags" do
+        html = "<p>a</p>\u{3000}<p>b</p>"
+        Hwaro::Utils::HtmlMinifier.minify(html).should eq(html)
+      end
+
+      it "still collapses ASCII whitespace next to a non-breaking space" do
+        html = "<p>a</p>\n<p>b</p>"
+        Hwaro::Utils::HtmlMinifier.minify(html).should eq("<p>a</p><p>b</p>")
+      end
+    end
+
     describe "trailing and blank-line whitespace" do
       it "strips trailing spaces from each line" do
         html = "<div>A</div>   \n<div>B</div>\t\t\n<div>C</div>"

--- a/spec/unit/image_processor_spec.cr
+++ b/spec/unit/image_processor_spec.cr
@@ -390,6 +390,49 @@ describe Hwaro::Content::Processors::ImageProcessor do
   end
 end
 
+# Exposes the private dimension math so the saturation guard can be asserted
+# without producing a multi-gigapixel image.
+module Hwaro::Content::Processors
+  module ImageProcessor
+    def self.calculate_dimensions_for_test(src_w, src_h, target_w, target_h)
+      calculate_dimensions(src_w, src_h, target_w, target_h)
+    end
+  end
+end
+
+describe "ImageProcessor#calculate_dimensions overflow" do
+  # `[image_processing] widths` is only bounded below (`> 0`), so an absurd
+  # entry made the proportional side exceed Int32 and `.round.to_i32` raised a
+  # bare OverflowError — an unclassified crash of the whole build rather than a
+  # skipped variant. It now saturates so the MAX_PIXELS guard can decline it.
+  it "saturates instead of raising for an oversized target width" do
+    w, h = Hwaro::Content::Processors::ImageProcessor
+      .calculate_dimensions_for_test(200, 500, 2_000_000_000, 0)
+    w.should eq(2_000_000_000)
+    h.should eq(Int32::MAX)
+  end
+
+  it "saturates instead of raising for an extreme source aspect ratio" do
+    Hwaro::Content::Processors::ImageProcessor
+      .calculate_dimensions_for_test(1, 2_000_000_000, 2_000_000_000, 0)
+      .last.should eq(Int32::MAX)
+  end
+
+  it "leaves ordinary proportional scaling unchanged" do
+    Hwaro::Content::Processors::ImageProcessor
+      .calculate_dimensions_for_test(200, 500, 100, 0).should eq({100, 250})
+    Hwaro::Content::Processors::ImageProcessor
+      .calculate_dimensions_for_test(800, 600, 400, 400).should eq({400, 300})
+  end
+
+  it "never returns a dimension below 1" do
+    w, h = Hwaro::Content::Processors::ImageProcessor
+      .calculate_dimensions_for_test(10_000, 3, 1, 0)
+    w.should eq(1)
+    h.should eq(1)
+  end
+end
+
 describe Hwaro::Content::Hooks::ImageHooks do
   # Helper to set up and tear down test resize map
   before_each do

--- a/spec/unit/jsonld_extended_spec.cr
+++ b/spec/unit/jsonld_extended_spec.cr
@@ -328,3 +328,28 @@ describe Hwaro::Content::Seo::JsonLd do
     end
   end
 end
+describe "JsonLd image absolutization" do
+  it "leaves a protocol-relative article image untouched" do
+    config = Hwaro::Models::Config.new
+    config.base_url = "https://site.com"
+    page = Hwaro::Models::Page.new("post.md")
+    page.title = "T"
+    page.url = "/post/"
+    page.image = "//cdn.example.com/hero.png"
+
+    Hwaro::Content::Seo::JsonLd.article(page, config)
+      .should contain(%("image":"//cdn.example.com/hero.png"))
+  end
+
+  it "absolutizes a relative image path that starts with 'http'" do
+    config = Hwaro::Models::Config.new
+    config.base_url = "https://site.com"
+    page = Hwaro::Models::Page.new("post.md")
+    page.title = "T"
+    page.url = "/post/"
+    page.image = "http-guide/hero.png"
+
+    Hwaro::Content::Seo::JsonLd.article(page, config)
+      .should contain(%("image":"https://site.com/http-guide/hero.png"))
+  end
+end

--- a/spec/unit/opengraph_spec.cr
+++ b/spec/unit/opengraph_spec.cr
@@ -13,6 +13,42 @@ describe Hwaro::Models::OpenGraphConfig do
     end
   end
 
+  describe "#resolve_image_url" do
+    # `starts_with?("http")` was wrong in both directions: it missed
+    # `//cdn…`/`data:` (which then took the root-relative branch and produced
+    # `https://site.com//cdn.example.com/og.png`), and it false-positived on a
+    # relative path that merely starts with the letters "http".
+    it "leaves a protocol-relative image untouched" do
+      config = Hwaro::Models::OpenGraphConfig.new
+      config.resolve_image_url("//cdn.example.com/og.png", "https://site.com")
+        .should eq("//cdn.example.com/og.png")
+    end
+
+    it "leaves a data: image untouched" do
+      config = Hwaro::Models::OpenGraphConfig.new
+      config.resolve_image_url("data:image/png;base64,AAAA", "https://site.com")
+        .should eq("data:image/png;base64,AAAA")
+    end
+
+    it "leaves an https image untouched" do
+      config = Hwaro::Models::OpenGraphConfig.new
+      config.resolve_image_url("https://cdn.example.com/og.png", "https://site.com")
+        .should eq("https://cdn.example.com/og.png")
+    end
+
+    it "absolutizes a relative path that merely starts with 'http'" do
+      config = Hwaro::Models::OpenGraphConfig.new
+      config.resolve_image_url("http-guide/cover.png", "https://site.com")
+        .should eq("https://site.com/http-guide/cover.png")
+    end
+
+    it "absolutizes a root-relative path" do
+      config = Hwaro::Models::OpenGraphConfig.new
+      config.resolve_image_url("/img/og.png", "https://site.com")
+        .should eq("https://site.com/img/og.png")
+    end
+  end
+
   describe "#og_tags" do
     it "generates basic OG tags with title, type, and url" do
       config = Hwaro::Models::OpenGraphConfig.new

--- a/spec/unit/robots_spec.cr
+++ b/spec/unit/robots_spec.cr
@@ -435,6 +435,40 @@ describe Hwaro::Models::RobotsConfig do
       config.rules.first.user_agent.should eq("Googlebot")
     end
 
+    # Sitemap.generate basenames the configured filename before writing, so
+    # advertising the raw config value pointed crawlers at a path that is
+    # never produced.
+    it "advertises the sitemap at the path the sitemap generator actually writes" do
+      Dir.mktmpdir do |output_dir|
+        config = Hwaro::Models::Config.new
+        config.base_url = "https://example.com"
+        config.robots.enabled = true
+        config.sitemap.enabled = true
+        config.sitemap.filename = "reports/sitemap.xml"
+
+        Hwaro::Content::Seo::Robots.generate(config, output_dir)
+
+        content = File.read(File.join(output_dir, "robots.txt"))
+        content.should contain("Sitemap: https://example.com/sitemap.xml")
+        content.should_not contain("reports/")
+      end
+    end
+
+    it "advertises a custom sitemap filename verbatim when it has no directory" do
+      Dir.mktmpdir do |output_dir|
+        config = Hwaro::Models::Config.new
+        config.base_url = "https://example.com"
+        config.robots.enabled = true
+        config.sitemap.enabled = true
+        config.sitemap.filename = "sitemap-index.xml"
+
+        Hwaro::Content::Seo::Robots.generate(config, output_dir)
+
+        File.read(File.join(output_dir, "robots.txt"))
+          .should contain("Sitemap: https://example.com/sitemap-index.xml")
+      end
+    end
+
     it "can set multiple rules" do
       config = Hwaro::Models::RobotsConfig.new
 

--- a/spec/unit/sass/expressions_spec.cr
+++ b/spec/unit/sass/expressions_spec.cr
@@ -173,3 +173,89 @@ describe "SassScript expressions in values" do
     end
   end
 end
+
+describe "Sass grouping parentheses" do
+  # Grouping parens are Sass syntax with no meaning in CSS. The lenient
+  # verbatim fallback only kicks in when nothing "computes", and a paren
+  # around a bare literal or a slash/space list computes nothing — so the
+  # parens were emitted into the stylesheet as part of the declaration
+  # value, which no browser accepts.
+  it "does not leak parentheses around a slash list" do
+    css = Hwaro::Assets::Sass.compile("a { width: (10px / 2); }")
+    css.should contain("width: 10px / 2;")
+    css.should_not contain("(10px")
+  end
+
+  it "does not leak parentheses around a space list" do
+    css = Hwaro::Assets::Sass.compile("a { margin: (1px 2px); }")
+    css.should contain("margin: 1px 2px;")
+    css.should_not contain("(1px")
+  end
+
+  it "does not leak parentheses around a bare literal" do
+    css = Hwaro::Assets::Sass.compile("a { width: (10px); }")
+    css.should contain("width: 10px;")
+    css.should_not contain("(10px)")
+  end
+
+  it "still evaluates arithmetic inside parentheses" do
+    css = Hwaro::Assets::Sass.compile("a { width: (1px + 2px) * 2; }")
+    css.should contain("width: 6px;")
+  end
+
+  it "leaves genuine CSS function calls untouched" do
+    css = Hwaro::Assets::Sass.compile("a { width: calc(100% - 10px); background: url(a.png); }")
+    css.should contain("calc(100% - 10px)")
+    css.should contain("url(a.png)")
+  end
+end
+
+private def capture_warnings(&) : String
+  io = IO::Memory.new
+  previous = Hwaro::Logger.io
+  Hwaro::Logger.io = io
+  begin
+    yield
+  ensure
+    Hwaro::Logger.io = previous
+  end
+  io.to_s
+end
+
+describe "Sass namespaced-reference failures" do
+  it "warns when a namespaced call falls back to literal text" do
+    warnings = capture_warnings do
+      Hwaro::Assets::Sass.compile("a { width: math.div(10px, 2); }").should contain("math.div(10px, 2)")
+    end
+    warnings.should contain("no module namespace")
+    warnings.should contain("not valid CSS")
+  end
+
+  it "warns when a namespaced call fails inside the function" do
+    warnings = capture_warnings do
+      Hwaro::Assets::Sass.compile(%(@use "sass:math";\na { width: math.div(1px, 0); }))
+    end
+    warnings.should contain("division by zero")
+  end
+
+  it "reports the failing location" do
+    warnings = capture_warnings do
+      Hwaro::Assets::Sass.compile("a {\n  width: math.div(10px, 2);\n}", "css/x.scss")
+    end
+    warnings.should contain("css/x.scss:2:")
+  end
+
+  it "stays silent for unknown plain CSS functions" do
+    warnings = capture_warnings do
+      Hwaro::Assets::Sass.compile("a { background: -webkit-linear-gradient(red, blue); }")
+    end
+    warnings.should_not contain("not valid CSS")
+  end
+
+  it "stays silent for the IE progid filter" do
+    warnings = capture_warnings do
+      Hwaro::Assets::Sass.compile(%(a { filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff'); }))
+    end
+    warnings.should_not contain("not valid CSS")
+  end
+end

--- a/spec/unit/table_parser_spec.cr
+++ b/spec/unit/table_parser_spec.cr
@@ -822,3 +822,42 @@ describe Hwaro::Content::Processors::TableParser do
     end
   end
 end
+describe "GFM delimiter-row lengths" do
+  # The delimiter cell was matched with `:?-{3,}:?`, but GFM's cell is
+  # `:?-+:?`. Any ALIGNED row shorter than three hyphens (`|:--|--:|`,
+  # `|:-:|`, `| - |`) failed the check and the whole table was left as a
+  # paragraph of literal pipes — the unaligned `|---|---|` form happened to
+  # clear the bar, so the bug only appeared once an author added alignment.
+  {
+    {"two hyphens with left colon", "| a | b |\n|:--|---|\n| 1 | 2 |"},
+    {"two hyphens with right colon", "| a | b |\n|---|--:|\n| 1 | 2 |"},
+    {"single hyphen with both colons", "| a | b |\n|:-:|---|\n| 1 | 2 |"},
+    {"short aligned on both columns", "| a | b |\n|:--|--:|\n| 1 | 2 |"},
+    {"spaced short delimiters", "| a | b |\n| :-- | --- |\n| 1 | 2 |"},
+    {"single hyphen cells", "| a | b |\n| - | - |\n| 1 | 2 |"},
+    {"no outer pipes, short", "a | b\n:--|--:\n1 | 2"},
+  }.each do |(label, md)|
+    it "renders a table for #{label}" do
+      result = Hwaro::Content::Processors::TableParser.process(md)
+      result.should contain("<table>")
+      result.should contain(">1</td>")
+      result.should_not contain("|:--")
+    end
+  end
+
+  it "keeps the alignment carried by a short delimiter cell" do
+    result = Hwaro::Content::Processors::TableParser.process("| a | b |\n|:-:|--:|\n| 1 | 2 |")
+    result.should contain("text-align: center;")
+    result.should contain("text-align: right;")
+  end
+
+  it "still rejects a row that is not a delimiter row" do
+    result = Hwaro::Content::Processors::TableParser.process("| a | b |\n| x | y |\n| 1 | 2 |")
+    result.should_not contain("<table>")
+  end
+
+  it "does not treat a bare list item as a delimiter row" do
+    result = Hwaro::Content::Processors::TableParser.process("intro | text\n- item\n- other")
+    result.should_not contain("<table>")
+  end
+end

--- a/spec/unit/text_utils_spec.cr
+++ b/spec/unit/text_utils_spec.cr
@@ -383,6 +383,31 @@ describe Hwaro::Utils::TextUtils do
     end
   end
 
+  describe ".slugify with Unicode whitespace" do
+    # `ascii_whitespace?` misses U+3000 (the CJK word separator) and U+00A0
+    # (what `&nbsp;` decodes to), so those characters were dropped and the
+    # words on either side were welded into one slug segment.
+    it "treats the ideographic space as a separator" do
+      Hwaro::Utils::TextUtils.slugify("日本語\u{3000}テスト").should eq("日本語-テスト")
+    end
+
+    it "treats a non-breaking space as a separator" do
+      Hwaro::Utils::TextUtils.slugify("Hello\u{00A0}World").should eq("hello-world")
+    end
+
+    it "treats an em space as a separator" do
+      Hwaro::Utils::TextUtils.slugify("a\u{2003}b").should eq("a-b")
+    end
+
+    it "collapses mixed ASCII and Unicode whitespace runs into one hyphen" do
+      Hwaro::Utils::TextUtils.slugify("a \u{00A0} b").should eq("a-b")
+    end
+
+    it "does not emit a trailing hyphen for trailing Unicode whitespace" do
+      Hwaro::Utils::TextUtils.slugify("한글 제목\u{3000}").should eq("한글-제목")
+    end
+  end
+
   describe ".cjk_char? (extended)" do
     it "returns true for CJK Extension A" do
       # U+3400 is in CJK Extension A range

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -1139,6 +1139,8 @@ module Hwaro
             if Expr.computes?(node, self)
               begin
                 return value_storage(Expr::Evaluator.new(self).eval(node))
+              rescue ex : NamespacedEvalError
+                warn_namespaced(template, ex)
               rescue SoftEvalError
                 # fall through to the verbatim path
               end
@@ -1158,6 +1160,8 @@ module Hwaro
               begin
                 value = Expr::Evaluator.new(self).eval(node)
                 return ResolvedValue.new(value.to_css, value.is_a?(NullV))
+              rescue ex : NamespacedEvalError
+                warn_namespaced(template, ex)
               rescue SoftEvalError
                 # fall through to the verbatim path
               end
@@ -1177,6 +1181,8 @@ module Hwaro
             if Expr.computes?(node, self)
               begin
                 return Expr::Evaluator.new(self).eval(node).to_css
+              rescue ex : NamespacedEvalError
+                warn_namespaced(template, ex)
               rescue SoftEvalError
                 # fall through to the verbatim path
               end
@@ -1307,9 +1313,9 @@ module Hwaro
         def expr_var(name : String, ns : String?) : String
           if ns
             mod = @env.module?(ns)
-            raise SoftEvalError.new("there is no module namespace \"#{ns}\"") unless mod
+            raise NamespacedEvalError.new("there is no module namespace \"#{ns}\"") unless mod
             mod.variables[Sass.normalize_ident(name)]? ||
-              raise SoftEvalError.new("undefined variable: \"#{ns}.$#{name}\"")
+              raise NamespacedEvalError.new("undefined variable: \"#{ns}.$#{name}\"")
           else
             @env.lookup_var(name) ||
               raise SoftEvalError.new("undefined variable: \"$#{name}\"")
@@ -1322,10 +1328,19 @@ module Hwaro
           norm = Sass.normalize_ident(name)
           if ns
             mod = @env.module?(ns)
-            raise SoftEvalError.new("there is no module namespace \"#{ns}\"") unless mod
+            raise NamespacedEvalError.new("there is no module namespace \"#{ns}\"") unless mod
             fn = mod.functions[norm]? ||
-                 raise SoftEvalError.new("undefined function: \"#{ns}.#{name}\"")
-            invoke_fn(fn, name, args, kwargs)
+                 raise NamespacedEvalError.new("undefined function: \"#{ns}.#{name}\"")
+            begin
+              invoke_fn(fn, name, args, kwargs)
+            rescue ex : NamespacedEvalError
+              raise ex
+            rescue ex : SoftEvalError
+              # A failure *inside* a namespaced built-in (`math.div(1px, 0)`,
+              # `math.percentage(1px)`, …) must not fall back either — the
+              # fallback emits `math.div(1px, 0)` as a CSS value.
+              raise NamespacedEvalError.new(ex.message || "call failed")
+            end
           elsif fn = @env.lookup_function(norm)
             invoke_fn(fn, name, args, kwargs)
           elsif builtin = Builtins::GLOBAL_FNS[norm]?
@@ -1488,6 +1503,18 @@ module Hwaro
 
         private def error_at(line : Int32, column : Int32, message : String) : NoReturn
           raise SyntaxError.new(message, @path, line, column)
+        end
+
+        # A namespaced reference that fails still takes the documented lenient
+        # fallback (see the `math.div` passthrough spec), but the fallback
+        # splices `math.div(1px, 0)` into the stylesheet — and no CSS function
+        # name may contain a `.`, so that declaration is dead on arrival in
+        # every browser. Leniency exists to preserve *valid* CSS the compiler
+        # doesn't model (`-webkit-…()`, `progid:…`), which is never namespaced,
+        # so this particular fallback is always a silent breakage: say so.
+        private def warn_namespaced(template : Ast::TextTemplate, ex : NamespacedEvalError) : Nil
+          Logger.warn "Sass: #{@path}:#{template.line}:#{template.column}: " \
+                      "#{ex.message} — emitted as literal text, which is not valid CSS."
         end
       end
     end

--- a/src/assets/sass/expr.cr
+++ b/src/assets/sass/expr.cr
@@ -994,7 +994,12 @@ module Hwaro
           when MapE
             node.pairs.any? { |pair| computes?(pair.key, host) || computes?(pair.value, host) }
           when ParenE
-            computes?(node.inner, host)
+            # Grouping parens ALWAYS count as work, even around a bare literal
+            # or a slash/space list: they are Sass syntax with no meaning in
+            # CSS, so the legacy verbatim path emitted them into the stylesheet
+            # (`width: (10px / 2)`, `margin: (1px 2px)`) — invalid declaration
+            # values that no browser accepts. Evaluating consumes them.
+            true
           when ConcatE
             node.parts.any? { |p| computes?(p, host) }
           else

--- a/src/assets/sass/value.cr
+++ b/src/assets/sass/value.cr
@@ -21,6 +21,20 @@ module Hwaro
       class SoftEvalError < Exception
       end
 
+      # A failure inside a NAMESPACED reference (`math.div(…)`, `$map.key`,
+      # i.e. anything reached through an `@use` namespace).
+      #
+      # These must NOT take the lenient verbatim fallback. Falling back
+      # reconstructs the call as `math.div(1px, 0)` and splices that straight
+      # into the stylesheet — but no CSS function name may contain a `.`, so
+      # the result is guaranteed-invalid CSS that no browser will apply. The
+      # author gets a silently broken declaration instead of a build error,
+      # which is the opposite of what leniency is for (leniency exists so
+      # *valid* CSS the compiler doesn't model — `-webkit-…()`, `progid:…` —
+      # survives untouched; those are never namespaced).
+      class NamespacedEvalError < SoftEvalError
+      end
+
       # "This call isn't mine" — raised by a built-in whose name shadows a
       # real CSS function (`rgba()`, `grayscale()`, `saturate()`, …) when
       # the arguments are the CSS shape rather than the Sass one.

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -276,34 +276,55 @@ module Hwaro
             links
           end
 
+          # Markdown link/image destination, allowing ONE level of balanced
+          # parentheses inside it. Plain `([^\)]+)` stopped at the first `)`,
+          # so `[x](/docs/foo_(bar))` was scanned as `/docs/foo_(bar` and
+          # reported dead — a false positive on a link the build resolves fine.
+          # The alternation branches start with disjoint characters, so there
+          # is no backtracking ambiguity.
+          LINK_DEST = /((?:[^()]|\([^()]*\))*)/
+
           # Normalize a Markdown link/image destination to a bare URL.
+          #
           # CommonMark allows an optional title after the destination
-          # (`[t](/url "title")` / `![a](/img 'title')`); the capturing regex
-          # `([^\)]+)` includes that title, so without stripping it the resolved
-          # target became e.g. `/posts/b/ "title"` and every titled internal link
-          # was falsely reported dead. A non-`<…>` destination cannot contain a
-          # space (CommonMark ends it at the first whitespace), so taking the
-          # first whitespace-delimited token yields the real destination.
+          # (`[t](/url "title")` / `![a](/img 'title')`); the capture includes
+          # that title, so without stripping it the resolved target became e.g.
+          # `/posts/b/ "title"` and every titled internal link was falsely
+          # reported dead.
+          #
+          # An angle-bracket destination (`[t](</my page.md> "title")`) is the
+          # one form that MAY contain spaces, so the whitespace split has to
+          # come after unwrapping it — otherwise the target was the literal
+          # `</my`, and even a space-free `</about/>` was reported dead while
+          # the build resolved it correctly.
           private def clean_link_target(raw : String) : String
-            dest = raw.strip.split(/\s/, 2).first
+            stripped = raw.strip
+            dest =
+              if stripped.starts_with?('<') && (close = stripped.index('>'))
+                stripped[1...close]
+              else
+                stripped.split(/\s/, 2).first
+              end
             dest.split("#").first.split("?").first.strip
           end
 
           private def find_internal_links(dir : String) : Array(Link)
             links = [] of Link
+            link_re = /(?<!!)\[([^\]]*)\]\(#{LINK_DEST.source}\)/
+            image_re = /!\[([^\]]*)\]\(#{LINK_DEST.source}\)/
 
             Dir.glob("#{dir}/**/*.md").each do |file|
               content = strip_code(File.read(file))
 
               # Regular links (exclude images by using negative lookbehind)
-              content.scan(/(?<!!)\[([^\]]*)\]\(([^\)]+)\)/) do |match|
+              content.scan(link_re) do |match|
                 url = clean_link_target(match[2])
                 next if url.empty? || url.starts_with?("#") || url.starts_with?("//") || url =~ /\A[a-z][a-z0-9+.\-]*:/i
                 links << Link.new(file: file, url: url, kind: :internal)
               end
 
               # Image links
-              content.scan(/!\[([^\]]*)\]\(([^\)]+)\)/) do |match|
+              content.scan(image_re) do |match|
                 url = clean_link_target(match[2])
                 next if url.empty? || url.starts_with?("//") || url =~ /\A[a-z][a-z0-9+.\-]*:/i
                 links << Link.new(file: file, url: url, kind: :image)

--- a/src/content/processors/filters/string_filter.cr
+++ b/src/content/processors/filters/string_filter.cr
@@ -1,4 +1,5 @@
 require "crinja"
+require "../../../utils/crinja_utils"
 
 module Hwaro
   module Content
@@ -12,7 +13,11 @@ module Hwaro
               # a leading "" token, consuming a word slot and emitting a stray
               # leading space (off-by-one truncation).
               text = target.to_s.strip
-              length = (arguments["length"].as_number rescue 50).to_i
+              # Lenient coercion: a quoted `length="20"` (which is all a
+              # shortcode can forward) used to fall into the `rescue` and
+              # silently mean 50, and a negative count sliced `words[0...-n]`
+              # and dropped words off the END of the text.
+              length = Utils::CrinjaUtils.to_count(arguments["length"], default: 50)
               ending = arguments["end"].to_s
 
               words = text.split(/\s+/, limit: length + 1)

--- a/src/content/processors/filters/url_filter.cr
+++ b/src/content/processors/filters/url_filter.cr
@@ -1,18 +1,38 @@
 require "crinja"
 require "uri"
+require "../internal_link_resolver"
 
 module Hwaro
   module Content
     module Processors
       module Filters
         module UrlFilters
+          # A value that already carries its own origin and must therefore be
+          # passed through untouched by both filters:
+          #
+          #   * any absolute URL (`https:`, `mailto:`, `tel:`, `data:`, …) —
+          #     matching only `http://`/`https://` meant `mailto:a@b.com`
+          #     came back as `https://site.com/mailto:a@b.com`;
+          #   * protocol-relative (`//cdn.example.com/x.js`) — it starts with
+          #     `/`, so the root-relative branch turned it into
+          #     `https://site.com//cdn.example.com/x.js`.
+          #
+          # Same rule (and same regex) as InternalLinkResolver's
+          # `absolute_or_anchor?`, minus the bare `#anchor` case: a
+          # fragment-only href has no origin of its own, and resolving it
+          # against base_url is the long-standing behaviour of these filters.
+          def self.has_own_origin?(url : String) : Bool
+            url.starts_with?("//") ||
+              url.matches?(InternalLinkResolver::SCHEME_PREFIX_REGEX)
+          end
+
           def self.register(env : Crinja)
             # Absolute URL filter
             env.filters["absolute_url"] = Crinja.filter do
               url = target.to_s
               base_url = env.resolve("base_url").to_s
 
-              if url.starts_with?("http://") || url.starts_with?("https://")
+              if UrlFilters.has_own_origin?(url)
                 url
               elsif url.starts_with?("/")
                 base_url.rstrip("/") + url
@@ -26,9 +46,15 @@ module Hwaro
               url = target.to_s
               base_url = env.resolve("base_url").to_s
 
-              if url.starts_with?("/")
-                # Extract path component from base_url (strip protocol + host)
-                base_path = URI.parse(base_url).path.rstrip("/")
+              if !UrlFilters.has_own_origin?(url) && url.starts_with?("/")
+                # Extract path component from base_url (strip protocol + host).
+                # A malformed base_url must not abort the whole build — fall
+                # back to no prefix, which is what an empty base_url yields.
+                base_path = begin
+                  URI.parse(base_url).path.rstrip("/")
+                rescue URI::Error
+                  ""
+                end
                 base_path + url
               else
                 url

--- a/src/content/processors/filters/url_filter.cr
+++ b/src/content/processors/filters/url_filter.cr
@@ -17,13 +17,12 @@ module Hwaro
           #     `/`, so the root-relative branch turned it into
           #     `https://site.com//cdn.example.com/x.js`.
           #
-          # Same rule (and same regex) as InternalLinkResolver's
-          # `absolute_or_anchor?`, minus the bare `#anchor` case: a
-          # fragment-only href has no origin of its own, and resolving it
-          # against base_url is the long-standing behaviour of these filters.
+          # Same rule as InternalLinkResolver's `absolute_or_anchor?`, minus
+          # the bare `#anchor` case: a fragment-only href has no origin of its
+          # own, and resolving it against base_url is the long-standing
+          # behaviour of these filters.
           def self.has_own_origin?(url : String) : Bool
-            url.starts_with?("//") ||
-              url.matches?(InternalLinkResolver::SCHEME_PREFIX_REGEX)
+            InternalLinkResolver.has_own_origin?(url)
           end
 
           def self.register(env : Crinja)

--- a/src/content/processors/html.cr
+++ b/src/content/processors/html.cr
@@ -62,8 +62,10 @@ module Hwaro
           minified = minified.gsub(/\x00HTML_PRESERVE_(\d+)\x00/) do |match|
             # Restore the preserved block. If the index is out of range — e.g.
             # the source content itself contained a literal marker — leave the
-            # matched text untouched rather than raising IndexError.
-            preserves[$1.to_i]? || match
+            # matched text untouched rather than raising IndexError. `to_i?`
+            # (not `to_i`) so a forged marker whose digit run overflows Int32
+            # returns nil instead of raising ArgumentError.
+            $1.to_i?.try { |i| preserves[i]? } || match
           end
 
           # Remove trailing whitespace on each line

--- a/src/content/processors/image_processor.cr
+++ b/src/content/processors/image_processor.cr
@@ -394,18 +394,31 @@ module Hwaro
             scale_w = target_w.to_f / src_w
             scale_h = target_h.to_f / src_h
             scale = Math.min(scale_w, scale_h)
-            {Math.max(1, (src_w * scale).round.to_i32), Math.max(1, (src_h * scale).round.to_i32)}
+            {saturating_i32(src_w * scale), saturating_i32(src_h * scale)}
           elsif target_w > 0
             # Width only: scale proportionally
             scale = target_w.to_f / src_w
-            {target_w, Math.max(1, (src_h * scale).round.to_i32)}
+            {target_w, saturating_i32(src_h * scale)}
           elsif target_h > 0
             # Height only: scale proportionally
             scale = target_h.to_f / src_h
-            {Math.max(1, (src_w * scale).round.to_i32), target_h}
+            {saturating_i32(src_w * scale), target_h}
           else
             {src_w, src_h}
           end
+        end
+
+        # Round a scaled dimension to at least 1, SATURATING at Int32::MAX.
+        # `[image_processing] widths` is only bounded below (`> 0`), so an
+        # absurd entry makes the proportional side exceed Int32 and the plain
+        # `.round.to_i32` raised a bare `OverflowError` — an unclassified crash
+        # of the whole build instead of a skipped variant. Saturating hands the
+        # oversized size to the existing MAX_PIXELS guard, which declines it
+        # with a debug line and moves on.
+        private def saturating_i32(value : Float64) : Int32
+          return 1 if value.nan? || value < 1
+          return Int32::MAX if value >= Int32::MAX.to_f
+          value.round.to_i32.clamp(1, Int32::MAX)
         end
 
         # Write image in the appropriate format based on extension

--- a/src/content/processors/internal_link_resolver.cr
+++ b/src/content/processors/internal_link_resolver.cr
@@ -32,6 +32,22 @@ module Hwaro
         # A URI scheme prefix (e.g. `https:`, `mailto:`, `tel:`, `data:`).
         SCHEME_PREFIX_REGEX = /\A[a-zA-Z][a-zA-Z0-9+.\-]*:/
 
+        # True when `value` already carries its own origin: any `scheme:` URL
+        # (`https:`, `mailto:`, `tel:`, `data:`, …) or a protocol-relative
+        # `//host/…`. Such a value must never have a base_url or page-URL
+        # prefix glued onto it.
+        #
+        # Single source of truth for every "is this already absolute?" test.
+        # The ad-hoc `starts_with?("http")` form it replaces was wrong in both
+        # directions: it missed `mailto:`/`data:`/`//cdn…` (which then got a
+        # base_url prefix — and `//cdn…` even took the *root-relative* branch,
+        # yielding `https://site.com//cdn.example.com/og.png`), and it
+        # false-positived on a relative path that merely starts with the
+        # letters "http" (`http-guide/cover.png`), leaving it un-absolutized.
+        def has_own_origin?(value : String) : Bool
+          value.starts_with?("//") || value.matches?(SCHEME_PREFIX_REGEX)
+        end
+
         # Resolve internal `@/` links in HTML to actual page URLs.
         #
         # - `html` — rendered HTML string
@@ -190,9 +206,7 @@ module Hwaro
         # URL: absolute URLs (scheme:), protocol-relative (//host), and pure
         # in-page anchors (#section).
         private def absolute_or_anchor?(value : String) : Bool
-          value.starts_with?('#') ||
-            value.starts_with?("//") ||
-            value.matches?(SCHEME_PREFIX_REGEX)
+          value.starts_with?('#') || has_own_origin?(value)
         end
       end
     end

--- a/src/content/processors/table_parser.cr
+++ b/src/content/processors/table_parser.cr
@@ -170,7 +170,13 @@ module Hwaro
         # markdown table (e.g. `|---|---|` or `---|---`).  This avoids false
         # positives from random `|` in code blocks, URLs, or inline code while
         # still catching tables with or without leading/trailing pipes.
-        TABLE_SEPARATOR_CHECK = /^\s*\|?\s*:?-{3,}:?\s*\|/m
+        # `-+`, not `-{3,}`: GFM's delimiter cell is `:?-+:?`, so `|:-:|`,
+        # `|:--|` and `| - |` are all valid tables. Requiring three hyphens
+        # silently demoted every short ALIGNED row (`|:--|--:|`) to a
+        # paragraph of literal pipes — the plain `|---|---|` form happened to
+        # clear the bar, so the bug only showed up once an author added
+        # alignment.
+        TABLE_SEPARATOR_CHECK = /^\s*\|?\s*:?-+:?\s*\|/m
 
         def has_table?(content : String) : Bool
           TABLE_SEPARATOR_CHECK.matches?(content)
@@ -195,11 +201,11 @@ module Hwaro
           cells = split_row(stripped)
           return false if cells.empty?
 
-          # Each cell should match the separator pattern
+          # Each cell must be GFM's delimiter cell: `:?-+:?` (one or more
+          # hyphens, optional leading/trailing colon for alignment).
           cells.all? do |cell|
             cell = cell.strip
-            # Must be at least 3 dashes (with optional colons)
-            cell.matches?(/^:?-{3,}:?$/)
+            cell.matches?(/^:?-+:?$/)
           end
         end
 

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -335,7 +335,13 @@ module Hwaro
             path = arguments["path"].to_s
             base_url = env.resolve("base_url").to_s
 
-            if path.starts_with?("/")
+            # A value that already carries its own origin (any `scheme:` URL, or
+            # a protocol-relative `//host/…`) is returned untouched — prefixing
+            # base_url produced `https://site.com/mailto:a@b.com` and
+            # `https://site.com//cdn.example.com/x.js`. Matches `absolute_url`.
+            if Filters::UrlFilters.has_own_origin?(path)
+              Crinja::Value.new(path)
+            elsif path.starts_with?("/")
               Crinja::Value.new(base_url.rstrip("/") + path)
             else
               Crinja::Value.new(base_url.rstrip("/") + "/" + path)
@@ -520,8 +526,11 @@ module Hwaro
           # Note: actual output dimensions depend on aspect ratio preservation.
           @env.functions["resize_image"] = Crinja.function({path: "", width: 0, height: 0}) do
             path = arguments["path"].to_s
-            width = Math.max(0, arguments["width"].as_number.to_i)
-            height = Math.max(0, arguments["height"].as_number.to_i)
+            # Lenient coercion: shortcode arguments are always Strings, so a
+            # `width="800"` forwarded from `{% img(width="800") %}` must resize
+            # rather than raise Crinja::TypeError and abort the page.
+            width = Utils::CrinjaUtils.to_count(arguments["width"])
+            height = Utils::CrinjaUtils.to_count(arguments["height"])
 
             base_url = env.resolve("base_url").to_s
 

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -497,21 +497,48 @@ module Hwaro
             # base slug. Fall back to safe_slugify when the map is absent or the
             # term is unknown — plain slugify("🎉") is "" → "/tags//" (a dead
             # double-slash link), so safe_slugify is the right fallback.
+            # A multilingual site writes `/<lang>/<taxonomy>/<slug>/` term pages
+            # for every non-default language that enables the taxonomy. Prefer
+            # the CURRENT page's language when such a page exists: the root
+            # `/tags/<slug>/` either 404s (term present only in that language) or
+            # lands the reader on the default language's listing.
+            # `__taxonomy_lang_slugs__` only carries terms the generator actually
+            # wrote, so a miss safely falls through to the root URL below.
+            lang = env.resolve("page_language").to_s
+            default_lang = env.resolve("_i18n_default_language").to_s
+            lang_prefix = ""
             slug = nil
-            slugs_raw = env.resolve("__taxonomy_slugs__").raw
-            if slugs_raw.is_a?(Hash)
-              if kind_map = slugs_raw[kind]?
-                kind_raw = kind_map.raw
-                if kind_raw.is_a?(Hash)
-                  if mapped = kind_raw[term]?
+
+            if !lang.empty? && lang != default_lang
+              lang_raw = env.resolve("__taxonomy_lang_slugs__").raw
+              if lang_raw.is_a?(Hash) && (per_lang = lang_raw[lang]?)
+                per_lang_raw = per_lang.raw
+                if per_lang_raw.is_a?(Hash) && (kind_map = per_lang_raw[kind]?)
+                  kind_raw = kind_map.raw
+                  if kind_raw.is_a?(Hash) && (mapped = kind_raw[term]?)
                     slug = mapped.to_s
+                    lang_prefix = "/#{lang}"
+                  end
+                end
+              end
+            end
+
+            unless slug
+              slugs_raw = env.resolve("__taxonomy_slugs__").raw
+              if slugs_raw.is_a?(Hash)
+                if kind_map = slugs_raw[kind]?
+                  kind_raw = kind_map.raw
+                  if kind_raw.is_a?(Hash)
+                    if mapped = kind_raw[term]?
+                      slug = mapped.to_s
+                    end
                   end
                 end
               end
             end
             slug ||= Utils::TextUtils.safe_slugify(term)
 
-            url = "/#{kind}/#{slug}/"
+            url = "#{lang_prefix}/#{kind}/#{slug}/"
             Crinja::Value.new(base_url.rstrip("/") + url)
           end
         end

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -93,12 +93,11 @@ module Hwaro
         fields = config.search.fields.map(&.downcase)
         cjk = config.search.tokenize_cjk
 
-        # Extract base path from base_url for subpath deployments
-        base_path = if config.base_url.empty?
-                      ""
-                    else
-                      URI.parse(config.base_url).path.rstrip("/")
-                    end
+        # Extract base path from base_url for subpath deployments. Use the
+        # memoized Config helper rather than re-parsing: it also rescues a
+        # malformed base_url (a bare `URI.parse` raised out of the generator
+        # and aborted the build) and normalizes a "/" path to "".
+        base_path = config.base_path
 
         pages.map do |page|
           data = {} of String => String | Array(String)

--- a/src/content/seo/jsonld.cr
+++ b/src/content/seo/jsonld.cr
@@ -1,6 +1,7 @@
 require "json"
 require "../../models/config"
 require "../../models/page"
+require "../processors/internal_link_resolver"
 
 module Hwaro
   module Content
@@ -13,9 +14,10 @@ module Hwaro
           "#{base}#{path.starts_with?("/") ? path : "/#{path}"}"
         end
 
-        # Like abs_path, but leaves an already-absolute http(s) URL untouched.
+        # Like abs_path, but leaves a value that already carries its own origin
+        # (any `scheme:` URL, or a protocol-relative `//host/…`) untouched.
         private def abs_or_external(base : String, value : String) : String
-          value.starts_with?("http") ? value : abs_path(base, value)
+          Processors::InternalLinkResolver.has_own_origin?(value) ? value : abs_path(base, value)
         end
 
         # Generate Article JSON-LD for a page

--- a/src/content/seo/robots.cr
+++ b/src/content/seo/robots.cr
@@ -39,7 +39,13 @@ module Hwaro
             # Add Sitemap directive if sitemap is enabled and base_url is set
             if config.sitemap.enabled && !config.base_url.empty?
               base_url = config.base_url.rstrip('/')
-              sitemap_filename = config.sitemap.filename
+              # `File.basename`, matching where Sitemap.generate actually writes
+              # the file: it basenames the configured filename so the output
+              # can't escape the public tree. Advertising the raw config value
+              # here pointed robots.txt at `/reports/sitemap.xml` while the
+              # file sat at `/sitemap.xml` — a 404 for every crawler that
+              # followed it.
+              sitemap_filename = File.basename(config.sitemap.filename)
               sitemap_url = "#{base_url}/#{sitemap_filename}"
               str << "Sitemap: #{sitemap_url}\n"
             end

--- a/src/content/seo/sitemap.cr
+++ b/src/content/seo/sitemap.cr
@@ -11,7 +11,10 @@ module Hwaro
           # Check if sitemap is enabled
           return unless site.config.sitemap.enabled
 
-          if skip_if_unchanged && File.exists?(File.join(output_dir, site.config.sitemap.filename))
+          # `File.basename` here too — the write below basenames the configured
+          # filename, so probing the raw value made the cache-hit check look for
+          # a path that is never written and re-emit the sitemap every build.
+          if skip_if_unchanged && File.exists?(File.join(output_dir, File.basename(site.config.sitemap.filename)))
             Logger.debug "  Sitemap unchanged (cache hit), skipping."
             return
           end

--- a/src/content/seo/tags.cr
+++ b/src/content/seo/tags.cr
@@ -2,6 +2,7 @@ require "html"
 require "../../models/config"
 require "../../models/page"
 require "../../utils/text_utils"
+require "../processors/internal_link_resolver"
 
 module Hwaro
   module Content
@@ -53,7 +54,11 @@ module Hwaro
             # Add translations (already ordered by ordered_language_codes via link_translations!)
             page.translations.each do |t|
               next if t.is_current
-              abs_url = t.url.starts_with?("http") ? t.url : "#{base}#{t.url.starts_with?("/") ? t.url : "/#{t.url}"}"
+              abs_url = if Processors::InternalLinkResolver.has_own_origin?(t.url)
+                          t.url
+                        else
+                          "#{base}#{t.url.starts_with?("/") ? t.url : "/#{t.url}"}"
+                        end
               abs_url = Utils::TextUtils.encode_url_path(abs_url)
               str << '\n'
               str << %(<link rel="alternate" hreflang="#{HTML.escape(t.code)}" href="#{HTML.escape(abs_url)}">)

--- a/src/core/build/cache.cr
+++ b/src/core/build/cache.cr
@@ -373,7 +373,11 @@ module Hwaro
         def save
           return unless @enabled
           return unless @dirty
-          tmp_path = "#{@cache_path}.tmp"
+          # Per-process temp name: a shared `.tmp` lets two hwaro processes in
+          # the same project (the common `hwaro serve` + `hwaro build` pair)
+          # interleave their writes into one file, and whichever renames last
+          # publishes the spliced bytes as the cache.
+          tmp_path = "#{@cache_path}.#{Process.pid}.tmp"
           begin
             # Snapshot shared state under the mutex: parallel fibers may still
             # be writing @entries via #update, and iterating a Hash mid-mutation

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1708,6 +1708,27 @@ module Hwaro::Core::Build::Phases::Render
     multilingual = config.multilingual?
     taxonomies_hash = {} of String => Crinja::Value
     taxonomy_slugs = {} of String => Crinja::Value
+    # {language => {taxonomy => {term => slug}}} for the LANGUAGE-PREFIXED term
+    # pages (`/ko/tags/foo/`) the taxonomy generator writes for every non-default
+    # language that enables the taxonomy. Without this, `get_taxonomy_url` on a
+    # Korean page emitted the root `/tags/foo/` — which for a term that appears
+    # only in Korean content was never written at all (a hard 404 on the built-in
+    # blog scaffold's tag pills), and for a shared term pointed readers at the
+    # English listing. Only populated for languages that actually enable the
+    # taxonomy, so the lookup can never invent a page the generator skipped.
+    taxonomy_lang_slugs = {} of String => Crinja::Value
+    lang_taxonomy_names = {} of String => Array(String)
+    if multilingual
+      config.languages.each do |code, lang_cfg|
+        next if code == default_lang
+        next if lang_cfg.taxonomies.empty?
+        lang_taxonomy_names[code] = lang_cfg.taxonomies
+      end
+    end
+    # Accumulated as plain hashes and converted to Crinja::Value once at the end —
+    # round-tripping through Crinja::Value per insert would re-wrap the inner hash
+    # each time and keep only the last term.
+    lang_slug_maps = {} of String => Hash(String, Hash(String, String))
     site.taxonomies.each do |name, terms|
       # Disambiguate over the SAME term set the taxonomy generator uses to write
       # pages — build_taxonomy_index counts only non-draft, non-generated pages.
@@ -1754,6 +1775,23 @@ module Hwaro::Core::Build::Phases::Render
         end
         slug = (has_root ? slug_map[term]? : nil) || Utils::TextUtils.safe_slugify(term)
         term_slug_values[term] = Crinja::Value.new(slug) if has_root
+
+        # Record the term under every non-default language that (a) enables this
+        # taxonomy and (b) has a publishable page carrying the term — exactly the
+        # two conditions under which generate_taxonomies_for_language writes
+        # `/<lang>/<taxonomy>/<slug>/`. The generator disambiguates over the same
+        # term set, so `slug_map[term]` is the slug it used.
+        unless lang_taxonomy_names.empty?
+          lang_taxonomy_names.each do |code, names|
+            next unless names.includes?(name)
+            next unless term_pages.any? do |p|
+                          !p.draft && !p.generated && (p.language || default_lang) == code
+                        end
+            per_lang = lang_slug_maps[code] ||= {} of String => Hash(String, String)
+            tax_map = per_lang[name] ||= {} of String => String
+            tax_map[term] = slug_map[term]? || slug
+          end
+        end
         Crinja::Value.new({
           "name"  => Crinja::Value.new(term),
           "slug"  => Crinja::Value.new(slug),
@@ -1767,8 +1805,18 @@ module Hwaro::Core::Build::Phases::Render
       })
       taxonomy_slugs[name] = Crinja::Value.new(term_slug_values)
     end
+    lang_slug_maps.each do |code, per_lang|
+      tax_values = {} of String => Crinja::Value
+      per_lang.each do |tax_name, term_slugs|
+        term_values = {} of String => Crinja::Value
+        term_slugs.each { |term, s| term_values[term] = Crinja::Value.new(s) }
+        tax_values[tax_name] = Crinja::Value.new(term_values)
+      end
+      taxonomy_lang_slugs[code] = Crinja::Value.new(tax_values)
+    end
     vars["__taxonomies__"] = Crinja::Value.new(taxonomies_hash)
     vars["__taxonomy_slugs__"] = Crinja::Value.new(taxonomy_slugs)
+    vars["__taxonomy_lang_slugs__"] = Crinja::Value.new(taxonomy_lang_slugs)
 
     # Menus: config [[menus.*]]-declared entries + front-matter menus/menu
     # registrations, resolved into one tree per language. `__menus__` backs

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -205,13 +205,49 @@ module Hwaro
         private def unmask_inline_code(text : String, spans : Array(String)) : String
           return text if spans.empty?
           return text unless text.includes?('\u{0}')
-          text.gsub(INLINE_CODE_MASK_RE) { |tok| spans[$1.to_i]? || tok }
+          # to_i? (not to_i): a counterfeit token whose digit run overflows
+          # Int32 would otherwise raise ArgumentError and abort the render.
+          text.gsub(INLINE_CODE_MASK_RE) { |tok| $1.to_i?.try { |i| spans[i]? } || tok }
         end
 
-        # Named-closer tags (`{% endcustom %}`) that process_shortcodes_in_chunk
-        # rewrites to `{% end %}`. Shared with `shortcode_scan_needed?` so the
+        # Every `{% end<name> %}` / `{% end <name> %}` closer. Whether a given
+        # match is a Jinja control tag (`{% endif %}`) or a shortcode's named
+        # closer (`{% endcallout %}`) is decided in code, against
+        # CRINJA_CONTROL_KEYWORDS — a regex lookahead cannot do it:
+        #
+        #   * `(?!if|for|set|call|block|raw|filter|comment|…)` has no word
+        #     boundary, so it also rejected every shortcode whose name merely
+        #     *starts* with a keyword — `callout`, `iframe`, `setup`, `format`,
+        #     `blockquote`, `rawdata`, `withdraw`, … Those closers were never
+        #     normalized, the block parser never found a `{% end %}`, and the
+        #     raw `{% callout(...) %}…{% endcallout %}` source leaked verbatim
+        #     into the published page.
+        #   * adding `\b` fixes those but breaks hyphenated names instead
+        #     (`{% endinclude-code %}`), since `-` is a word boundary.
+        #
+        # Shared with `shortcode_scan_needed?` (via `named_closer?`) so the
         # skip decision and the rewrite can never drift apart.
-        NAMED_CLOSER_RE = /\{\%\s*end\s*(?!if|for|macro|block|call|set|with|autoescape|raw|filter|trans|pluralize|comment)[a-zA-Z_][\w\-]*\s*\%\}/i
+        NAMED_CLOSER_RE = /\{\%\s*end\s*([a-zA-Z_][\w\-]*)\s*\%\}/i
+
+        # Rewrite shortcode named closers to the canonical `{% end %}`, leaving
+        # real Jinja/Crinja control closers (`{% endif %}`, `{% endfor %}`, …)
+        # untouched.
+        private def normalize_named_closers(content : String) : String
+          content.gsub(NAMED_CLOSER_RE) do |match|
+            CRINJA_CONTROL_KEYWORDS.includes?($1.downcase) ? match : "{% end %}"
+          end
+        end
+
+        # True when `text` carries at least one shortcode named closer (i.e.
+        # one that `normalize_named_closers` would actually rewrite).
+        private def named_closer?(text : String) : Bool
+          pos = 0
+          while m = NAMED_CLOSER_RE.match_at_byte_index(text, pos)
+            return true unless CRINJA_CONTROL_KEYWORDS.includes?(m[1].downcase)
+            pos = m.byte_begin + m[0].bytesize
+          end
+          false
+        end
 
         # Matches both shortcode invocation forms handled by
         # process_shortcodes_in_chunk: `{{ shortcode("name", …) }}` and the
@@ -228,7 +264,7 @@ module Hwaro
         # call, or a non-control `{% name %}` block opener.
         def shortcode_scan_needed?(text : String) : Bool
           return false unless text.includes?("{{") || text.includes?("{%")
-          return true if NAMED_CLOSER_RE.matches?(text)
+          return true if named_closer?(text)
           return true if SHORTCODE_CALL_SCAN_RE.matches?(text)
 
           pos = 0
@@ -242,7 +278,7 @@ module Hwaro
         private def process_shortcodes_in_chunk(content : String, templates : Hash(String, String), context : Hash(String, Crinja::Value), shortcode_results : Hash(String, String)?, crinja_env_override : Crinja?, template_cache_override : Hash(UInt64, Crinja::Template)?, depth : Int32, spans : Array(String) = [] of String, warnings : Array(String)? = nil) : String
           # Localized normalization for named closers (only affects shortcode block content).
           # Avoid touching real Jinja/Crinja control tags (endif, endfor, etc.).
-          normalized = content.gsub(NAMED_CLOSER_RE, "{% end %}")
+          normalized = normalize_named_closers(content)
 
           # 1. Block shortcodes
           processed = process_block_shortcodes(normalized, templates, context, shortcode_results, crinja_env_override, template_cache_override, depth, spans, warnings)

--- a/src/main.cr
+++ b/src/main.cr
@@ -1,3 +1,24 @@
 require "./hwaro"
 
+# Size the default execution context so the build's fiber fan-out actually
+# runs in parallel.
+#
+# Hwaro used to get its parallelism from `-Dpreview_mt`. Crystal 1.21
+# deprecated that flag ("Resize the default execution context, or start
+# additional contexts instead") and its legacy MT scheduler is buggy on the
+# way out: under CPU oversubscription the `CRYSTAL-MT-*` worker threads spin
+# forever inside `Crystal::EventLoop::Polling#run` → `Crystal::SpinLock#lock`
+# and the process never exits, burning a core per thread. Measured on this
+# repo's spec harness: 4/120 short-lived `-Dpreview_mt` invocations hung under
+# load, 0/120 without the flag — and a hung `hwaro build` in CI never returns.
+#
+# Without the flag Crystal 1.21 starts a `Fiber::ExecutionContext::Parallel`
+# default context, but with parallelism pinned to 1 — which made the docs
+# build 3.1x slower (1.46s → 4.58s). `CRYSTAL_WORKERS` alone does NOT fix
+# that: it only feeds `default_workers_count`, which nothing consults until
+# the context is resized. Resizing here is the migration the deprecation
+# message prescribes; every `spawn` in the build pipeline lands in the default
+# context, so no call site changes.
+Fiber::ExecutionContext.default.resize(Fiber::ExecutionContext.default_workers_count)
+
 Hwaro::CLI::Runner.new.run

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -6,6 +6,7 @@ require "../utils/text_utils"
 require "../utils/permalink_resolver"
 require "../utils/env_substitutor"
 require "../utils/path_utils"
+require "../content/processors/internal_link_resolver"
 
 module Hwaro
   module Models
@@ -521,11 +522,18 @@ module Hwaro
         end
       end
 
-      # Resolve an image path to an absolute URL, falling back to default_image
+      # Resolve an image path to an absolute URL, falling back to default_image.
+      # A value that already carries its own origin (any `scheme:` URL, or a
+      # protocol-relative `//cdn.example.com/og.png`) is returned untouched:
+      # the old `starts_with?("http")` test sent `//cdn…` down the
+      # root-relative branch and emitted `https://site.com//cdn.example.com/og.png`
+      # as og:image, while a relative path merely starting with the letters
+      # "http" (`http-guide/cover.png`) was left relative — invalid for OG.
       def resolve_image_url(image : String?, base_url : String) : String?
         img = image || @default_image
         return unless img
-        img.starts_with?("http") ? img : "#{base_url}#{img.starts_with?("/") ? img : "/#{img}"}"
+        return img if Content::Processors::InternalLinkResolver.has_own_origin?(img)
+        "#{base_url}#{img.starts_with?("/") ? img : "/#{img}"}"
       end
 
       # Generate both OG and Twitter tags

--- a/src/utils/crinja_utils.cr
+++ b/src/utils/crinja_utils.cr
@@ -116,6 +116,29 @@ module Hwaro
           Crinja::Value.new(value.to_s)
         end
       end
+
+      # Coerce a template/filter argument to an Int32 count, clamped to
+      # [min, max], with `default` for anything that isn't a number at all.
+      #
+      # Numeric arguments reach templates as strings far more often than not:
+      # `parse_shortcode_args_jinja` produces a `Hash(String, String)`, so every
+      # value a shortcode forwards is a String. `Crinja::Value#as_number` raises
+      # `Crinja::TypeError` on those, and the raise propagated out of the filter
+      # and aborted the whole page render — `resize_image(width="800")` killed
+      # the page instead of resizing. Out-of-range and NaN values clamp here too
+      # rather than raising OverflowError from `Float64#to_i`.
+      def to_count(value : Crinja::Value, default : Int32 = 0, min : Int32 = 0, max : Int32 = Int32::MAX) : Int32
+        num = begin
+          value.as_number.to_f
+        rescue Exception
+          value.to_s.strip.to_f?
+        end
+        return default unless num
+        return default if num.nan?
+        return min if num <= min.to_f
+        return max if num >= max.to_f
+        num.to_i32
+      end
     end
   end
 end

--- a/src/utils/css_minifier.cr
+++ b/src/utils/css_minifier.cr
@@ -10,81 +10,260 @@
 # - Strip trailing semicolons before }
 # - Preserve url() contents and string literals
 #
-# Processing order is critical: strings and urls are extracted first
-# so that comment removal and whitespace rules cannot damage their
-# contents (e.g. "/* not a comment */" or url(http://example.com)).
+# Comments, string literals and `url(...)` values are recognised in a
+# SINGLE left-to-right scan rather than by three ordered regex passes.
+# Ordering separate passes cannot be made correct: a quote inside a
+# comment (`/* don't */`) starts a bogus string literal that swallows
+# real rules up to the next quote, while a comment marker inside a
+# string (`content: "/* x */"`) must not be stripped. Only a scanner
+# that consumes whichever construct opens first gets both right.
+#
+# All whitespace classes below are the five HTML/CSS space characters
+# (`[ \t\r\n\f]`) rather than `\s`: Crystal compiles patterns with
+# PCRE2's UCP flag, so `\s` would also match U+00A0/U+3000, which are
+# not CSS whitespace.
 
 module Hwaro
   module Utils
     module CssMinifier
       extend self
 
+      # Sentinel wrapper for stashed strings/urls. `\x00` cannot appear in
+      # a stylesheet, so the placeholder can't collide with author content.
+      private PRESERVE_PREFIX = "\x00PRESERVE_"
+      private PRESERVE_SUFFIX = "\x00"
+
+      private WS_RUN        = /[ \t\r\n\f]+/
+      private WS_STRUCTURAL = /[ \t\r\n\f]*([{};,])[ \t\r\n\f]*/
+      private WS_COLON      = /[ \t\r\n\f]*:[ \t\r\n\f]*/
+      private PAREN_GROUP   = /\(([^)]*)\)/
+      private RESTORE_TOKEN = /\x00PRESERVE_(\d+)\x00/
+
       # Perform conservative CSS minification
       def minify(css : String) : String
-        result = css
         preserves = [] of String
-        placeholder_prefix = "\x00PRESERVE_"
 
-        # ── Step 1: Extract url() contents FIRST ─────────────────────────
-        # Must run before string extraction, because url('...') contains
-        # quotes that would otherwise be captured as standalone strings.
-        result = result.gsub(/url\(\s*(['"]?)(.+?)\1\s*\)/m) do |_match|
-          quote = $1
-          inner = $2
-          idx = preserves.size
-          preserves << "url(#{quote}#{inner}#{quote})"
-          "#{placeholder_prefix}#{idx}\x00"
-        end
+        # ── Step 1: strip comments, stash strings and url() values ────────
+        result = extract_tokens(css, preserves)
 
-        # ── Step 2: Extract remaining string literals ─────────────────────
-        # Prevents comment-like patterns inside strings from being stripped.
-        # e.g. content: "/* not a comment */"
-        result = result.gsub(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/m) do |match|
-          idx = preserves.size
-          preserves << match
-          "#{placeholder_prefix}#{idx}\x00"
-        end
+        # ── Step 2: Collapse whitespace ───────────────────────────────────
+        result = result.gsub(WS_RUN, " ")
 
-        # ── Step 3: Remove comments (safe now — strings/urls are protected) ─
-        result = result.gsub(/\/\*.*?\*\//m, "")
+        # ── Step 3: Remove space around structural characters ─────────────
+        # Single pass for `{`, `}`, `;`, `,` — these targets are disjoint
+        # (none can appear inside another's match) so one scan is equivalent
+        # to four sequential gsubs but allocates only one string.
+        result = result.gsub(WS_STRUCTURAL) { $1 }
 
-        # ── Step 4: Collapse whitespace ───────────────────────────────────
-        result = result.gsub(/\s+/, " ")
+        # ── Step 4: Collapse `:` spacing, structurally ────────────────────
+        result = collapse_colons(result)
 
-        # ── Step 5: Remove space around structural characters ─────────────
-        # Combined single-pass for `{`, `}`, `;`, `,` — these targets are
-        # disjoint (none can appear inside another's match) so one scan is
-        # equivalent to four sequential gsubs but allocates only one string.
-        # Running this before the `:` trims below is safe because `:` trimming
-        # operates on `:` context only and never interacts with `;` or `,`.
-        result = result.gsub(/\s*([{};,])\s*/) { $1 }
-        # Only remove spaces around `:` inside declaration blocks (after `{`)
-        # and parenthesized expressions (e.g. media queries `(max-width: 600px)`)
-        # to preserve descendant combinator spaces in selectors (e.g. `div :hover`)
-        result = result.gsub(/\{([^}]*)\}/) do |_|
-          inner = $1
-          "{" + inner.gsub(/\s*:\s*/, ":") + "}"
-        end
-        # Only strip colon spaces inside at-rule conditions (e.g. @media (max-width: 600px))
-        # Avoid stripping inside functional pseudo-classes like :is(div :hover)
-        result = result.gsub(/@[\w-]+[^{]*\{/) do |at_header|
-          at_header.gsub(/\(([^)]*)\)/) do
-            "(" + $1.gsub(/\s*:\s*/, ":") + ")"
+        # ── Step 5: Strip trailing semicolons before } ────────────────────
+        result = result.gsub(";}", "}")
+
+        # ── Step 6: Restore preserved tokens (single-pass) ────────────────
+        unless preserves.empty?
+          result = result.gsub(RESTORE_TOKEN) do
+            # to_i? guards against a counterfeit token whose index overflows
+            # Int32 — return $0 unchanged rather than raising ArgumentError.
+            idx = $1.to_i?
+            idx && idx < preserves.size ? preserves[idx] : $0
           end
         end
 
-        # ── Step 6: Strip trailing semicolons before } ────────────────────
-        result = result.gsub(/;\}/, "}")
+        result.strip
+      end
 
-        # ── Step 7: Restore preserved tokens (single-pass) ─────────────────
-        result = result.gsub(/\x00PRESERVE_(\d+)\x00/) do
-          # to_i? guards against a counterfeit token whose index overflows
-          # Int32 — return $0 unchanged rather than raising ArgumentError.
-          idx = $1.to_i?
-          idx && idx < preserves.size ? preserves[idx] : $0
+      # Single scan that drops comments and replaces string literals and
+      # `url(...)` values with placeholders. Operates on the UTF-8 byte view:
+      # every delimiter it looks for is 7-bit ASCII and a UTF-8 continuation
+      # byte is always >= 0x80, so a byte scan can never mistake part of a
+      # multi-byte character for a delimiter — and it avoids the O(n²) that
+      # `String#[](Int32)` random access costs on non-ASCII input.
+      private def extract_tokens(css : String, preserves : Array(String)) : String
+        bytes = css.to_slice
+        n = bytes.size
+        String.build(css.bytesize) do |io|
+          i = 0
+          while i < n
+            b = bytes[i]
+            case b
+            when '/'.ord
+              if i + 1 < n && bytes[i + 1] == '*'.ord
+                # Comment — dropped. An unterminated comment runs to EOF,
+                # which is how browsers parse it too.
+                i = skip_comment(bytes, i, n)
+                next
+              end
+            when '"'.ord, '\''.ord
+              if (stop = scan_string_end(bytes, i, n)) >= 0
+                stash(io, preserves, String.new(bytes[i, stop - i]))
+                i = stop
+                next
+              end
+              # Unterminated literal: emit verbatim, like the old regex pass.
+            when 'u'.ord, 'U'.ord
+              if stop = scan_url(bytes, i, n, preserves, io)
+                i = stop
+                next
+              end
+            end
+            io.write_byte(b)
+            i += 1
+          end
+        end
+      end
+
+      # Append `text` to `preserves` and write its placeholder to `io`.
+      private def stash(io : IO, preserves : Array(String), text : String) : Nil
+        preserves << text
+        io << PRESERVE_PREFIX << (preserves.size - 1) << PRESERVE_SUFFIX
+      end
+
+      # Index just past the closing `*/`, or `n` when the comment is
+      # unterminated. `start` points at the opening `/`.
+      private def skip_comment(bytes : Bytes, start : Int32, n : Int32) : Int32
+        i = start + 2
+        while i + 1 < n
+          return i + 2 if bytes[i] == '*'.ord && bytes[i + 1] == '/'.ord
+          i += 1
+        end
+        n
+      end
+
+      # Index just past the closing quote of the literal starting at
+      # `start`, or -1 when unterminated.
+      private def scan_string_end(bytes : Bytes, start : Int32, n : Int32) : Int32
+        quote = bytes[start]
+        i = start + 1
+        while i < n
+          b = bytes[i]
+          if b == '\\'.ord
+            i += 2
+            next
+          end
+          return i + 1 if b == quote
+          i += 1
+        end
+        -1
+      end
+
+      # Recognise `url( ... )` at `start` (case-insensitive, and only when
+      # `url` is a standalone identifier). On success the normalised value —
+      # inner whitespace trimmed, quoting preserved — is stashed and the
+      # index just past the closing `)` is returned. Returns nil when this
+      # is not a url token, so the caller falls back to copying bytes.
+      private def scan_url(bytes : Bytes, start : Int32, n : Int32, preserves : Array(String), io : IO) : Int32?
+        return unless start + 4 <= n
+        return unless lower(bytes[start]) == 'u'.ord &&
+                      lower(bytes[start + 1]) == 'r'.ord &&
+                      lower(bytes[start + 2]) == 'l'.ord &&
+                      bytes[start + 3] == '('.ord
+        return if start > 0 && ident_byte?(bytes[start - 1])
+
+        i = start + 4
+        while i < n && space_byte?(bytes[i])
+          i += 1
         end
 
-        result.strip
+        quote = 0_u8
+        if i < n && (bytes[i] == '"'.ord || bytes[i] == '\''.ord)
+          stop = scan_string_end(bytes, i, n)
+          return if stop < 0
+          quote = bytes[i]
+          inner = String.new(bytes[i + 1, stop - i - 2])
+          i = stop
+        else
+          j = i
+          while j < n && bytes[j] != ')'.ord
+            j += 1
+          end
+          return if j >= n
+          inner = String.new(bytes[i, j - i]).rstrip(" \t\r\n\f")
+          i = j
+        end
+
+        while i < n && space_byte?(bytes[i])
+          i += 1
+        end
+        return unless i < n && bytes[i] == ')'.ord
+        return if inner.empty?
+
+        q = quote == 0_u8 ? "" : quote.unsafe_chr.to_s
+        # Keep the author's casing of the function name (`URL(` stays `URL(`).
+        stash(io, preserves, "#{String.new(bytes[start, 3])}(#{q}#{inner}#{q})")
+        i + 1
+      end
+
+      private def lower(b : UInt8) : Int32
+        (b | 0x20).to_i
+      end
+
+      private def space_byte?(b : UInt8) : Bool
+        b == ' '.ord || b == '\t'.ord || b == '\r'.ord || b == '\n'.ord || b == '\f'.ord
+      end
+
+      private def ident_byte?(b : UInt8) : Bool
+        (b >= 'a'.ord && b <= 'z'.ord) || (b >= 'A'.ord && b <= 'Z'.ord) ||
+          (b >= '0'.ord && b <= '9'.ord) || b == '-'.ord || b == '_'.ord || b >= 0x80
+      end
+
+      # Collapse whitespace around `:` — but only where a `:` separates a
+      # property from its value, never where it introduces a pseudo-class.
+      #
+      # The stylesheet is split into runs delimited by `{`, `}` and `;`,
+      # and each run is classified by its terminator and brace depth:
+      #
+      #   * terminated by `{`  → a prelude (selector or at-rule condition)
+      #   * `;`/`}` at depth 0 → a top-level at-rule statement (`@import …;`)
+      #   * `;`/`}` deeper     → a declaration
+      #
+      # Only declarations get their colons tightened. Preludes keep theirs,
+      # so the descendant combinator in `.card :hover` survives; the sole
+      # exception is an at-rule prelude, where a colon inside parentheses is
+      # a media/supports feature test (`@media (max-width: 600px)`).
+      #
+      # A depth-blind regex over `\{([^}]*)\}` cannot make this distinction:
+      # inside `@media screen{.card :hover{…}}` the first `{`…`}` span
+      # reaches into the *nested* selector, and `.card :hover` was being
+      # rewritten to the (differently-matching) compound `.card:hover`.
+      private def collapse_colons(css : String) : String
+        return css unless css.includes?(':')
+        String.build(css.bytesize) do |io|
+          run = String::Builder.new
+          depth = 0
+          css.each_char do |ch|
+            case ch
+            when '{'
+              io << collapse_prelude(run.to_s)
+              io << ch
+              run = String::Builder.new
+              depth += 1
+            when '}', ';'
+              io << (depth > 0 ? collapse_declaration(run.to_s) : collapse_prelude(run.to_s))
+              io << ch
+              run = String::Builder.new
+              depth -= 1 if ch == '}' && depth > 0
+            else
+              run << ch
+            end
+          end
+          io << collapse_prelude(run.to_s)
+        end
+      end
+
+      # Selector / at-rule condition: only an at-rule's parenthesised
+      # feature tests get their colons tightened.
+      private def collapse_prelude(run : String) : String
+        return run unless run.includes?(':')
+        return run unless run.lstrip(" \t\r\n\f").starts_with?('@')
+        run.gsub(PAREN_GROUP) { "(" + $1.gsub(WS_COLON, ":") + ")" }
+      end
+
+      # Declaration: every `:` is a property/value separator.
+      private def collapse_declaration(run : String) : String
+        return run unless run.includes?(':')
+        run.gsub(WS_COLON, ":")
       end
     end
   end

--- a/src/utils/html_minifier.cr
+++ b/src/utils/html_minifier.cr
@@ -115,7 +115,16 @@ module Hwaro
       # and runs first, but it cannot rewrite the value text itself —
       # in those rare cases this pass simply leaves the surrounding
       # whitespace untouched (the prior conservative behaviour).
-      private REGEX_INTERTOKEN_WS  = /(<\/?[A-Za-z][\w-]*[^>]*>|\x00HW_HTML_P[BI]_\d+\x00)(\s+)(?=(<\/?[A-Za-z][\w-]*[^>]*>|\x00HW_HTML_P[BI]_\d+\x00))/
+      #
+      # The whitespace run is `[ \t\r\n\f]+`, NOT `\s+`. Crystal compiles
+      # patterns with PCRE2's UCP flag, so `\s` also matches U+00A0
+      # (NBSP), U+3000 and the other Unicode space separators — none of
+      # which are HTML "space characters". Those are *content*: an
+      # `&nbsp;` written between two tags decodes to a literal U+00A0 in
+      # the rendered HTML, and collapsing it either downgraded it to a
+      # breakable space (inline neighbours) or deleted it outright
+      # (block neighbours), silently changing the rendered page.
+      private REGEX_INTERTOKEN_WS  = /(<\/?[A-Za-z][\w-]*[^>]*>|\x00HW_HTML_P[BI]_\d+\x00)([ \t\r\n\f]+)(?=(<\/?[A-Za-z][\w-]*[^>]*>|\x00HW_HTML_P[BI]_\d+\x00))/
       private REGEX_TAG_NAME       = /^<\/?([A-Za-z][\w-]*)/
       private REGEX_BLANK_LINES    = /\n{2,}/
       private REGEX_PRESERVE_TOKEN = /\x00HW_HTML_P[BI]_(\d+)\x00/

--- a/src/utils/text_utils.cr
+++ b/src/utils/text_utils.cr
@@ -20,17 +20,23 @@ module Hwaro
       #   slugify("My Blog Post")  # => "my-blog-post"
       #   slugify("한글 제목")      # => "한글-제목"
       #   slugify("CJK 테스트!")   # => "cjk-테스트"
+      #   slugify("日本語　テスト") # => "日本語-テスト"  (U+3000)
       #
       def slugify(text : String) : String
         # Single-pass: directly emit hyphens for separators, collapsing runs.
         # Avoids intermediate String allocation + regex gsub.
         String.build(text.bytesize) do |io|
           last_was_sep = true # suppress leading hyphen
+          # Separator test is `whitespace?`, not `ascii_whitespace?`: the
+          # ideographic space U+3000 is the ordinary word separator in CJK
+          # titles, and an `&nbsp;` in a title decodes to U+00A0. Neither is
+          # a letter, so the old test dropped them entirely and welded the
+          # surrounding words together ("日本語　テスト" → "日本語テスト").
           text.each_char do |char|
             if char.ascii_letter? || char.ascii_number?
               io << char.downcase
               last_was_sep = false
-            elsif char.ascii_whitespace? || char == '-' || char == '_'
+            elsif char.whitespace? || char == '-' || char == '_'
               unless last_was_sep
                 io << '-'
                 last_was_sep = true


### PR DESCRIPTION
Ten rounds of source-wide auditing. Every round: read a subsystem, reproduce the defect, fix the root cause, add regression specs, run the full suite + ameba + a docs build.

**Total: 24 defects fixed, 98 regression specs added.** Full suite 6713 → 6807 examples, 0 failures. Docs output verified byte-identical (`diff -r`) against the pre-audit binary for every round that could touch rendering.

## The big one — release binaries could hang forever at exit

Every build path passed `-Dpreview_mt`. Crystal 1.21 deprecated that flag, and its legacy MT scheduler is broken on the way out: under CPU oversubscription the `CRYSTAL-MT-*` threads spin inside `Crystal::EventLoop::Polling#run` → `Crystal::SpinLock#lock` and the process never exits, burning a core per thread.

This is what made this repo's own spec suite hang intermittently (a functional spec `Process.run`s `bin/hwaro` and waits for a child that never returns). In CI it wedges the job until timeout.

```
-Dpreview_mt      4/120 and 2/120 hung   (`hwaro tool list all`, 12x oversubscribed)
without the flag  0/120 hung             (three separate runs)
```

Dropping the flag alone isn't enough — Crystal 1.21's default parallel context is pinned to parallelism 1 and `CRYSTAL_WORKERS` doesn't change that on its own, which made the docs build 3.1x slower. `src/main.cr` now resizes the default execution context, which is what the deprecation message prescribes. Result: docs build **1.46s → 1.21s**, output byte-identical, `CRYSTAL_WORKERS` still honoured, 0/120 hangs.

Per maintainer decision the minimum Crystal is raised to **1.21** and the flag is removed from shard.yml, justfile, both CI jobs, release-binary, Dockerfile, snapcraft, flake.nix, README, AGENTS.md and the EN/KO install docs.

## Output-corrupting defects

- **HTML minifier deleted rendered `&nbsp;`.** Crystal compiles patterns with PCRE2's UCP flag, so the inter-token `\s+` also matched U+00A0/U+3000 — content, not layout whitespace. Between inline tags it was downgraded to a breakable space; between block tags, dropped.
- **CSS minifier mangled selectors inside at-rules.** Colon tightening ran as a depth-blind `gsub(/\{([^}]*)\}/)`, so in `@media screen{.card :hover{…}}` the span reached into the nested selector and `.card :hover` became the compound `.card:hover`.
- **CSS minifier leaked comments containing an apostrophe.** Comments were stripped *after* string extraction, so `/* don't */` opened a bogus literal that swallowed every rule up to the next quote. Comments/strings/`url(...)` are now one left-to-right byte scan.
- **Block shortcodes named after a Jinja keyword prefix shipped raw.** The named-closer normalizer used a lookahead with no word boundary, so `{% endcallout %}` read as the `call` closer, the block never closed, and `{% callout(…) %}…{% endcallout %}` landed verbatim in the page. Hit `callout`, `iframe`, `setup`, `format`, `blockquote`, `rawdata`, … — including the built-in `callout`, whose own docs advertise that closer.
- **Sass grouping parens leaked into declaration values** — `width: (10px / 2)`, `margin: (1px 2px)`: syntax with no meaning in CSS, dropped by every browser.
- **GFM tables with short alignment delimiters weren't tables.** The delimiter cell was matched with `:?-{3,}:?` instead of GFM's `:?-+:?`, so `|:--|--:|`, `|:-:|` and `| - |` fell through as a paragraph of literal pipes. `|---|---|` cleared the bar, so it only showed up once an author added alignment.
- **`slugify()` dropped Unicode whitespace** instead of separating on it — `日本語　テスト` welded into one segment (U+3000 is *the* CJK word separator).

## Links that pointed nowhere

- `absolute_url` / `relative_url` / `url_for` / `get_url` only knew `http(s)://`, so `mailto:a@b.com` became `https://site.com/mailto:a@b.com` and a protocol-relative `//cdn…` took the *root-relative* branch → `https://site.com//cdn.example.com/x.js`.
- Same test in `og:image` / `twitter:image` / JSON-LD `image`, plus the inverse: a relative path merely *starting* with the letters "http" was left relative, which is invalid for og:image. `InternalLinkResolver.has_own_origin?` is now the single source of truth.
- `robots.txt` advertised the raw configured sitemap filename while the generator basenames it — `filename = "reports/sitemap.xml"` pointed every crawler at a 404.
- `get_taxonomy_url` on a multilingual site always emitted the root term URL. A term appearing only in Korean content has no root page, so the built-in blog scaffold's tag pills were a hard 404 (reproduced on a real build). Now prefers the current language's term page *when the generator actually wrote one*.
- `hwaro tool check-links` reported valid links as dead — angle-bracket destinations (`[t](</about/>)`, and worse, ones containing spaces) and destinations with balanced parens (`/docs/foo_(bar)`). It's a CI gate, so a false positive fails the pipeline.

## Crashes and silent breakage

- `resize_image(width="800")` raised `Crinja::TypeError` and aborted the page render — but *every* shortcode argument is a String, so that's the normal shape. `truncate_words(length="20")` silently meant 50, and a negative length sliced words off the end. All three now route through a shared lenient coercion that clamps instead of overflowing.
- An oversized `[image_processing] widths` entry crashed the build with a bare `OverflowError` (no error code, no file context). Rounding saturates so the existing pixel-count guard declines the variant instead.
- `$1.to_i` in two placeholder-restore paths could raise `ArgumentError` on a counterfeit token; the build cache wrote through a shared `.tmp` so two hwaro processes in one project could publish spliced bytes.
- A failing *namespaced* Sass reference (`math.div(1px, 0)`) fell back to emitting `math.div(1px, 0)` as a CSS value. No CSS function name contains a `.`, so that fallback is always dead CSS — it now warns with `path:line:col` while keeping the documented passthrough.

## Deliberately left alone

Two candidates turned out to be documented decisions, not bugs, so they were reverted rather than "fixed": Sass's lenient passthrough for an un-`@use`d `math.div` (pinned by a spec) and the table renderer omitting `text-align: left` (also pinned by a spec, and correct in LTR).
