### PR TITLE
test: cover FrontmatterWriter, DevPath, SassCompiler and PathUtils gaps

### DIFF
--- a/spec/unit/dev_path_spec.cr
+++ b/spec/unit/dev_path_spec.cr
@@ -1,0 +1,202 @@
+require "../spec_helper"
+
+# DevPath exists to keep the dev server's routing identical to a static
+# host's. Its whole value is in the shapes it REFUSES, so those are pinned
+# here directly rather than only through the HTTP handlers that call it.
+describe Hwaro::Services::DevPath do
+  describe ".dots_only?" do
+    it "is true for the parent link" do
+      Hwaro::Services::DevPath.dots_only?("..").should be_true
+    end
+
+    it "is true for the current-directory link" do
+      Hwaro::Services::DevPath.dots_only?(".").should be_true
+    end
+
+    # Windows strips BOTH trailing dots and trailing ASCII spaces, which can
+    # collapse these onto a segment that traverses.
+    it "is true for dot/space forms Windows collapses onto . or .." do
+      ["...", ".. ", ". ", "..  ", "   "].each do |segment|
+        Hwaro::Services::DevPath.dots_only?(segment).should be_true
+      end
+    end
+
+    # Deliberately NOT "contains ..": these are ordinary filenames a static
+    # host serves, and refusing them would reintroduce dev/prod divergence.
+    it "is false for ordinary names that merely contain dots" do
+      ["lib.v1..2.js", "a..b", "..foo", "index.html", "a.b.c"].each do |segment|
+        Hwaro::Services::DevPath.dots_only?(segment).should be_false
+      end
+    end
+
+    it "is true for an empty segment" do
+      Hwaro::Services::DevPath.dots_only?("").should be_true
+    end
+
+    # Only ASCII space and `.` are trimmed by Win32, so these stay distinct.
+    it "is false for non-ASCII-space suffixed dot forms" do
+      Hwaro::Services::DevPath.dots_only?("..\t").should be_false
+      Hwaro::Services::DevPath.dots_only?(".. ").should be_false
+    end
+  end
+
+  describe ".unservable?" do
+    it "accepts an ordinary path" do
+      Hwaro::Services::DevPath.unservable?("/guide/index.html").should be_false
+    end
+
+    it "accepts a legitimately percent-encoded non-ASCII path" do
+      Hwaro::Services::DevPath.unservable?("/%ED%95%9C%EA%B8%80/").should be_false
+    end
+
+    it "accepts a raw UTF-8 path" do
+      Hwaro::Services::DevPath.unservable?("/한글/").should be_false
+    end
+
+    # A static host 404s these; the dev server used to answer 200, so a broken
+    # link worked locally and broke after deploy.
+    it "refuses a backslash separator" do
+      Hwaro::Services::DevPath.unservable?("/guide\\index.html").should be_true
+    end
+
+    it "refuses an encoded forward slash in any casing" do
+      ["/%2Fguide%2Findex.html", "/%2fguide%2findex.html"].each do |path|
+        Hwaro::Services::DevPath.unservable?(path).should be_true
+      end
+    end
+
+    it "refuses an encoded backslash in any casing" do
+      ["/guide%5Cindex.html", "/guide%5cindex.html"].each do |path|
+        Hwaro::Services::DevPath.unservable?(path).should be_true
+      end
+    end
+
+    # StaticFileHandler answers a decoded NUL with 400; deleting it (what the
+    # lenient shared sanitizer does) served the real homepage with a 200.
+    it "refuses a NUL in raw or encoded form" do
+      Hwaro::Services::DevPath.unservable?("/index%00.html").should be_true
+      Hwaro::Services::DevPath.unservable?("/index%2500.html").should be_false
+      Hwaro::Services::DevPath.unservable?("/index\u{0000}.html").should be_true
+    end
+
+    # MUST be checked before the regexes: PCRE2 over invalid UTF-8 raises
+    # ArgumentError straight out of the handler — a 500 where a static host
+    # answers 404.
+    it "refuses invalid UTF-8 without raising" do
+      invalid = String.new(Bytes[0x2f, 0xff, 0xfe])
+      invalid.valid_encoding?.should be_false
+      Hwaro::Services::DevPath.unservable?(invalid).should be_true
+    end
+
+    # Double-encoded forms survive the single decode as a literal `%2f` inside
+    # one segment, which simply doesn't exist on disk.
+    it "does not need a separate rule for double-encoded separators" do
+      Hwaro::Services::DevPath.unservable?("/guide%252findex.html").should be_false
+      Hwaro::Services::DevPath.safe_relative("/guide%252findex.html").should eq("guide%2findex.html")
+    end
+  end
+
+  describe ".safe_relative" do
+    it "strips the leading slash" do
+      Hwaro::Services::DevPath.safe_relative("/guide/index.html").should eq("guide/index.html")
+    end
+
+    it "returns an empty string for the output root itself" do
+      Hwaro::Services::DevPath.safe_relative("/").should eq("")
+      Hwaro::Services::DevPath.safe_relative("").should eq("")
+    end
+
+    it "collapses repeated and trailing slashes" do
+      Hwaro::Services::DevPath.safe_relative("//guide///a/").should eq("guide/a")
+    end
+
+    it "drops bare current-directory segments" do
+      Hwaro::Services::DevPath.safe_relative("/./guide/./a.html").should eq("guide/a.html")
+    end
+
+    it "decodes exactly once" do
+      Hwaro::Services::DevPath.safe_relative("/a%20b/c.html").should eq("a b/c.html")
+    end
+
+    it "resolves a percent-encoded non-ASCII path" do
+      Hwaro::Services::DevPath.safe_relative("/%ED%95%9C%EA%B8%80/").should eq("한글")
+    end
+
+    it "resolves a raw UTF-8 path" do
+      Hwaro::Services::DevPath.safe_relative("/한글/index.html").should eq("한글/index.html")
+    end
+
+    it "returns nil for an unservable path" do
+      ["/guide\\a.html", "/%2Fetc%2Fpasswd", "/a%00.html"].each do |path|
+        Hwaro::Services::DevPath.safe_relative(path).should be_nil
+      end
+    end
+
+    it "returns nil for a traversing segment" do
+      ["/../etc/passwd", "/a/../../etc", "/%2e%2e/etc"].each do |path|
+        Hwaro::Services::DevPath.safe_relative(path).should be_nil
+      end
+    end
+
+    it "returns nil for the dot/space traversal variants" do
+      ["/.. /a", "/.../a", "/a/. /b"].each do |path|
+        Hwaro::Services::DevPath.safe_relative(path).should be_nil
+      end
+    end
+
+    it "keeps ordinary filenames that merely contain dots" do
+      Hwaro::Services::DevPath.safe_relative("/js/lib.v1..2.js").should eq("js/lib.v1..2.js")
+    end
+
+    # Percent-encoded invalid UTF-8 only becomes invalid after decoding, and
+    # every operation below would raise on it.
+    it "returns nil for percent-encoded invalid UTF-8 without raising" do
+      ["/%c0%ae%c0%ae/etc", "/%ff"].each do |path|
+        Hwaro::Services::DevPath.safe_relative(path).should be_nil
+      end
+    end
+
+    it "never returns a path that escapes the output root" do
+      [
+        "/../a", "/..%2fa", "/%2e%2e%2fa", "/a/../../b",
+        "/....//a", "/. /a", "/%2e%2e/%2e%2e/a",
+      ].each do |path|
+        result = Hwaro::Services::DevPath.safe_relative(path)
+        next if result.nil?
+        result.split('/').none? { |s| Hwaro::Services::DevPath.dots_only?(s) }.should be_true
+      end
+    end
+  end
+
+  describe ".encode_relative" do
+    it "leaves an empty path alone" do
+      Hwaro::Services::DevPath.encode_relative("").should eq("")
+    end
+
+    it "leaves an already-safe path alone" do
+      Hwaro::Services::DevPath.encode_relative("guide/index.html").should eq("guide/index.html")
+    end
+
+    # safe_relative hands back decoded bytes, so a redirect built straight from
+    # it would put a raw space into `Location:`.
+    it "encodes a raw space" do
+      Hwaro::Services::DevPath.encode_relative("a b/c.html").should eq("a%20b/c.html")
+    end
+
+    it "encodes raw UTF-8" do
+      Hwaro::Services::DevPath.encode_relative("한글/a.html")
+        .should eq("%ED%95%9C%EA%B8%80/a.html")
+    end
+
+    it "encodes segments but never the separator" do
+      Hwaro::Services::DevPath.encode_relative("a b/c d").should eq("a%20b/c%20d")
+    end
+
+    it "round-trips back through safe_relative" do
+      ["a b/c.html", "한글/a.html", "guide/index.html"].each do |relative|
+        encoded = Hwaro::Services::DevPath.encode_relative(relative)
+        Hwaro::Services::DevPath.safe_relative("/" + encoded).should eq(relative)
+      end
+    end
+  end
+end

--- a/spec/unit/digest_utils_spec.cr
+++ b/spec/unit/digest_utils_spec.cr
@@ -1,0 +1,69 @@
+require "../spec_helper"
+
+# One implementation backs every fingerprint site (template/config checksums,
+# the data-directory digest, cascade fingerprints). If the length prefix ever
+# drops out, two different inputs hash identically and a stale cache is served
+# forever — so the anti-ambiguity property is pinned directly here.
+private def digest_of(*values : String) : String
+  digest = Digest::SHA256.new
+  values.each { |v| Hwaro::Utils::DigestUtils.update_length_prefixed(digest, v) }
+  digest.hexfinal
+end
+
+describe Hwaro::Utils::DigestUtils do
+  describe ".update_length_prefixed" do
+    it "is deterministic for the same input" do
+      digest_of("a", "bc").should eq(digest_of("a", "bc"))
+    end
+
+    # The whole point: "a"+"bc" and "ab"+"c" concatenate to the same bytes.
+    it "distinguishes field boundaries that concatenate identically" do
+      digest_of("a", "bc").should_not eq(digest_of("ab", "c"))
+    end
+
+    it "distinguishes a split field from the joined one" do
+      digest_of("ab").should_not eq(digest_of("a", "b"))
+    end
+
+    it "distinguishes field order" do
+      digest_of("a", "b").should_not eq(digest_of("b", "a"))
+    end
+
+    it "distinguishes an empty field from a missing one" do
+      digest_of("a", "", "b").should_not eq(digest_of("a", "b"))
+    end
+
+    it "distinguishes differing counts of empty fields" do
+      digest_of("", "").should_not eq(digest_of(""))
+    end
+
+    # A value that itself looks like the framing must not be able to forge a
+    # boundary.
+    it "cannot be spoofed by a value containing the delimiter" do
+      digest_of("1:x").should_not eq(digest_of("x"))
+      digest_of("2:ab", "c").should_not eq(digest_of("ab", "c"))
+    end
+
+    it "handles multi-byte values by byte length, not char count" do
+      # "한" is 3 bytes, 1 char; the prefix must use bytesize so a 3-char
+      # ASCII value cannot collide with it.
+      digest_of("한").should_not eq(digest_of("abc"))
+    end
+
+    it "keeps non-ASCII values distinct" do
+      digest_of("한글").should_not eq(digest_of("한국"))
+    end
+
+    it "returns nil and mutates the digest in place" do
+      digest = Digest::SHA256.new
+      Hwaro::Utils::DigestUtils.update_length_prefixed(digest, "x").should be_nil
+      digest.hexfinal.should eq(digest_of("x"))
+    end
+
+    it "accepts any ::Digest implementation" do
+      digest = Digest::MD5.new
+      Hwaro::Utils::DigestUtils.update_length_prefixed(digest, "x")
+      digest.hexfinal.size.should eq(32)
+    end
+  end
+end

--- a/spec/unit/frontmatter_converter_spec.cr
+++ b/spec/unit/frontmatter_converter_spec.cr
@@ -912,16 +912,40 @@ describe Hwaro::Services::ConversionResult do
       end
     end
 
-    it "emits maps inside arrays as inline tables" do
+    it "emits maps nested inside arrays as inline tables" do
       Dir.mktmpdir do |dir|
         converter = Hwaro::Services::FrontmatterConverter.new(dir)
         file_path = File.join(dir, "inline.md")
-        File.write(file_path, "---\ntitle: I\nlinks:\n  - name: home\n    url: /\n  - plain\n---\n\nBody")
+        # An array OF arrays: the inner array is homogeneous, so its map member
+        # can keep inline-table form and still reparse.
+        File.write(file_path, "---\ntitle: I\ngroups:\n  - - name: home\n      url: /\n---\n\nBody")
 
         converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
 
         converted = File.read(file_path)
         converted.should contain("{name = \"home\", url = \"/\"}")
+        fm = converted.match!(/\A\+\+\+\n(.*?)\+\+\+/m)[1]
+        TOML.parse(fm)["groups"].as_a.first.as_a.first.as_h["name"].should eq("home")
+      end
+    end
+
+    # Regression: a map mixed with a scalar used to keep its inline-table form,
+    # producing `["plain", {name = "home"}]` — the mixed array toml.cr refuses.
+    # The converted file then failed the very next build with "cannot mix types
+    # in array", so `tool convert to-toml` corrupted its own output.
+    it "keeps a map mixed with a scalar parseable rather than inline" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "mixed_inline.md")
+        File.write(file_path, "---\ntitle: I\nlinks:\n  - name: home\n    url: /\n  - plain\n---\n\nBody")
+
+        converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+
+        fm = File.read(file_path).match!(/\A\+\+\+\n(.*?)\+\+\+/m)[1]
+        links = TOML.parse(fm)["links"].as_a
+        links.size.should eq(2)
+        links.last.should eq("plain")
+        links.first.as_s.should contain(%q("name":"home"))
       end
     end
 

--- a/spec/unit/frontmatter_writer_spec.cr
+++ b/spec/unit/frontmatter_writer_spec.cr
@@ -1,0 +1,404 @@
+require "../spec_helper"
+
+# FrontmatterWriter is the single source of truth for how `tool convert`,
+# `tool export` and every importer serialize frontmatter back to disk. Its
+# rules are byte-level contracts (TOML key quoting, string escaping, date
+# emission), so they are pinned here directly rather than only through the
+# commands that happen to call them.
+private def toml_build(fields : Hash(String, YAML::Any)) : String
+  Hwaro::Utils::FrontmatterWriter::TomlBuilder.new.build(fields)
+end
+
+private def yaml_any(value) : YAML::Any
+  YAML.parse(value.to_yaml)
+end
+
+describe Hwaro::Utils::FrontmatterWriter do
+  describe ".serialize_time" do
+    # The whole reason this helper exists: `to_rfc3339` converts to UTC, so a
+    # local date in any positive-offset zone rolls back a calendar day.
+    it "emits a bare date when the value carries no time-of-day" do
+      time = Time.local(2026, 5, 20, 0, 0, 0, location: Time::Location.fixed(9 * 3600))
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20")
+    end
+
+    it "emits a bare date for a midnight UTC value too" do
+      time = Time.utc(2026, 5, 20, 0, 0, 0)
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20")
+    end
+
+    it "keeps a non-zero offset instead of normalizing to UTC" do
+      time = Time.local(2026, 5, 20, 8, 0, 0, location: Time::Location.fixed(9 * 3600))
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20T08:00:00+09:00")
+    end
+
+    it "does not roll a positive-offset morning back to the previous day" do
+      time = Time.local(2026, 5, 20, 8, 0, 0, location: Time::Location.fixed(9 * 3600))
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should start_with("2026-05-20")
+    end
+
+    it "uses rfc3339 for genuine UTC timestamps" do
+      time = Time.utc(2026, 5, 20, 8, 30, 15)
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20T08:30:15Z")
+    end
+
+    it "treats a sub-second-only value as a timestamp, not a date" do
+      time = Time.utc(2026, 5, 20, 0, 0, 0) + 500.milliseconds
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should_not eq("2026-05-20")
+    end
+
+    it "renders a negative offset" do
+      time = Time.local(2026, 5, 20, 8, 0, 0, location: Time::Location.fixed(-5 * 3600))
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20T08:00:00-05:00")
+    end
+  end
+
+  describe ".escape_toml_string" do
+    it "escapes backslashes before quotes so the result is not double-escaped" do
+      Hwaro::Utils::FrontmatterWriter.escape_toml_string(%q(a\b)).should eq(%q(a\\b))
+    end
+
+    it "escapes double quotes" do
+      Hwaro::Utils::FrontmatterWriter.escape_toml_string(%q(say "hi")).should eq(%q(say \"hi\"))
+    end
+
+    it "escapes newline, tab and carriage return" do
+      Hwaro::Utils::FrontmatterWriter.escape_toml_string("a\nb\tc\rd").should eq("a\\nb\\tc\\rd")
+    end
+
+    # `String#inspect` would emit `\a` / `\e` / `\v`, none of which TOML accepts.
+    it "escapes control characters with \\uXXXX rather than TOML-invalid short escapes" do
+      Hwaro::Utils::FrontmatterWriter.escape_toml_string("bell").should eq("bell\\u0007")
+      Hwaro::Utils::FrontmatterWriter.escape_toml_string("esc").should eq("esc\\u001B")
+      Hwaro::Utils::FrontmatterWriter.escape_toml_string("vt").should eq("vt\\u000B")
+    end
+
+    it "escapes DEL" do
+      Hwaro::Utils::FrontmatterWriter.escape_toml_string("x").should eq("x\\u007F")
+    end
+
+    # toml.cr's \uXXXX reader greedily eats a following hex digit, so escaping
+    # non-ASCII would corrupt "Auto<ZWSP>build" into an unparseable file.
+    it "leaves non-ASCII text raw" do
+      Hwaro::Utils::FrontmatterWriter.escape_toml_string("한글 café").should eq("한글 café")
+    end
+
+    it "leaves a zero-width space raw" do
+      Hwaro::Utils::FrontmatterWriter.escape_toml_string("Auto​build").should eq("Auto​build")
+    end
+
+    it "round-trips through a TOML parser" do
+      original = "quote \" backslash \\ tab \t bell  한글"
+      escaped = Hwaro::Utils::FrontmatterWriter.escape_toml_string(original)
+      TOML.parse(%(k = "#{escaped}"))["k"].should eq(original)
+    end
+  end
+
+  describe ".format_toml_key" do
+    it "leaves a bare key unquoted" do
+      Hwaro::Utils::FrontmatterWriter.format_toml_key("my_key-1").should eq("my_key-1")
+    end
+
+    it "quotes a key containing a dot, which TOML would read as a path" do
+      Hwaro::Utils::FrontmatterWriter.format_toml_key("a.b").should eq(%q("a.b"))
+    end
+
+    it "quotes a key containing a space" do
+      Hwaro::Utils::FrontmatterWriter.format_toml_key("my key").should eq(%q("my key"))
+    end
+
+    it "quotes a non-ASCII key" do
+      Hwaro::Utils::FrontmatterWriter.format_toml_key("제목").should eq(%q("제목"))
+    end
+
+    it "quotes an empty key" do
+      Hwaro::Utils::FrontmatterWriter.format_toml_key("").should eq(%q(""))
+    end
+
+    it "escapes a quote inside a quoted key" do
+      Hwaro::Utils::FrontmatterWriter.format_toml_key(%q(a"b)).should eq(%q("a\"b"))
+    end
+  end
+
+  describe ".yaml_scalar" do
+    it "leaves a simple identifier-like value bare" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("hello-world").should eq("hello-world")
+    end
+
+    it "leaves an internal space bare" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("My Post Title").should eq("My Post Title")
+    end
+
+    # `beta: gamma` parses as a nested mapping when left bare.
+    it "quotes a value containing a colon" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("beta: gamma").should eq(%q("beta: gamma"))
+    end
+
+    it "quotes YAML 1.1 boolean-ish words in any casing" do
+      %w[true false yes no on off null none y n ~].each do |word|
+        Hwaro::Utils::FrontmatterWriter.yaml_scalar(word).should eq(%("#{word}"))
+      end
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("NO").should eq(%q("NO"))
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("Yes").should eq(%q("Yes"))
+    end
+
+    it "quotes a date-shaped value so YAML does not reparse it as a date" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("2024-01-15").should eq(%q("2024-01-15"))
+    end
+
+    it "quotes an alias/anchor sigil" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("*x").should eq(%q("*x"))
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("&x").should eq(%q("&x"))
+    end
+
+    it "quotes a value with a trailing space" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("trailing ").should eq(%q("trailing "))
+    end
+
+    it "quotes an empty string" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("").should eq(%q(""))
+    end
+
+    it "quotes a non-ASCII value" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("한글").should eq(%q("한글"))
+    end
+
+    # YAML rejects Crystal's brace form (`\u{E0001}`) — only the fixed-width
+    # forms are legal.
+    it "escapes unprintable codepoints with fixed-width forms only" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("ab").should eq(%q("a\x07b"))
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("a\u{200B}b").should eq(%q("a\u200Bb"))
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("a\u{E0001}b").should eq(%q("a\U000E0001b"))
+    end
+
+    it "never emits the brace escape form YAML cannot read" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar("a\u{E0001}b").should_not contain("\\u{")
+    end
+
+    it "escapes quote, backslash and whitespace controls" do
+      Hwaro::Utils::FrontmatterWriter.yaml_scalar(%(a"b\\c\nd\te\rf))
+        .should eq(%q("a\"b\\c\nd\te\rf"))
+    end
+
+    it "round-trips quoted output through a YAML parser" do
+      ["beta: gamma", "NO", "2024-01-15", "*x", "ab", ""].each do |value|
+        YAML.parse("k: #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(value)}")["k"].as_s.should eq(value)
+      end
+    end
+
+    it "round-trips bare output through a YAML parser" do
+      ["hello-world", "My Post Title", "a/b", "v1.2"].each do |value|
+        YAML.parse("k: #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(value)}")["k"].as_s.should eq(value)
+      end
+    end
+  end
+
+  describe ".toml_to_yaml_any" do
+    it "carries scalars across unchanged" do
+      parsed = TOML.parse(%(s = "x"\ni = 3\nf = 1.5\nb = true))
+      Hwaro::Utils::FrontmatterWriter.toml_to_yaml_any(parsed["s"]).as_s.should eq("x")
+      Hwaro::Utils::FrontmatterWriter.toml_to_yaml_any(parsed["i"]).as_i.should eq(3)
+      Hwaro::Utils::FrontmatterWriter.toml_to_yaml_any(parsed["f"]).as_f.should eq(1.5)
+      Hwaro::Utils::FrontmatterWriter.toml_to_yaml_any(parsed["b"]).as_bool.should be_true
+    end
+
+    it "converts a TOML date leaf into a frontmatter date string" do
+      parsed = TOML.parse("date = 2026-05-20T08:30:15Z")
+      Hwaro::Utils::FrontmatterWriter.toml_to_yaml_any(parsed["date"]).as_s.should eq("2026-05-20T08:30:15Z")
+    end
+
+    it "converts an array recursively" do
+      parsed = TOML.parse(%(tags = ["a", "b"]))
+      result = Hwaro::Utils::FrontmatterWriter.toml_to_yaml_any(parsed["tags"])
+      result.as_a.map(&.as_s).should eq(["a", "b"])
+    end
+
+    it "converts a nested table recursively and preserves key order" do
+      parsed = TOML.parse(%([extra]\nz = "last"\na = "first"))
+      result = Hwaro::Utils::FrontmatterWriter.toml_to_yaml_any(parsed["extra"])
+      result.as_h.keys.map(&.as_s).should eq(["z", "a"])
+      result["a"].as_s.should eq("first")
+    end
+  end
+
+  describe Hwaro::Utils::FrontmatterWriter::TomlBuilder do
+    it "returns an empty string for a non-mapping root" do
+      Hwaro::Utils::FrontmatterWriter::TomlBuilder.new.build(YAML::Any.new("scalar")).should eq("")
+    end
+
+    it "emits scalars with their TOML types intact" do
+      doc = toml_build({
+        "title" => yaml_any("Hello"),
+        "draft" => yaml_any(false),
+        "count" => yaml_any(3),
+      })
+      parsed = TOML.parse(doc)
+      parsed["title"].should eq("Hello")
+      parsed["draft"].raw.should be_false
+      parsed["count"].should eq(3)
+    end
+
+    it "preserves source key order among scalars" do
+      doc = toml_build({"z" => yaml_any("1"), "a" => yaml_any("2"), "m" => yaml_any("3")})
+      doc.lines.map(&.split(" =").first).should eq(["z", "a", "m"])
+    end
+
+    # Ordering is not cosmetic: a scalar emitted after a `[table]` header would
+    # be swallowed into that table.
+    it "emits every scalar before the first table header" do
+      doc = toml_build({
+        "extra" => YAML.parse({"k" => "v"}.to_yaml),
+        "title" => yaml_any("Hello"),
+      })
+      doc.index!("title =").should be < doc.index!("[extra]")
+      TOML.parse(doc)["title"].should eq("Hello")
+    end
+
+    it "quotes a key that is not a bare TOML key" do
+      doc = toml_build({"my key" => yaml_any("v")})
+      doc.should contain(%q("my key" = "v"))
+      TOML.parse(doc)["my key"].should eq("v")
+    end
+
+    it "emits a nested table as a [table] section" do
+      doc = toml_build({"extra" => YAML.parse({"a" => "1", "b" => "2"}.to_yaml)})
+      TOML.parse(doc)["extra"].as_h.should eq({"a" => "1", "b" => "2"})
+    end
+
+    it "emits a deeply nested table with a dotted header" do
+      doc = toml_build({"a" => YAML.parse({"b" => {"c" => "deep"}}.to_yaml)})
+      doc.should contain("[a.b]")
+      TOML.parse(doc)["a"].as_h["b"].as_h["c"].should eq("deep")
+    end
+
+    # An empty table has no values to force a header doc; dropping the key
+    # entirely would silently lose it.
+    it "keeps an empty table as a bare header" do
+      doc = toml_build({"extra" => YAML.parse(({} of String => String).to_yaml)})
+      doc.should contain("[extra]")
+      TOML.parse(doc)["extra"].as_h.should be_empty
+    end
+
+    it "emits an array of tables as [[section]] entries" do
+      doc = toml_build({"authors" => YAML.parse([{"name" => "a"}, {"name" => "b"}].to_yaml)})
+      doc.scan(/\[\[authors\]\]/).size.should eq(2)
+      TOML.parse(doc)["authors"].as_a.map(&.as_h["name"]).should eq(["a", "b"])
+    end
+
+    it "escapes strings through the shared TOML escaper" do
+      doc = toml_build({"title" => yaml_any(%(say "hi"\nbye))})
+      TOML.parse(doc)["title"].should eq(%(say "hi"\nbye))
+    end
+
+    it "emits nil as an empty string, since TOML has no null" do
+      doc = toml_build({"x" => YAML.parse("---\n")})
+      TOML.parse(doc)["x"].should eq("")
+    end
+
+    # Crystal spells these "Infinity"/"NaN", which TOML cannot reparse.
+    it "spells non-finite floats the way TOML does" do
+      doc = toml_build({
+        "pos" => YAML::Any.new(Float64::INFINITY),
+        "neg" => YAML::Any.new(-Float64::INFINITY),
+        "nan" => YAML::Any.new(Float64::NAN),
+      })
+      doc.should contain("pos = inf")
+      doc.should contain("neg = -inf")
+      doc.should contain("nan = nan")
+    end
+
+    it "emits a homogeneous array unchanged" do
+      doc = toml_build({"tags" => yaml_any(["a", "b"])})
+      TOML.parse(doc)["tags"].as_a.should eq(["a", "b"])
+    end
+
+    it "emits an empty array" do
+      doc = toml_build({"tags" => yaml_any([] of String)})
+      TOML.parse(doc)["tags"].as_a.should be_empty
+    end
+
+    # toml.cr refuses arrays that mix type families.
+    it "promotes an int/float mix to floats so the array stays homogeneous" do
+      doc = toml_build({"nums" => YAML::Any.new([YAML::Any.new(1_i64), YAML::Any.new(2.5)])})
+      TOML.parse(doc)["nums"].as_a.map(&.raw).should eq([1.0, 2.5])
+    end
+
+    it "coerces any other scalar mix to strings" do
+      doc = toml_build({"mixed" => YAML::Any.new([YAML::Any.new(1_i64), YAML::Any.new("two")])})
+      TOML.parse(doc)["mixed"].as_a.should eq(["1", "two"])
+    end
+
+    it "coerces a bool/string mix to strings" do
+      doc = toml_build({"mixed" => YAML::Any.new([YAML::Any.new(true), YAML::Any.new("x")])})
+      TOML.parse(doc)["mixed"].as_a.should eq(["true", "x"])
+    end
+
+    # A hash reached from inside an array cannot become a [table] section, so
+    # it is emitted as an inline table — valid only while the array stays
+    # homogeneous.
+    it "emits a hash inside an all-table array as an inline table" do
+      value = YAML::Any.new([
+        YAML.parse({"k" => "v"}.to_yaml),
+        YAML.parse({"k" => "w"}.to_yaml),
+      ])
+      doc = toml_build({"items" => value})
+      TOML.parse(doc)["items"].as_a.map(&.as_h["k"]).should eq(["v", "w"])
+    end
+
+    # Regression: `["plain", {k = "v"}]` is exactly the mixed array toml.cr
+    # refuses, so `tool convert to-toml` used to write a file that the next
+    # `hwaro build` rejected with "cannot mix types in array".
+    it "keeps a scalar/table mix parseable by stringifying the table" do
+      value = YAML::Any.new([
+        YAML::Any.new("plain"),
+        YAML.parse({"k" => "v"}.to_yaml),
+      ])
+      doc = toml_build({"items" => value})
+      TOML.parse(doc)["items"].as_a.should eq(["plain", %q({"k":"v"})])
+    end
+
+    it "keeps a scalar/array mix parseable by stringifying the array" do
+      value = YAML::Any.new([
+        YAML::Any.new("plain"),
+        YAML::Any.new([YAML::Any.new("a"), YAML::Any.new("b")]),
+      ])
+      doc = toml_build({"items" => value})
+      TOML.parse(doc)["items"].as_a.should eq(["plain", %q(["a","b"])])
+    end
+
+    it "never emits an array TOML cannot reparse, whatever the mix" do
+      mixes = [
+        [YAML::Any.new("s"), YAML::Any.new(1_i64)],
+        [YAML::Any.new(true), YAML.parse({"k" => "v"}.to_yaml)],
+        [YAML::Any.new(1_i64), YAML::Any.new([YAML::Any.new("a")])],
+        [YAML::Any.new("s"), YAML::Any.new(2.5), YAML.parse({"k" => "v"}.to_yaml)],
+      ]
+      mixes.each do |items|
+        doc = toml_build({"items" => YAML::Any.new(items)})
+        TOML.parse(doc)["items"].as_a.size.should eq(items.size)
+      end
+    end
+
+    it "produces parseable output for a realistic frontmatter tree" do
+      doc = toml_build({
+        "title"   => yaml_any("My Post"),
+        "date"    => yaml_any("2026-05-20"),
+        "draft"   => yaml_any(false),
+        "tags"    => yaml_any(["crystal", "ssg"]),
+        "extra"   => YAML.parse({"cover" => "a.png"}.to_yaml),
+        "authors" => YAML.parse([{"name" => "hahwul"}].to_yaml),
+      })
+      parsed = TOML.parse(doc)
+      parsed["title"].should eq("My Post")
+      parsed["tags"].as_a.should eq(["crystal", "ssg"])
+      parsed["extra"].as_h["cover"].should eq("a.png")
+      parsed["authors"].as_a.first.as_h["name"].should eq("hahwul")
+    end
+
+    it "accepts a string-keyed field map as well as a YAML::Any root" do
+      fields = {"title" => yaml_any("X")}
+      Hwaro::Utils::FrontmatterWriter::TomlBuilder.new.build(fields)
+        .should eq(%(title = "X"\n))
+    end
+  end
+end

--- a/spec/unit/path_utils_spec.cr
+++ b/spec/unit/path_utils_spec.cr
@@ -137,5 +137,150 @@ describe Hwaro::Utils::PathUtils do
         Hwaro::Utils::PathUtils.resolves_within?(File.join(root, "nope.txt"), root).should be_false
       end
     end
+
+    it "accepts the root itself" do
+      Dir.mktmpdir do |root|
+        Hwaro::Utils::PathUtils.resolves_within?(root, root).should be_true
+      end
+    end
+
+    it "returns false for a missing root rather than raising" do
+      Dir.mktmpdir do |root|
+        file = File.join(root, "a.txt")
+        File.write(file, "x")
+        Hwaro::Utils::PathUtils.resolves_within?(file, File.join(root, "nope")).should be_false
+      end
+    end
+
+    # A sibling whose name merely starts with the root's name is outside it;
+    # the check must compare on a separator boundary.
+    it "rejects a sibling directory sharing the root's name prefix" do
+      Dir.mktmpdir do |parent|
+        root = File.join(parent, "site")
+        sibling = File.join(parent, "site-backup")
+        Dir.mkdir(root)
+        Dir.mkdir(sibling)
+        file = File.join(sibling, "a.txt")
+        File.write(file, "x")
+        Hwaro::Utils::PathUtils.resolves_within?(file, root).should be_false
+      end
+    end
+  end
+
+  # `split_safe_segments` is the shared predicate behind BOTH traversal
+  # policies: neutralize-and-continue (`sanitize_path`) and refuse-outright
+  # (the build's `url_output_path`). The `refused` flag is what lets the
+  # writers refuse instead of silently RELOCATING a page onto whatever already
+  # occupies the shortened path — that is how `content/a..b/` once overwrote
+  # the site's index.html.
+  describe ".split_safe_segments" do
+    it "reports no refusal for an ordinary path" do
+      segments, refused = Hwaro::Utils::PathUtils.split_safe_segments("foo/bar/baz")
+      segments.should eq(["foo", "bar", "baz"])
+      refused.should be_false
+    end
+
+    it "flags a refusal when a traversal segment is dropped" do
+      segments, refused = Hwaro::Utils::PathUtils.split_safe_segments("foo/../bar")
+      segments.should eq(["foo", "bar"])
+      refused.should be_true
+    end
+
+    it "flags a refusal for percent-encoded traversal" do
+      segments, refused = Hwaro::Utils::PathUtils.split_safe_segments("%2e%2e/etc")
+      segments.should eq(["etc"])
+      refused.should be_true
+    end
+
+    it "flags a refusal for double-encoded traversal" do
+      _, refused = Hwaro::Utils::PathUtils.split_safe_segments("%252e%252e/etc")
+      refused.should be_true
+    end
+
+    # Newly REFUSED versus the pre-2026-08 rule, which let all-space segments
+    # through.
+    it "flags a refusal for an all-space segment" do
+      segments, refused = Hwaro::Utils::PathUtils.split_safe_segments("a/   /b")
+      segments.should eq(["a", "b"])
+      refused.should be_true
+    end
+
+    it "flags a refusal for the Windows dot/space collapse forms" do
+      ["a/.. /b", "a/. /b", "a/.../b"].each do |path|
+        _, refused = Hwaro::Utils::PathUtils.split_safe_segments(path)
+        refused.should be_true
+      end
+    end
+
+    # Newly KEPT versus the old "contains .." rule: these cannot traverse on
+    # any supported platform, and refusing them would break ordinary slugs.
+    it "keeps segments that merely contain dots without flagging a refusal" do
+      ["notes/v1..v2", "a..b/c", "..foo/c", "lib.v1..2.js"].each do |path|
+        _, refused = Hwaro::Utils::PathUtils.split_safe_segments(path)
+        refused.should be_false
+      end
+    end
+
+    # Only ASCII space and `.` are trimmed by Win32, so these stay distinct
+    # filenames rather than traversal.
+    it "keeps whitespace-suffixed dot forms other than ASCII space" do
+      _, refused = Hwaro::Utils::PathUtils.split_safe_segments("a/..\t/b")
+      refused.should be_false
+    end
+
+    it "does not flag a refusal for empty segments from repeated slashes" do
+      segments, refused = Hwaro::Utils::PathUtils.split_safe_segments("//foo///bar//")
+      segments.should eq(["foo", "bar"])
+      refused.should be_false
+    end
+
+    it "treats a backslash as a separator too" do
+      segments, refused = Hwaro::Utils::PathUtils.split_safe_segments("foo\\bar")
+      segments.should eq(["foo", "bar"])
+      refused.should be_false
+    end
+
+    it "strips null bytes without flagging a refusal" do
+      segments, refused = Hwaro::Utils::PathUtils.split_safe_segments("fo\u{0000}o/bar")
+      segments.should eq(["foo", "bar"])
+      refused.should be_false
+    end
+
+    it "returns no segments and no refusal for an empty path" do
+      segments, refused = Hwaro::Utils::PathUtils.split_safe_segments("")
+      segments.should be_empty
+      refused.should be_false
+    end
+
+    it "agrees with sanitize_path on the segments it keeps" do
+      ["foo/../bar", "a/   /b", "notes/v1..v2", "%2e%2e/etc", "//a//b//"].each do |path|
+        segments, _ = Hwaro::Utils::PathUtils.split_safe_segments(path)
+        segments.join("/").should eq(Hwaro::Utils::PathUtils.sanitize_path(path))
+      end
+    end
+  end
+
+  # A single config typo must not crash a whole build or deploy.
+  describe ".glob_match?" do
+    it "matches a simple glob" do
+      Hwaro::Utils::PathUtils.glob_match?("*.css", "style.css").should be_true
+    end
+
+    it "does not match a non-matching path" do
+      Hwaro::Utils::PathUtils.glob_match?("*.css", "style.js").should be_false
+    end
+
+    it "matches a character class" do
+      Hwaro::Utils::PathUtils.glob_match?("a[0-9].txt", "a1.txt").should be_true
+    end
+
+    it "returns false for a malformed glob instead of raising" do
+      Hwaro::Utils::PathUtils.glob_match?("[", "a").should be_false
+      Hwaro::Utils::PathUtils.glob_match?("a[0-", "a1").should be_false
+    end
+
+    it "returns false for an empty pattern" do
+      Hwaro::Utils::PathUtils.glob_match?("", "a").should be_false
+    end
   end
 end

--- a/spec/unit/sass_compiler_spec.cr
+++ b/spec/unit/sass_compiler_spec.cr
@@ -1,0 +1,237 @@
+require "../spec_helper"
+
+# SassCompiler is the build-side orchestrator for the built-in SCSS compiler
+# (peer of Pipeline). The Sass language itself is covered under spec/unit/sass;
+# what is pinned here is the orchestration contract: which entry files are
+# picked up, which are skipped, and how compiler/filesystem failures surface as
+# classified build errors rather than raw exceptions.
+private def sass_config(enabled = true, minify = false) : Hwaro::Models::SassConfig
+  config = Hwaro::Models::SassConfig.new
+  config.enabled = enabled
+  config.minify = minify
+  config
+end
+
+private def static_config(exclude = [] of String) : Hwaro::Models::StaticConfig
+  config = Hwaro::Models::StaticConfig.new
+  config.exclude = exclude
+  config
+end
+
+# Runs `compile_all` with `dir` as both the project root and the CWD, since the
+# symlink guard and the importer both resolve against `Dir.current`. Paths stay
+# relative — as they are in a real build — so macOS's /var -> /private/var
+# symlink can't make an in-project entry look external.
+private def compile_in(dir : String, config = sass_config, static = static_config, &)
+  Dir.cd(dir) do
+    Dir.mkdir_p("public")
+    compiler = Hwaro::Assets::SassCompiler.new(config, static, "static")
+    yield compiler, "public"
+  end
+end
+
+describe Hwaro::Assets::SassCompiler do
+  describe "#compile_all" do
+    it "compiles a top-level entry to a sibling .css file" do
+      Dir.mktmpdir do |dir|
+        Dir.mkdir_p(File.join(dir, "static", "css"))
+        File.write(File.join(dir, "static", "css", "style.scss"), "a { color: red; }")
+        compile_in(dir) do |compiler, output|
+          compiler.compile_all(output).should eq(1)
+          File.read(File.join(output, "css", "style.css")).should contain("color: red")
+        end
+      end
+    end
+
+    it "returns 0 when sass is disabled" do
+      Dir.mktmpdir do |dir|
+        Dir.mkdir_p(File.join(dir, "static"))
+        File.write(File.join(dir, "static", "a.scss"), "a { color: red; }")
+        compile_in(dir, config: sass_config(enabled: false)) do |compiler, output|
+          compiler.compile_all(output).should eq(0)
+          File.exists?(File.join(output, "a.css")).should be_false
+        end
+      end
+    end
+
+    it "returns 0 when the source directory does not exist" do
+      Dir.mktmpdir do |dir|
+        compile_in(dir) do |compiler, output|
+          compiler.compile_all(output).should eq(0)
+        end
+      end
+    end
+
+    # Partials are imported by entries, never compiled on their own.
+    it "skips partials" do
+      Dir.mktmpdir do |dir|
+        Dir.mkdir_p(File.join(dir, "static"))
+        File.write(File.join(dir, "static", "_vars.scss"), "$c: red;")
+        File.write(File.join(dir, "static", "main.scss"), "@import 'vars'; a { color: $c; }")
+        compile_in(dir) do |compiler, output|
+          compiler.compile_all(output).should eq(1)
+          File.exists?(File.join(output, "_vars.css")).should be_false
+          File.read(File.join(output, "main.css")).should contain("red")
+        end
+      end
+    end
+
+    it "skips statically-excluded entries" do
+      Dir.mktmpdir do |dir|
+        Dir.mkdir_p(File.join(dir, "static", "vendor"))
+        File.write(File.join(dir, "static", "vendor", "skip.scss"), "a { color: red; }")
+        File.write(File.join(dir, "static", "keep.scss"), "b { color: blue; }")
+        compile_in(dir, static: static_config(["vendor/**"])) do |compiler, output|
+          compiler.compile_all(output).should eq(1)
+          File.exists?(File.join(output, "vendor", "skip.css")).should be_false
+          File.exists?(File.join(output, "keep.css")).should be_true
+        end
+      end
+    end
+
+    it "compiles nested entries preserving their relative path" do
+      Dir.mktmpdir do |dir|
+        Dir.mkdir_p(File.join(dir, "static", "a", "b"))
+        File.write(File.join(dir, "static", "a", "b", "deep.scss"), "a { color: red; }")
+        compile_in(dir) do |compiler, output|
+          compiler.compile_all(output).should eq(1)
+          File.exists?(File.join(output, "a", "b", "deep.css")).should be_true
+        end
+      end
+    end
+
+    it "minifies when configured" do
+      Dir.mktmpdir do |dir|
+        Dir.mkdir_p(File.join(dir, "static"))
+        File.write(File.join(dir, "static", "m.scss"), "a {\n  color: red;\n}\n")
+        compile_in(dir, config: sass_config(minify: true)) do |compiler, output|
+          compiler.compile_all(output)
+          File.read(File.join(output, "m.css")).should_not contain("\n  ")
+        end
+      end
+    end
+
+    # A `static/css/style.scss -> /etc/passwd` symlink would otherwise publish
+    # the target's contents as CSS.
+    it "skips an entry that resolves outside the project root" do
+      Dir.mktmpdir do |outside|
+        secret = File.join(outside, "secret.scss")
+        File.write(secret, "a { color: red; }")
+        Dir.mktmpdir do |dir|
+          Dir.mkdir_p(File.join(dir, "static"))
+          File.symlink(secret, File.join(dir, "static", "leak.scss"))
+          log = with_captured_log do
+            compile_in(dir) do |compiler, output|
+              compiler.compile_all(output).should eq(0)
+              File.exists?(File.join(output, "leak.css")).should be_false
+            end
+          end
+          log.should contain("outside project root")
+        end
+      end
+    end
+
+    it "keeps an in-project symlinked entry" do
+      Dir.mktmpdir do |dir|
+        Dir.mkdir_p(File.join(dir, "static"))
+        real = File.join(dir, "static", "real.scss")
+        File.write(real, "a { color: red; }")
+        File.symlink(real, File.join(dir, "static", "alias.scss"))
+        compile_in(dir) do |compiler, output|
+          compiler.compile_all(output).should eq(2)
+        end
+      end
+    end
+
+    # Full builds copy the raw sibling first and clobber it here, while a serve
+    # session re-copies the raw file OVER the compiled one on edit.
+    it "warns when a hand-written sibling .css occupies the same output path" do
+      Dir.mktmpdir do |dir|
+        Dir.mkdir_p(File.join(dir, "static"))
+        File.write(File.join(dir, "static", "clash.scss"), "a { color: red; }")
+        File.write(File.join(dir, "static", "clash.css"), "a { color: blue; }")
+        log = with_captured_log do
+          compile_in(dir) do |compiler, output|
+            compiler.compile_all(output).should eq(1)
+          end
+        end
+        log.should contain("also exists as a static source")
+      end
+    end
+
+    it "raises a classified content error for a bad entry" do
+      Dir.mktmpdir do |dir|
+        Dir.mkdir_p(File.join(dir, "static"))
+        File.write(File.join(dir, "static", "bad.scss"), "a { color: ; ")
+        compile_in(dir) do |compiler, output|
+          error = expect_raises(Hwaro::HwaroError) { compiler.compile_all(output) }
+          error.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+        end
+      end
+    end
+  end
+
+  describe ".compile_source" do
+    it "compiles a plain rule" do
+      Hwaro::Assets::SassCompiler.compile_source("a { color: red; }", "x.scss")
+        .should contain("color: red")
+    end
+
+    it "compiles nesting" do
+      css = Hwaro::Assets::SassCompiler.compile_source("a { b { color: red; } }", "x.scss")
+        .gsub(/\s+/, " ")
+      css.should contain("a b")
+    end
+
+    it "passes plain CSS through" do
+      Hwaro::Assets::SassCompiler.compile_source("a{color:red}", "x.scss").should contain("red")
+    end
+
+    it "returns empty output for empty input" do
+      Hwaro::Assets::SassCompiler.compile_source("", "x.scss").strip.should eq("")
+    end
+
+    # Syntax errors must surface classified, with a path:line:col location, not
+    # as a bare Sass::SyntaxError the hook manager downgrades to a generic abort.
+    it "converts a syntax error into a classified content error" do
+      error = expect_raises(Hwaro::HwaroError) do
+        Hwaro::Assets::SassCompiler.compile_source("a { color: ; ", "broken.scss")
+      end
+      error.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+      error.message.not_nil!.should contain("Sass:")
+    end
+
+    it "names the failing file in the error" do
+      error = expect_raises(Hwaro::HwaroError) do
+        Hwaro::Assets::SassCompiler.compile_source("@mixin", "named.scss")
+      end
+      error.message.not_nil!.should contain("named.scss")
+    end
+
+    it "carries a fix hint" do
+      error = expect_raises(Hwaro::HwaroError) do
+        Hwaro::Assets::SassCompiler.compile_source("a { color: ; ", "broken.scss")
+      end
+      error.hint.not_nil!.should contain("features/sass")
+    end
+
+    # ELOOP / permission failures during import resolution must come out
+    # classified too, not as a raw File::Error.
+    it "converts a filesystem error during import resolution into a content error" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          # A self-referential symlink makes the importer's stat/read fail with
+          # ELOOP rather than "missing", so the File::Error rescue is the one
+          # that runs. Kept in-project so the outside-root guard cannot answer
+          # first and mask which branch is under test.
+          File.symlink("_loop.scss", "_loop.scss")
+          error = expect_raises(Hwaro::HwaroError) do
+            Hwaro::Assets::SassCompiler.compile_source(%(@import "loop";), "entry.scss")
+          end
+          error.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+          error.message.not_nil!.should contain("filesystem error while resolving imports")
+        end
+      end
+    end
+  end
+end

--- a/src/utils/frontmatter_writer.cr
+++ b/src/utils/frontmatter_writer.cr
@@ -6,6 +6,7 @@
 # identical across every tool that produces content files.
 
 require "yaml"
+require "json"
 require "toml"
 require "time"
 
@@ -296,8 +297,16 @@ module Hwaro
           else
             items.map do |v|
               case toml_kind(v)
-              when :array, :table, :string
+              when :string
                 to_toml_value(v)
+              when :array, :table
+                # A structured member inside an otherwise-scalar array cannot
+                # keep its TOML shape: `["plain", {k = "v"}]` is precisely the
+                # mixed array toml.cr refuses, so `tool convert to-toml` wrote
+                # a file the very next `hwaro build` failed to parse. Emit it
+                # as JSON text — lossy for the reader, but the document stays
+                # loadable instead of corrupting the round-trip.
+                "\"#{FrontmatterWriter.escape_toml_string(v.to_json)}\""
               when :time
                 "\"#{FrontmatterWriter.escape_toml_string(FrontmatterWriter.serialize_time(v.raw.as(Time)))}\""
               else


### PR DESCRIPTION
## What

A gap sweep over `src/` looking for units that no spec names directly — code only ever exercised incidentally through full builds, so its documented invariants were unpinned. **+148 examples** (7241 → 7389).

| Unit | Lines | Before |
|---|---|---|
| `Utils::FrontmatterWriter` | 312 | no spec file at all |
| `Services::DevPath` | 96 | referenced by 1 spec |
| `Assets::SassCompiler` | 97 | no spec file at all |
| `PathUtils.split_safe_segments` / `.glob_match?` | — | untested half of a tested file |
| `Utils::DigestUtils` | 24 | no spec file at all |

These were picked because each is a source of truth with invariants documented in-comment but unenforced:

- **FrontmatterWriter** backs `tool convert`, `tool export` and every importer. Pins date emission (the local-date/UTC day-rollback rule), TOML escaping (why not `String#inspect`), YAML scalar quoting (YAML 1.1 reserved words, fixed-width escapes only) and TomlBuilder layout.
- **DevPath** is the dev server's strict resolver; its whole value is the shapes it *refuses*, so encoded separators, NUL, and invalid UTF-8 are pinned directly rather than through the HTTP handlers.
- **SassCompiler** — which entries compile, which are skipped (partials, excluded, out-of-project symlinks), and that compiler/filesystem failures surface as classified `HWARO_E_CONTENT` errors rather than raw exceptions.
- **PathUtils** — the `refused` flag that lets writers refuse a traversal instead of silently *relocating* a page onto whatever occupies the shortened path.
- **DigestUtils** — the length-prefix property that stops `"a"+"bc"` and `"ab"+"c"` from hashing alike and pinning a stale cache.

## Bug found and fixed

The FrontmatterWriter specs surfaced a real round-trip defect. `TomlBuilder#array_items` coerced a mixed array to strings but exempted structured members "to keep their shape", so `["plain", {k: v}]` became `["plain", {k = "v"}]` — precisely the mixed array `toml.cr` refuses. `hwaro tool convert to-toml` wrote a file the very next `hwaro build` rejected:

```
Error [HWARO_E_CONTENT]: Invalid TOML frontmatter in content/blog/post.md:
cannot mix types in array at 2:28
```

Reproduced end-to-end with the built binary before and after. Structured members in a genuinely mixed array now serialize as JSON text — lossy for the reader, but the document stays loadable instead of corrupting the round-trip. Inline tables are unaffected where they still reparse (an all-table array, or one nested in an array of arrays).

One existing `frontmatter_converter` example asserted the broken output: its fixture was a table/string mix and it only checked that the inline-table text appeared, never that the file parsed back. Split into the nested case (still inline) and the mixed case (must reparse).

## Verification

- Full suite green: **7389 examples, 0 failures**
- `crystal tool format` clean; `ameba` **471 inspected, 0 failures**
- The 3 regression examples were confirmed to **fail before** the `array_items` fix and pass after
- `tool convert to-toml` → `hwaro build` round-trip verified with a rebuilt binary