### PR TITLE
fix: 52 build/serve defects from a three-round adversarial audit

### DIFF
--- a/spec/functional/cache_fingerprint_gaps_spec.cr
+++ b/spec/functional/cache_fingerprint_gaps_spec.cr
@@ -1,0 +1,320 @@
+require "./support/build_helper"
+
+# =============================================================================
+# Regression specs for cache fingerprint gaps (issue ledger C1/C2/C3/R7).
+#
+#   * C1: the page-set fingerprint omitted `image`, `updated`, `authors`,
+#     `series`, `toc`; the section-set fingerprint omitted `date`, `assets`,
+#     `sort_by`, `reverse`, `transparent`, `paginate` — so listings kept the
+#     previous build's values after a front-matter-only edit under --cache.
+#   * C2: a page bundle's colocated assets were absent from every cache key,
+#     so adding/removing an asset left the page HTML (which renders
+#     `page.assets`) stale while the file itself was copied.
+#   * C3: literal template refs the snapshot loader cannot serve (./-prefixed,
+#     non-template extensions, shadowed extension variants) were hashed as a
+#     constant or as the wrong winner, so edits to those files never
+#     invalidated anything.
+#   * R7: tags/taxonomies joined with bare `,`/`;` — `["a,b"]` and
+#     `["a", "b"]` fingerprinted identically, hiding the edit from listings.
+# =============================================================================
+
+private FP_CONFIG = <<-TOML
+  title = "FP Site"
+  base_url = "http://localhost"
+  TOML
+
+private def fp_run_builder(output_dir : String, cache : Bool)
+  builder = Hwaro::Core::Build::Builder.new
+  Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+  builder.run(Hwaro::Config::Options::BuildOptions.new(
+    output_dir: output_dir, parallel: false, cache: cache,
+    minify: false, highlight: false))
+end
+
+private def fp_cached_build(output_dir : String = "public")
+  fp_run_builder(output_dir, true)
+end
+
+private def fp_clean_build(output_dir : String = "public")
+  FileUtils.rm_rf(output_dir)
+  FileUtils.rm_rf(".hwaro_cache.json")
+  fp_run_builder(output_dir, false)
+end
+
+# A listing template iterating `site.pages` (the page-set marker), so the
+# homepage re-renders only when the page-set fingerprint moves.
+private def fp_listing_project(listing_body : String)
+  File.write("config.toml", FP_CONFIG)
+  FileUtils.mkdir_p("content/posts")
+  FileUtils.mkdir_p("templates")
+  File.write("content/index.md", "---\ntitle: Home\n---\nHome")
+  File.write("templates/index.html",
+    "{% for p in site.pages %}#{listing_body}{% endfor %}")
+  File.write("templates/page.html", "{{ content }}")
+  File.write("templates/section.html", "{{ content }}")
+end
+
+describe "cache: page-set fingerprint covers listing-rendered front matter (C1)" do
+  it "re-renders listings when image/updated/authors/series/toc change" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        fp_listing_project(%([{{ p.image }}|{{ p.series }}|{{ p.toc }}|{{ p.authors | join("+") }}|{{ p.updated }}]))
+        File.write("content/posts/p1.md", <<-MD)
+          +++
+          title = "P1"
+          image = "/img/a.png"
+          series = "alpha"
+          toc = false
+          authors = ["alice"]
+          updated = "2026-01-02"
+          +++
+
+          body
+          MD
+
+        fp_cached_build
+        home = File.read("public/index.html")
+        home.should contain("/img/a.png")
+        home.should contain("alpha")
+        home.should contain("alice")
+        home.should contain("2026-01-02")
+
+        sleep 150.milliseconds
+        File.write("content/posts/p1.md", <<-MD)
+          +++
+          title = "P1"
+          image = "/img/b.png"
+          series = "beta"
+          toc = true
+          authors = ["bob"]
+          updated = "2026-02-03"
+          +++
+
+          body
+          MD
+
+        fp_cached_build
+        warm = File.read("public/index.html")
+
+        fp_clean_build
+        warm.should eq(File.read("public/index.html"))
+        warm.should contain("/img/b.png")
+        warm.should contain("beta")
+        warm.should contain("bob")
+        warm.should contain("2026-02-03")
+        warm.should_not contain("/img/a.png")
+      end
+    end
+  end
+end
+
+describe "cache: section-set fingerprint covers nav-rendered section fields (C1)" do
+  it "re-renders section-set consumers when date/sort_by/reverse/transparent/paginate change" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", FP_CONFIG)
+        FileUtils.mkdir_p("content/posts")
+        FileUtils.mkdir_p("templates")
+        File.write("content/index.md", "---\ntitle: Home\n---\nHome")
+        File.write("templates/index.html",
+          %({% for s in site.sections %}[{{ s.date }}|{{ s.sort_by }}|{{ s.reverse }}|{{ s.transparent }}|{{ s.paginate }}]{% endfor %}))
+        File.write("templates/page.html", "{{ content }}")
+        File.write("templates/section.html", "{{ content }}")
+        File.write("content/posts/_index.md", <<-MD)
+          +++
+          title = "Posts"
+          date = "2026-01-01"
+          sort_by = "weight"
+          transparent = false
+          paginate = 2
+          +++
+          MD
+        File.write("content/posts/one.md", "---\ntitle: One\n---\nOne")
+
+        fp_cached_build
+        home = File.read("public/index.html")
+        home.should contain("2026-01-01")
+        home.should contain("weight")
+
+        sleep 150.milliseconds
+        File.write("content/posts/_index.md", <<-MD)
+          +++
+          title = "Posts"
+          date = "2026-05-05"
+          sort_by = "date"
+          reverse = true
+          transparent = true
+          paginate = 7
+          +++
+          MD
+
+        fp_cached_build
+        warm = File.read("public/index.html")
+
+        fp_clean_build
+        warm.should eq(File.read("public/index.html"))
+        warm.should contain("2026-05-05")
+        warm.should contain("date")
+        warm.should contain("|7]")
+        warm.should_not contain("2026-01-01")
+      end
+    end
+  end
+end
+
+describe "cache: bundle assets are part of the page cache key (C2)" do
+  it "re-renders a bundle page when a colocated asset is added" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", FP_CONFIG)
+        FileUtils.mkdir_p("content/gallery")
+        FileUtils.mkdir_p("templates")
+        File.write("content/index.md", "---\ntitle: Home\n---\nHome")
+        File.write("templates/index.html", "{{ content }}")
+        File.write("templates/page.html",
+          %({% for a in page.assets %}[{{ a }}]{% endfor %}))
+        File.write("templates/section.html",
+          %({% for a in page.assets %}[{{ a }}]{% endfor %}))
+        File.write("content/gallery/index.md", "---\ntitle: Gallery\ntemplate: page\n---\nGallery")
+        File.write("content/gallery/one.txt", "1")
+
+        fp_cached_build
+        File.read("public/gallery/index.html").should contain("one.txt")
+
+        sleep 150.milliseconds
+        File.write("content/gallery/two.txt", "2")
+
+        fp_cached_build
+        warm = File.read("public/gallery/index.html")
+
+        fp_clean_build
+        warm.should eq(File.read("public/gallery/index.html"))
+        warm.should contain("one.txt")
+        warm.should contain("two.txt")
+      end
+    end
+  end
+
+  it "still skips an unchanged bundle page on a warm rebuild" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", FP_CONFIG)
+        FileUtils.mkdir_p("content/gallery")
+        FileUtils.mkdir_p("templates")
+        File.write("content/index.md", "---\ntitle: Home\n---\nHome")
+        File.write("templates/index.html", "{{ content }}")
+        File.write("templates/page.html",
+          %({% for a in page.assets %}[{{ a }}]{% endfor %}))
+        File.write("templates/section.html",
+          %({% for a in page.assets %}[{{ a }}]{% endfor %}))
+        File.write("content/gallery/index.md", "---\ntitle: Gallery\ntemplate: page\n---\nGallery")
+        File.write("content/gallery/one.txt", "1")
+
+        fp_cached_build
+        before = File.info("public/gallery/index.html").modification_time
+
+        fp_cached_build
+        File.info("public/gallery/index.html").modification_time.should eq(before)
+      end
+    end
+  end
+end
+
+describe "cache: refs outside the template snapshot invalidate (C3)" do
+  it "re-renders when a shadowed extension variant (foo.j2 vs foo.html) is edited" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", FP_CONFIG)
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates/partials")
+        File.write("content/about.md", "---\ntitle: About\n---\nAbout")
+        File.write("templates/page.html", %({% include "partials/note.j2" %} {{ content }}))
+        File.write("templates/partials/note.html", "HTML-VARIANT")
+        File.write("templates/partials/note.j2", "J2-OLD")
+
+        fp_cached_build
+        File.read("public/about/index.html").should contain("J2-OLD")
+
+        sleep 150.milliseconds
+        File.write("templates/partials/note.j2", "J2-NEW")
+
+        fp_cached_build
+        html = File.read("public/about/index.html")
+        html.should contain("J2-NEW")
+        html.should_not contain("J2-OLD")
+      end
+    end
+  end
+
+  it "re-renders when a ./-prefixed include target is edited" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", FP_CONFIG)
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates/partials")
+        File.write("content/about.md", "---\ntitle: About\n---\nAbout")
+        File.write("templates/page.html", %({% include "./partials/nav.html" %} {{ content }}))
+        File.write("templates/partials/nav.html", "NAV-OLD")
+
+        fp_cached_build
+        File.read("public/about/index.html").should contain("NAV-OLD")
+
+        sleep 150.milliseconds
+        File.write("templates/partials/nav.html", "NAV-NEW")
+
+        fp_cached_build
+        html = File.read("public/about/index.html")
+        html.should contain("NAV-NEW")
+        html.should_not contain("NAV-OLD")
+      end
+    end
+  end
+
+  it "re-renders when a non-template-extension include target is edited" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", FP_CONFIG)
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates/partials")
+        File.write("content/about.md", "---\ntitle: About\n---\nAbout")
+        File.write("templates/page.html", %({% include "partials/legal.txt" %} {{ content }}))
+        File.write("templates/partials/legal.txt", "LEGAL-OLD")
+
+        fp_cached_build
+        File.read("public/about/index.html").should contain("LEGAL-OLD")
+
+        sleep 150.milliseconds
+        File.write("templates/partials/legal.txt", "LEGAL-NEW")
+
+        fp_cached_build
+        html = File.read("public/about/index.html")
+        html.should contain("LEGAL-NEW")
+        html.should_not contain("LEGAL-OLD")
+      end
+    end
+  end
+end
+
+describe "cache: fingerprint joins are collision-proof (R7)" do
+  it "distinguishes tags [\"a,b\"] from tags [\"a\", \"b\"]" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        fp_listing_project(%([{{ p.tags | join("~") }}]))
+        File.write("content/posts/t.md", "+++\ntitle = \"T\"\ntags = [\"a,b\"]\n+++\n\nbody\n")
+
+        fp_cached_build
+        File.read("public/index.html").should contain("[a,b]")
+
+        sleep 150.milliseconds
+        File.write("content/posts/t.md", "+++\ntitle = \"T\"\ntags = [\"a\", \"b\"]\n+++\n\nbody\n")
+
+        fp_cached_build
+        warm = File.read("public/index.html")
+
+        fp_clean_build
+        warm.should eq(File.read("public/index.html"))
+        warm.should contain("[a~b]")
+      end
+    end
+  end
+end

--- a/spec/functional/pwa_phase_order_spec.cr
+++ b/spec/functional/pwa_phase_order_spec.cr
@@ -1,0 +1,132 @@
+require "../spec_helper"
+
+# Regression coverage for the PWA generation-phase fixes:
+#
+# - A3: sw.js used to be generated at BeforeGenerate, BEFORE the phases that
+#   write 404.html (Write) and search_index/search.json (AfterGenerate) — so a
+#   CLEAN build dropped those URLs from the precache list ("no matching output
+#   file"), while a warm build hashed the PREVIOUS build's bytes. Generation
+#   now runs at AfterWrite, over the final output tree.
+# - A10: serve's incremental rebuild paths (run_incremental / run_rerender)
+#   never regenerated sw.js, so registered service workers kept serving stale
+#   bytes through live reloads. regenerate_seo_surfaces now rewrites it.
+
+private PWA_CONFIG = <<-TOML
+  title = "PWA Site"
+  base_url = "https://example.com"
+
+  [pwa]
+  enabled = true
+  precache_urls = ["/404.html", "/search.json"]
+
+  [search]
+  enabled = true
+  TOML
+
+private def write_pwa_site
+  File.write("config.toml", PWA_CONFIG)
+  FileUtils.mkdir_p("content")
+  FileUtils.mkdir_p("templates")
+  File.write("templates/page.html", "<html><body>{{ content }}</body></html>")
+  File.write("templates/404.html", "<html><body>not found</body></html>")
+  File.write("content/index.md", "---\ntitle: Home\n---\nhome body v1")
+  File.write("content/about.md", "---\ntitle: About\n---\nabout body")
+end
+
+private def pwa_builder : Hwaro::Core::Build::Builder
+  builder = Hwaro::Core::Build::Builder.new
+  Hwaro::Content::Hooks.all.each { |hookable| builder.register(hookable) }
+  builder
+end
+
+private def pwa_options(preserve : Bool = false) : Hwaro::Config::Options::BuildOptions
+  options = Hwaro::Config::Options::BuildOptions.new(
+    output_dir: "public",
+    parallel: false,
+    highlight: false,
+  )
+  options.preserve_output = preserve
+  options
+end
+
+private def precache_urls(sw_source : String) : Array(String)
+  block = sw_source[/PRECACHE_URLS = \[(.*?)\];/m, 1]? || ""
+  block.scan(/"([^"]*)"/).map(&.[1])
+end
+
+private def cache_name(sw_source : String) : String
+  sw_source[/CACHE_NAME = '([^']+)'/, 1]
+end
+
+describe "PWA generation phase order (A3/A10)" do
+  it "includes 404.html and the search index in the precache on a CLEAN build (A3)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_pwa_site
+        pwa_builder.run(pwa_options).should be_true
+
+        File.exists?("public/404.html").should be_true
+        File.exists?("public/search.json").should be_true
+        sw = File.read("public/sw.js")
+
+        urls = precache_urls(sw)
+        urls.should contain("/404.html")
+        urls.should contain("/search.json")
+      end
+    end
+  end
+
+  it "emits byte-identical sw.js for a clean build and an immediately following warm build (A3)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_pwa_site
+        builder = pwa_builder
+        builder.run(pwa_options).should be_true
+        first = File.read("public/sw.js")
+
+        # Warm rebuild over the same output tree (serve's watch options).
+        builder.run(pwa_options(preserve: true)).should be_true
+        File.read("public/sw.js").should eq(first)
+      end
+    end
+  end
+
+  it "regenerates sw.js (new CACHE_NAME) on an incremental content rebuild (A10)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_pwa_site
+        builder = pwa_builder
+        options = pwa_options
+        builder.run(options).should be_true
+        before = cache_name(File.read("public/sw.js"))
+
+        # The homepage backs the precached start_url "/", so its bytes feed
+        # the content-derived cache version.
+        File.write("content/index.md", "---\ntitle: Home\n---\nhome body v2 — changed")
+        watch = pwa_options(preserve: true)
+        builder.run_incremental(["content/index.md"], watch).should be_true
+
+        File.read("public/index.html").should contain("v2")
+        cache_name(File.read("public/sw.js")).should_not eq(before)
+      end
+    end
+  end
+
+  it "regenerates sw.js on a template-only re-render (A10)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_pwa_site
+        builder = pwa_builder
+        options = pwa_options
+        builder.run(options).should be_true
+        before = cache_name(File.read("public/sw.js"))
+
+        File.write("templates/page.html", "<html><body class=\"v2\">{{ content }}</body></html>")
+        builder.run_rerender(pwa_options(preserve: true)).should be_true
+
+        File.read("public/index.html").should contain("v2")
+        cache_name(File.read("public/sw.js")).should_not eq(before)
+      end
+    end
+  end
+end

--- a/spec/functional/render_vars_regression_spec.cr
+++ b/spec/functional/render_vars_regression_spec.cr
@@ -1,0 +1,144 @@
+require "./support/build_helper"
+
+# =============================================================================
+# Regressions in per-page template variables (render phase).
+#
+# These cover cross-page cache-sharing bugs in build_template_variables:
+# values that are correct in isolation but wrong when the Crinja value
+# caches are shared between a section-index page and its member pages.
+# =============================================================================
+
+describe "Render vars: page.ancestors cache" do
+  # Regression: @ancestors_crinja_cache was keyed {section, language}, a key
+  # SHARED by the section-index page (whose ancestors exclude itself) and its
+  # member pages (whose ancestors include the section). First writer won, so
+  # either the section listed itself in its own breadcrumb or member pages
+  # lost their parent section — nondeterministically across --cache builds.
+  it "keeps section-index and member-page ancestors distinct" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "posts/_index.md" => "---\ntitle: Posts\n---\n",
+        "posts/a.md"      => "---\ntitle: A\n---\nBody",
+      },
+      template_files: {
+        "page.html"    => "ANC:[{% for a in page.ancestors %}{{ a.url }};{% endfor %}]",
+        "section.html" => "ANC:[{% for a in page.ancestors %}{{ a.url }};{% endfor %}]",
+      },
+    ) do
+      # The top-level section has no ancestors — in particular NOT itself.
+      section_html = File.read("public/posts/index.html")
+      section_html.should contain("ANC:[]")
+
+      # A member page's ancestors still include its parent section.
+      page_html = File.read("public/posts/a/index.html")
+      page_html.should contain("ANC:[/posts/;]")
+    end
+  end
+
+  it "keeps nested section ancestors distinct from member pages too" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "docs/_index.md"       => "---\ntitle: Docs\n---\n",
+        "docs/guide/_index.md" => "---\ntitle: Guide\n---\n",
+        "docs/guide/a.md"      => "---\ntitle: A\n---\nBody",
+      },
+      template_files: {
+        "page.html"    => "ANC:[{% for a in page.ancestors %}{{ a.url }};{% endfor %}]",
+        "section.html" => "ANC:[{% for a in page.ancestors %}{{ a.url }};{% endfor %}]",
+      },
+    ) do
+      # The nested section's ancestors stop at its parent (no self).
+      guide_html = File.read("public/docs/guide/index.html")
+      guide_html.should contain("ANC:[/docs/;]")
+
+      # The member page keeps the full chain including its own section.
+      page_html = File.read("public/docs/guide/a/index.html")
+      page_html.should contain("ANC:[/docs/;/docs/guide/;]")
+    end
+  end
+end
+
+describe "Render vars: section.subsections pages_count" do
+  # Regression: subsection entries in the per-page `section` object read
+  # `sub.pages.size` — but `Models::Section#pages` is never populated by the
+  # build (the live list is site.pages_for_section), so pages_count was
+  # always 0 while the get_section() global-vars path reported the truth.
+  it "reports the real page count for each subsection" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {
+        "s/_index.md"     => "---\ntitle: S\n---\n",
+        "s/sub/_index.md" => "---\ntitle: Sub\n---\n",
+        "s/sub/a.md"      => "---\ntitle: A\n---\nBody",
+      },
+      template_files: {
+        "page.html"    => "{{ content }}",
+        "section.html" => "SUBC:[{% for sub in section.subsections %}{{ sub.title }}={{ sub.pages_count }};{% endfor %}]",
+      },
+    ) do
+      html = File.read("public/s/index.html")
+      html.should contain("SUBC:[Sub=1;]")
+    end
+  end
+end
+
+describe "Render vars: get_taxonomy_url language slugs" do
+  # get_taxonomy_url on a non-default-language page must emit exactly the
+  # term-page URL the taxonomy generator wrote for that language — including
+  # when distinct terms collide on the same base slug ("C#"/"C++" → "c") and
+  # disambiguation assigns "-N" suffixes.
+  it "links to the term page the generator actually wrote for the page's language" do
+    config = <<-TOML
+      title = "Test Site"
+      base_url = "http://localhost"
+      default_language = "en"
+
+      [[taxonomies]]
+      name = "tags"
+
+      [languages.en]
+      language_name = "English"
+      weight = 1
+      taxonomies = ["tags"]
+
+      [languages.ko]
+      language_name = "한국어"
+      weight = 2
+      taxonomies = ["tags"]
+      TOML
+
+    build_site(
+      config,
+      content_files: {
+        "blog/_index.md"     => "---\ntitle: Blog\n---\n",
+        "blog/_index.ko.md"  => "---\ntitle: 블로그\n---\n",
+        "blog/en-post.md"    => "---\ntitle: En Post\ntags:\n  - \"C#\"\n---\nEnglish post",
+        "blog/ko-post.ko.md" => "---\ntitle: Ko Post\ntags:\n  - \"C++\"\n---\n한국어 포스트",
+      },
+      template_files: {
+        "page.html"          => %(TAXURL:[{{ get_taxonomy_url(kind="tags", term="C++") }}]{{ content }}),
+        "section.html"       => "{{ content }}",
+        "taxonomy.html"      => "<h1>{{ taxonomy_name }}</h1>",
+        "taxonomy_term.html" => "<h1>{{ taxonomy_term }}</h1>",
+      },
+    ) do
+      html = File.read("public/ko/blog/ko-post/index.html")
+      match = /TAXURL:\[http:\/\/localhost(\/[^\]]*)\]/.match(html)
+      match.should_not be_nil
+      url = match.not_nil![1]
+      url.should start_with("/ko/tags/")
+      # The emitted link must resolve to a file the generator wrote.
+      File.exists?(File.join("public", url, "index.html")).should be_true
+
+      # And it must be THE ko term page (only C++ has Korean pages), so the
+      # link and the written path agree on the disambiguated slug.
+      written = Dir.children("public/ko/tags").select do |d|
+        File.directory?(File.join("public/ko/tags", d))
+      end
+      written.size.should eq(1)
+      url.should eq("/ko/tags/#{written.first}/")
+    end
+  end
+end

--- a/spec/functional/serve_image_reprocess_spec.cr
+++ b/spec/functional/serve_image_reprocess_spec.cr
@@ -1,0 +1,136 @@
+require "../spec_helper"
+require "../../src/services/server/server"
+require "../../src/ext/stb_bindings"
+
+# Regression coverage for A12: modified image bytes under serve left the
+# resized variants (and LQIP data) stale — the `image:resize` hook only runs
+# on full builds, and the :static / :content_files watch strategies just
+# copied the changed original. The change paths now re-run the resize
+# pipeline for the changed image.
+
+# Reopened seams (same pattern as serve_watch_fixes_spec; distinct names so
+# the two files can't collide when compiled together).
+module Hwaro
+  module Services
+    class Server
+      def img_fix_builder : Hwaro::Core::Build::Builder
+        @builder
+      end
+
+      def img_fix_apply_changeset(changeset : ChangeSet, options : Config::Options::BuildOptions)
+        apply_changeset(changeset, options)
+      end
+    end
+  end
+end
+
+# Write a real, decodable PNG (solid color) via the stb bindings — the resize
+# pipeline decodes with stbi_load, so a hand-rolled fake won't do.
+private def write_solid_png(path : String, width : Int32, height : Int32, r : UInt8, g : UInt8, b : UInt8)
+  pixels = Array(UInt8).new(width * height * 3) { |i| [r, g, b][i % 3] }
+  FileUtils.mkdir_p(File.dirname(path))
+  LibStb.stbi_write_png(path, width, height, 3, pixels.to_unsafe.as(Void*), width * 3)
+end
+
+private def img_options : Hwaro::Config::Options::BuildOptions
+  options = Hwaro::Config::Options::BuildOptions.new(
+    output_dir: "public",
+    parallel: false,
+    highlight: false,
+  )
+  options.serve_mode = true
+  options
+end
+
+private def write_image_site
+  File.write("config.toml", <<-TOML
+    title = "Image Site"
+    base_url = "https://example.com"
+
+    [image_processing]
+    enabled = true
+    widths = [32]
+
+    [content.files]
+    allow_extensions = ["png"]
+    TOML
+  )
+  FileUtils.mkdir_p("content")
+  FileUtils.mkdir_p("templates")
+  File.write("templates/page.html", "<html><body>{{ content }}</body></html>")
+  File.write("content/index.md", "---\ntitle: Home\n---\nhome body")
+end
+
+private def static_changeset(paths : Array(String)) : Hwaro::Services::ChangeSet
+  Hwaro::Services::ChangeSet.new(
+    modified_content: [] of String,
+    modified_templates: [] of String,
+    modified_static: paths,
+    added_files: [] of String,
+    removed_files: [] of String,
+    config_changed: false,
+  )
+end
+
+private def content_files_changeset(paths : Array(String)) : Hwaro::Services::ChangeSet
+  Hwaro::Services::ChangeSet.new(
+    modified_content: [] of String,
+    modified_templates: [] of String,
+    modified_static: [] of String,
+    added_files: [] of String,
+    removed_files: [] of String,
+    config_changed: false,
+    modified_content_files: paths,
+  )
+end
+
+describe "serve image reprocessing on changed bytes (A12)" do
+  it "regenerates static image variants when the source bytes change" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_image_site
+        write_solid_png("static/img/photo.png", 64, 64, 255_u8, 0_u8, 0_u8)
+
+        server = Hwaro::Services::Server.new
+        options = img_options
+        server.img_fix_builder.run(options).should be_true
+
+        variant = "public/img/photo_32w.png"
+        File.exists?(variant).should be_true
+        before = File.read(variant)
+
+        # Overwrite the source with different pixels and run the serve
+        # static-change path.
+        write_solid_png("static/img/photo.png", 64, 64, 0_u8, 0_u8, 255_u8)
+        server.img_fix_apply_changeset(static_changeset(["static/img/photo.png"]), options)
+
+        # Original was republished (pre-existing behavior) …
+        File.read("public/img/photo.png").should eq(File.read("static/img/photo.png"))
+        # … and the resized variant now reflects the new bytes too.
+        File.read(variant).should_not eq(before)
+      end
+    end
+  end
+
+  it "regenerates content-file image variants when the source bytes change" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_image_site
+        write_solid_png("content/media/pic.png", 64, 64, 255_u8, 0_u8, 0_u8)
+
+        server = Hwaro::Services::Server.new
+        options = img_options
+        server.img_fix_builder.run(options).should be_true
+
+        variant = "public/media/pic_32w.png"
+        File.exists?(variant).should be_true
+        before = File.read(variant)
+
+        write_solid_png("content/media/pic.png", 64, 64, 0_u8, 255_u8, 0_u8)
+        server.img_fix_apply_changeset(content_files_changeset(["content/media/pic.png"]), options)
+
+        File.read(variant).should_not eq(before)
+      end
+    end
+  end
+end

--- a/spec/functional/serve_og_incremental_spec.cr
+++ b/spec/functional/serve_og_incremental_spec.cr
@@ -163,6 +163,48 @@ describe "serve lazy OG generation (A9)" do
     end
   end
 
+  it "keeps slug-colliding pages on their own advertised files (review item 1)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_og_site(lazy: true)
+        # /posts/foo/ and /posts-foo/ both slugify to "posts-foo";
+        # assign_lazy_urls disambiguates the second with a URL-hash suffix.
+        File.write("content/posts/foo.md", "---\ntitle: Nested Foo\n---\nnested body")
+        File.write("content/posts-foo.md", "---\ntitle: Flat Foo\n---\nflat body")
+        builder = og_builder
+        builder.run(og_options).should be_true
+
+        site = builder.site.not_nil!
+        nested = site.pages.find! { |p| p.url == "/posts/foo/" }
+        flat = site.pages.find! { |p| p.url == "/posts-foo/" }
+        nested_url = nested.image.not_nil!
+        flat_url = flat.image.not_nil!
+        nested_url.should_not eq(flat_url)
+
+        handler = Hwaro::Services::OgLazyImageHandler.new(builder, "public")
+        og_request(handler, nested_url)
+        og_request(handler, flat_url)
+
+        nested_file = File.join("public", nested_url.lchop('/'))
+        flat_file = File.join("public", flat_url.lchop('/'))
+        File.exists?(nested_file).should be_true
+        File.exists?(flat_file).should be_true
+        File.read(nested_file).should contain("Nested Foo")
+        File.read(flat_file).should contain("Flat Foo")
+
+        # Repeat requests must hit the manifest cache, not regenerate
+        # (regeneration would rewrite the files and bump their mtimes).
+        stamp = Time.utc - 5.minutes
+        File.touch(nested_file, stamp)
+        File.touch(flat_file, stamp)
+        og_request(handler, nested_url)
+        og_request(handler, flat_url)
+        File.info(nested_file).modification_time.should be_close(stamp, 2.seconds)
+        File.info(flat_file).modification_time.should be_close(stamp, 2.seconds)
+      end
+    end
+  end
+
   it "passes unrelated requests through untouched" do
     Dir.mktmpdir do |dir|
       Dir.cd(dir) do

--- a/spec/functional/serve_og_incremental_spec.cr
+++ b/spec/functional/serve_og_incremental_spec.cr
@@ -1,0 +1,180 @@
+require "../spec_helper"
+require "../../src/services/server/server"
+
+# Regression coverage for the serve-mode auto-OG fixes:
+#
+# - A8: the serve incremental re-parse (run_incremental) resets page.image
+#   from front matter, erasing the auto-OG og:image meta from the edited
+#   page's HTML — and the OG file was never regenerated (og_image:generate is
+#   a BeforeRender hook the incremental paths never run). The re-parse now
+#   preserves the auto-assigned URL and regenerate_seo_surfaces refreshes the
+#   image file.
+# - A9: `[og.auto_image] lazy_generate = true` under serve skipped generation
+#   entirely — page.image stayed nil, so pages advertised NO og:image and the
+#   promised on-request generation had no server handler. Pages now get their
+#   predicted URL assigned, and OgLazyImageHandler generates the file on
+#   first request.
+#
+# format = "svg" throughout: the SVG renderer needs no system fonts (the PNG
+# path degrades to SVG when font init fails), and the emitted SVG embeds the
+# page title as text — letting the specs assert content freshness directly.
+
+private def write_og_site(lazy : Bool = false)
+  File.write("config.toml", <<-TOML
+    title = "OG Site"
+    base_url = "https://example.com"
+
+    [og.auto_image]
+    enabled = true
+    format = "svg"
+    lazy_generate = #{lazy}
+    TOML
+  )
+  FileUtils.mkdir_p("content/posts")
+  FileUtils.mkdir_p("templates")
+  File.write("templates/page.html", "<html><head>{{ og_all_tags }}</head><body>{{ content }}</body></html>")
+  File.write("content/posts/hello.md", "---\ntitle: First Title\n---\nhello body")
+end
+
+private def og_builder : Hwaro::Core::Build::Builder
+  builder = Hwaro::Core::Build::Builder.new
+  Hwaro::Content::Hooks.all.each { |hookable| builder.register(hookable) }
+  builder
+end
+
+private def og_options(preserve : Bool = false) : Hwaro::Config::Options::BuildOptions
+  options = Hwaro::Config::Options::BuildOptions.new(
+    output_dir: "public",
+    parallel: false,
+    highlight: false,
+  )
+  options.serve_mode = true
+  options.preserve_output = preserve
+  options
+end
+
+private class OgSpecTerminal
+  include HTTP::Handler
+
+  property called : Bool = false
+
+  def call(context)
+    @called = true
+    context.response.status_code = 404
+  end
+end
+
+private def og_request(handler : HTTP::Handler, path : String) : {HTTP::Server::Context, OgSpecTerminal}
+  terminal = OgSpecTerminal.new
+  handler.next = terminal
+  request = HTTP::Request.new("GET", path)
+  io = IO::Memory.new
+  response = HTTP::Server::Response.new(io)
+  context = HTTP::Server::Context.new(request, response)
+  handler.call(context)
+  response.close
+  {context, terminal}
+end
+
+describe "serve auto-OG incremental behavior (A8)" do
+  it "keeps og:image meta and refreshes the OG file after an incremental edit" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_og_site
+        builder = og_builder
+        builder.run(og_options).should be_true
+
+        html = File.read("public/posts/hello/index.html")
+        html.should contain(%(property="og:image"))
+        html.should contain("/og-images/posts-hello.svg")
+        File.read("public/og-images/posts-hello.svg").should contain("First Title")
+
+        # Incremental edit: new title, still no front-matter image.
+        File.write("content/posts/hello.md", "---\ntitle: Second Title\n---\nhello body edited")
+        builder.run_incremental(["content/posts/hello.md"], og_options(preserve: true)).should be_true
+
+        html = File.read("public/posts/hello/index.html")
+        html.should contain(%(property="og:image"))
+        html.should contain("/og-images/posts-hello.svg")
+        File.read("public/og-images/posts-hello.svg").should contain("Second Title")
+      end
+    end
+  end
+
+  it "lets a newly added front-matter image win over the auto-assigned one" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_og_site
+        builder = og_builder
+        builder.run(og_options).should be_true
+
+        File.write("content/posts/hello.md", "---\ntitle: First Title\nimage: /custom.png\n---\nhello body")
+        builder.run_incremental(["content/posts/hello.md"], og_options(preserve: true)).should be_true
+
+        html = File.read("public/posts/hello/index.html")
+        html.should contain("https://example.com/custom.png")
+        html.should_not contain("/og-images/posts-hello.svg")
+      end
+    end
+  end
+end
+
+describe "serve lazy OG generation (A9)" do
+  it "advertises the predicted og:image URL without generating the file" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_og_site(lazy: true)
+        og_builder.run(og_options).should be_true
+
+        html = File.read("public/posts/hello/index.html")
+        html.should contain(%(property="og:image"))
+        html.should contain("/og-images/posts-hello.svg")
+
+        # Lazy: nothing rendered up front.
+        File.exists?("public/og-images/posts-hello.svg").should be_false
+      end
+    end
+  end
+
+  it "generates the OG image on first request and serves from disk afterwards" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_og_site(lazy: true)
+        builder = og_builder
+        builder.run(og_options).should be_true
+        File.exists?("public/og-images/posts-hello.svg").should be_false
+
+        handler = Hwaro::Services::OgLazyImageHandler.new(builder, "public")
+
+        # First request: generated on demand, then handed to the next
+        # handler (the static file handler in the real chain).
+        _, terminal = og_request(handler, "/og-images/posts-hello.svg")
+        terminal.called.should be_true
+        File.exists?("public/og-images/posts-hello.svg").should be_true
+        File.read("public/og-images/posts-hello.svg").should contain("First Title")
+
+        # Second request: served from disk without regeneration. Backdate the
+        # file — a rewrite would bump its mtime.
+        stamp = Time.utc - 5.minutes
+        File.touch("public/og-images/posts-hello.svg", stamp)
+        og_request(handler, "/og-images/posts-hello.svg")
+        File.info("public/og-images/posts-hello.svg").modification_time.should be_close(stamp, 2.seconds)
+      end
+    end
+  end
+
+  it "passes unrelated requests through untouched" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_og_site(lazy: true)
+        builder = og_builder
+        builder.run(og_options).should be_true
+
+        handler = Hwaro::Services::OgLazyImageHandler.new(builder, "public")
+        _, terminal = og_request(handler, "/posts/hello/")
+        terminal.called.should be_true
+        Dir.exists?("public/og-images").should be_false
+      end
+    end
+  end
+end

--- a/spec/functional/serve_watch_fixes_spec.cr
+++ b/spec/functional/serve_watch_fixes_spec.cr
@@ -1,0 +1,298 @@
+require "../spec_helper"
+require "../../src/services/server/server"
+
+# Regression coverage for the serve watch-lane fixes:
+# - S1: apply_changeset owns the @rebuild_failed reset (success only)
+# - S2: post-rebuild stale pruning must not delete outputs the rebuilt
+#   site re-created from a different source
+# - S3: the watcher baseline is captured BEFORE the initial build
+# - A2: plain (non-Sass) bundle-source saves refresh fingerprinted
+#   bundles AND the pages that reference them
+# - A13: a draft flip on the content+template path refreshes the SEO
+#   surfaces even when the template edit was a bare touch
+
+# Reopened for the private seams; names are prefixed so they can't collide
+# with the shims other spec files install.
+module Hwaro
+  module Services
+    class Server
+      def watch_fixes_builder : Hwaro::Core::Build::Builder
+        @builder
+      end
+
+      def watch_fixes_apply_changeset(changeset : ChangeSet, options : Config::Options::BuildOptions)
+        apply_changeset(changeset, options)
+      end
+
+      def watch_fixes_rebuild_failed? : Bool
+        @rebuild_failed
+      end
+
+      def watch_fixes_set_rebuild_failed(value : Bool)
+        @rebuild_failed = value
+      end
+
+      def watch_fixes_capture_baseline
+        capture_watch_baseline
+      end
+
+      def watch_fixes_initial_watch_mtimes : Hash(String, FileStamp)
+        initial_watch_mtimes
+      end
+
+      def watch_fixes_scan_mtimes : Hash(String, FileStamp)
+        scan_mtimes
+      end
+
+      def watch_fixes_detect_changes(old_mtimes : Hash(String, FileStamp), new_mtimes : Hash(String, FileStamp)) : ChangeSet
+        detect_changes(old_mtimes, new_mtimes)
+      end
+    end
+  end
+end
+
+private def watch_changeset(
+  modified_content = [] of String,
+  modified_static = [] of String,
+  added = [] of String,
+  removed = [] of String,
+) : Hwaro::Services::ChangeSet
+  Hwaro::Services::ChangeSet.new(
+    modified_content: modified_content,
+    modified_templates: [] of String,
+    modified_static: modified_static,
+    added_files: added,
+    removed_files: removed,
+    config_changed: false,
+  )
+end
+
+private def watch_options : Hwaro::Config::Options::BuildOptions
+  options = Hwaro::Config::Options::BuildOptions.new(
+    output_dir: "public",
+    parallel: false,
+    highlight: false,
+  )
+  options.serve_mode = true
+  options
+end
+
+private def write_minimal_site
+  File.write("config.toml", <<-TOML
+    title = "Watch Fixes"
+    base_url = "https://example.com"
+
+    [sitemap]
+    enabled = true
+    TOML
+  )
+  FileUtils.mkdir_p("content")
+  FileUtils.mkdir_p("templates")
+  File.write("templates/page.html", "<html><body>{{ content }}</body></html>")
+end
+
+describe "serve watch-lane regressions" do
+  # S1: a Bool-failure build (pre-hook failure — Builder#run returns false
+  # without raising) must leave @rebuild_failed set. The watch loop used to
+  # clobber it back to false in the same iteration because apply_changeset
+  # returned normally.
+  it "keeps the failure flag set after a build that fails without raising (S1)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_minimal_site
+        File.write("content/foo.md", "---\ntitle: Foo\n---\nBody")
+        File.write("config.toml", <<-TOML
+          title = "Watch Fixes"
+          base_url = "https://example.com"
+
+          [build.hooks]
+          pre = ["false"]
+          TOML
+        )
+
+        server = Hwaro::Services::Server.new
+        server.watch_fixes_set_rebuild_failed(false)
+        server.watch_fixes_apply_changeset(watch_changeset(modified_content: ["content/foo.md"]), watch_options)
+
+        server.watch_fixes_rebuild_failed?.should be_true
+      end
+    end
+  end
+
+  # S1: the reset now lives inside apply_changeset, gated on success — the
+  # recovery contract (next changeset escalates to :full, then clears).
+  it "clears the failure flag only through a successful apply_changeset (S1)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_minimal_site
+        File.write("content/foo.md", "---\ntitle: Foo\n---\nBody")
+
+        server = Hwaro::Services::Server.new
+        options = watch_options
+        server.watch_fixes_builder.run(options).should be_true
+
+        server.watch_fixes_set_rebuild_failed(true)
+        server.watch_fixes_apply_changeset(watch_changeset(modified_content: ["content/foo.md"]), options)
+
+        server.watch_fixes_rebuild_failed?.should be_false
+      end
+    end
+  end
+
+  # S2: one changeset deletes foo.md and re-creates the same URL from
+  # foo/index.md. The stale list (mapped through the OLD site) contains
+  # public/foo/index.html — which the rebuild just rewrote for the new
+  # owner. It must survive the post-rebuild pruning.
+  it "does not delete an output the rebuilt site re-created from a different source (S2)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_minimal_site
+        File.write("content/foo.md", "---\ntitle: Foo\n---\nfirst body")
+
+        server = Hwaro::Services::Server.new
+        options = watch_options
+        server.watch_fixes_builder.run(options).should be_true
+        File.exists?("public/foo/index.html").should be_true
+
+        File.delete("content/foo.md")
+        FileUtils.mkdir_p("content/foo")
+        File.write("content/foo/index.md", "---\ntitle: Foo\n---\nsecond body")
+
+        server.watch_fixes_apply_changeset(
+          watch_changeset(removed: ["content/foo.md"], added: ["content/foo/index.md"]),
+          options,
+        )
+
+        File.exists?("public/foo/index.html").should be_true
+        File.read("public/foo/index.html").should contain("second body")
+      end
+    end
+  end
+
+  # S2: pruning must still remove outputs the rebuilt site does NOT claim.
+  it "still prunes outputs whose source is gone for good (S2)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_minimal_site
+        File.write("content/foo.md", "---\ntitle: Foo\n---\nBody")
+        File.write("content/keep.md", "---\ntitle: Keep\n---\nBody")
+
+        server = Hwaro::Services::Server.new
+        options = watch_options
+        server.watch_fixes_builder.run(options).should be_true
+        File.exists?("public/foo/index.html").should be_true
+
+        File.delete("content/foo.md")
+        server.watch_fixes_apply_changeset(watch_changeset(removed: ["content/foo.md"]), options)
+
+        File.exists?("public/foo/index.html").should be_false
+        File.exists?("public/keep/index.html").should be_true
+      end
+    end
+  end
+
+  # S3: the baseline snapshot is taken before the initial build, so an edit
+  # saved while the build runs shows up in the watcher's first diff.
+  it "seeds the watcher baseline from the pre-build snapshot (S3)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_minimal_site
+        File.write("content/foo.md", "---\ntitle: Foo\n---\nbefore")
+
+        server = Hwaro::Services::Server.new
+        server.watch_fixes_capture_baseline
+
+        # Simulates a save landing during the initial build (size change so
+        # the FileStamp differs even under coarse mtime granularity).
+        File.write("content/foo.md", "---\ntitle: Foo\n---\nafter — a longer body")
+
+        initial = server.watch_fixes_initial_watch_mtimes
+        changes = server.watch_fixes_detect_changes(initial, server.watch_fixes_scan_mtimes)
+        changes.modified_content.should eq(["content/foo.md"])
+
+        # The baseline is consumed exactly once; afterwards the loop falls
+        # back to a fresh scan.
+        second = server.watch_fixes_initial_watch_mtimes
+        server.watch_fixes_detect_changes(second, server.watch_fixes_scan_mtimes).empty?.should be_true
+      end
+    end
+  end
+
+  # A2: a plain JS bundle-source save under the :static strategy must
+  # re-run the bundle pipeline (new fingerprinted file) AND re-render pages
+  # so their asset() references point at the new hash.
+  it "refreshes fingerprinted bundles and page references on a plain bundle-source save (A2)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", <<-TOML
+          title = "Watch Fixes"
+          base_url = "https://example.com"
+
+          [assets]
+          enabled = true
+          minify = false
+          fingerprint = true
+
+          [[assets.bundles]]
+          name = "app.js"
+          files = ["js/app.js"]
+          TOML
+        )
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates")
+        FileUtils.mkdir_p("static/js")
+        File.write("templates/page.html", %(<script src="{{ asset(name='app.js') }}"></script>{{ content }}))
+        File.write("content/page.md", "---\ntitle: Test\n---\nHello")
+        File.write("static/js/app.js", "console.log('one');")
+
+        server = Hwaro::Services::Server.new
+        options = watch_options
+        server.watch_fixes_builder.run(options).should be_true
+
+        old_bundles = Dir.glob("public/assets/app.*.js")
+        old_bundles.size.should eq(1)
+        old_name = File.basename(old_bundles[0])
+        File.read("public/page/index.html").should contain(old_name)
+
+        File.write("static/js/app.js", "console.log('two, changed');")
+        server.watch_fixes_apply_changeset(watch_changeset(modified_static: ["static/js/app.js"]), options)
+
+        new_name = Dir.glob("public/assets/app.*.js").map { |p| File.basename(p) }.find { |n| n != old_name }
+        new_name = new_name.should_not be_nil
+        File.read(File.join("public/assets", new_name)).should contain("two, changed")
+        File.read("public/page/index.html").should contain(new_name)
+      end
+    end
+  end
+
+  # A13: on the content+template path, a page flipped to draft alongside a
+  # bare template touch (identical template bytes) must vanish from the
+  # sitemap — the SEO refresh used to be gated on template semantics only,
+  # and the identical-templates early return skipped everything.
+  it "drops a page flipped to draft from the sitemap on the content+template path (A13)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_minimal_site
+        File.write("content/post.md", "---\ntitle: Post\n---\nBody")
+        # A second, live page: Sitemap.generate keeps the OLD file on disk
+        # when the page set is empty, so the refresh is only observable with
+        # a survivor in the set (the realistic shape anyway).
+        File.write("content/keep.md", "---\ntitle: Keep\n---\nBody")
+
+        builder = Hwaro::Core::Build::Builder.new
+        Hwaro::Content::Hooks.all.each { |hookable| builder.register(hookable) }
+        options = watch_options
+        builder.run(options).should be_true
+        File.read("public/sitemap.xml").should contain("/post/")
+
+        File.write("content/post.md", "---\ntitle: Post\ndraft: true\n---\nBody")
+        FileUtils.touch("templates/page.html")
+
+        builder.run_incremental_then_rerender(["content/post.md"], options).should be_true
+
+        File.exists?("public/post/index.html").should be_false
+        File.read("public/sitemap.xml").should_not contain("/post/")
+      end
+    end
+  end
+end

--- a/spec/functional/server_highlight_spec.cr
+++ b/spec/functional/server_highlight_spec.cr
@@ -414,6 +414,42 @@ describe "Fence options — server mode" do
     reset_highlight_mode
   end
 
+  # Regression: the per-fence copy probe used to run inside
+  # build_template_variables, where pages WITH shortcodes pass content=""
+  # (the shortcode pre-render context). The probe never re-ran against the
+  # final rendered content, so a `{copy=true}` fence on any page that also
+  # used a shortcode silently shipped no copy runtime.
+  it "per-fence {copy=true} still ships the runtime when the page also uses a shortcode" do
+    opted = <<-MD
+      +++
+      title = "Opted"
+      +++
+      {{ badge(label="x") }}
+
+      ```python {copy=true}
+      pass
+      ```
+      MD
+
+    build_site(
+      SERVER_HIGHLIGHT_CONFIG,
+      content_files: {"opted.md" => opted},
+      template_files: {
+        "page.html"             => HIGHLIGHT_TEMPLATE,
+        "shortcodes/badge.html" => %(<span class="badge">{{ label }}</span>),
+      },
+      highlight: true,
+    ) do
+      html = File.read("public/opted/index.html")
+      # The shortcode itself rendered (proves the shortcode path was taken).
+      html.should contain(%(<span class="badge">x</span>))
+      html.should contain(%(<pre data-copy="true">))
+      html.scan("code-copy-btn").size.should be > 0
+    end
+  ensure
+    reset_highlight_mode
+  end
+
   it "the global [highlight] line_numbers default wraps a bare fence, and a per-block override opts out" do
     config = <<-TOML
       title = "Test Site"

--- a/spec/functional/template_deps_spec.cr
+++ b/spec/functional/template_deps_spec.cr
@@ -381,6 +381,25 @@ describe "TemplateDeps: refs the snapshot loader cannot serve (C3)" do
     deps.snapshot_escaping_refs.should be_empty
   end
 
+  it "marks the graph dynamic for extension-less references missing from the snapshot" do
+    # `{% include "partials/nav" %}` naming a literal extension-less file
+    # (templates/partials/nav) resolves via the disk loader but lives in no
+    # snapshot hash — its edits would be invisible to invalidation.
+    templates = {"page" => %({% include "partials/nav" %})}
+    paths = {"page" => "templates/page.html"}
+    deps = Hwaro::Core::Build::TemplateDeps.new(templates, paths)
+    deps.dynamic?.should be_true
+    deps.snapshot_escaping_refs.should contain("partials/nav")
+  end
+
+  it "stays static for extension-less references to a real snapshot key" do
+    templates = {"page" => %({% include "partials/nav" %}), "partials/nav" => "n"}
+    paths = {"page" => "templates/page.html", "partials/nav" => "templates/partials/nav.html"}
+    deps = Hwaro::Core::Build::TemplateDeps.new(templates, paths)
+    deps.dynamic?.should be_false
+    deps.snapshot_escaping_refs.should be_empty
+  end
+
   it "stays static for references to templates with dotted names (page.json.jinja)" do
     templates = {"page" => %({% include "page.json.jinja" %}), "page.json" => "{}"}
     paths = {"page" => "templates/page.html", "page.json" => "templates/page.json.jinja"}

--- a/spec/functional/template_deps_spec.cr
+++ b/spec/functional/template_deps_spec.cr
@@ -351,3 +351,41 @@ describe "Template deps: review regressions" do
     end
   end
 end
+
+describe "TemplateDeps: refs the snapshot loader cannot serve (C3)" do
+  it "marks the graph dynamic for ./-prefixed references" do
+    deps = Hwaro::Core::Build::TemplateDeps.new({"page" => %({% include "./partials/nav.html" %}), "partials/nav" => "n"})
+    deps.dynamic?.should be_true
+    deps.snapshot_escaping_refs.should contain("./partials/nav.html")
+  end
+
+  it "marks the graph dynamic for non-template-extension references" do
+    deps = Hwaro::Core::Build::TemplateDeps.new({"page" => %({% include "partials/legal.txt" %})})
+    deps.dynamic?.should be_true
+    deps.snapshot_escaping_refs.should contain("partials/legal.txt")
+  end
+
+  it "marks the graph dynamic for shadowed extension-variant references" do
+    templates = {"page" => %({% include "partials/note.j2" %}), "partials/note" => "html variant"}
+    paths = {"page" => "templates/page.html", "partials/note" => "templates/partials/note.html"}
+    deps = Hwaro::Core::Build::TemplateDeps.new(templates, paths)
+    deps.dynamic?.should be_true
+    deps.snapshot_escaping_refs.should contain("partials/note.j2")
+  end
+
+  it "stays static for exact-extension references matching their snapshot source" do
+    templates = {"page" => %({% include "partials/note.html" %}), "partials/note" => "html variant"}
+    paths = {"page" => "templates/page.html", "partials/note" => "templates/partials/note.html"}
+    deps = Hwaro::Core::Build::TemplateDeps.new(templates, paths)
+    deps.dynamic?.should be_false
+    deps.snapshot_escaping_refs.should be_empty
+  end
+
+  it "stays static for references to templates with dotted names (page.json.jinja)" do
+    templates = {"page" => %({% include "page.json.jinja" %}), "page.json" => "{}"}
+    paths = {"page" => "templates/page.html", "page.json" => "templates/page.json.jinja"}
+    deps = Hwaro::Core::Build::TemplateDeps.new(templates, paths)
+    deps.dynamic?.should be_false
+    deps.snapshot_escaping_refs.should be_empty
+  end
+end

--- a/spec/lifecycle_spec.cr
+++ b/spec/lifecycle_spec.cr
@@ -105,8 +105,10 @@ describe Hwaro::Core::Lifecycle do
         Hwaro::Core::Lifecycle::HookResult::Skip
       end
 
+      # Skip only suppresses the remaining hooks at this hook point; the
+      # phase sequence continues, so trigger reports Continue.
       result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeInitialize, ctx)
-      result.should eq(Hwaro::Core::Lifecycle::HookResult::Skip)
+      result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
     end
 
     it "handles HookResult::Abort" do

--- a/spec/unit/build_command_spec.cr
+++ b/spec/unit/build_command_spec.cr
@@ -107,6 +107,26 @@ describe Hwaro::CLI::Commands::BuildCommand do
       options.workers.should eq(2)
     end
 
+    it "warns that --jobs is ignored when combined with --no-parallel" do
+      cmd = Hwaro::CLI::Commands::BuildCommand.new
+      log = with_captured_log do
+        result, _ = cmd.parse_options(["--no-parallel", "--jobs", "4"])
+        options, _ = result
+        options.parallel.should be_false
+        options.workers.should eq(4)
+      end
+      log.should contain("--jobs")
+      log.should contain("--no-parallel")
+    end
+
+    it "does not warn about --jobs when parallel rendering is enabled" do
+      cmd = Hwaro::CLI::Commands::BuildCommand.new
+      log = with_captured_log do
+        cmd.parse_options(["--jobs", "4"])
+      end
+      log.should_not contain("--no-parallel")
+    end
+
     it "raises HwaroError(HWARO_E_USAGE) when --jobs is not a positive integer" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
 

--- a/spec/unit/builder_orchestration_run_spec.cr
+++ b/spec/unit/builder_orchestration_run_spec.cr
@@ -17,6 +17,10 @@ module Hwaro::Core::Build
     def test_set_orch_run_config(config : Models::Config?)
       @config = config
     end
+
+    def test_global_templates_hash : String
+      @global_templates_hash
+    end
   end
 end
 
@@ -91,6 +95,98 @@ describe Hwaro::Core::Build::Builder do
     end
   end
 
+  describe "#run(options) option fidelity" do
+    it "passes full and serve_mode through to the build context verbatim" do
+      with_minimal_site do
+        builder = Hwaro::Core::Build::Builder.new
+        captured = nil.as(Hwaro::Config::Options::BuildOptions?)
+        builder.lifecycle.before(
+          Hwaro::Core::Lifecycle::Phase::Initialize, name: "capture-options"
+        ) do |ctx|
+          captured = ctx.options
+          Hwaro::Core::Lifecycle::HookResult::Continue
+        end
+
+        options = Hwaro::Config::Options::BuildOptions.new(
+          output_dir: "public", parallel: false, cache: true, full: true,
+          highlight: false, serve_mode: true,
+        )
+        builder.run(options).should be_true
+
+        captured.should_not be_nil
+        opts = captured.not_nil!
+        opts.full.should be_true
+        opts.serve_mode.should be_true
+        opts.cache.should be_true
+      end
+    end
+
+    it "clears the cache when full: true so unchanged pages re-render" do
+      with_minimal_site do
+        seed = Hwaro::Core::Build::Builder.new
+        seed.run(Hwaro::Config::Options::BuildOptions.new(
+          output_dir: "public", parallel: false, cache: true, highlight: false,
+        )).should be_true
+        File.exists?(".hwaro_cache.json").should be_true
+
+        # Sanity: without full the second build serves the page from cache.
+        warm = Hwaro::Core::Build::Builder.new
+        warm.run(Hwaro::Config::Options::BuildOptions.new(
+          output_dir: "public", parallel: false, cache: true, highlight: false,
+        )).should be_true
+        warm_ctx = warm.context.not_nil!
+        warm_ctx.stats.cache_hits.should eq(1)
+        warm_ctx.stats.pages_rendered.should eq(0)
+
+        # full: true must ignore/clear that cache and re-render everything.
+        full = Hwaro::Core::Build::Builder.new
+        full.run(Hwaro::Config::Options::BuildOptions.new(
+          output_dir: "public", parallel: false, cache: true, full: true, highlight: false,
+        )).should be_true
+        full_ctx = full.context.not_nil!
+        full_ctx.stats.pages_rendered.should eq(1)
+        full_ctx.stats.cache_hits.should eq(0)
+      end
+    end
+  end
+
+  describe "HookResult::Skip phase semantics" do
+    it "skips remaining hooks of the phase but completes the build" do
+      with_minimal_site do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_orch_run_config(Hwaro::Models::Config.new)
+
+        # Transform has no hook-override semantics (unlike ParseContent/
+        # Generate, whose default body is replaced when before-hooks are
+        # registered), so the phase body still runs after the Skip.
+        second_ran = false
+        builder.lifecycle.before(
+          Hwaro::Core::Lifecycle::Phase::Transform, priority: 10, name: "skipper"
+        ) do |_ctx|
+          Hwaro::Core::Lifecycle::HookResult::Skip
+        end
+        builder.lifecycle.before(
+          Hwaro::Core::Lifecycle::Phase::Transform, priority: 0, name: "second"
+        ) do |_ctx|
+          second_ran = true
+          Hwaro::Core::Lifecycle::HookResult::Continue
+        end
+
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+        profiler = Hwaro::Profiler.new(enabled: false)
+
+        result = builder.test_execute_phases(ctx, profiler)
+        # Skip is documented as "skip remaining hooks in current phase" —
+        # the phase body and every subsequent phase still run.
+        result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+        second_ran.should be_false
+        File.exists?("public/about/index.html").should be_true
+        ctx.stats.pages_rendered.should eq(1)
+      end
+    end
+  end
+
   describe "#run_incremental" do
     it "falls back to a full build when no prior state exists" do
       with_minimal_site do
@@ -130,6 +226,89 @@ describe Hwaro::Core::Build::Builder do
           # The nested SUBSECTION index (a site.sections page, not a site.pages
           # page) must pick up the parent's new title in its breadcrumb.
           File.read("public/blog/news/index.html").should contain("BC:BlogNew;")
+        end
+      end
+    end
+  end
+
+  describe "#run_incremental orphaned output pruning" do
+    it "deletes the orphaned sibling format file when front matter drops the format" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = "http://localhost"))
+          FileUtils.mkdir_p("content")
+          File.write("content/about.md", "---\ntitle: About\noutputs: [json]\n---\nbody")
+          FileUtils.mkdir_p("templates")
+          File.write("templates/page.html", "<p>{{ content }}</p>")
+          File.write("templates/page.json.jinja", %({"v": 1}))
+
+          builder = Hwaro::Core::Build::Builder.new
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          builder.run(options)
+          File.exists?("public/about/index.json").should be_true
+
+          # Drop the format. The primary output path is UNCHANGED, so a
+          # primary-path-only relocation check would leave index.json
+          # orphaned — served and deployed forever.
+          File.write("content/about.md", "---\ntitle: About\n---\nbody")
+          builder.run_incremental(["content/about.md"], options)
+
+          File.exists?("public/about/index.html").should be_true
+          File.exists?("public/about/index.json").should be_false
+        end
+      end
+    end
+
+    it "still prunes the old output on a pure relocation (slug change)" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = "http://localhost"))
+          FileUtils.mkdir_p("content")
+          File.write("content/about.md", "---\ntitle: About\nslug: old-place\n---\nbody")
+          FileUtils.mkdir_p("templates")
+          File.write("templates/page.html", "<p>{{ content }}</p>")
+
+          builder = Hwaro::Core::Build::Builder.new
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          builder.run(options)
+          File.exists?("public/old-place/index.html").should be_true
+
+          File.write("content/about.md", "---\ntitle: About\nslug: new-place\n---\nbody")
+          builder.run_incremental(["content/about.md"], options)
+
+          File.exists?("public/new-place/index.html").should be_true
+          File.exists?("public/old-place/index.html").should be_false
+        end
+      end
+    end
+  end
+
+  describe "#run_rerender global templates hash" do
+    it "matches the initial build's folded hash when snapshot-escaping refs exist" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = "http://localhost"))
+          FileUtils.mkdir_p("content")
+          File.write("content/about.md", "---\ntitle: About\n---\nbody")
+          FileUtils.mkdir_p("templates")
+          # nav.j2 is shadowed by nav.html in the snapshot; the exact-ext
+          # include reads it from DISK — a snapshot-escaping ref that the
+          # initial build folds into the global templates hash.
+          File.write("templates/nav.html", "NAV-HTML")
+          File.write("templates/nav.j2", "NAV-J2")
+          File.write("templates/page.html", %({% include "nav.j2" %}|{{ content }}))
+
+          builder = Hwaro::Core::Build::Builder.new
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          builder.run(options).should be_true
+          initial_hash = builder.test_global_templates_hash
+          initial_hash.should_not be_empty
+
+          # Nothing changed on disk — a serve-triggered rerender must land
+          # on the SAME folded hash, or build --cache and serve disagree on
+          # every page's cache entry.
+          builder.run_rerender(options).should be_true
+          builder.test_global_templates_hash.should eq(initial_hash)
         end
       end
     end
@@ -185,6 +364,34 @@ describe Hwaro::Core::Build::Builder do
           builder.run_incremental_then_rerender(["content/about.md"], options)
 
           File.read("public/search.json").should contain("Refreshed")
+        end
+      end
+    end
+
+    it "deletes the orphaned sibling format file when front matter drops the format" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          File.write("config.toml", %(title = "T"\nbase_url = "http://localhost"))
+          FileUtils.mkdir_p("content")
+          File.write("content/about.md", "---\ntitle: About\noutputs: [json]\n---\nbody")
+          FileUtils.mkdir_p("templates")
+          File.write("templates/page.html", "<p>{{ content }}</p>")
+          File.write("templates/page.json.jinja", %({"v": 1}))
+
+          builder = Hwaro::Core::Build::Builder.new
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+          builder.run(options)
+          File.exists?("public/about/index.json").should be_true
+
+          # Content edit drops the format; template edit forces the
+          # combined content+template path (mirrors the watcher's
+          # :content_and_template strategy).
+          File.write("content/about.md", "---\ntitle: About\n---\nbody")
+          File.write("templates/page.html", "<div>{{ content }}</div>")
+          builder.run_incremental_then_rerender(["content/about.md"], options)
+
+          File.exists?("public/about/index.html").should be_true
+          File.exists?("public/about/index.json").should be_false
         end
       end
     end

--- a/spec/unit/builder_orchestration_spec.cr
+++ b/spec/unit/builder_orchestration_spec.cr
@@ -174,6 +174,80 @@ describe Hwaro::Core::Build::Builder do
         end
       end
     end
+
+    it "skips a symlink whose target resolves outside the project" do
+      Dir.mktmpdir do |outside_dir|
+        secret = File.join(outside_dir, "secret.txt")
+        File.write(secret, "SECRET")
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("static")
+            FileUtils.mkdir_p("public")
+            File.symlink(secret, "static/leak.txt")
+
+            builder = Hwaro::Core::Build::Builder.new
+            log = with_captured_log do
+              builder.copy_changed_static(["static/leak.txt"], "public")
+            end
+
+            File.exists?("public/leak.txt").should be_false
+            log.should contain("Skipping static symlink pointing outside the project")
+          end
+        end
+      end
+    end
+
+    it "copies a symlink that resolves within the project" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("static")
+          FileUtils.mkdir_p("public")
+          File.write("real.txt", "REAL")
+          File.symlink(File.join(Dir.current, "real.txt"), "static/ok.txt")
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.copy_changed_static(["static/ok.txt"], "public")
+
+          File.exists?("public/ok.txt").should be_true
+          File.read("public/ok.txt").should eq("REAL")
+        end
+      end
+    end
+
+    it "skips a dangling symlink without raising" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("static")
+          FileUtils.mkdir_p("public")
+          File.symlink(File.join(Dir.current, "missing.txt"), "static/gone.txt")
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.copy_changed_static(["static/gone.txt"], "public")
+          File.exists?("public/gone.txt").should be_false
+        end
+      end
+    end
+
+    it "refuses a destination that escapes the output directory" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("sub")
+          FileUtils.mkdir_p("public/out")
+          File.write("sub/evil.txt", "x")
+
+          builder = Hwaro::Core::Build::Builder.new
+          # Path outside static/ → relative becomes "../sub/evil.txt" via
+          # the lchop fallback → dest "public/out/../sub/evil.txt", which
+          # escapes the output dir and must be refused, not written.
+          log = with_captured_log do
+            builder.copy_changed_static(["sub/evil.txt"], "public/out")
+          end
+
+          File.exists?("public/sub/evil.txt").should be_false
+          log.should contain("outside output directory")
+        end
+      end
+    end
   end
 
   describe "#invalidate_caches_for_pages" do

--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -827,6 +827,9 @@ describe Hwaro::Core::Build::Builder do
     it "renders alert shortcode as block" do
       builder = Hwaro::Core::Build::Builder.new
       env = Crinja.new
+      # The builtin alert pipes `body` through markdownify (parity with the
+      # scaffold override), so the bare test env needs the HTML filters.
+      Hwaro::Content::Processors::Filters::HtmlFilters.register(env)
       templates = {} of String => String
       context = {} of String => Crinja::Value
 
@@ -840,6 +843,7 @@ describe Hwaro::Core::Build::Builder do
     it "renders callout shortcode as alias for alert" do
       builder = Hwaro::Core::Build::Builder.new
       env = Crinja.new
+      Hwaro::Content::Processors::Filters::HtmlFilters.register(env)
       templates = {} of String => String
       context = {} of String => Crinja::Value
 

--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -1043,6 +1043,73 @@ describe Hwaro::Core::Build::Builder do
       output.should contain("{% name(arg=\"v\") %}")
     end
 
+    # Regression: documented Hugo-migration examples live in fenced code
+    # blocks and inline code spans; scanning the raw source without fence
+    # awareness warned on every such page even though the fenced `{{<` never
+    # reaches Markdown as a live shortcode.
+    it "does not warn when {{< appears only inside a fenced code block" do
+      builder = Hwaro::Core::Build::Builder.new
+      io = IO::Memory.new
+      original_io = Hwaro::Logger.io
+      Hwaro::Logger.io = io
+      begin
+        raw = <<-MD
+          # Migrating from Hugo
+
+          Hugo used this syntax:
+
+          ```
+          {{< youtube id="abc" >}}
+          {{< alert type="info" >}}body{{< /alert >}}
+          ```
+
+          Done.
+          MD
+        builder.test_warn_hugo_shortcode_syntax(raw, "content/doc.md")
+      ensure
+        Hwaro::Logger.io = original_io
+      end
+      io.to_s.should be_empty
+    end
+
+    it "does not warn when {{< appears only inside inline code" do
+      builder = Hwaro::Core::Build::Builder.new
+      io = IO::Memory.new
+      original_io = Hwaro::Logger.io
+      Hwaro::Logger.io = io
+      begin
+        builder.test_warn_hugo_shortcode_syntax(
+          "Hugo's `{{< youtube id=\"abc\" >}}` form is not supported.",
+          "content/doc.md")
+      ensure
+        Hwaro::Logger.io = original_io
+      end
+      io.to_s.should be_empty
+    end
+
+    it "still warns for a real Hugo shortcode outside fences on a page that also has fenced examples" do
+      builder = Hwaro::Core::Build::Builder.new
+      io = IO::Memory.new
+      original_io = Hwaro::Logger.io
+      Hwaro::Logger.io = io
+      begin
+        raw = <<-MD
+          ```
+          {{< fencedname id="x" >}}
+          ```
+
+          {{< youtube id="abc" >}}
+          MD
+        builder.test_warn_hugo_shortcode_syntax(raw, "content/mixed.md")
+      ensure
+        Hwaro::Logger.io = original_io
+      end
+      output = io.to_s
+      output.should contain("Hugo-style shortcode syntax")
+      output.should contain("youtube")
+      output.should_not contain("fencedname")
+    end
+
     it "stays silent when content has no Hugo-style shortcodes" do
       builder = Hwaro::Core::Build::Builder.new
       io = IO::Memory.new

--- a/spec/unit/deadlink_language_routes_spec.cr
+++ b/spec/unit/deadlink_language_routes_spec.cr
@@ -64,13 +64,21 @@ describe "check-links language routes" do
       end
     end
 
-    it "rejects a hyphenated locale prefix the build cannot route" do
-      # `ReadContent::LANGUAGE_FILENAME_PATTERN` only matches 2-3 lowercase
-      # letters, so `about.pt-BR.md` is read as an ordinary page published at
-      # `/about.pt-BR/` — `/pt-BR/about/` 404s.
+    it "accepts a declared hyphenated locale prefix the build now routes" do
+      # The build matches language suffixes against DECLARED codes (not the
+      # old 2-3 lowercase alphabet), so `about.pt-BR.md` IS the translation
+      # published at `/pt-BR/about/`.
       Dir.mktmpdir do |dir|
         File.write(File.join(dir, "about.md"), "---\ntitle: A\n---\nen")
         File.write(File.join(dir, "about.pt-BR.md"), "---\ntitle: A pt\n---\npt")
+
+        dead_urls(dir, "/pt-BR/about/", ["pt-BR"]).should be_empty
+      end
+    end
+
+    it "still reports an untranslated page under a hyphenated locale prefix" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "about.md"), "---\ntitle: A\n---\nen")
 
         dead_urls(dir, "/pt-BR/about/", ["pt-BR"]).should eq(["/pt-BR/about/"])
       end

--- a/spec/unit/deadlink_regression_spec.cr
+++ b/spec/unit/deadlink_regression_spec.cr
@@ -105,6 +105,37 @@ describe "check-links regressions" do
     end
   end
 
+  # `.markdown` is a first-class page extension (read_content
+  # PAGE_EXTENSIONS), so the resolver must probe the same section-index and
+  # translated-source candidates it probes for `.md`.
+  describe ".markdown source resolution" do
+    it "resolves a section index backed by _index.markdown" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "guides"))
+        File.write(File.join(dir, "guides", "_index.markdown"), "---\ntitle: Guides\n---\n")
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+          file: File.join(dir, "index.md"), url: "/guides/", kind: :internal)
+
+        cmd.resolve_internal_for_test([link], dir, [] of String, "", [] of String).should be_empty
+      end
+    end
+
+    it "resolves a language-prefixed section index backed by _index.<code>.markdown" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "guides"))
+        File.write(File.join(dir, "guides", "_index.ko.markdown"), "---\ntitle: 안내\n---\n")
+
+        cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+        link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+          file: File.join(dir, "index.ko.md"), url: "/ko/guides/", kind: :internal)
+
+        cmd.resolve_internal_for_test([link], dir, [] of String, "", ["ko"]).should be_empty
+      end
+    end
+  end
+
   # Finding 6: PCRE2 raises ArgumentError on invalid UTF-8, which used to abort
   # the whole run with a bare "Error: Regex match error" and exit 1 — the same
   # code as "dead links found".

--- a/spec/unit/feeds_spec.cr
+++ b/spec/unit/feeds_spec.cr
@@ -509,9 +509,9 @@ describe Hwaro::Content::Seo::Feeds do
       Dir.mktmpdir do |output_dir|
         Hwaro::Content::Seo::Feeds.generate([ko_page], config, output_dir)
 
-        # Language feeds should still be generated even when main feed is disabled,
-        # because the multilingual block runs independently
-        File.exists?(File.join(output_dir, "ko", "rss.xml")).should be_true
+        # Global [feeds] enabled=false means no feeds at all: per-language
+        # generate_feed only opts OUT within a globally-enabled config.
+        File.exists?(File.join(output_dir, "ko", "rss.xml")).should be_false
       end
     end
 
@@ -2453,6 +2453,203 @@ describe Hwaro::Content::Seo::Feeds do
         Hwaro::Content::Seo::Feeds.generate([page], config, output_dir)
         feed = File.read(File.join(output_dir, "atom.xml"))
         feed.should contain("<updated>2026-03-05T00:00:00Z</updated>")
+      end
+    end
+
+    it "picks the feed-level <updated> from normalized entry times, not raw instants" do
+      # Regression (A19): the feed-level <updated> took max over raw
+      # instants BEFORE timezone re-anchoring. A date-only entry parsed as
+      # local midnight in +09:00 (raw instant 2026-03-04T15:00Z, normalized
+      # 2026-03-05T00:00Z) lost the raw max to a 2026-03-04T20:00Z entry,
+      # leaving the feed <updated> older than its newest entry <updated>.
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "atom"
+      config.feeds.filename = "atom.xml"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+
+      newest = Hwaro::Models::Page.new("posts/newest.md")
+      newest.title = "Newest"
+      newest.url = "/posts/newest/"
+      newest.render = true
+      newest.is_index = false
+      newest.raw_content = "body"
+      # Normalizes to 2026-03-05T00:00:00Z (raw instant 2026-03-04T15:00Z).
+      newest.date = Time.local(2026, 3, 5, 0, 0, 0, location: Time::Location.fixed(9 * 3600))
+
+      older = Hwaro::Models::Page.new("posts/older.md")
+      older.title = "Older"
+      older.url = "/posts/older/"
+      older.render = true
+      older.is_index = false
+      older.raw_content = "body"
+      # Raw instant is newer than newest's raw instant, but normalized older.
+      older.date = Time.utc(2026, 3, 4, 20, 0, 0)
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([newest, older], config, output_dir)
+        feed = File.read(File.join(output_dir, "atom.xml"))
+        feed_head = feed.split("<entry>").first
+        feed_head.should contain("<updated>2026-03-05T00:00:00Z</updated>")
+        feed_head.should_not contain("<updated>2026-03-04T20:00:00Z</updated>")
+      end
+    end
+  end
+
+  describe "section feed language filtering" do
+    it "filters the default-language section feed by default_language_only" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+      config.feeds.default_language_only = true
+
+      section = Hwaro::Models::Section.new("posts/_index.md")
+      section.title = "Posts"
+      section.url = "/posts/"
+      section.section = "posts"
+      section.render = true
+      section.generate_feeds = true
+
+      en_post = Hwaro::Models::Page.new("posts/hello.md")
+      en_post.title = "EN Post"
+      en_post.url = "/posts/hello/"
+      en_post.section = "posts"
+      en_post.render = true
+      en_post.raw_content = "English"
+
+      ko_post = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_post.title = "KO Post"
+      ko_post.url = "/ko/posts/hello/"
+      ko_post.section = "posts"
+      ko_post.language = "ko"
+      ko_post.render = true
+      ko_post.raw_content = "한국어"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([section.as(Hwaro::Models::Page), en_post, ko_post], config, output_dir)
+
+        feed = File.read(File.join(output_dir, "posts", "rss.xml"))
+        feed.should contain("EN Post")
+        feed.should_not contain("KO Post")
+      end
+    end
+
+    it "keeps all languages in the default-language section feed when default_language_only is false" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+      config.feeds.default_language_only = false
+
+      section = Hwaro::Models::Section.new("posts/_index.md")
+      section.title = "Posts"
+      section.url = "/posts/"
+      section.section = "posts"
+      section.render = true
+      section.generate_feeds = true
+
+      en_post = Hwaro::Models::Page.new("posts/hello.md")
+      en_post.title = "EN Post"
+      en_post.url = "/posts/hello/"
+      en_post.section = "posts"
+      en_post.render = true
+      en_post.raw_content = "English"
+
+      ko_post = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_post.title = "KO Post"
+      ko_post.url = "/ko/posts/hello/"
+      ko_post.section = "posts"
+      ko_post.language = "ko"
+      ko_post.render = true
+      ko_post.raw_content = "한국어"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([section.as(Hwaro::Models::Page), en_post, ko_post], config, output_dir)
+
+        feed = File.read(File.join(output_dir, "posts", "rss.xml"))
+        feed.should contain("EN Post")
+        feed.should contain("KO Post")
+      end
+    end
+
+    it "filters a non-default-language section feed to that language only" do
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+      ko_section = Hwaro::Models::Section.new("posts/_index.ko.md")
+      ko_section.title = "포스트"
+      ko_section.url = "/ko/posts/"
+      ko_section.section = "posts"
+      ko_section.language = "ko"
+      ko_section.render = true
+      ko_section.generate_feeds = true
+
+      en_post = Hwaro::Models::Page.new("posts/hello.md")
+      en_post.title = "EN Post"
+      en_post.url = "/posts/hello/"
+      en_post.section = "posts"
+      en_post.render = true
+      en_post.raw_content = "English"
+
+      ko_post = Hwaro::Models::Page.new("posts/hello.ko.md")
+      ko_post.title = "KO Post"
+      ko_post.url = "/ko/posts/hello/"
+      ko_post.section = "posts"
+      ko_post.language = "ko"
+      ko_post.render = true
+      ko_post.raw_content = "한국어"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([ko_section.as(Hwaro::Models::Page), en_post, ko_post], config, output_dir)
+
+        feed = File.read(File.join(output_dir, "ko", "posts", "rss.xml"))
+        feed.should contain("KO Post")
+        feed.should_not contain("EN Post")
+      end
+    end
+  end
+
+  describe "RSS content:encoded truncation" do
+    it "honors feeds.truncate in content:encoded when full_content is true" do
+      # Regression (A7): feeds.truncate is documented as "truncate content
+      # to N characters (0 = full content)" and the Atom generator honors it
+      # even under full_content=true; the RSS <content:encoded> emitted the
+      # full body regardless.
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.feeds.full_content = true
+      config.feeds.truncate = 10
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+
+      page = Hwaro::Models::Page.new("posts/long.md")
+      page.title = "Long Post"
+      page.url = "/posts/long/"
+      page.render = true
+      page.is_index = false
+      page.raw_content = "This is a very long body that must be truncated in the feed output."
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([page], config, output_dir)
+
+        feed = File.read(File.join(output_dir, "rss.xml"))
+        feed.should contain("<content:encoded><![CDATA[This is a ...]]></content:encoded>")
+        feed.should_not contain("truncated in the feed output")
       end
     end
   end

--- a/spec/unit/feeds_spec.cr
+++ b/spec/unit/feeds_spec.cr
@@ -2652,5 +2652,33 @@ describe Hwaro::Content::Seo::Feeds do
         feed.should_not contain("truncated in the feed output")
       end
     end
+
+    it "HTML-escapes the truncated plain text so a literal < survives feed readers" do
+      # With truncate > 0 the CDATA carries entity-DECODED plain text, but
+      # consumers parse <content:encoded> as HTML — a literal `<`/`&` breaks
+      # rendering. The truncated text must be re-escaped before embedding.
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.type = "rss"
+      config.feeds.filename = "rss.xml"
+      config.feeds.full_content = true
+      config.feeds.truncate = 10
+      config.base_url = "https://example.com"
+      config.title = "Test Site"
+
+      page = Hwaro::Models::Page.new("posts/code.md")
+      page.title = "Code Post"
+      page.url = "/posts/code/"
+      page.render = true
+      page.is_index = false
+      page.raw_content = "for n < 10 the loop keeps running and running"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Feeds.generate([page], config, output_dir)
+
+        feed = File.read(File.join(output_dir, "rss.xml"))
+        feed.should contain("<content:encoded><![CDATA[for n &lt; 10...]]></content:encoded>")
+      end
+    end
   end
 end

--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -1841,6 +1841,81 @@ describe Hwaro::Content::Processors::Markdown do
   end
 
   # ---------------------------------------------------------------------------
+  # Content that merely RESEMBLES front matter
+  #
+  # Regression (P2/P3): a document may legitimately open with a `---`
+  # thematic break or a `{`-leading construct (shortcode, Jinja tag,
+  # attribute list). Those must parse as body content — the old code
+  # truncated the first block (YAML shape) or aborted the whole build
+  # (JSON shape).
+  # ---------------------------------------------------------------------------
+  describe "content that merely resembles front matter" do
+    it "keeps the full body when the file opens with a --- thematic break (scalar YAML)" do
+      raw = "---\n\nFirst paragraph block.\n\n---\n\nSecond block.\n"
+
+      result = processor.parse(raw, "content/breaks.md")
+      result[:title].should eq("Untitled")
+      result[:content].should contain("First paragraph block.")
+      result[:content].should contain("Second block.")
+    end
+
+    it "treats a YAML sequence between --- fences as content, not front matter" do
+      raw = "---\n- alpha\n- beta\n---\nrest of the document\n"
+
+      result = processor.parse(raw, "content/list.md")
+      result[:title].should eq("Untitled")
+      result[:content].should contain("- alpha")
+      result[:content].should contain("rest of the document")
+    end
+
+    it "does not abort on an invalid-YAML first block that does not look like front matter" do
+      # `*emphasis*` reads as a YAML alias and fails to parse, but nothing in
+      # the block is a `key:` line — this is a document opening with a
+      # thematic break, not broken front matter.
+      raw = "---\n*emphasis* opening line\n---\nbody text\n"
+
+      result = processor.parse(raw, "content/em.md")
+      result[:title].should eq("Untitled")
+      result[:content].should contain("*emphasis* opening line")
+      result[:content].should contain("body text")
+    end
+
+    it "still strips empty front matter fences (--- immediately closed)" do
+      raw = "---\n---\nbody only\n"
+
+      result = processor.parse(raw, "content/empty.md")
+      result[:title].should eq("Untitled")
+      result[:content].should_not contain("---")
+      result[:content].should contain("body only")
+    end
+
+    it "treats a body starting with {{ shortcode }} as content, not JSON front matter" do
+      raw = "{{ youtube(id=\"abc\") }}\n\nMore body\n"
+
+      result = processor.parse(raw, "content/sc.md")
+      result[:title].should eq("Untitled")
+      result[:content].should contain("{{ youtube(id=\"abc\") }}")
+      result[:content].should contain("More body")
+    end
+
+    it "treats a body starting with a {% ... %} tag as content" do
+      raw = "{% alert(type=\"info\") %}hey{% end %}\n"
+
+      result = processor.parse(raw, "content/tag.md")
+      result[:title].should eq("Untitled")
+      result[:content].should contain("{% alert")
+    end
+
+    it "treats a body starting with a {:...} attribute list as content" do
+      raw = "{:.lead}\nA styled opening paragraph.\n"
+
+      result = processor.parse(raw, "content/attr.md")
+      result[:title].should eq("Untitled")
+      result[:content].should contain("{:.lead}")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # UTF-8 BOM
   #
   # Regression: the fences below are `\A`-anchored and the JSON test is a bare

--- a/spec/unit/frontmatter_parsing_spec.cr
+++ b/spec/unit/frontmatter_parsing_spec.cr
@@ -1889,6 +1889,28 @@ describe Hwaro::Content::Processors::Markdown do
       result[:content].should contain("body only")
     end
 
+    it "keeps a lone ~ block as body content (YAML null scalar is not empty front matter)" do
+      # `~` parses to YAML null, but the block TEXT is not empty — treating
+      # a null-parse as empty front matter silently dropped the `~` line.
+      raw = "---\n~\n---\nbody text\n"
+
+      result = processor.parse(raw, "content/tilde.md")
+      result[:title].should eq("Untitled")
+      result[:content].should contain("~")
+      result[:content].should contain("body text")
+    end
+
+    it "raises HWARO_E_CONTENT for invalid YAML front matter with a Unicode key" do
+      # The `key:` heuristic must recognize non-ASCII keys, otherwise broken
+      # front matter with a Korean key silently renders as body text.
+      raw = "---\n제목: [broken\n---\nbody\n"
+
+      err = expect_raises(Hwaro::HwaroError) do
+        processor.parse(raw, "content/ko.md")
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONTENT)
+    end
+
     it "treats a body starting with {{ shortcode }} as content, not JSON front matter" do
       raw = "{{ youtube(id=\"abc\") }}\n\nMore body\n"
 

--- a/spec/unit/html_minifier_spec.cr
+++ b/spec/unit/html_minifier_spec.cr
@@ -146,6 +146,39 @@ describe Hwaro::Utils::HtmlMinifier do
       end
     end
 
+    describe "inline replaced elements (A14)" do
+      # iframe/video/audio/canvas (and embed/object) default to
+      # display:inline — whitespace adjacent to them is a rendered
+      # space and must survive minification.
+      it "keeps a space between an inline closer and a video element" do
+        html = "<a>x</a>\n<video src=\"v.mp4\"></video>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<a>x</a> <video src=\"v.mp4\"></video>")
+      end
+
+      it "treats iframe, audio and canvas as inline" do
+        Hwaro::Utils::HtmlMinifier.minify("<span>see</span>\n<iframe src=\"x\"></iframe>")
+          .should eq("<span>see</span> <iframe src=\"x\"></iframe>")
+        Hwaro::Utils::HtmlMinifier.minify("<em>a</em>  <audio controls></audio>")
+          .should eq("<em>a</em> <audio controls></audio>")
+        Hwaro::Utils::HtmlMinifier.minify("<b>x</b>\n<canvas></canvas>")
+          .should eq("<b>x</b> <canvas></canvas>")
+      end
+
+      it "treats embed and object as inline" do
+        Hwaro::Utils::HtmlMinifier.minify("<em>a</em>\n<embed src=\"x\">")
+          .should eq("<em>a</em> <embed src=\"x\">")
+        Hwaro::Utils::HtmlMinifier.minify("<em>a</em>\n<object data=\"x\"></object>")
+          .should eq("<em>a</em> <object data=\"x\"></object>")
+      end
+
+      it "still strips whitespace between a block neighbour and a video element" do
+        html = "<div>\n  <video src=\"v.mp4\"></video>\n</div>"
+        result = Hwaro::Utils::HtmlMinifier.minify(html)
+        result.should eq("<div><video src=\"v.mp4\"></video></div>")
+      end
+    end
+
     describe "protected blocks (whitespace-sensitive elements)" do
       it "preserves content inside <pre><code> unchanged" do
         html = "<pre><code>  line1\n    line2\n  line3</code></pre>"

--- a/spec/unit/image_hooks_spec.cr
+++ b/spec/unit/image_hooks_spec.cr
@@ -428,5 +428,65 @@ describe Hwaro::Content::Hooks::ImageHooks do
           .should be_nil
       end
     end
+
+    # A11: the source width used to be inferred from the LARGEST on-disk
+    # variant, so adding a bigger width to [image_processing] widths was
+    # silently "satisfied" by clamping to the old largest variant — the new
+    # variant never got generated on warm builds. The true source width now
+    # comes from the image file itself.
+    it "does not reuse when the config gains a width the true source can satisfy (A11)" do
+      Dir.mktmpdir do |dir|
+        source = File.join(dir, "photo.png")
+        pixels = Array(UInt8).new(1200 * 8 * 3, 128_u8)
+        LibStb.stbi_write_png(source, 1200, 8, 3, pixels.to_unsafe.as(Void*), 1200 * 3)
+
+        dest_dir = File.join(dir, "out")
+        Dir.mkdir_p(dest_dir)
+        # Only the old config's [320] variant exists. The source is 1200px
+        # wide, so a newly configured 1024 variant is NOT a clamp — the set
+        # must be reprocessed.
+        File.write(File.join(dest_dir, "photo_320w.png"), "320")
+
+        Hwaro::Content::Hooks::ImageHooks
+          .reusable_widths(source, dest_dir, [320, 1024])
+          .should be_nil
+      end
+    end
+
+    it "still reuses when the on-disk variants cover the config for the true source width (A11)" do
+      Dir.mktmpdir do |dir|
+        source = File.join(dir, "photo.png")
+        pixels = Array(UInt8).new(1200 * 8 * 3, 128_u8)
+        LibStb.stbi_write_png(source, 1200, 8, 3, pixels.to_unsafe.as(Void*), 1200 * 3)
+
+        dest_dir = File.join(dir, "out")
+        Dir.mkdir_p(dest_dir)
+        File.write(File.join(dest_dir, "photo_320w.png"), "320")
+        File.write(File.join(dest_dir, "photo_1024w.png"), "1024")
+
+        result = Hwaro::Content::Hooks::ImageHooks.reusable_widths(source, dest_dir, [320, 1024])
+        result.should_not be_nil
+        result.not_nil!.should eq({320 => "photo_320w.png", 1024 => "photo_1024w.png"})
+      end
+    end
+
+    it "reuses the clamped variant when a configured width exceeds the TRUE source width (A11)" do
+      Dir.mktmpdir do |dir|
+        source = File.join(dir, "photo.png")
+        pixels = Array(UInt8).new(640 * 8 * 3, 128_u8)
+        LibStb.stbi_write_png(source, 640, 8, 3, pixels.to_unsafe.as(Void*), 640 * 3)
+
+        dest_dir = File.join(dir, "out")
+        Dir.mkdir_p(dest_dir)
+        # 1280 clamps to the 640px source, so the on-disk {320, 640} set is
+        # exactly what the current config produces → reuse.
+        File.write(File.join(dest_dir, "photo_320w.png"), "320")
+        File.write(File.join(dest_dir, "photo_640w.png"), "640")
+
+        result = Hwaro::Content::Hooks::ImageHooks.reusable_widths(source, dest_dir, [320, 1280])
+        result.should_not be_nil
+        result.not_nil!.should eq({320 => "photo_320w.png", 640 => "photo_640w.png"})
+      end
+    end
   end
 end

--- a/spec/unit/js_minifier_spec.cr
+++ b/spec/unit/js_minifier_spec.cr
@@ -604,6 +604,32 @@ describe Hwaro::Utils::JsMinifier do
       result.should contain("(a + b) / c")
     end
 
+    # =========================================================================
+    # Block-comment removal must leave a token separator (A1)
+    # =========================================================================
+    it "keeps tokens separated when a block comment sits between them" do
+      result = Hwaro::Utils::JsMinifier.minify("return/*x*/g(1)")
+      result.should eq("return g(1)")
+    end
+
+    it "keeps the function keyword separated from its name across a block comment" do
+      result = Hwaro::Utils::JsMinifier.minify("function/*c*/name(){}")
+      result.should eq("function name(){}")
+    end
+
+    it "emits a newline for a block comment containing a line terminator (ASI)" do
+      # A multi-line comment counts as a LineTerminator for automatic
+      # semicolon insertion, so `return /*\n*/ 42` must stay `return` and
+      # `42` on separate lines — collapsing to one line changes semantics.
+      result = Hwaro::Utils::JsMinifier.minify("return /*\n*/ 42")
+      result.should eq("return\n 42")
+    end
+
+    it "handles terser-style pure annotations without fusing tokens" do
+      result = Hwaro::Utils::JsMinifier.minify("return/*#__PURE__*/e(t)")
+      result.should eq("return e(t)")
+    end
+
     it "leaves a counterfeit out-of-range JSPL placeholder token intact" do
       # A real template literal makes protected_spans non-empty so the restore
       # gsub actually runs; the bogus \x00JSPL999\x00 token has an out-of-range

--- a/spec/unit/json_xml_processors_spec.cr
+++ b/spec/unit/json_xml_processors_spec.cr
@@ -338,6 +338,30 @@ describe Hwaro::Content::Processors::Xml do
       result.content.should contain("<![CDATA[ keep   these    spaces\n  and newline ]]>")
     end
 
+    it "does not collapse cross-line whitespace between tag-like text inside CDATA (A15)" do
+      # The `>\s*\n\s*<` collapse is for markup between tags; inside CDATA
+      # those bytes are character data and must survive byte-exact.
+      processor = Hwaro::Content::Processors::Xml.new
+      context = Hwaro::Content::Processors::ProcessorContext.new
+
+      input = "<root><d><![CDATA[</a>\n<em>]]></d></root>"
+      result = processor.process(input, context)
+      result.error.should be_nil
+      result.content.should contain("<![CDATA[</a>\n<em>]]>")
+    end
+
+    it "preserves a CDATA section byte-exact while still minifying surrounding markup" do
+      processor = Hwaro::Content::Processors::Xml.new
+      context = Hwaro::Content::Processors::ProcessorContext.new
+
+      input = "<root>\n  <d><![CDATA[pre >\n< post]]></d>\n</root>"
+      result = processor.process(input, context)
+      result.error.should be_nil
+      result.content.should contain("<![CDATA[pre >\n< post]]>")
+      result.content.should contain("<root><d>")
+      result.content.should contain("</d></root>")
+    end
+
     it "preserves whitespace and newlines inside an XML comment" do
       processor = Hwaro::Content::Processors::Xml.new
       context = Hwaro::Content::Processors::ProcessorContext.new

--- a/spec/unit/lifecycle_hooks_spec.cr
+++ b/spec/unit/lifecycle_hooks_spec.cr
@@ -281,7 +281,7 @@ describe Hwaro::Core::Lifecycle::Manager do
       result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
     end
 
-    it "stops on Skip result" do
+    it "skips remaining hooks at the point on Skip without failing the sequence" do
       manager = Hwaro::Core::Lifecycle::Manager.new
       second_called = false
 
@@ -297,7 +297,30 @@ describe Hwaro::Core::Lifecycle::Manager do
       ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
       result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeRender, ctx)
 
-      result.should eq(Hwaro::Core::Lifecycle::HookResult::Skip)
+      # Skip is scoped to the CURRENT hook point (per HookResult's doc):
+      # the second hook must not run, but phase sequencing continues — so
+      # trigger reports Continue rather than a phase-terminating result.
+      result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+      second_called.should be_false
+    end
+
+    it "still propagates Abort from a hook" do
+      manager = Hwaro::Core::Lifecycle::Manager.new
+      second_called = false
+
+      manager.on(Hwaro::Core::Lifecycle::HookPoint::BeforeRender, priority: 10, name: "aborter") do |_ctx|
+        Hwaro::Core::Lifecycle::HookResult::Abort
+      end
+      manager.on(Hwaro::Core::Lifecycle::HookPoint::BeforeRender, priority: 0, name: "second") do |_ctx|
+        second_called = true
+        Hwaro::Core::Lifecycle::HookResult::Continue
+      end
+
+      options = Hwaro::Config::Options::BuildOptions.new
+      ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+      result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeRender, ctx)
+
+      result.should eq(Hwaro::Core::Lifecycle::HookResult::Abort)
       second_called.should be_false
     end
   end

--- a/spec/unit/lifecycle_manager_spec.cr
+++ b/spec/unit/lifecycle_manager_spec.cr
@@ -63,7 +63,7 @@ describe Hwaro::Core::Lifecycle::Manager do
       end
 
       result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeInitialize, ctx)
-      result.should eq(Hwaro::Core::Lifecycle::HookResult::Skip)
+      result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
       second_ran.should be_false
     end
   end
@@ -182,7 +182,7 @@ describe Hwaro::Core::Lifecycle::Manager do
       order.should eq(["before", "action", "after"])
     end
 
-    it "skips action when before hook returns Skip" do
+    it "runs the action when a before hook returns Skip (only remaining hooks are skipped)" do
       manager = Hwaro::Core::Lifecycle::Manager.new
       ctx = Hwaro::Core::Lifecycle::BuildContext.new(Hwaro::Config::Options::BuildOptions.new)
       action_ran = false
@@ -195,8 +195,8 @@ describe Hwaro::Core::Lifecycle::Manager do
         action_ran = true
       end
 
-      result.should eq(Hwaro::Core::Lifecycle::HookResult::Skip)
-      action_ran.should be_false
+      result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
+      action_ran.should be_true
     end
 
     it "skips action and after hooks when before hook returns Abort" do

--- a/spec/unit/llms_spec.cr
+++ b/spec/unit/llms_spec.cr
@@ -358,6 +358,89 @@ describe Hwaro::Content::Seo::Llms do
         File.exists?(File.join(output_dir, "llms-full.txt")).should be_true
       end
     end
+
+    it "lists only the path-sort-first collision winner in llms.txt and llms-full.txt" do
+      # Regression (A18): on a URL collision the render phase writes the
+      # page whose source path sorts FIRST; llms.txt listed both pages and
+      # llms-full.txt dumped the unwritten loser's content too.
+      config = Hwaro::Models::Config.new
+      config.llms.enabled = true
+      config.llms.full_enabled = true
+      config.title = "Test Site"
+      config.base_url = "https://example.com"
+
+      winner = Hwaro::Models::Page.new("posts/a.md")
+      winner.title = "Winner Page"
+      winner.url = "/posts/same/"
+      winner.section = "posts"
+      winner.render = true
+      winner.raw_content = "winner body"
+
+      loser = Hwaro::Models::Page.new("posts/z.md")
+      loser.title = "Loser Page"
+      loser.url = "/posts/same/"
+      loser.section = "posts"
+      loser.render = true
+      loser.raw_content = "loser body"
+
+      Dir.mktmpdir do |output_dir|
+        Hwaro::Content::Seo::Llms.generate(config, [winner, loser], output_dir)
+
+        index = File.read(File.join(output_dir, "llms.txt"))
+        index.should contain("Winner Page")
+        index.should_not contain("Loser Page")
+
+        full = File.read(File.join(output_dir, "llms-full.txt"))
+        full.should contain("winner body")
+        full.should_not contain("loser body")
+      end
+    end
+
+    it "regenerates when skip_if_unchanged finds llms.txt but llms-full.txt is missing" do
+      # Regression (A18): the warm-build skip probe only checked llms.txt,
+      # so a missing llms-full.txt was never re-emitted on warm builds.
+      config = Hwaro::Models::Config.new
+      config.llms.enabled = true
+      config.llms.full_enabled = true
+      config.title = "Test Site"
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.title = "Test"
+      page.url = "/test/"
+      page.render = true
+      page.raw_content = "Content"
+
+      Dir.mktmpdir do |output_dir|
+        File.write(File.join(output_dir, "llms.txt"), "stale")
+
+        Hwaro::Content::Seo::Llms.generate(config, [page], output_dir, skip_if_unchanged: true)
+
+        File.exists?(File.join(output_dir, "llms-full.txt")).should be_true
+      end
+    end
+
+    it "still skips on warm builds when both llms outputs exist" do
+      config = Hwaro::Models::Config.new
+      config.llms.enabled = true
+      config.llms.full_enabled = true
+      config.title = "Test Site"
+
+      page = Hwaro::Models::Page.new("test.md")
+      page.title = "Test"
+      page.url = "/test/"
+      page.render = true
+      page.raw_content = "Content"
+
+      Dir.mktmpdir do |output_dir|
+        File.write(File.join(output_dir, "llms.txt"), "sentinel-index")
+        File.write(File.join(output_dir, "llms-full.txt"), "sentinel-full")
+
+        Hwaro::Content::Seo::Llms.generate(config, [page], output_dir, skip_if_unchanged: true)
+
+        File.read(File.join(output_dir, "llms.txt")).should eq("sentinel-index")
+        File.read(File.join(output_dir, "llms-full.txt")).should eq("sentinel-full")
+      end
+    end
   end
 
   describe ".generate_full" do

--- a/spec/unit/multilingual_spec.cr
+++ b/spec/unit/multilingual_spec.cr
@@ -24,6 +24,27 @@ describe Hwaro::Content::Multilingual do
     ko.translations.map(&.url).should eq(["/about/", "/ko/about/"])
   end
 
+  it "links translation variants on .markdown pages" do
+    config = Hwaro::Models::Config.new
+    config.default_language = "en"
+    config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+
+    en = Hwaro::Models::Page.new("about.markdown")
+    en.title = "About"
+    en.url = "/about/"
+
+    ko = Hwaro::Models::Page.new("about.ko.markdown")
+    ko.title = "소개"
+    ko.url = "/ko/about/"
+    ko.language = "ko"
+
+    Hwaro::Content::Multilingual.link_translations!([en, ko], config)
+
+    en.translations.map(&.code).should eq(["en", "ko"])
+    ko.translations.map(&.code).should eq(["en", "ko"])
+    ko.translations.map(&.url).should eq(["/about/", "/ko/about/"])
+  end
+
   # Regression for https://github.com/hahwul/hwaro/issues/486
   # `link_translations!` used to populate `page.translations` with a
   # single self-entry for pages that have no actual cross-language

--- a/spec/unit/phases_parse_content_spec.cr
+++ b/spec/unit/phases_parse_content_spec.cr
@@ -124,14 +124,17 @@ describe Hwaro::Core::Build::Phases::ParseContent do
       end
     end
 
-    it "is a no-op when the source file is missing" do
+    it "marks the page parse-failed when the source file is missing" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do
           builder = Hwaro::Core::Build::Builder.new
           builder.test_set_parse_config(Hwaro::Models::Config.new)
           page = Hwaro::Models::Page.new("missing.md")
-          # Should not raise
+          # Should not raise — but must NOT pass silently either: a ghost
+          # page with url "" resolves to <output>/index.html and clobbers
+          # the homepage nondeterministically under parallel render.
           builder.test_parse_single_page(page)
+          page.parse_failed.should be_true
           page.title.should eq("Untitled")
         end
       end
@@ -153,8 +156,9 @@ describe Hwaro::Core::Build::Phases::ParseContent do
         builder.test_parse_content_sequential([good, missing])
         good.title.should eq("Good")
         good.parse_failed.should be_false
-        # Missing file is silently skipped (parse_single_page returns early)
-        missing.parse_failed.should be_false
+        # A missing file (dangling symlink, deleted mid-rebuild) is a parse
+        # failure — the page must be filtered out, not become a ghost page.
+        missing.parse_failed.should be_true
       end
     end
 
@@ -279,6 +283,27 @@ describe Hwaro::Core::Build::Phases::ParseContent do
 
         builder.test_parse_content_default(ctx)
         ctx.pages.map(&.title).sort!.should eq(["Now"])
+      end
+    end
+
+    it "warns about sections expiring soon, not only pages" do
+      soon = (Time.utc + 3.days).to_s("%Y-%m-%dT%H:%M:%SZ")
+      with_content_dir({
+        "notice/_index.md" => %(---\ntitle: Notice\nexpires: "#{soon}"\n---\nbody),
+      }) do
+        builder = Hwaro::Core::Build::Builder.new
+        builder.test_set_parse_config(Hwaro::Models::Config.new)
+
+        options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false)
+        ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+        ctx.config = Hwaro::Models::Config.new
+        ctx.sections = [Hwaro::Models::Section.new("notice/_index.md")]
+
+        log = with_captured_log do
+          builder.test_parse_content_default(ctx)
+        end
+        log.should contain("expires on")
+        log.should contain("notice/_index.md")
       end
     end
 

--- a/spec/unit/phases_read_content_spec.cr
+++ b/spec/unit/phases_read_content_spec.cr
@@ -70,6 +70,26 @@ describe Hwaro::Core::Build::Phases::ReadContent do
       config.languages["ko"] = Hwaro::Models::LanguageConfig.new(code: "ko")
       builder.test_extract_language_from_filename("about.md", config).should be_nil
     end
+
+    it "matches declared language keys outside the 2-3 lowercase alphabet (zh-tw)" do
+      # Language suffixes are matched against DECLARED codes, not a fixed
+      # [a-z]{2,3} pattern — a declared `zh-tw` must produce a translation
+      # instead of a regular page published at /about.zh-tw/.
+      builder = Hwaro::Core::Build::Builder.new
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      config.languages["zh-tw"] = Hwaro::Models::LanguageConfig.new(code: "zh-tw")
+      builder.test_extract_language_from_filename("about.zh-tw.md", config).should eq("zh-tw")
+      builder.test_extract_language_from_filename("_index.zh-tw.md", config).should eq("zh-tw")
+    end
+
+    it "keeps an undeclared long suffix as no language (regular page)" do
+      builder = Hwaro::Core::Build::Builder.new
+      config = Hwaro::Models::Config.new
+      config.default_language = "en"
+      config.languages["ko"] = Hwaro::Models::LanguageConfig.new(code: "ko")
+      builder.test_extract_language_from_filename("about.zh-tw.md", config).should be_nil
+    end
   end
 
   describe "#collect_content_paths" do
@@ -155,6 +175,68 @@ describe Hwaro::Core::Build::Phases::ReadContent do
           builder.test_collect_content_paths(ctx)
           page = ctx.pages.first
           page.language.should eq("ko")
+        end
+      end
+    end
+
+    it "collects .markdown files as pages, sections, and bundles" do
+      # The markdown processor declares [".md", ".markdown"]; read_content
+      # must agree, or `.markdown` sources silently vanish from the build.
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/blog")
+          FileUtils.mkdir_p("content/bundle")
+          File.write("content/notes.markdown", "---\ntitle: Notes\n---\nbody")
+          File.write("content/blog/_index.markdown", "---\ntitle: Blog\n---\n")
+          File.write("content/bundle/index.markdown", "---\ntitle: B\n---\nbody")
+
+          builder = Hwaro::Core::Build::Builder.new
+          ctx = make_ctx(Hwaro::Models::Config.new)
+          builder.test_collect_content_paths(ctx)
+
+          ctx.pages.map(&.path).sort!.should eq(["bundle/index.markdown", "notes.markdown"])
+          ctx.sections.map(&.path).should eq(["blog/_index.markdown"])
+          ctx.sections.first.is_index.should be_true
+          ctx.pages.find! { |p| p.path == "bundle/index.markdown" }.is_index.should be_true
+          ctx.pages.find! { |p| p.path == "notes.markdown" }.is_index.should be_false
+          # .markdown sources are pages, never raw files
+          ctx.raw_files.should be_empty
+        end
+      end
+    end
+
+    it "strips the language suffix from .markdown files too" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          File.write("content/about.ko.markdown", "---\ntitle: 소개\n---\n")
+
+          builder = Hwaro::Core::Build::Builder.new
+          config = Hwaro::Models::Config.new
+          config.default_language = "en"
+          config.languages["ko"] = Hwaro::Models::LanguageConfig.new(code: "ko")
+          ctx = make_ctx(config)
+
+          builder.test_collect_content_paths(ctx)
+          ctx.pages.first.language.should eq("ko")
+        end
+      end
+    end
+
+    it "routes a declared hyphenated language code (zh-tw) as a translation" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          File.write("content/about.zh-tw.md", "---\ntitle: TW\n---\n")
+
+          builder = Hwaro::Core::Build::Builder.new
+          config = Hwaro::Models::Config.new
+          config.default_language = "en"
+          config.languages["zh-tw"] = Hwaro::Models::LanguageConfig.new(code: "zh-tw")
+          ctx = make_ctx(config)
+
+          builder.test_collect_content_paths(ctx)
+          ctx.pages.first.language.should eq("zh-tw")
         end
       end
     end

--- a/spec/unit/phases_render_spec.cr
+++ b/spec/unit/phases_render_spec.cr
@@ -388,6 +388,54 @@ describe Hwaro::Core::Build::Phases::Render do
       posts_val["pages"].raw.as(Array).size.should eq(2)
     end
 
+    # Regression: the fallback for a section without `sort_by` must be "date"
+    # (newest first) — the same default the paginator (paginator.cr), the
+    # prev/next navigation (transform.cr), and the docs promise. It used to
+    # be "title", so `get_section(...).pages` and `section.pages` on member
+    # pages disagreed with the section template's own listing order.
+    it "defaults section page order to date (newest first) when sort_by is unset" do
+      config = Hwaro::Models::Config.new
+      config.base_url = "http://example.com"
+      site = Hwaro::Models::Site.new(config)
+
+      posts = Hwaro::Models::Section.new("posts/_index.md")
+      posts.title = "Posts"
+      posts.section = "posts"
+      posts.url = "/posts/"
+      posts.language = "en"
+      # No sort_by / reverse set — exercise the default.
+
+      # Title order (Alpha, Zulu) is the REVERSE of date order (Zulu is
+      # newer) so the title fallback and the date default can't coincide.
+      older = Hwaro::Models::Page.new("posts/older.md")
+      older.title = "Alpha"
+      older.section = "posts"
+      older.url = "/posts/older/"
+      older.language = "en"
+      older.date = Time.utc(2024, 1, 1)
+
+      newer = Hwaro::Models::Page.new("posts/newer.md")
+      newer.title = "Zulu"
+      newer.section = "posts"
+      newer.url = "/posts/newer/"
+      newer.language = "en"
+      newer.date = Time.utc(2024, 12, 1)
+
+      site.sections << posts
+      site.pages << older << newer
+      site.build_lookup_index
+
+      builder = Hwaro::Core::Build::Builder.new
+      vars = builder.test_build_global_vars(site)
+      sections_by_key = vars["__sections_by_key__"].raw.as(Hash)
+      posts_val = sections_by_key["posts"].raw.as(Hash)
+
+      titles = posts_val["pages"].raw.as(Array).map do |v|
+        v.raw.as(Hash)["title"].to_s
+      end
+      titles.should eq(["Zulu", "Alpha"])
+    end
+
     it "exposes subsections so {{ section.subsections }} works inside get_section()" do
       config = Hwaro::Models::Config.new
       config.base_url = "http://example.com"

--- a/spec/unit/phases_transform_spec.cr
+++ b/spec/unit/phases_transform_spec.cr
@@ -368,6 +368,35 @@ describe Hwaro::Core::Build::Phases::Transform do
       site.taxonomies["tags"]["crystal"].size.should eq(1)
     end
 
+    it "skips empty and whitespace-only terms like the taxonomy generator" do
+      # Content::Taxonomies.build_taxonomy_index guards `term.strip.empty?`;
+      # the render-phase map must match, or get_taxonomy exposes a "" term
+      # whose get_taxonomy_url link 404s (no term page is ever written).
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      page = make_page("p.md")
+      page.taxonomies = {"tags" => ["", "  ", "real"]}
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_rebuild_taxonomies(site, [page])
+
+      site.taxonomies["tags"].keys.should eq(["real"])
+    end
+
+    it "skips empty terms in the incremental update path too" do
+      site = Hwaro::Models::Site.new(Hwaro::Models::Config.new)
+      page = make_page("p.md")
+      page.taxonomies = {"tags" => ["real"]}
+
+      builder = Hwaro::Core::Build::Builder.new
+      builder.test_rebuild_taxonomies(site, [page])
+
+      snapshot = {"p.md" => {"tags" => ["real"]}}
+      page.taxonomies = {"tags" => ["", "real"]}
+      builder.test_update_taxonomies_incremental(site, [page], snapshot)
+
+      site.taxonomies["tags"].keys.should eq(["real"])
+    end
+
     it "populates taxonomies via the context-aware variant" do
       options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
       ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
@@ -596,6 +625,43 @@ describe Hwaro::Core::Build::Phases::Transform do
           builder.test_collect_assets(ctx)
 
           page.assets.any?(&.ends_with?("cover.png")).should be_true
+        end
+      end
+    end
+
+    it "does not re-collect a translated-only bundle's assets into the ancestor section" do
+      # `photos/` holds only `index.ko.md` — a bundle by ReadContent's
+      # language-stripped rule. A literal index.md/_index.md probe misses
+      # it, so the ancestor section re-published `pic.jpg` under its own
+      # URL alongside the bundle's copy.
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content/gallery/photos")
+          File.write("content/gallery/_index.md", "---\ntitle: G\n---\n")
+          File.write("content/gallery/photos/index.ko.md", "---\ntitle: P\n---\nbody")
+          File.write("content/gallery/photos/pic.jpg", "jpg")
+
+          config = Hwaro::Models::Config.new
+          config.default_language = "en"
+          config.languages["ko"] = Hwaro::Models::LanguageConfig.new(code: "ko")
+
+          options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+          ctx = Hwaro::Core::Lifecycle::BuildContext.new(options)
+          ctx.config = config
+
+          section = make_section("gallery/_index.md", "gallery")
+          section.is_index = true
+          bundle = make_page("gallery/photos/index.ko.md", "gallery")
+          bundle.is_index = true
+          bundle.language = "ko"
+          ctx.sections = [section]
+          ctx.pages = [bundle]
+
+          builder = Hwaro::Core::Build::Builder.new
+          builder.test_collect_assets(ctx)
+
+          bundle.assets.should contain("gallery/photos/pic.jpg")
+          section.assets.should_not contain("gallery/photos/pic.jpg")
         end
       end
     end

--- a/spec/unit/phases_write_spec.cr
+++ b/spec/unit/phases_write_spec.cr
@@ -111,6 +111,48 @@ describe Hwaro::Core::Build::Phases::Write do
       end
     end
 
+    it "skips a raw-file symlink pointing outside the project" do
+      # Mirrors the bundle-asset guard in process_assets: FileUtils.cp
+      # follows symlinks, so a `content/leak.json -> /outside/secret.json`
+      # link would publish a file from outside the site.
+      Dir.mktmpdir do |dir|
+        outside = File.join(dir, "outside.json")
+        File.write(outside, %({"secret": true}))
+        project = File.join(dir, "proj")
+        FileUtils.mkdir_p(File.join(project, "content"))
+        FileUtils.mkdir_p(File.join(project, "public"))
+        Dir.cd(project) do
+          File.symlink(outside, "content/leak.json")
+          raw = Hwaro::Core::Lifecycle::RawFile.new("content/leak.json", "leak.json")
+          builder = Hwaro::Core::Build::Builder.new
+
+          log = with_captured_log do
+            builder.test_process_raw_files([raw], "public", false, false).should eq(0)
+          end
+
+          File.exists?("public/leak.json").should be_false
+          log.should contain("symlink")
+        end
+      end
+    end
+
+    it "still copies an in-project raw-file symlink" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          FileUtils.mkdir_p("public")
+          File.write("content/real.json", "{}")
+          File.symlink(File.expand_path("content/real.json"), "content/link.json")
+
+          raw = Hwaro::Core::Lifecycle::RawFile.new("content/link.json", "link.json")
+          builder = Hwaro::Core::Build::Builder.new
+
+          builder.test_process_raw_files([raw], "public", false, false).should eq(1)
+          File.exists?("public/link.json").should be_true
+        end
+      end
+    end
+
     it "returns zero when no raw files are provided" do
       Dir.mktmpdir do |dir|
         Dir.cd(dir) do

--- a/spec/unit/platform_config_spec.cr
+++ b/spec/unit/platform_config_spec.cr
@@ -201,6 +201,25 @@ describe Hwaro::Services::PlatformConfig do
         end
       end
 
+      it "routes aliases for declared hyphenated language codes (zh-tw)" do
+        # Mirror of the build's declared-code suffix matching: a declared
+        # `zh-tw` produces `/zh-tw/…` URLs, so the redirect target must too.
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            FileUtils.mkdir_p("content/posts")
+            File.write("content/posts/hello.zh-tw.md", "---\ntitle: Hello TW\naliases:\n  - /old-tw-url/\n---\nContent here\n")
+
+            config = Hwaro::Models::Config.new
+            config.languages["zh-tw"] = Hwaro::Models::LanguageConfig.new("zh-tw")
+            generator = Hwaro::Services::PlatformConfig.new(config)
+            result = generator.generate("netlify")
+
+            result.should contain("from = \"/old-tw-url/\"")
+            result.should contain("to = \"/zh-tw/posts/hello/\"")
+          end
+        end
+      end
+
       it "includes redirects in vercel JSON format" do
         Dir.mktmpdir do |dir|
           Dir.cd(dir) do

--- a/spec/unit/pwa_hooks_spec.cr
+++ b/spec/unit/pwa_hooks_spec.cr
@@ -7,12 +7,12 @@ require "../../src/config/options/build_options"
 
 describe Hwaro::Content::Hooks::PwaHooks do
   describe "#register_hooks" do
-    it "registers a BeforeGenerate hook" do
+    it "registers an AfterWrite hook" do
       manager = Hwaro::Core::Lifecycle::Manager.new
       hooks = Hwaro::Content::Hooks::PwaHooks.new
       hooks.register_hooks(manager)
 
-      manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate).should be_true
+      manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::AfterWrite).should be_true
     end
 
     it "registers hook named pwa:generate" do
@@ -20,7 +20,7 @@ describe Hwaro::Content::Hooks::PwaHooks do
       hooks = Hwaro::Content::Hooks::PwaHooks.new
       hooks.register_hooks(manager)
 
-      registered = manager.hooks_at(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate)
+      registered = manager.hooks_at(Hwaro::Core::Lifecycle::HookPoint::AfterWrite)
       registered.any? { |h| h.name == "pwa:generate" }.should be_true
     end
 
@@ -29,7 +29,7 @@ describe Hwaro::Content::Hooks::PwaHooks do
       hooks = Hwaro::Content::Hooks::PwaHooks.new
       hooks.register_hooks(manager)
 
-      registered = manager.hooks_at(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate)
+      registered = manager.hooks_at(Hwaro::Core::Lifecycle::HookPoint::AfterWrite)
       hook = registered.find { |h| h.name == "pwa:generate" }
       hook.should_not be_nil
       hook.not_nil!.priority.should eq(50)
@@ -42,6 +42,7 @@ describe Hwaro::Content::Hooks::PwaHooks do
 
       manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::AfterRender).should be_false
       manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::BeforeRender).should be_false
+      manager.has_hooks?(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate).should be_false
     end
   end
 
@@ -57,7 +58,7 @@ describe Hwaro::Content::Hooks::PwaHooks do
         hooks = Hwaro::Content::Hooks::PwaHooks.new
         hooks.register_hooks(manager)
 
-        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate, ctx)
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::AfterWrite, ctx)
         result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
       end
     end
@@ -80,7 +81,7 @@ describe Hwaro::Content::Hooks::PwaHooks do
         hooks = Hwaro::Content::Hooks::PwaHooks.new
         hooks.register_hooks(manager)
 
-        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate, ctx)
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::AfterWrite, ctx)
         result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
 
         # PWA manifest should be generated
@@ -104,7 +105,7 @@ describe Hwaro::Content::Hooks::PwaHooks do
         hooks = Hwaro::Content::Hooks::PwaHooks.new
         hooks.register_hooks(manager)
 
-        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::BeforeGenerate, ctx)
+        result = manager.trigger(Hwaro::Core::Lifecycle::HookPoint::AfterWrite, ctx)
         result.should eq(Hwaro::Core::Lifecycle::HookResult::Continue)
 
         # PWA manifest should NOT be generated when disabled

--- a/spec/unit/pwa_spec.cr
+++ b/spec/unit/pwa_spec.cr
@@ -304,6 +304,29 @@ describe Hwaro::Content::Seo::Pwa do
       end
     end
 
+    it "excludes /sw.js from its own precache list and converges across builds" do
+      Dir.mktmpdir do |dir|
+        site = make_site(<<-TOML)
+          [pwa]
+          enabled = true
+          precache_urls = ["/sw.js", "/index.html"]
+          TOML
+
+        File.write(File.join(dir, "index.html"), "<html>home</html>")
+
+        # First (clean) build: sw.js doesn't exist yet. Second build: it
+        # does — without the exclusion it would hash its own previous
+        # bytes and churn CACHE_NAME forever.
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+        first = File.read(File.join(dir, "sw.js"))
+        Hwaro::Content::Seo::Pwa.generate(site, dir)
+        second = File.read(File.join(dir, "sw.js"))
+
+        first.should_not contain(%("/sw.js"))
+        second.should eq(first)
+      end
+    end
+
     it "generates sw.js" do
       Dir.mktmpdir do |dir|
         site = make_site(<<-TOML)

--- a/spec/unit/server_dev_fixes_spec.cr
+++ b/spec/unit/server_dev_fixes_spec.cr
@@ -48,6 +48,10 @@ module Hwaro
       def dev_fixes_config_loaded? : Bool
         !@builder.config.nil?
       end
+
+      def dev_fixes_url_openable?(url : String) : Bool
+        url_openable?(url)
+      end
     end
   end
 end
@@ -466,6 +470,52 @@ describe Hwaro::Services::LiveReloadInjectHandler do
     end
   end
 
+  # S7: a non-canonical path (`//`, `/./` segments) must not be served with
+  # a 200 — StaticFileHandler (and the base-path mount) answer it with a
+  # canonicalising 302, so the injector defers instead of short-circuiting.
+  it "defers non-canonical paths to the next handler" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "guide"))
+      File.write(File.join(dir, "guide", "index.html"), "<html><body>g</body></html>")
+      handler = Hwaro::Services::LiveReloadInjectHandler.new(dir)
+
+      ["/guide//index.html", "/./guide/index.html", "/guide/./index.html"].each do |path|
+        spy = ServeFixesSpy.new
+        handler.next = spy
+        context, response, io = build_context("GET", path)
+        handler.call(context)
+        response.close
+
+        spy.called.should be_true
+        io.to_s.includes?("__hwaro_livereload").should be_false
+      end
+    end
+  end
+
+  # S7: chained with the real static handler, the deferral becomes the same
+  # canonicalising redirect production hosts issue — while the canonical
+  # path keeps its 200 + injection.
+  it "redirects non-canonical paths when chained with the static handler" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "guide"))
+      File.write(File.join(dir, "guide", "index.html"), "<html><body>g</body></html>")
+      handler = Hwaro::Services::LiveReloadInjectHandler.new(dir)
+      handler.next = HTTP::StaticFileHandler.new(dir, directory_listing: false, fallthrough: true)
+
+      context, response, _ = build_context("GET", "/guide//index.html")
+      handler.call(context)
+      response.close
+      context.response.status_code.should eq(302)
+      context.response.headers["Location"].should eq("/guide/index.html")
+
+      ok_context, ok_response, ok_io = build_context("GET", "/guide/index.html")
+      handler.call(ok_context)
+      ok_response.close
+      ok_context.response.status_code.should eq(200)
+      ok_io.to_s.should contain("__hwaro_livereload")
+    end
+  end
+
   # Finding 10: the strictness must not cost unicode routes.
   it "still serves percent-encoded and raw unicode paths" do
     Dir.mktmpdir do |dir|
@@ -774,6 +824,28 @@ describe Hwaro::Services::Server do
         handlers = server.dev_fixes_build_handlers(dir, server.dev_fixes_base_path_for("http://127.0.0.1:3000"))
         handlers.any?(Hwaro::Services::BasePathHandler).should be_false
       end
+    end
+  end
+
+  # S4: the --open allowlist must accept serve's own URL shapes — a
+  # bracketed IPv6 bind (`-b ::1`) and percent-encoded base paths — while
+  # still refusing shell metacharacters and non-http schemes.
+  describe "#url_openable?" do
+    it "accepts bracketed IPv6 hosts and percent-encoded paths" do
+      server = Hwaro::Services::Server.new
+      server.dev_fixes_url_openable?("http://[::1]:3000").should be_true
+      server.dev_fixes_url_openable?("http://[fe80::1]:8080/blog/").should be_true
+      server.dev_fixes_url_openable?("http://127.0.0.1:3000/my%20blog/").should be_true
+      server.dev_fixes_url_openable?("http://127.0.0.1:3000").should be_true
+    end
+
+    it "still refuses shell metacharacters and non-http schemes" do
+      server = Hwaro::Services::Server.new
+      server.dev_fixes_url_openable?("http://localhost:3000/$(touch pwned)").should be_false
+      server.dev_fixes_url_openable?("http://localhost:3000/a;b").should be_false
+      server.dev_fixes_url_openable?("http://localhost:3000/`id`").should be_false
+      server.dev_fixes_url_openable?("file:///etc/passwd").should be_false
+      server.dev_fixes_url_openable?("ftp://example.com").should be_false
     end
   end
 

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -683,6 +683,23 @@ describe "stale output cleanup on file removal" do
     builder.stale_outputs_for_removed(["content/posts/gone.md"], "public").should be_empty
   end
 
+  it "maps a removed .markdown page to its rendered output file" do
+    config = Hwaro::Models::Config.new
+    site = Hwaro::Models::Site.new(config)
+    page = Hwaro::Models::Page.new("about.markdown")
+    page.url = "/about/"
+    site.pages << page
+
+    builder = Hwaro::Core::Build::Builder.new
+    builder.test_set_site(site)
+    builder.test_set_config(config)
+
+    outputs = builder.stale_outputs_for_removed(["content/about.markdown"], "public")
+    outputs.any?(&.ends_with?(File.join("public", "about", "index.html"))).should be_true
+    # Never the raw source copied verbatim — .markdown is a page source.
+    outputs.any?(&.ends_with?("about.markdown")).should be_false
+  end
+
   it "includes cache-recorded sibling output-format files for a removed page" do
     Dir.mktmpdir do |dir|
       Dir.cd(dir) do

--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -555,4 +555,70 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
       builder.test_content_may_contain_shortcodes?(content).should be_true
     end
   end
+
+  describe "fence protection with hyphenated keyword-prefixed block names" do
+    it "keeps a fenced code block inside a {% include-code %} body intact" do
+      # The outer depth scan must classify openers/closers with the same
+      # EXACT keyword matching as the block parser. The old prefix regex
+      # treated `-` as a word boundary, so `include-code` read as the Jinja
+      # `include` control tag: the fence line split the buffer and both the
+      # opener and `{% end %}` leaked into the output as literal text.
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {
+        "shortcodes/include-code" => %(<div class="inc">{{ body }}</div>),
+      }
+      content = <<-MD
+      {% include-code(lang="js") %}
+      before
+
+      ```
+      literal fence
+      ```
+
+      after
+      {% end %}
+      MD
+      result = builder.test_sc_process(content, templates)
+      result.should contain(%(<div class="inc">))
+      result.should_not contain("{% include-code")
+      result.should_not contain("{% end %}")
+    end
+  end
+
+  describe "explicit shortcode() call with single-quoted name" do
+    it "renders {{ shortcode('name', args) }} like the double-quoted form" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/note" => %(<em>{{ text }}</em>)}
+      result = builder.test_sc_process(%({{ shortcode('note', text="hi") }}), templates)
+      result.should contain("<em>hi</em>")
+      result.should_not contain("missing shortcode")
+    end
+
+    it "renders a single-quoted name with no further args" do
+      builder = Hwaro::Core::Build::Builder.new
+      templates = {"shortcodes/hr" => %(<hr class="fancy">)}
+      result = builder.test_sc_process(%({{ shortcode('hr') }}), templates)
+      result.should contain(%(<hr class="fancy">))
+    end
+  end
+
+  describe "builtin alert markdown body" do
+    it "markdownifies the builtin alert body (parity with the scaffold override)" do
+      builder = Hwaro::Core::Build::Builder.new
+      result = builder.test_sc_process(
+        %({% alert(type="info") %}some **bold** text{% end %}),
+        {} of String => String,
+      )
+      result.should contain("<strong>bold</strong>")
+    end
+
+    it "markdownifies the builtin callout body" do
+      builder = Hwaro::Core::Build::Builder.new
+      result = builder.test_sc_process(
+        %({% callout(type="tip") %}a [link](https://example.com){% end %}),
+        {} of String => String,
+      )
+      result.should contain(%(<a href="https://example.com">link</a>))
+    end
+  end
 end

--- a/spec/unit/shortcode_processor_edge_cases_spec.cr
+++ b/spec/unit/shortcode_processor_edge_cases_spec.cr
@@ -568,16 +568,16 @@ describe Hwaro::Core::Build::ShortcodeProcessor do
         "shortcodes/include-code" => %(<div class="inc">{{ body }}</div>),
       }
       content = <<-MD
-      {% include-code(lang="js") %}
-      before
+        {% include-code(lang="js") %}
+        before
 
-      ```
-      literal fence
-      ```
+        ```
+        literal fence
+        ```
 
-      after
-      {% end %}
-      MD
+        after
+        {% end %}
+        MD
       result = builder.test_sc_process(content, templates)
       result.should contain(%(<div class="inc">))
       result.should_not contain("{% include-code")

--- a/spec/unit/sitemap_spec.cr
+++ b/spec/unit/sitemap_spec.cr
@@ -49,6 +49,33 @@ describe Hwaro::Content::Seo::Sitemap do
       end
     end
 
+    it "rewrites sitemap.xml as an empty urlset when no eligible pages remain" do
+      # Drafting the last sitemap-eligible page used to leave the previous
+      # sitemap.xml on disk untouched (early return) — stale URLs kept being
+      # served/deployed. An empty (valid) urlset is written instead.
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.sitemap.enabled = true
+        config.base_url = "https://example.com"
+        site = Hwaro::Models::Site.new(config)
+
+        page = Hwaro::Models::Page.new("blog/hello.md")
+        page.url = "/blog/hello/"
+        page.in_sitemap = true
+        page.render = true
+
+        Hwaro::Content::Seo::Sitemap.generate([page], site, dir)
+        File.read(File.join(dir, "sitemap.xml")).should contain("<url>")
+
+        page.draft = true
+        Hwaro::Content::Seo::Sitemap.generate([page], site, dir)
+
+        content = File.read(File.join(dir, "sitemap.xml"))
+        content.should contain("<urlset")
+        content.should_not contain("<url>")
+      end
+    end
+
     it "skips when sitemap is disabled" do
       Dir.mktmpdir do |dir|
         config = Hwaro::Models::Config.new
@@ -105,7 +132,12 @@ describe Hwaro::Content::Seo::Sitemap do
 
         Hwaro::Content::Seo::Sitemap.generate([page], site, dir)
 
-        File.exists?(File.join(dir, "sitemap.xml")).should be_false
+        # An (empty, valid) sitemap is still written — a stale previous
+        # sitemap must never survive on disk — but the filtered page is not
+        # in it.
+        content = File.read(File.join(dir, "sitemap.xml"))
+        content.should contain("<urlset")
+        content.should_not contain("<url>")
       end
     end
 

--- a/spec/unit/sitemap_spec.cr
+++ b/spec/unit/sitemap_spec.cr
@@ -280,5 +280,71 @@ describe Hwaro::Content::Seo::Sitemap do
         content.should end_with("</urlset>\n")
       end
     end
+
+    it "keeps the path-sort-first collision winner, matching the render phase" do
+      # Regression (A6): on a URL collision the render phase writes the page
+      # whose source path sorts FIRST (compute_output_url_winners); the
+      # sitemap kept the LAST occurrence, advertising lastmod from the
+      # unwritten loser.
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.sitemap.enabled = true
+        config.base_url = "https://example.com"
+        site = Hwaro::Models::Site.new(config)
+
+        winner = Hwaro::Models::Page.new("blog/a.md")
+        winner.url = "/blog/same/"
+        winner.in_sitemap = true
+        winner.render = true
+        winner.date = Time.utc(2024, 1, 1)
+
+        loser = Hwaro::Models::Page.new("blog/z.md")
+        loser.url = "/blog/same/"
+        loser.in_sitemap = true
+        loser.render = true
+        loser.date = Time.utc(2025, 12, 31)
+
+        Hwaro::Content::Seo::Sitemap.generate([winner, loser], site, dir)
+
+        content = File.read(File.join(dir, "sitemap.xml"))
+        content.scan("<loc>").size.should eq(1)
+        content.should contain("<lastmod>2024-01-01</lastmod>")
+        content.should_not contain("<lastmod>2025-12-31</lastmod>")
+      end
+    end
+
+    it "excludes render=false translations from hreflang alternates" do
+      # Regression (A17): a translation with render=false has no written
+      # output; advertising it as an hreflang alternate points crawlers at
+      # a 404.
+      Dir.mktmpdir do |dir|
+        config = Hwaro::Models::Config.new
+        config.sitemap.enabled = true
+        config.base_url = "https://example.com"
+        site = Hwaro::Models::Site.new(config)
+
+        en_page = Hwaro::Models::Page.new("about.md")
+        en_page.url = "/about/"
+        en_page.in_sitemap = true
+        en_page.render = true
+        en_page.translations = [
+          Hwaro::Models::TranslationLink.new(code: "en", url: "/about/", title: "About", is_current: true, is_default: true),
+          Hwaro::Models::TranslationLink.new(code: "ko", url: "/ko/about/", title: "소개"),
+        ]
+
+        ko_page = Hwaro::Models::Page.new("about.ko.md")
+        ko_page.url = "/ko/about/"
+        ko_page.language = "ko"
+        ko_page.in_sitemap = true
+        ko_page.render = false
+
+        Hwaro::Content::Seo::Sitemap.generate([en_page, ko_page], site, dir)
+
+        content = File.read(File.join(dir, "sitemap.xml"))
+        content.should contain("hreflang=\"en\"")
+        content.should_not contain("hreflang=\"ko\"")
+        content.should_not contain("/ko/about/")
+      end
+    end
   end
 end

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -235,6 +235,14 @@ module Hwaro
             CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
           end
 
+          # `--no-parallel` renders on a single fiber, so a worker count has
+          # nothing to size — surface the conflict instead of silently
+          # ignoring `--jobs` (the flags aren't contradictory enough to make
+          # this a usage error; the build proceeds single-threaded).
+          if !parallel && workers > 0
+            Logger.warn "--jobs #{workers} is ignored because --no-parallel disables parallel rendering."
+          end
+
           { {Config::Options::BuildOptions.new(
             output_dir: output_dir,
             base_url: base_url,

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -639,7 +639,9 @@ module Hwaro
                            File.exists?(target_no_slash + ".md") ||
                            File.exists?(target_no_slash + ".markdown") ||
                            File.exists?(File.join(target_no_slash, "_index.md")) ||
+                           File.exists?(File.join(target_no_slash, "_index.markdown")) ||
                            File.exists?(File.join(target_no_slash, "index.md")) ||
+                           File.exists?(File.join(target_no_slash, "index.markdown")) ||
                            (link.kind != :image && taxonomy_url?(url, taxonomy_names))
 
             # Also accept assets that live in static/ (source) or public/ (after
@@ -663,7 +665,9 @@ module Hwaro
             File.exists?("#{target_no_slash}.#{code}.md") ||
               File.exists?("#{target_no_slash}.#{code}.markdown") ||
               File.exists?(File.join(target_no_slash, "_index.#{code}.md")) ||
+              File.exists?(File.join(target_no_slash, "_index.#{code}.markdown")) ||
               File.exists?(File.join(target_no_slash, "index.#{code}.md")) ||
+              File.exists?(File.join(target_no_slash, "index.#{code}.markdown")) ||
               (link.kind != :image && taxonomy_url?(url, taxonomy_names))
           end
 

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -607,23 +607,18 @@ module Hwaro
             config.languages.keys.reject { |code| code.empty? || code == config.default_language }
           end
 
-          # The build only recognizes a language suffix in a content filename
-          # when the code is 2–3 lowercase letters (`ReadContent::
-          # LANGUAGE_FILENAME_PATTERN`). A declared `pt-BR` therefore never
-          # produces `/pt-BR/…` routes — `about.pt-BR.md` is read as an
-          # ordinary page and published at `/about.pt-BR/`. Mirroring that
-          # rule here keeps the checker from inventing a translation route the
-          # build will not serve.
-          TRANSLATABLE_CODE = /\A[a-z]{2,3}\z/
-
           # Returns the leading language segment of an absolute URL when it
-          # names a non-default language the build can actually route, else nil.
+          # names a non-default language the build can actually route, else
+          # nil. The build matches filename suffixes against DECLARED codes
+          # (ReadContent#extract_language_from_filename), so every declared
+          # non-default code — including hyphenated ones like `pt-BR` —
+          # produces `/<code>/…` routes.
           private def translatable_language_prefix(url : String, codes : Array(String)) : String?
             return if codes.empty?
             return unless url.starts_with?("/")
             segment = url.lstrip("/").split("/").first?
             return unless segment
-            return unless codes.includes?(segment) && segment.matches?(TRANSLATABLE_CODE)
+            return unless codes.includes?(segment)
             segment
           end
 

--- a/src/content/discovery_pages.cr
+++ b/src/content/discovery_pages.cr
@@ -8,11 +8,21 @@ module Hwaro
     module DiscoveryPages
       extend self
 
-      # Deduplicate by URL, keeping the LAST occurrence — matching build
-      # behavior, where the page rendered last wins the output path.
+      # Deduplicate by URL, keeping the page the build actually wrote: the
+      # render phase resolves an output-URL collision in source-path sort
+      # order, first claim wins (render.cr#compute_output_url_winners), so
+      # the winner is the page whose `path` sorts FIRST. Original list
+      # order is preserved.
       def dedupe_by_url(pages : Array(Models::Page)) : Array(Models::Page)
-        seen_urls = Set(String).new
-        pages.reverse.select { |p| seen_urls.add?(p.url) }.reverse!
+        winners = {} of String => Models::Page
+        pages.each do |p|
+          if prev = winners[p.url]?
+            winners[p.url] = p if p.path < prev.path
+          else
+            winners[p.url] = p
+          end
+        end
+        pages.select { |p| winners[p.url].same?(p) }
       end
 
       # Drop pages whose URL equals an excluded path or lives under an

--- a/src/content/hooks/image_hooks.cr
+++ b/src/content/hooks/image_hooks.cr
@@ -261,9 +261,9 @@ module Hwaro
           # resize_and_lqip clamps any requested width larger than the source to
           # the source's true width (writing a single `_<src_w>w` variant), so a
           # `_<width>w` file does NOT exist for every configured width. Read the
-          # variants that ARE on disk, infer the clamp ceiling from the largest
-          # one, then require the on-disk set to match exactly what the CURRENT
-          # config would produce — otherwise the config changed and we reprocess.
+          # variants that ARE on disk, then require the set to match exactly
+          # what the CURRENT config would produce — otherwise the config
+          # changed and we reprocess.
           variant_re = /\A#{Regex.escape(basename)}_(\d+)w#{Regex.escape(ext)}\z/
           on_disk = {} of Int32 => String
           Dir.each_child(dest_dir) do |name|
@@ -273,7 +273,14 @@ module Hwaro
           end
           return if on_disk.empty?
 
-          src_w = on_disk.keys.max
+          # The clamp ceiling must come from the SOURCE image's intrinsic
+          # width. Inferring it from the largest on-disk variant silently
+          # ignored a newly configured larger width: variants from the old
+          # config "satisfied" the new one after clamping to the stale
+          # inferred ceiling, so e.g. adding 1024 to `widths = [320]` never
+          # generated the 1024 variant on warm builds. The old inference
+          # stays as the fallback for headers we can't read.
+          src_w = Processors::ImageProcessor.dimensions(source_path).try(&.[0]) || on_disk.keys.max
           expected = widths.map { |w| Math.min(w, src_w) }.uniq!
           return unless expected.sort == on_disk.keys.sort!
 
@@ -413,11 +420,122 @@ module Hwaro
           end
         end
 
+        # --- Serve-time targeted reprocessing (A12) ---
+
+        # The `image:resize` hook only runs on full builds, so modified image
+        # BYTES under serve's :static / :content_files change paths left the
+        # resized variants (and LQIP data) stale — the watcher only re-copied
+        # the original. Re-runs the resize pipeline for exactly the changed
+        # images and folds the results into the class-level maps.
+        #
+        # `pages` (when given) also covers page-bundle assets: an image
+        # inside a page bundle publishes its variants under the owning
+        # page's URL, not its content-relative path.
+        #
+        # Returns the number of variant sets regenerated.
+        def self.reprocess_changed_images(
+          changed_paths : Array(String),
+          config : Models::Config,
+          output_dir : String,
+          pages : Array(Models::Page)? = nil,
+        ) : Int32
+          ip = config.image_processing
+          return 0 unless ip.enabled
+          return 0 if ip.widths.empty?
+
+          resolved_output = File.expand_path(output_dir)
+          count = 0
+          changed_paths.each do |src_path|
+            next unless Processors::ImageProcessor.image?(src_path)
+            next unless File.file?(src_path)
+
+            if src_path.starts_with?("static/")
+              next unless safe_source_path?(src_path, "static")
+              relative = Path[src_path].relative_to("static").to_s
+              next if config.static.excluded?(relative)
+              count += reprocess_published(src_path, relative, config, output_dir, resolved_output)
+            elsif src_path.starts_with?("content/")
+              next unless safe_source_path?(src_path, "content")
+              relative = Path[src_path].relative_to("content").to_s
+              if config.content_files.enabled? && config.content_files.publish?(relative)
+                count += reprocess_published(src_path, relative, config, output_dir, resolved_output)
+              end
+              if bundle_pages = pages
+                count += reprocess_bundle_asset(src_path, relative, config, output_dir, resolved_output, bundle_pages)
+              end
+            end
+          end
+          Logger.outcome("resized", "#{count} image variant set#{count == 1 ? "" : "s"}") if count > 0
+          count
+        end
+
+        # Variants published at the file's own relative path (static/ and
+        # [content.files] images) — mirrors collect_static_jobs /
+        # collect_content_file_jobs URL derivation.
+        private def self.reprocess_published(src_path : String, relative : String, config : Models::Config, output_dir : String, resolved_output : String) : Int32
+          dest_dir = File.join(output_dir, File.dirname(relative))
+          return 0 unless safe_dest_path?(dest_dir, resolved_output)
+
+          dir_part = File.dirname(relative)
+          url_prefix = dir_part == "." ? "/" : "/#{dir_part}/"
+          run_targeted_resize(src_path, dest_dir, "/" + relative, url_prefix, config)
+        end
+
+        # Variants published under the owning page's URL (page-bundle
+        # assets) — mirrors collect_page_asset_jobs.
+        private def self.reprocess_bundle_asset(src_path : String, relative : String, config : Models::Config, output_dir : String, resolved_output : String, pages : Array(Models::Page)) : Int32
+          count = 0
+          pages.each do |page|
+            next if page.assets.empty?
+            next unless page.assets.includes?(relative)
+
+            page_bundle_dir = File.dirname(page.path)
+            url_path = page.url.lchop("/")
+            relative_to_bundle = begin
+              Path[relative].relative_to(page_bundle_dir).to_s
+            rescue ArgumentError
+              next
+            end
+            original_url = "/" + url_path + relative_to_bundle
+            asset_dest_dir = File.join(output_dir, url_path, File.dirname(relative_to_bundle))
+            next unless safe_dest_path?(asset_dest_dir, resolved_output)
+
+            url_prefix = "/" + url_path + File.dirname(relative_to_bundle).rstrip(".") + "/"
+            url_prefix = url_prefix.gsub("//", "/")
+
+            count += run_targeted_resize(src_path, asset_dest_dir, original_url, url_prefix, config)
+          end
+          count
+        end
+
+        # One resize_and_lqip pass for a single image, updating the
+        # class-level maps in place (unlike process_images, which rebuilds
+        # them wholesale — a targeted pass must not drop other entries).
+        private def self.run_targeted_resize(src_path : String, dest_dir : String, original_url : String, url_prefix : String, config : Models::Config) : Int32
+          ip = config.image_processing
+          lqip_width = ip.lqip_enabled ? ip.lqip_width : 0
+          path_map, lqip_uri, dom_color = Processors::ImageProcessor.resize_and_lqip(
+            src_path, dest_dir, ip.widths, ip.quality, lqip_width, ip.lqip_quality
+          )
+          return 0 if path_map.empty?
+
+          width_urls = {} of Int32 => String
+          path_map.each { |width, dest| width_urls[width] = url_prefix + File.basename(dest) }
+          @@resize_map_mutex.synchronize { @@resize_map[original_url] = width_urls }
+          if lqip_uri
+            @@lqip_map_mutex.synchronize { @@lqip_map[original_url] = {"lqip" => lqip_uri, "dominant_color" => dom_color} }
+          end
+          1
+        rescue ex
+          Logger.warn "  Image reprocess failed for #{src_path}: #{ex.message}"
+          0
+        end
+
         # --- Security helpers ---
 
         # Verify that a source path resolves within the expected base directory.
         # Uses File.realpath to resolve symlinks before the boundary check.
-        private def safe_path?(path : String, base : String) : Bool
+        def self.safe_source_path?(path : String, base : String) : Bool
           resolved = begin
             File.realpath(path)
           rescue File::Error
@@ -432,9 +550,17 @@ module Hwaro
         end
 
         # Verify destination directory is within output (dest may not exist yet)
-        private def safe_path_dest?(path : String, resolved_output : String) : Bool
+        def self.safe_dest_path?(path : String, resolved_output : String) : Bool
           resolved = File.expand_path(path)
           resolved == resolved_output || resolved.starts_with?(resolved_output + "/")
+        end
+
+        private def safe_path?(path : String, base : String) : Bool
+          ImageHooks.safe_source_path?(path, base)
+        end
+
+        private def safe_path_dest?(path : String, resolved_output : String) : Bool
+          ImageHooks.safe_dest_path?(path, resolved_output)
         end
       end
     end

--- a/src/content/hooks/og_image_hooks.cr
+++ b/src/content/hooks/og_image_hooks.cr
@@ -29,10 +29,16 @@ module Hwaro
           ai = site.config.og.auto_image
 
           # Lazy mode: skip automatic bulk generation during `hwaro serve`.
-          # OG images will be generated on first request instead (much faster
-          # initial dev server startup on large sites).
+          # OG images are generated on first request instead (much faster
+          # initial dev server startup on large sites) — but pages must still
+          # ADVERTISE their og:image URL, or every page ships without the
+          # meta tag for the whole session. Assign the predicted URLs without
+          # rendering; the dev server's OgLazyImageHandler creates the files
+          # on demand.
           if ai.lazy_generate && ctx.options.serve_mode
-            Logger.debug "  Skipping OG image generation (lazy_generate enabled in serve mode)"
+            lazy_pages = ctx.priority_pages || ctx.all_pages
+            assigned = Content::Seo::OgImage.assign_lazy_urls(lazy_pages, site.config)
+            Logger.debug "  Skipping OG image generation (lazy_generate enabled in serve mode); assigned #{assigned} on-demand URL(s)"
             return
           end
 

--- a/src/content/hooks/pwa_hooks.cr
+++ b/src/content/hooks/pwa_hooks.cr
@@ -8,7 +8,15 @@ module Hwaro
         include Core::Lifecycle::Hookable
 
         def register_hooks(manager : Core::Lifecycle::Manager)
-          manager.on(Core::Lifecycle::HookPoint::BeforeGenerate, priority: 50, name: "pwa:generate") do |ctx|
+          # AfterWrite, not BeforeGenerate: sw.js checks precache URLs against
+          # the files on disk and content-hashes their bytes into CACHE_NAME.
+          # Running before Generate/Write meant a CLEAN build couldn't see
+          # 404.html, raw files, bundle assets (Write) or the search index
+          # (AfterGenerate) — those precache URLs were dropped — while a warm
+          # build hashed the PREVIOUS build's bytes (clean vs warm builds
+          # emitted different sw.js). AfterWrite is the last hook point before
+          # Finalize (which only saves the cache), so the output tree is final.
+          manager.on(Core::Lifecycle::HookPoint::AfterWrite, priority: 50, name: "pwa:generate") do |ctx|
             generate_pwa_files(ctx)
             Core::Lifecycle::HookResult::Continue
           end

--- a/src/content/multilingual.cr
+++ b/src/content/multilingual.cr
@@ -6,6 +6,16 @@ module Hwaro
     module Multilingual
       extend self
 
+      # Mirrors Core::Build::Phases::ReadContent::PAGE_EXTENSIONS (not
+      # required here to avoid pulling the build phases into the content
+      # layer). `.md` first so the common case short-circuits.
+      PAGE_EXTENSIONS = {".md", ".markdown"}
+
+      # The page extension of `path`, or nil when it is not a page source.
+      def page_extension(path : String) : String?
+        PAGE_EXTENSIONS.find { |ext| path.ends_with?(ext) }
+      end
+
       def multilingual?(config : Models::Config) : Bool
         config.multilingual?
       end
@@ -21,7 +31,8 @@ module Hwaro
       end
 
       def translation_key(page_path : String, config : Models::Config) : String
-        return page_path unless page_path.ends_with?(".md")
+        ext = page_extension(page_path)
+        return page_path unless ext
 
         relative_path = page_path.gsub('\\', '/')
         dir = Path[relative_path].dirname.to_s
@@ -32,17 +43,17 @@ module Hwaro
         # Uses string suffix check instead of per-call Regex compilation.
         cleaned = basename
         config.languages.each_key do |code|
-          suffix = ".#{code}.md"
+          suffix = ".#{code}#{ext}"
           if cleaned.ends_with?(suffix)
-            cleaned = "#{cleaned[0, cleaned.size - suffix.size]}.md"
+            cleaned = "#{cleaned[0, cleaned.size - suffix.size]}#{ext}"
             break
           end
         end
         # Also check default language if no match above
         if cleaned == basename
-          suffix = ".#{config.default_language}.md"
+          suffix = ".#{config.default_language}#{ext}"
           if cleaned.ends_with?(suffix)
-            cleaned = "#{cleaned[0, cleaned.size - suffix.size]}.md"
+            cleaned = "#{cleaned[0, cleaned.size - suffix.size]}#{ext}"
           end
         end
 
@@ -54,7 +65,7 @@ module Hwaro
 
         groups = Hash(String, Array(Models::Page)).new { |h, k| h[k] = [] of Models::Page }
         pages.each do |page|
-          next unless page.path.ends_with?(".md")
+          next unless page_extension(page.path)
           groups[translation_key(page.path, config)] << page
         end
 

--- a/src/content/processors/image_processor.cr
+++ b/src/content/processors/image_processor.cr
@@ -49,6 +49,25 @@ module Hwaro
           dir == "." ? name : File.join(dir, name)
         end
 
+        # Read the intrinsic {width, height} of an image from its file header
+        # without decoding pixel data (pure Crystal, no stb round-trip).
+        # Supports the formats `image?` accepts (PNG/JPEG/BMP); returns nil
+        # for anything unreadable so callers can fall back to other
+        # heuristics. Used by the warm-build variant-reuse check: inferring
+        # the source width from the largest on-disk variant silently ignored
+        # newly configured LARGER widths (the variant set "matched" after
+        # clamping to the stale inferred width).
+        def dimensions(path : String) : {Int32, Int32}?
+          return unless File.file?(path)
+          case File.extname(path).downcase
+          when ".png"          then png_dimensions(path)
+          when ".jpg", ".jpeg" then jpeg_dimensions(path)
+          when ".bmp"          then bmp_dimensions(path)
+          end
+        rescue IO::Error | File::Error
+          nil
+        end
+
         # Resize a single image to the given width, preserving aspect ratio.
         # Returns the output path on success, nil on failure.
         def resize(source : String, dest : String, width : Int32, height : Int32 = 0, quality : Int32 = 85) : String?
@@ -372,6 +391,66 @@ module Hwaro
         end
 
         # --- Private helpers ---
+
+        PNG_SIGNATURE = Bytes[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+
+        # PNG: width/height are big-endian UInt32s at offsets 16/20 (IHDR).
+        private def png_dimensions(path : String) : {Int32, Int32}?
+          header = Bytes.new(24)
+          read = File.open(path, &.read(header))
+          return if read < 24
+          return unless header[0, 8] == PNG_SIGNATURE
+          width = IO::ByteFormat::BigEndian.decode(UInt32, header[16, 4])
+          height = IO::ByteFormat::BigEndian.decode(UInt32, header[20, 4])
+          return if width == 0 || height == 0 || width > Int32::MAX || height > Int32::MAX
+          {width.to_i32, height.to_i32}
+        end
+
+        # JPEG: scan the marker stream for the first SOF frame header
+        # (C0–CF, excluding the non-frame C4/C8/CC markers); height/width are
+        # big-endian UInt16s at offsets 3/5 of its payload.
+        private def jpeg_dimensions(path : String) : {Int32, Int32}?
+          File.open(path) do |io|
+            return unless io.read_byte == 0xFF && io.read_byte == 0xD8
+            loop do
+              byte = io.read_byte
+              return if byte.nil?
+              next unless byte == 0xFF
+              marker = io.read_byte
+              return if marker.nil?
+              next if marker == 0xFF               # fill bytes
+              next if marker == 0x00               # stuffed byte (not a marker)
+              next if (0xD0..0xD9).covers?(marker) # RST/SOI/EOI: no payload
+              length = io.read_bytes(UInt16, IO::ByteFormat::BigEndian)
+              return if length < 2
+              if (0xC0..0xCF).covers?(marker) && marker != 0xC4 && marker != 0xC8 && marker != 0xCC
+                return if length < 7
+                io.read_byte # sample precision
+                height = io.read_bytes(UInt16, IO::ByteFormat::BigEndian)
+                width = io.read_bytes(UInt16, IO::ByteFormat::BigEndian)
+                return if width == 0 || height == 0
+                return {width.to_i32, height.to_i32}
+              end
+              io.skip(length - 2)
+            end
+          end
+        end
+
+        # BMP: signature "BM"; width/height are little-endian Int32s at
+        # offsets 18/22 (BITMAPINFOHEADER). Height may be negative
+        # (top-down rows) — the magnitude is the pixel height.
+        private def bmp_dimensions(path : String) : {Int32, Int32}?
+          header = Bytes.new(26)
+          read = File.open(path, &.read(header))
+          return if read < 26
+          return unless header[0] == 0x42 && header[1] == 0x4D
+          width = IO::ByteFormat::LittleEndian.decode(Int32, header[18, 4])
+          height = IO::ByteFormat::LittleEndian.decode(Int32, header[22, 4])
+          return if height == Int32::MIN # .abs would overflow
+          height = height.abs
+          return if width <= 0 || height == 0
+          {width, height}
+        end
 
         # Calculate output dimensions preserving aspect ratio.
         # Returns {0, 0} for invalid inputs to signal caller to skip.

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -337,7 +337,10 @@ module Hwaro
         # A top-level `key:` line is what distinguishes broken front matter
         # (worth a hard error) from a document that merely opens with a `---`
         # thematic break (whose first block may fail YAML parsing entirely).
-        YAML_KEY_LINE_RE = /^[A-Za-z_][\w.-]*\s*:(\s|$)/
+        # `\p{L}` so non-ASCII keys (e.g. Korean `제목:`) count as front
+        # matter too — otherwise their invalid-YAML blocks silently render
+        # as body text instead of erroring.
+        YAML_KEY_LINE_RE = /^[\p{L}_][\p{L}\p{N}_.-]*\s*:(\s|$)/
 
         private def yaml_front_matter_like?(raw : String) : Bool
           raw.each_line do |line|
@@ -348,9 +351,16 @@ module Hwaro
 
         # True when the fenced block parses to YAML null — `---\n---` and
         # comment-only blocks. Those are empty front matter (fences stripped),
-        # unlike scalar/sequence blocks, which are document content.
+        # unlike scalar/sequence blocks, which are document content. A
+        # null-parse alone is not enough: `~` / `null` scalars ALSO parse to
+        # nil but are content, so the raw text must carry nothing beyond
+        # whitespace and comments.
         private def yaml_empty_front_matter?(raw : String) : Bool
-          YAML.parse(raw).raw.nil?
+          return false unless YAML.parse(raw).raw.nil?
+          raw.each_line.all? do |line|
+            stripped = line.strip
+            stripped.empty? || stripped.starts_with?('#')
+          end
         rescue
           false
         end

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -197,14 +197,25 @@ module Hwaro
           raw_content = Utils::TextUtils.strip_bom(raw_content)
           markdown_content = raw_content
 
-          # Try TOML (+++), YAML (---), then JSON ({...}) front matter
+          # Try TOML (+++), YAML (---), then JSON ({...}) front matter.
+          # The body is only truncated to match[2] when the fenced block really
+          # WAS front matter: `---` doubles as a Markdown thematic break, so a
+          # document opening with one (scalar/sequence YAML, or invalid YAML
+          # with no `key:` line) must keep its FULL content — assigning
+          # match[2] up front silently dropped the first block.
           if match = raw_content.match(TOML_FRONT_MATTER_REGEX)
-            result = extract_from_toml(match[1], file_path)
-            markdown_content = match[2]
+            if result = extract_from_toml(match[1], file_path)
+              markdown_content = match[2]
+            end
           elsif match = raw_content.match(YAML_FRONT_MATTER_REGEX)
-            result = extract_from_yaml(match[1], file_path)
-            markdown_content = match[2]
-          elsif raw_content.starts_with?('{')
+            if result = extract_from_yaml(match[1], file_path)
+              markdown_content = match[2]
+            elsif yaml_empty_front_matter?(match[1])
+              # `---\n---` / comment-only blocks are EMPTY front matter:
+              # strip the fences and fall through to defaults.
+              markdown_content = match[2]
+            end
+          elsif raw_content.starts_with?('{') && json_front_matter_start?(raw_content)
             # A leading `{` signals JSON frontmatter intent. If the scanner can
             # locate a balanced object we parse it; if not, the file is almost
             # certainly a truncated/mistyped JSON header — surface it as a
@@ -306,6 +317,44 @@ module Hwaro
           end
         end
 
+        # A `{` also opens shortcodes (`{{ … }}`), Jinja tags (`{% … %}`) and
+        # attribute lists (`{:.class}`) — constructs that legitimately start a
+        # body. Only a `"` (first key) or `}` (empty object) after the leading
+        # brace plausibly starts a JSON front-matter object; anything else is
+        # content, not a broken JSON header worth aborting the build over.
+        private def json_front_matter_start?(raw : String) : Bool
+          reader = Char::Reader.new(raw)
+          reader.next_char # skip the leading '{'
+          while reader.has_next?
+            ch = reader.current_char
+            return true if ch == '"' || ch == '}'
+            return false unless ch.whitespace?
+            reader.next_char
+          end
+          false
+        end
+
+        # A top-level `key:` line is what distinguishes broken front matter
+        # (worth a hard error) from a document that merely opens with a `---`
+        # thematic break (whose first block may fail YAML parsing entirely).
+        YAML_KEY_LINE_RE = /^[A-Za-z_][\w.-]*\s*:(\s|$)/
+
+        private def yaml_front_matter_like?(raw : String) : Bool
+          raw.each_line do |line|
+            return true if line.matches?(YAML_KEY_LINE_RE)
+          end
+          false
+        end
+
+        # True when the fenced block parses to YAML null — `---\n---` and
+        # comment-only blocks. Those are empty front matter (fences stripped),
+        # unlike scalar/sequence blocks, which are document content.
+        private def yaml_empty_front_matter?(raw : String) : Bool
+          YAML.parse(raw).raw.nil?
+        rescue
+          false
+        end
+
         # Extract front matter fields from TOML content
         private def extract_from_toml(raw : String, file_path : String)
           toml_fm = begin
@@ -373,6 +422,11 @@ module Hwaro
               Logger.warn "Invalid YAML: #{ex.message}"
               return
             end
+            # A document opening with a `---` thematic break can put ANY prose
+            # in the "front matter" slot; only abort when the block plausibly
+            # is front matter (carries a top-level `key:` line). Otherwise the
+            # caller keeps the full content as body text.
+            return unless yaml_front_matter_like?(raw)
             raise Hwaro::HwaroError.new(
               code: Hwaro::Errors::HWARO_E_CONTENT,
               message: "Invalid YAML frontmatter in #{file_path}: #{ex.message}",

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -354,7 +354,7 @@ module Hwaro
               raw_map = pages_map.raw.as(Hash)
               if found = raw_map[path_arg]?
                 return found
-              elsif found = raw_map["/#{path_arg.chomp(".md")}/"]?
+              elsif found = raw_map["/#{path_arg.chomp(".markdown").chomp(".md")}/"]?
                 return found
               end
               # If map is present but page not found, return nil (miss)
@@ -375,7 +375,7 @@ module Hwaro
                   page_path = raw_page["path"]?.try(&.to_s) || ""
                   page_url = raw_page["url"]?.try(&.to_s) || ""
 
-                  if page_path == path_arg || page_url == path_arg || page_url == "/#{path_arg.chomp(".md")}/"
+                  if page_path == path_arg || page_url == path_arg || page_url == "/#{path_arg.chomp(".markdown").chomp(".md")}/"
                     result = page_val
                     break
                   end

--- a/src/content/processors/xml.cr
+++ b/src/content/processors/xml.cr
@@ -38,10 +38,25 @@ module Hwaro
           ProcessorResult.error("XML processing failed: #{ex.message}")
         end
 
+        # CDATA sections and comments extracted as opaque placeholders
+        # before minification. `\x00` is illegal in XML, so the token
+        # cannot collide with author content.
+        private CDATA_COMMENT_RE  = /<!\[CDATA\[.*?\]\]>|<!--.*?-->/m
+        private PRESERVE_TOKEN_RE = /\x00HWXMLP(\d+)\x00/
+
         # Simple XML minification - removes excess whitespace
         # Only removes whitespace-only text nodes between tags (preserves mixed content)
         private def minify_xml(xml : String) : String
-          xml
+          # CDATA sections and comments are raw character data — the
+          # cross-line collapse below must never reach inside them (a
+          # CDATA body containing `</a>\n<em>` is content, not markup).
+          # Stash them behind placeholders and restore verbatim at the end.
+          preserved = [] of String
+          work = xml.gsub(CDATA_COMMENT_RE) do |m|
+            preserved << m
+            "\x00HWXMLP#{preserved.size - 1}\x00"
+          end
+          result = work
             .gsub(/>\s*\n\s*</, "><") # Remove whitespace-only text between tags (cross-line only)
             .gsub(/<[^>]+>/) do |tag|
               # Never touch comments or CDATA sections: their bytes are
@@ -57,6 +72,13 @@ module Hwaro
               end
             end
             .strip
+          return result if preserved.empty?
+          result.gsub(PRESERVE_TOKEN_RE) do
+            # to_i? bounds-guards a counterfeit token (NUL is illegal in
+            # XML, but be defensive): emit it unchanged instead of raising.
+            idx = $1.to_i?
+            idx && idx < preserved.size ? preserved[idx] : $0
+          end
         end
       end
 

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -78,7 +78,28 @@ module Hwaro
           pages.each do |page|
             # Check if it's a section and has feed generation enabled
             if page.is_a?(Models::Section) && page.generate_feeds && page.render && !page.draft && !page.unpublished
-              section_pages = dedupe_by_output_url(pages_by_section[page.section]? || [] of Models::Page)
+              section_pages = pages_by_section[page.section]? || [] of Models::Page
+
+              # A section feed is a per-language surface: the section object
+              # for each language carries that language's URL (e.g. /posts/
+              # vs /ko/posts/), so its feed must not interleave other
+              # languages. The default-language section feed follows the
+              # same `default_language_only` rule as the main feed; a
+              # non-default-language section feed only ever carries its own
+              # language.
+              if config.multilingual?
+                default_lang = config.default_language
+                section_lang = page.language || default_lang
+                if section_lang == default_lang
+                  if config.feeds.default_language_only
+                    section_pages = section_pages.select { |p| (p.language || default_lang) == default_lang }
+                  end
+                else
+                  section_pages = section_pages.select { |p| p.language == section_lang }
+                end
+              end
+
+              section_pages = dedupe_by_output_url(section_pages)
 
               # Construct output path for section feed
               # e.g., output_dir/posts/rss.xml — sanitize + OutputGuard so a
@@ -94,8 +115,10 @@ module Hwaro
             end
           end
 
-          # 3. Generate Language-specific Feeds (for non-default languages)
-          if config.multilingual?
+          # 3. Generate Language-specific Feeds (for non-default languages).
+          # Global `[feeds] enabled = false` disables these too — per-language
+          # `generate_feed` only opts OUT within a globally-enabled config.
+          if config.feeds.enabled && config.multilingual?
             generate_language_feeds(pages, config, output_dir, verbose, templates, renderer)
           end
         end
@@ -307,9 +330,12 @@ module Hwaro
 
           # Deterministic feed timestamp: newest content date across entries
           # (same rule as the Atom generator) so identical input renders
-          # byte-identical output.
-          newest = pages.compact_map { |p| p.updated || p.date }.max?
-          feed_updated = newest ? normalize_feed_time(newest) : Utils::SortUtils::FALLBACK_DATE
+          # byte-identical output. Normalize BEFORE taking the max — the
+          # timezone re-anchor can reorder instants (a date-only +09:00
+          # midnight normalizes 9h forward), and the feed <updated> must
+          # never be older than its newest entry's <updated>.
+          newest = pages.compact_map { |p| (src = p.updated || p.date) ? normalize_feed_time(src) : nil }.max?
+          feed_updated = newest || Utils::SortUtils::FALLBACK_DATE
           feed_author = config.title.empty? ? feed_title : config.title
 
           page_values = pages.map do |page|
@@ -474,13 +500,18 @@ module Hwaro
               summary = summary_for_feed(page, config)
               str << "      <description>#{Utils::TextUtils.escape_xml(summary)}</description>\n"
 
-              # Emit the full body in `<content:encoded>` when the user
-              # opts into full content (default). CDATA so consumers
-              # don't have to double-decode entities.
+              # Emit the body in `<content:encoded>` when the user opts
+              # into full content (default). `feeds.truncate` applies here
+              # too — it is documented as "truncate content to N characters
+              # (0 = full content)" and the Atom generator already honors it
+              # under full_content via get_content_for_feed, so RSS routes
+              # through the same helper (truncated plain text when
+              # truncate > 0, full absolutized HTML otherwise). CDATA so
+              # consumers don't have to double-decode entities.
               if full_content
-                full_html = full_content_for_feed(page, config)
-                unless full_html.empty?
-                  str << "      <content:encoded><![CDATA[#{escape_cdata(full_html)}]]></content:encoded>\n"
+                encoded = get_content_for_feed(page, config)
+                unless encoded.empty?
+                  str << "      <content:encoded><![CDATA[#{escape_cdata(encoded)}]]></content:encoded>\n"
                 end
               end
 
@@ -520,9 +551,13 @@ module Hwaro
           # Atom <updated> must be deterministic: derive it from the newest
           # content date (updated||date) across entries rather than the build
           # wall-clock, so two builds of identical input stay byte-identical.
-          # Falls back to the epoch sentinel when no entry carries a date.
-          newest = pages.compact_map { |p| p.updated || p.date }.max?
-          feed_updated = newest ? normalize_feed_time(newest) : Utils::SortUtils::FALLBACK_DATE
+          # Normalize BEFORE taking the max — the timezone re-anchor can
+          # reorder instants (a date-only +09:00 midnight normalizes 9h
+          # forward), and the feed <updated> must never be older than its
+          # newest entry's <updated>. Falls back to the epoch sentinel when
+          # no entry carries a date.
+          newest = pages.compact_map { |p| (src = p.updated || p.date) ? normalize_feed_time(src) : nil }.max?
+          feed_updated = newest || Utils::SortUtils::FALLBACK_DATE
           # RFC 4287 §4.1.1: a feed MUST carry an author unless every entry
           # does. Emit a feed-level author unconditionally using the site title.
           feed_author = config.title.empty? ? feed_title : config.title

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -510,6 +510,12 @@ module Hwaro
               # consumers don't have to double-decode entities.
               if full_content
                 encoded = get_content_for_feed(page, config)
+                # truncate > 0 makes get_content_for_feed return
+                # entity-DECODED plain text, but feed readers parse
+                # <content:encoded> as HTML — re-escape it so a literal
+                # `<` or `&` can't break rendering. The full-HTML path
+                # (truncate = 0) must stay byte-identical.
+                encoded = Utils::TextUtils.escape_xml(encoded) if config.feeds.truncate > 0
                 unless encoded.empty?
                   str << "      <content:encoded><![CDATA[#{escape_cdata(encoded)}]]></content:encoded>\n"
                 end

--- a/src/content/seo/llms.cr
+++ b/src/content/seo/llms.cr
@@ -2,6 +2,7 @@ require "../../models/config"
 require "../../models/page"
 require "../../models/section"
 require "../../utils/logger"
+require "../discovery_pages"
 
 module Hwaro
   module Content
@@ -21,7 +22,13 @@ module Hwaro
 
           if skip_if_unchanged
             filename = File.basename(config.llms.filename.empty? ? "llms.txt" : config.llms.filename)
-            if File.exists?(File.join(output_dir, filename))
+            # The probe must cover every file this generator writes: when
+            # full output is enabled, a present llms.txt with a missing
+            # llms-full.txt must NOT skip, or the full document is never
+            # re-emitted on warm builds.
+            full_present = !config.llms.full_enabled ||
+                           File.exists?(File.join(output_dir, full_output_filename(config)))
+            if File.exists?(File.join(output_dir, filename)) && full_present
               Logger.debug "  LLMs.txt unchanged (cache hit), skipping."
               return
             end
@@ -56,7 +63,10 @@ module Hwaro
         private def self.build_index(config : Models::Config, pages : Array(Models::Page)) : String
           base_url = config.base_url.rstrip('/')
 
-          eligible = pages.select(&.search_index_eligible?)
+          # Dedupe URL collisions to the page the build actually wrote
+          # (path-sort-first winner, same rule as sitemap/search/feeds) so
+          # the index never lists an unwritten loser.
+          eligible = DiscoveryPages.dedupe_by_url(pages.select(&.search_index_eligible?))
 
           # Group by section, keyed by display heading. A section's heading
           # comes from its `_index.md`, which is the only page modeled as a
@@ -134,13 +144,19 @@ module Hwaro
           end
         end
 
+        # Resolved output basename for llms-full.txt — shared by the writer
+        # and the warm-build skip probe so they can never drift.
+        private def self.full_output_filename(config : Models::Config) : String
+          filename = config.llms.full_filename
+          filename = "llms-full.txt" if filename.empty?
+          File.basename(filename)
+        end
+
         def self.generate_full(pages : Array(Models::Page), config : Models::Config, output_dir : String, verbose : Bool = false)
           return unless config.llms.enabled
           return unless config.llms.full_enabled
 
-          filename = config.llms.full_filename
-          filename = "llms-full.txt" if filename.empty?
-          filename = File.basename(filename)
+          filename = full_output_filename(config)
 
           file_path = File.join(output_dir, filename)
           content = build_full_document(pages, config)
@@ -156,7 +172,11 @@ module Hwaro
           # author excluded via `in_search_index = false` must not have its
           # entire raw markdown dumped into llms-full.txt either — previously
           # only render/draft were checked here, leaking opted-out pages.
-          eligible_pages = pages.select { |page| page.search_index_eligible? && !page.raw_content.empty? }.sort_by!(&.url)
+          # Dedupe collisions to the written winner BEFORE the raw-content
+          # filter so an unwritten loser's body never leaks in.
+          eligible_pages = DiscoveryPages.dedupe_by_url(pages.select(&.search_index_eligible?))
+            .reject!(&.raw_content.empty?)
+            .sort_by!(&.url)
 
           base_url = config.base_url
           base_url = base_url.rstrip('/') unless base_url.empty?

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -406,29 +406,15 @@ module Hwaro
           # slug => page.url that owns it, so colliding slugs get disambiguated.
           seen_slugs = {} of String => String
           pages.each do |page|
-            next if page.draft
-            next if page.generated
-            next unless page.render
-            next if page.image # Skip pages that already have a custom image
+            next unless eligible_for_auto_image?(page)
+            # Skip pages that carry a CUSTOM image (front matter / default).
+            # An image pointing into our own output_dir was assigned by a
+            # previous auto-OG pass (a serve incremental re-parse preserves
+            # it, and lazy serve mode pre-assigns the URL) — those must fall
+            # through so the file gets (re)generated when the page changed.
+            next if (img = page.image) && !auto_assigned?(img, ai)
 
-            # Use URL-based slug to avoid collisions between pages with the same title
-            # in different sections (e.g., /posts/hello/ and /guides/hello/)
-            url_slug = page.url.gsub("/", "-").strip("-")
-            slug = url_slug.empty? ? Utils::TextUtils.slugify(page.title) : url_slug
-            slug = "page" if slug.empty?
-
-            # The gsub("/", "-") collapses distinct URLs that differ only in
-            # slash-vs-hyphen placement (e.g. /posts/foo/ and /posts-foo/) onto
-            # the same slug. Left unresolved, the second page overwrites the
-            # first's manifest entry and both Pass-2 workers issue a concurrent
-            # File.write to the SAME .png/.svg path (torn file under -Dpreview_mt),
-            # and one page advertises an OG image rendered for the other. Append
-            # a short stable hash of the URL so each distinct URL owns a path.
-            if (owner = seen_slugs[slug]?) && owner != page.url
-              slug = "#{slug}-#{Digest::SHA256.hexdigest(page.url)[0, 8]}"
-            end
-            seen_slugs[slug] = page.url
-
+            slug = slug_for(page, seen_slugs)
             page_hash = compute_page_hash(page)
             new_entries[slug] = page_hash
 
@@ -526,6 +512,79 @@ module Hwaro
           end
 
           {generated: generated, skipped: skipped}
+        end
+
+        # Pages auto-OG generation applies to (mirrors the Pass-1 filters,
+        # minus the custom-image skip which callers evaluate themselves).
+        def self.eligible_for_auto_image?(page : Models::Page) : Bool
+          !page.draft && !page.generated && page.render
+        end
+
+        # True when `image` was assigned by auto-OG generation — it points
+        # into the auto-OG output directory — rather than set by the user.
+        # Used by the serve incremental re-parse to preserve the assignment
+        # (front matter alone can't restore it) and by Pass 1 above so a
+        # preserved URL doesn't read as a "custom image" that blocks
+        # regeneration.
+        def self.auto_assigned?(image : String?, ai : Models::AutoImageConfig) : Bool
+          return false unless image
+          image.starts_with?("/#{ai.output_dir.strip("/")}/")
+        end
+
+        # The OG image slug for a page. Uses the URL-based slug to avoid
+        # collisions between pages with the same title in different sections
+        # (e.g. /posts/hello/ and /guides/hello/).
+        #
+        # The gsub("/", "-") collapses distinct URLs that differ only in
+        # slash-vs-hyphen placement (e.g. /posts/foo/ and /posts-foo/) onto
+        # the same slug. Left unresolved, the second page overwrites the
+        # first's manifest entry and both Pass-2 workers issue a concurrent
+        # File.write to the SAME .png/.svg path (torn file under -Dpreview_mt),
+        # and one page advertises an OG image rendered for the other. Append
+        # a short stable hash of the URL so each distinct URL owns a path.
+        # `seen_slugs` (slug => owning page.url) carries that disambiguation
+        # state across calls within one pass.
+        def self.slug_for(page : Models::Page, seen_slugs : Hash(String, String)) : String
+          url_slug = page.url.gsub("/", "-").strip("-")
+          slug = url_slug.empty? ? Utils::TextUtils.slugify(page.title) : url_slug
+          slug = "page" if slug.empty?
+
+          if (owner = seen_slugs[slug]?) && owner != page.url
+            slug = "#{slug}-#{Digest::SHA256.hexdigest(page.url)[0, 8]}"
+          end
+          seen_slugs[slug] = page.url
+          slug
+        end
+
+        # Lazy serve mode (`[og.auto_image] lazy_generate = true`): assign
+        # each eligible page the URL its OG image WILL live at without
+        # rendering anything, so page HTML carries the same og:image meta a
+        # full build would emit. The dev server's OgLazyImageHandler
+        # generates the file on first request. Returns the number of pages
+        # assigned.
+        #
+        # The extension assumes PNG rendering will be available when the
+        # format asks for it; if font initialization fails at request time
+        # the handler serves the SVG fallback bytes under the advertised
+        # path (dev-only pragmatism).
+        def self.assign_lazy_urls(pages : Array(Models::Page), config : Models::Config) : Int32
+          ai = config.og.auto_image
+          return 0 unless ai.enabled
+
+          # Mirrors generate's format validation: anything but "png" (unknown
+          # formats included) renders as SVG.
+          ext = ai.format == "png" ? "png" : "svg"
+          seen_slugs = {} of String => String
+          count = 0
+          pages.each do |page|
+            next unless eligible_for_auto_image?(page)
+            next if (img = page.image) && !auto_assigned?(img, ai)
+
+            slug = slug_for(page, seen_slugs)
+            page.image = "/#{ai.output_dir}/#{slug}.#{ext}"
+            count += 1
+          end
+          count
         end
 
         # Font stacks for the SVG fallback renderer. They lead with the

--- a/src/content/seo/og_image.cr
+++ b/src/content/seo/og_image.cr
@@ -286,6 +286,13 @@ module Hwaro
         # rather than overwriting; in full mode (default) we still
         # truncate so manifest entries — and the disk files they
         # describe — for deleted pages get pruned naturally.
+        #
+        # `forced_slug` is for single-page callers (the dev server's
+        # OgLazyImageHandler) whose page already advertises a slug computed
+        # by assign_lazy_urls against the FULL page set: recomputing the
+        # slug here with a fresh `seen_slugs` would collapse slug-colliding
+        # pages (/posts/foo/ vs /posts-foo/) onto one file. Only meaningful
+        # when `pages` holds exactly one page.
         def self.generate(
           pages : Array(Models::Page),
           config : Models::Config,
@@ -293,6 +300,7 @@ module Hwaro
           verbose : Bool = false,
           partial : Bool = false,
           parallel : Bool = true,
+          forced_slug : String? = nil,
         )
           ai = config.og.auto_image
           return {generated: 0, skipped: 0} unless ai.enabled
@@ -414,7 +422,7 @@ module Hwaro
             # through so the file gets (re)generated when the page changed.
             next if (img = page.image) && !auto_assigned?(img, ai)
 
-            slug = slug_for(page, seen_slugs)
+            slug = forced_slug || slug_for(page, seen_slugs)
             page_hash = compute_page_hash(page)
             new_entries[slug] = page_hash
 

--- a/src/content/seo/pwa.cr
+++ b/src/content/seo/pwa.cr
@@ -80,6 +80,17 @@ module Hwaro
             precache_urls << resolved_offline unless precache_urls.includes?(resolved_offline)
           end
 
+          # sw.js can never precache itself: on a clean build the file does
+          # not exist yet (so it would be dropped), and on a warm build the
+          # hash below would fold the PREVIOUS build's sw.js bytes into
+          # CACHE_NAME — changing sw.js, which changes the next build's
+          # hash, churning the cache name forever.
+          sw_url = config.with_base_path("/sw.js")
+          if precache_urls.includes?(sw_url)
+            Logger.warn "PWA: sw.js cannot precache itself — dropping #{sw_url.inspect} from the sw.js precache list"
+            precache_urls = precache_urls.reject { |u| u == sw_url }
+          end
+
           # cache.addAll() is all-or-nothing: a single 404 aborts the whole
           # service-worker install. Drop any site-internal precache URL whose
           # resolved output file does not exist (external http(s):// URLs are

--- a/src/content/seo/sitemap.cr
+++ b/src/content/seo/sitemap.cr
@@ -50,11 +50,22 @@ module Hwaro
           priority = site.config.sitemap.priority.clamp(0.0, 1.0)
           priority_str = "    <priority>#{priority}</priority>\n"
 
+          # A translation link whose target page is never written (render =
+          # false, or a draft/preview-only unpublished page) would advertise
+          # a 404 to crawlers. Build the set of URLs that actually get output
+          # (same eligibility the <loc> entries use, minus in_sitemap — an
+          # in_sitemap=false page is still written and is a valid alternate)
+          # and filter hreflang alternates through it.
+          written_urls = Set(String).new
+          pages.each do |p|
+            written_urls << p.url if p.render && !p.draft && !p.unpublished
+          end
+
           # Multilingual sites benefit from `<xhtml:link rel="alternate"
           # hreflang="...">` entries on every translated URL — Google's
           # recommended way to expose hreflang in sitemaps. Only declare
           # the namespace when we'll actually use it (#486).
-          has_translations = sitemap_pages.any? { |p| !p.translations.empty? }
+          has_translations = sitemap_pages.any? { |p| p.translations.any? { |t| written_urls.includes?(t.url) } }
 
           xml_content = String.build(sitemap_pages.size * 256) do |str|
             str << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
@@ -79,6 +90,7 @@ module Hwaro
               # the current page itself; Google's spec asks for a self-
               # referencing entry).
               page.translations.each do |t|
+                next unless written_urls.includes?(t.url)
                 t_path = t.url.starts_with?('/') ? t.url : "/#{t.url}"
                 t_full = base.empty? ? t_path : base + t_path
                 str << "    <xhtml:link rel=\"alternate\" hreflang=\""

--- a/src/content/seo/sitemap.cr
+++ b/src/content/seo/sitemap.cr
@@ -30,7 +30,18 @@ module Hwaro
           DiscoveryPages.reject_excluded!(sitemap_pages, site.config.sitemap.exclude)
 
           if sitemap_pages.empty?
-            Logger.info "  No pages to include in sitemap."
+            # Still (re)write the file: returning here left a PREVIOUS
+            # build's sitemap on disk when the last eligible page was
+            # drafted/excluded — stale URLs kept being served and deployed.
+            # An empty urlset is valid per the sitemap protocol.
+            Logger.info "  No pages to include in sitemap — writing an empty sitemap."
+            empty_xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" \
+                        "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n" \
+                        "</urlset>\n"
+            filename = File.basename(site.config.sitemap.filename)
+            sitemap_path = Path[output_dir, filename].to_s
+            Hwaro::Utils::FileSafe.atomic_write(sitemap_path, empty_xml)
+            Logger.action :create, sitemap_path if verbose
             return
           end
 

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -43,6 +43,8 @@ require "../../content/seo/robots"
 require "../../content/seo/llms"
 require "../../content/seo/tags"
 require "../../content/seo/jsonld"
+require "../../content/seo/pwa"
+require "../../content/seo/og_image"
 require "../../content/search"
 require "../../content/pagination/paginator"
 require "../../content/pagination/renderer"
@@ -286,6 +288,13 @@ module Hwaro
         # after a config-triggered rebuild.
         def config : Models::Config?
           @config
+        end
+
+        # The most recently built site (nil before the first build). The dev
+        # server's lazy OG handler reads it to match a requested image path
+        # back to the page that owns it.
+        def site : Models::Site?
+          @site
         end
 
         # Register all cache layers with the unified manager
@@ -751,7 +760,7 @@ module Hwaro
           seo_pages = taxonomy_sections.empty? ? all_pages : all_pages + taxonomy_sections
 
           # --- 6. Regenerate lightweight SEO / search files in parallel ---
-          regenerate_seo_surfaces(seo_pages, site, output_dir, verbose, options.parallel, include_robots: true)
+          regenerate_seo_surfaces(seo_pages, site, output_dir, verbose, options.parallel, include_robots: true, options: options)
 
           elapsed = Time.instant - start_time
           Logger.outcome("rebuilt", "#{render_list.size}/#{all_pages.size} pages", :result, elapsed.total_milliseconds)
@@ -1115,7 +1124,13 @@ module Hwaro
           if summaries_affected || feed_templates_affected || membership_changed
             seo_pages = (site.pages + site.sections).as(Array(Models::Page))
             seo_pages += taxonomy_sections unless taxonomy_sections.empty?
-            regenerate_seo_surfaces(seo_pages, site, output_dir, verbose, options.parallel, include_robots: true)
+            regenerate_seo_surfaces(seo_pages, site, output_dir, verbose, options.parallel, include_robots: true, options: options)
+          elsif site.config.pwa.enabled
+            # A layout-only template edit rightly skips the SEO surfaces
+            # (their inputs didn't change) — but it DID rewrite page HTML,
+            # and sw.js content-hashes the precached pages' bytes, so the
+            # service worker must still be refreshed.
+            Content::Seo::Pwa.generate(site, output_dir, verbose)
           end
 
           cache.save if options.cache
@@ -1229,7 +1244,7 @@ module Hwaro
           # had no effect on this deferred pass).
           taxonomy_sections = Content::Taxonomies.generate(site, output_dir, templates, verbose, builder: self)
           all_pages = (site.pages + site.sections + taxonomy_sections).as(Array(Models::Page))
-          regenerate_seo_surfaces(all_pages, site, output_dir, verbose, options.parallel)
+          regenerate_seo_surfaces(all_pages, site, output_dir, verbose, options.parallel, options: options)
 
           # Persist cache updates from the deferred pass. The initial build
           # already saved once; without this second save, killing the server
@@ -1670,7 +1685,7 @@ module Hwaro
         # deferred-pages cleanup, and the live-reload signal even though
         # every page rendered fine. The cold-build Generate phase keeps the
         # fail-loud default via its own ParallelHelper.execute call.
-        private def regenerate_seo_surfaces(pages : Array(Models::Page), site : Models::Site, output_dir : String, verbose : Bool, parallel : Bool, include_robots : Bool = false)
+        private def regenerate_seo_surfaces(pages : Array(Models::Page), site : Models::Site, output_dir : String, verbose : Bool, parallel : Bool, include_robots : Bool = false, options : Config::Options::BuildOptions? = nil)
           seo_tasks = [
             -> { Content::Seo::Sitemap.generate(pages, site, output_dir, verbose); nil },
             -> { Content::Seo::Feeds.generate(pages, site.config, output_dir, verbose, templates: @templates, renderer: feed_template_renderer); nil },
@@ -1681,7 +1696,41 @@ module Hwaro
           seo_tasks << -> { Content::Seo::Robots.generate(site.config, output_dir, verbose); nil } if include_robots
           seo_tasks << -> { Content::Seo::Llms.generate(site.config, pages, output_dir, verbose); nil }
           seo_tasks << -> { Content::Search.generate(pages, site.config, output_dir, verbose); nil }
+          # Auto-OG images: the incremental/rerender passes never run the
+          # BeforeRender `og_image:generate` hook, so a re-parsed page's
+          # OG file went stale even though its HTML keeps the auto-assigned
+          # URL (see ParseContent#parse_single_page). The manifest hash makes
+          # this a near no-op when no title/description changed. Lazy serve
+          # mode keeps its on-request contract (OgLazyImageHandler), and
+          # --skip-og-image is honored like the hook does. Runs BEFORE the
+          # surface pool (not inside it): generate assigns page.image, which
+          # the feed/search tasks read.
+          if opts = options
+            ai = site.config.og.auto_image
+            if ai.enabled && !opts.skip_og_image && !(ai.lazy_generate && opts.serve_mode)
+              begin
+                Content::Seo::OgImage.generate(pages, site.config, output_dir, verbose, parallel: false)
+              rescue ex
+                # Same warn-and-continue contract as the surface pool below —
+                # a transient OG failure must not skip cache.save / reload.
+                Logger.warn "  OG image regeneration failed: #{ex.message}"
+              end
+            end
+          end
           ParallelHelper.execute(seo_tasks, parallel, raise_on_error: false)
+          # PWA sw.js content-hashes the bytes of the files it precaches —
+          # including the search index the tasks above just rewrote — so it
+          # regenerates AFTER they finish, mirroring the full build's
+          # AfterWrite hook. Without this no serve incremental path ever
+          # rewrote sw.js and registered service workers kept serving stale
+          # bytes through live reloads.
+          if site.config.pwa.enabled
+            begin
+              Content::Seo::Pwa.generate(site, output_dir, verbose)
+            rescue ex
+              Logger.warn "  PWA regeneration failed: #{ex.message}"
+            end
+          end
         end
 
         # Emit the end-of-build cache statistics at the requested verbosity.

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1129,8 +1129,14 @@ module Hwaro
             # A layout-only template edit rightly skips the SEO surfaces
             # (their inputs didn't change) — but it DID rewrite page HTML,
             # and sw.js content-hashes the precached pages' bytes, so the
-            # service worker must still be refreshed.
-            Content::Seo::Pwa.generate(site, output_dir, verbose)
+            # service worker must still be refreshed. Warn-and-continue,
+            # matching regenerate_seo_surfaces: a transient failure here
+            # must not skip cache.save below.
+            begin
+              Content::Seo::Pwa.generate(site, output_dir, verbose)
+            rescue ex
+              Logger.warn "  PWA regeneration failed: #{ex.message}"
+            end
           end
 
           cache.save if options.cache
@@ -1441,7 +1447,7 @@ module Hwaro
               dest = File.join(output_dir, relative)
               outputs << dest if Utils::OutputGuard.within_output_dir?(dest, output_dir)
             elsif path.starts_with?("content/")
-              if path.downcase.ends_with?(".md")
+              if path.downcase.ends_with?(".md") || path.downcase.ends_with?(".markdown")
                 next unless site
                 rel = path.lchop("content/")
                 # Section _index pages live in site.sections, not site.pages —

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -331,35 +331,63 @@ module Hwaro
           self
         end
 
-        # Returns false when the build failed without raising (pre-hook
-        # failure or a phase abort) — the serve watcher branches on this to
-        # surface the failure instead of live-reloading onto a broken site.
-        def run(options : Config::Options::BuildOptions) : Bool
-          @render_workers = options.workers
-          run(
-            output_dir: options.output_dir,
-            base_url: options.base_url,
-            drafts: options.drafts,
-            include_expired: options.include_expired,
-            include_future: options.include_future,
-            minify: options.minify,
-            parallel: options.parallel,
-            cache: options.cache,
-            highlight: options.highlight,
-            verbose: options.verbose,
-            profile: options.profile,
-            debug: options.debug,
-            error_overlay: options.error_overlay,
-            stream: options.stream,
-            memory_limit: options.memory_limit,
-            env: options.env,
-            fast_start: options.fast_start,
-            fast_start_count: options.fast_start_count,
-            skip_og_image: options.skip_og_image,
-            skip_image_processing: options.skip_image_processing,
-            preserve_output: options.preserve_output,
-            cache_busting: options.cache_busting,
-          )
+        # Keyword-argument convenience form of `run`: packs the arguments
+        # into a BuildOptions and delegates to the struct overload, which is
+        # the REAL implementation. Callers holding a BuildOptions (the build
+        # command, the serve watcher) must call that overload directly so
+        # fields this form doesn't expose — `full`, `serve_mode`, `workers`
+        # — reach the build context verbatim instead of being silently
+        # dropped in a re-pack.
+        def run(
+          output_dir : String = "public",
+          base_url : String? = nil,
+          drafts : Bool = false,
+          include_expired : Bool = false,
+          include_future : Bool = false,
+          minify : Bool = false,
+          parallel : Bool = true,
+          cache : Bool = false,
+          full : Bool = false,
+          highlight : Bool = true,
+          verbose : Bool = false,
+          profile : Bool = false,
+          debug : Bool = false,
+          error_overlay : Bool = false,
+          stream : Bool = false,
+          memory_limit : String? = nil,
+          env : String? = nil,
+          fast_start : Bool = false,
+          fast_start_count : Int32 = 20,
+          skip_og_image : Bool = false,
+          skip_image_processing : Bool = false,
+          preserve_output : Bool = false,
+          cache_busting : Bool = true,
+        ) : Bool
+          run(Config::Options::BuildOptions.new(
+            output_dir: output_dir,
+            base_url: base_url,
+            drafts: drafts,
+            include_expired: include_expired,
+            include_future: include_future,
+            minify: minify,
+            parallel: parallel,
+            cache: cache,
+            full: full,
+            highlight: highlight,
+            verbose: verbose,
+            profile: profile,
+            debug: debug,
+            error_overlay: error_overlay,
+            stream: stream,
+            memory_limit: memory_limit,
+            env: env,
+            fast_start: fast_start,
+            fast_start_count: fast_start_count,
+            skip_og_image: skip_og_image,
+            skip_image_processing: skip_image_processing,
+            preserve_output: preserve_output,
+            cache_busting: cache_busting,
+          ))
         end
 
         # Drop unresolved-link records from the previous pass so a fixed
@@ -561,12 +589,16 @@ module Hwaro
             end
           end
 
-          # Delete originals of pages whose edit relocated their output file
-          # (slug/custom_path change) — excluded pages were handled above.
+          # Delete outputs the edit orphaned — a relocation (slug/custom_path
+          # change) moves EVERY output, but a front-matter edit can also drop
+          # just a sibling format (`outputs = ["json"]` removed) while the
+          # primary path stays put, so diff the full old/new path sets
+          # instead of comparing only the primary path. Excluded pages were
+          # handled above.
           relocated = [] of String
           changed_pages.each do |page|
             next unless olds = old_output_paths[page.path]?
-            relocated.concat(olds) if olds.first? != get_output_path(page, output_dir)
+            relocated.concat(olds - collect_page_output_paths(page, output_dir))
           end
           delete_orphaned_outputs(relocated, output_dir) unless relocated.empty?
 
@@ -831,12 +863,12 @@ module Hwaro
             end
           end
 
-          # Delete originals of pages whose edit relocated their output file
-          # (slug/custom_path change) — mirrors run_incremental.
+          # Delete outputs the edit orphaned (relocation or a dropped sibling
+          # output format) — set diff, mirrors run_incremental.
           relocated = [] of String
           changed_pages.each do |page|
             next unless olds = old_output_paths[page.path]?
-            relocated.concat(olds) if olds.first? != get_output_path(page, output_dir)
+            relocated.concat(olds - collect_page_output_paths(page, output_dir))
           end
           delete_orphaned_outputs(relocated, output_dir) unless relocated.empty?
 
@@ -884,9 +916,17 @@ module Hwaro
           templates = load_templates
           @templates = templates
 
-          # Refresh invalidation mode for the reloaded template set
+          # Refresh invalidation mode for the reloaded template set. Mirror
+          # phases/initialize.cr: snapshot-escaping refs (./-prefixed,
+          # non-template extensions, shadowed exact-ext variants) are read
+          # from disk at render time, so their contents must be folded into
+          # the global hash here too — otherwise serve rerenders and
+          # `build --cache` disagree on every page's cache entry.
           deps = @template_deps
           @global_templates_hash = Cache.compute_templates_hash(templates)
+          if (graph = deps) && !graph.snapshot_escaping_refs.empty?
+            @global_templates_hash = fold_snapshot_escaping_refs(@global_templates_hash, graph.snapshot_escaping_refs)
+          end
           @per_page_template_hash = config.build.template_deps &&
                                     (deps.try { |d| !d.dynamic? } || false)
 
@@ -1197,8 +1237,26 @@ module Hwaro
           sass_on = config.try(&.sass.enabled) || false
           copied = 0
           changed_files.each do |src_path|
-            next unless File.exists?(src_path)
-            next if File.directory?(src_path)
+            # lstat first — mirrors the full build's collect_static_files
+            # (phases/initialize.cr): a symlinked file whose target escapes
+            # the project must not be published into the output during
+            # serve (e.g. `static/leak -> ~/.ssh/id_rsa` whose target's
+            # mtime change trips the watcher). Dangling symlinks and
+            # directories are skipped like before.
+            lstat = File.info?(src_path, follow_symlinks: false)
+            next if lstat.nil?
+
+            if lstat.symlink?
+              info = File.info?(src_path, follow_symlinks: true)
+              next if info.nil? || info.directory?
+
+              unless Hwaro::Utils::PathUtils.resolves_within?(src_path, Dir.current)
+                Logger.warn "Skipping static symlink pointing outside the project: #{src_path}"
+                next
+              end
+            else
+              next if lstat.directory?
+            end
 
             relative = path_relative_to(src_path, "static")
             next if static_config.excluded?(relative)
@@ -1215,6 +1273,13 @@ module Hwaro
               end
             end
             dest_path = File.join(output_dir, relative)
+            # Parity with copy_changed_content_files: a watcher path outside
+            # static/ yields a `../`-relative destination that must never be
+            # written outside the output directory.
+            unless Utils::OutputGuard.within_output_dir?(dest_path, output_dir)
+              Logger.warn "Skipping static file outside output directory: #{relative}"
+              next
+            end
 
             Hwaro::Utils::FileSafe.mkdir_p(File.dirname(dest_path))
             FileUtils.cp(src_path, dest_path)
@@ -1380,37 +1445,23 @@ module Hwaro
           end
         end
 
-        def run(
-          output_dir : String = "public",
-          base_url : String? = nil,
-          drafts : Bool = false,
-          include_expired : Bool = false,
-          include_future : Bool = false,
-          minify : Bool = false,
-          parallel : Bool = true,
-          cache : Bool = false,
-          full : Bool = false,
-          highlight : Bool = true,
-          verbose : Bool = false,
-          profile : Bool = false,
-          debug : Bool = false,
-          error_overlay : Bool = false,
-          stream : Bool = false,
-          memory_limit : String? = nil,
-          env : String? = nil,
-          fast_start : Bool = false,
-          fast_start_count : Int32 = 20,
-          skip_og_image : Bool = false,
-          skip_image_processing : Bool = false,
-          preserve_output : Bool = false,
-          cache_busting : Bool = true,
-        ) : Bool
+        # Full build — the real implementation behind both `run` forms.
+        # The incoming struct is stored on the BuildContext verbatim, so
+        # fields the keyword form doesn't expose (`full`, `serve_mode`)
+        # survive to the phases and hooks that branch on them (`--full`
+        # cache clearing, `[og.image] lazy_generate` under serve).
+        #
+        # Returns false when the build failed without raising (pre-hook
+        # failure or a phase abort) — the serve watcher branches on this to
+        # surface the failure instead of live-reloading onto a broken site.
+        def run(options : Config::Options::BuildOptions) : Bool
+          @render_workers = options.workers
           # Load config once and reuse throughout the build.
           # `Models::Config.load` raises `HwaroError(HWARO_E_CONFIG)` directly
           # for missing files and TOML parse failures, so callers (and
           # `--json` consumers) can branch on HWARO_E_CONFIG without the
           # build pipeline rewrapping the exception.
-          config = Models::Config.load(env: env)
+          config = Models::Config.load(env: options.env)
           @config = config
           pre_hooks = config.build.hooks.pre
           post_hooks = config.build.hooks.post
@@ -1428,36 +1479,10 @@ module Hwaro
           start_time = Time.instant
 
           # Initialize profiler
-          profiler = Profiler.new(enabled: profile)
+          profiler = Profiler.new(enabled: options.profile)
           @profiler = profiler
           profiler.start
 
-          # Create build context for lifecycle
-          options = Config::Options::BuildOptions.new(
-            output_dir: output_dir,
-            base_url: base_url,
-            drafts: drafts,
-            include_expired: include_expired,
-            include_future: include_future,
-            minify: minify,
-            parallel: parallel,
-            cache: cache,
-            full: full,
-            highlight: highlight,
-            verbose: verbose,
-            profile: profile,
-            debug: debug,
-            error_overlay: error_overlay,
-            stream: stream,
-            memory_limit: memory_limit,
-            env: env,
-            fast_start: fast_start,
-            fast_start_count: fast_start_count,
-            skip_og_image: skip_og_image,
-            skip_image_processing: skip_image_processing,
-            preserve_output: preserve_output,
-            cache_busting: cache_busting,
-          )
           if options.streaming?
             Logger.info "  Streaming mode enabled (batch size: #{options.batch_size})"
           end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -880,7 +880,16 @@ module Hwaro
           # Re-render with reloaded templates. The selective path inside
           # run_rerender only covers template-affected pages, so the content
           # pages re-parsed above must be forced into the render set.
-          run_rerender(options, force_pages: changed_pages)
+          #
+          # membership_changed: a page whose draft/expired/future status just
+          # flipped it OUT of the built set leaves changed_pages (so
+          # force_pages can't carry the signal), yet sitemap/feeds/search and
+          # taxonomy pages still list it — run_rerender must refresh those
+          # surfaces even when the template edit itself was layout-only (or a
+          # bare mtime touch). Flips INTO the set escalate to a full rebuild
+          # via the pages_map miss above, so exclusions are the only
+          # membership change this path can see.
+          run_rerender(options, force_pages: changed_pages, membership_changed: !excluded_pages.empty?)
         end
 
         # Re-render pages using reloaded templates without re-parsing content.
@@ -895,7 +904,12 @@ module Hwaro
         # the selective path can't skip a content-changed page. Their taxonomy
         # membership may have changed too, so taxonomy pages regenerate
         # whenever force_pages are present.
-        def run_rerender(options : Config::Options::BuildOptions, force_pages : Array(Models::Page)? = nil) : Bool
+        #
+        # `membership_changed` signals that pages left the built set in this
+        # pass (a draft/expired/future flip): the SEO surfaces and taxonomy
+        # pages must refresh even when no template content changed, and the
+        # identical-templates early return must not skip that work.
+        def run_rerender(options : Config::Options::BuildOptions, force_pages : Array(Models::Page)? = nil, membership_changed : Bool = false) : Bool
           @render_workers = options.workers
           config = @config
           site = @site
@@ -957,7 +971,7 @@ module Hwaro
               changed << name if old_templates[name]? != source
             end
             changed_template_names = changed
-            if changed.empty? && (force_pages.nil? || force_pages.empty?)
+            if changed.empty? && (force_pages.nil? || force_pages.empty?) && !membership_changed
               Logger.info "Template change detected, but contents are identical — nothing to re-render."
               return true
             end
@@ -1081,6 +1095,7 @@ module Hwaro
           # pages may have changed taxonomy membership — regenerate then too.
           taxonomy_sections = if affected_templates.nil? ||
                                  (force_pages && !force_pages.empty?) ||
+                                 membership_changed ||
                                  feed_templates_affected ||
                                  ["taxonomy", "taxonomy_term", "page"].any? { |name| affected_templates.includes?(name) }
                                 Content::Taxonomies.generate(site, output_dir, templates, verbose, builder: self)
@@ -1094,8 +1109,10 @@ module Hwaro
           # search, and llms embed. Refresh those surfaces. A pure layout
           # edit still skips this — template output doesn't feed them —
           # UNLESS the edit touched a user feed template, whose output IS a
-          # generated surface (see feed_templates_affected above).
-          if summaries_affected || feed_templates_affected
+          # generated surface (see feed_templates_affected above) — or pages
+          # LEFT the built set this pass (membership_changed): sitemap,
+          # feeds, search and llms would keep listing them otherwise.
+          if summaries_affected || feed_templates_affected || membership_changed
             seo_pages = (site.pages + site.sections).as(Array(Models::Page))
             seo_pages += taxonomy_sections unless taxonomy_sections.empty?
             regenerate_seo_surfaces(seo_pages, site, output_dir, verbose, options.parallel, include_robots: true)
@@ -1291,9 +1308,13 @@ module Hwaro
         # Recompile all SCSS entries into the output directory. Used by
         # serve mode when a `.scss` source changes — such files publish as
         # compiled `.css`, never verbatim. No-ops unless [sass] is enabled.
-        def recompile_sass(output_dir : String)
+        #
+        # Returns true when reprocessing the asset bundles changed the
+        # manifest (a fingerprinted filename moved) — see
+        # reprocess_asset_bundles for what callers must do then.
+        def recompile_sass(output_dir : String) : Bool
           config = @config
-          return unless config && config.sass.enabled
+          return false unless config && config.sass.enabled
 
           compiler = Assets::SassCompiler.new(config.sass, config.static)
           count = compiler.compile_all(output_dir)
@@ -1302,22 +1323,45 @@ module Hwaro
           # Bundle entries with `.scss` sources only recompile inside the asset
           # pipeline (AfterInitialize on a full build). Static-only serve
           # reloads would otherwise leave fingerprinted bundles stale.
-          reprocess_asset_bundles(output_dir) if config.assets.enabled
+          config.assets.enabled ? reprocess_asset_bundles(output_dir) : false
+        end
+
+        # True when a watcher-relative path (e.g. "static/js/app.js") is a
+        # source file of a configured [assets] bundle. The serve watcher uses
+        # this to know a plain (non-Sass) static save must re-run the bundle
+        # pipeline — bundle inputs are `source_dir`-joined `bundle.files`,
+        # exactly how Assets::Pipeline reads them.
+        def asset_bundle_source?(path : String) : Bool
+          config = @config
+          return false unless config && config.assets.enabled
+
+          normalized = Path[path].normalize.to_s
+          config.assets.bundles.any? do |bundle|
+            bundle.files.any? do |file|
+              Path[config.assets.source_dir, file].normalize.to_s == normalized
+            end
+          end
         end
 
         # Re-run the asset pipeline so SCSS (or plain CSS/JS) bundle sources
         # refresh under serve. Updates the AssetHooks class-level manifest so
         # subsequent renders see new fingerprint paths.
-        def reprocess_asset_bundles(output_dir : String)
+        #
+        # Returns true when the manifest changed — with fingerprinting on,
+        # every already-rendered page still references the OLD hashed
+        # filename, so callers must follow up with a page re-render.
+        def reprocess_asset_bundles(output_dir : String) : Bool
           config = @config
-          return unless config && config.assets.enabled
+          return false unless config && config.assets.enabled
 
+          old_manifest = Content::Hooks::AssetHooks.manifest
           pipeline = Assets::Pipeline.new(config.assets, config.base_url, config.sass.enabled)
           pipeline.process(output_dir)
           Content::Hooks::AssetHooks.replace_manifest(pipeline.manifest)
           if pipeline.manifest.size > 0
             Logger.outcome("bundled", "#{pipeline.manifest.size} asset #{pipeline.manifest.size == 1 ? "bundle" : "bundles"}")
           end
+          pipeline.manifest != old_manifest
         end
 
         # Republish non-Markdown content assets (images, etc.) to the output
@@ -1411,6 +1455,23 @@ module Hwaro
             end
           end
           outputs
+        end
+
+        # Every output file the CURRENT site claims — primary page outputs
+        # plus output-format siblings, computed exactly like
+        # collect_page_output_paths so the two can never drift. The serve
+        # watcher filters its pre-rebuild stale list through this AFTER the
+        # rebuild: a source deleted and re-created under a different path in
+        # one changeset (foo.md → foo/index.md) maps to the same output file,
+        # which the rebuild just rewrote and must not be deleted.
+        def owned_output_paths(output_dir : String) : Set(String)
+          owned = Set(String).new
+          if site = @site
+            (site.pages + site.sections).each do |page|
+              collect_page_output_paths(page, output_dir).each { |path| owned << path }
+            end
+          end
+          owned
         end
 
         # Primary output file plus output-format siblings for a page — used

--- a/src/core/build/builtin_shortcodes.cr
+++ b/src/core/build/builtin_shortcodes.cr
@@ -97,11 +97,14 @@ module Hwaro
           #        {% alert(type="info", title="Note") %}Some info{% end %}
           #        {% alert(type="tip") %}Named closer recommended{% endalert %}
           # Types: info, warning, danger, tip, success
+          # The body is markdownified so **bold**/`code`/[links](…) render as
+          # HTML — parity with the scaffold override (scaffolds/base.cr),
+          # which has always piped `body | markdownify`.
           t["shortcodes/alert"] = <<-HTML
             {% set tone = type | default(value="info") | lower %}
             <div class="sc-alert sc-alert--{{ tone | e }}" role="alert">
               {% if title %}<div class="sc-alert__title">{{ title | e }}</div>{% endif %}
-              <div class="sc-alert__body">{{ body }}</div>
+              <div class="sc-alert__body">{{ body | markdownify }}</div>
             </div>
             HTML
 

--- a/src/core/build/cache.cr
+++ b/src/core/build/cache.cr
@@ -35,6 +35,16 @@ module Hwaro
         @[JSON::Field(key: "cascade_hash", emit_null: false)]
         property cascade_hash : String
 
+        # Fingerprint of the page bundle's colocated asset names (sorted,
+        # length-prefixed) as of the build that wrote this entry. Adding or
+        # removing a bundle asset changes what `page.assets` renders without
+        # touching the page's own source, so it must be part of the cache
+        # key. "" for pages with no assets AND for entries written before
+        # this field existed — asset-carrying pages rebuild once when
+        # upgrading from a legacy cache, asset-less pages don't.
+        @[JSON::Field(key: "assets_hash", emit_null: false)]
+        property assets_hash : String
+
         # Secondary sibling output files this page emitted beyond
         # `output_path` (e.g. `index.json`, `index.xml` — see `[outputs]`).
         # Empty for pages with no extra formats and for every entry written
@@ -51,6 +61,7 @@ module Hwaro
           @config_hash : String = "",
           @cascade_hash : String = "",
           @output_paths : Array(String) = [] of String,
+          @assets_hash : String = "",
         )
         end
 
@@ -63,6 +74,7 @@ module Hwaro
           template_hash = ""
           config_hash = ""
           cascade_hash = ""
+          assets_hash = ""
           output_paths = [] of String
 
           pull.read_object do |key|
@@ -74,6 +86,7 @@ module Hwaro
             when "template_hash" then template_hash = pull.read_string
             when "config_hash"   then config_hash = pull.read_string
             when "cascade_hash"  then cascade_hash = pull.read_string
+            when "assets_hash"   then assets_hash = pull.read_string
             when "output_paths"
               output_paths = [] of String
               pull.read_array { output_paths << pull.read_string }
@@ -83,7 +96,7 @@ module Hwaro
 
           new(path: path, mtime: mtime, hash: hash, output_path: output_path,
             template_hash: template_hash, config_hash: config_hash, cascade_hash: cascade_hash,
-            output_paths: output_paths)
+            output_paths: output_paths, assets_hash: assets_hash)
         end
       end
 
@@ -246,7 +259,7 @@ module Hwaro
         # `extra_outputs` are secondary sibling output files (see `[outputs]`)
         # that must also still exist on disk — a manually deleted `index.json`
         # forces a rebuild just like a deleted `index.html` does.
-        def changed?(file_path : String, output_path : String = "", cascade_hash : String = "", template_hash : String? = nil, extra_outputs : Array(String) = [] of String) : Bool
+        def changed?(file_path : String, output_path : String = "", cascade_hash : String = "", template_hash : String? = nil, extra_outputs : Array(String) = [] of String, assets_hash : String = "") : Bool
           return true unless @enabled
           return true unless File.exists?(file_path)
 
@@ -270,6 +283,12 @@ module Hwaro
           # A parent section's [cascade] changed what this page inherits —
           # the source file is unchanged but the rendered output isn't.
           return true if entry.cascade_hash != cascade_hash
+
+          # The bundle's colocated asset set changed (file added/removed) —
+          # `page.assets` renders differently though the source is untouched.
+          # Legacy entries store "" here, so an asset-carrying page rebuilds
+          # once after upgrading (same handling as cascade_hash).
+          return true if entry.assets_hash != assets_hash
 
           # A template in this page's dependency closure changed.
           if template_hash && entry.template_hash != template_hash
@@ -328,7 +347,7 @@ module Hwaro
         # `output_paths` are the secondary sibling output files this page
         # emitted (see `[outputs]`); empty when the feature isn't in use.
         # Thread-safe: protected by mutex for concurrent parallel builds.
-        def update(file_path : String, output_path : String = "", cascade_hash : String = "", template_hash : String? = nil, output_paths : Array(String) = [] of String)
+        def update(file_path : String, output_path : String = "", cascade_hash : String = "", template_hash : String? = nil, output_paths : Array(String) = [] of String, assets_hash : String = "")
           return unless @enabled
           return unless File.exists?(file_path)
 
@@ -342,7 +361,7 @@ module Hwaro
               existing = @entries[file_path]?
               if existing && existing.mtime == mtime && existing.output_path == output_path &&
                  existing.cascade_hash == cascade_hash && existing.template_hash == effective_template_hash &&
-                 existing.output_paths == output_paths
+                 existing.output_paths == output_paths && existing.assets_hash == assets_hash
                 return
               end
             end
@@ -359,6 +378,7 @@ module Hwaro
               config_hash: @current_config_hash,
               cascade_hash: cascade_hash,
               output_paths: output_paths,
+              assets_hash: assets_hash,
             )
 
             @mutex.synchronize do

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -70,6 +70,9 @@ module Hwaro::Core::Build::Phases::Initialize
       # template checksum when dependency tracking is on AND every template
       # reference resolved statically (no variable includes).
       @global_templates_hash = Cache.compute_templates_hash(ctx.templates)
+      if (graph = @template_deps) && !graph.snapshot_escaping_refs.empty?
+        @global_templates_hash = fold_snapshot_escaping_refs(@global_templates_hash, graph.snapshot_escaping_refs)
+      end
       @per_page_template_hash = config.build.template_deps &&
                                 (@template_deps.try { |deps| !deps.dynamic? } || false)
       if (deps = @template_deps) && deps.dynamic? && config.build.template_deps
@@ -366,8 +369,11 @@ module Hwaro::Core::Build::Phases::Initialize
     @template_paths = template_paths
     @shadowed_template_hashes = shadowed_hashes
 
-    # (Re)build the template dependency graph for selective invalidation
-    @template_deps = TemplateDeps.new(templates)
+    # (Re)build the template dependency graph for selective invalidation.
+    # `template_paths` lets the graph detect literal refs the snapshot
+    # loader cannot serve (shadowed extension variants etc.) — see
+    # TemplateDeps#snapshot_escaping_refs.
+    @template_deps = TemplateDeps.new(templates, template_paths)
 
     # (Re)build the render-hook registry — nil when no templates/hooks/render-*
     # template exists, which is the zero-cost gate the render path checks
@@ -393,6 +399,31 @@ module Hwaro::Core::Build::Phases::Initialize
     @crinja_env = setup_crinja_env
 
     templates
+  end
+
+  # Templates referenced by literal name that the snapshot loader cannot
+  # serve (./-prefixed, non-template extensions, shadowed extension
+  # variants — see TemplateDeps#snapshot_escaping_refs) are read from DISK
+  # at render time: their bytes reach the output but live in no snapshot
+  # hash. Fold their current disk contents into the global templates
+  # checksum so editing one invalidates the `--cache` entries. The graph is
+  # dynamic whenever such refs exist, so this folded hash is exactly the
+  # one every page's cache entry stores and compares.
+  private def fold_snapshot_escaping_refs(base : String, refs : Set(String)) : String
+    digest = Digest::MD5.new
+    Utils::DigestUtils.update_length_prefixed(digest, base)
+    refs.to_a.sort!.each do |ref|
+      path = File.join("templates", ref)
+      content_hash = begin
+        File.exists?(path) ? Digest::MD5.hexdigest(File.read(path)) : "<absent>"
+      rescue
+        # Unreadable mid-save: treat as absent; the next build re-hashes.
+        "<absent>"
+      end
+      Utils::DigestUtils.update_length_prefixed(digest, ref)
+      Utils::DigestUtils.update_length_prefixed(digest, content_hash)
+    end
+    digest.final.hexstring
   end
 
   # How long `read_template_source` rides out a template file that a glob

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -298,9 +298,26 @@ module Hwaro::Core::Build::Phases::ParseContent
     raw_content = File.read(source_path)
     data = Processor::Markdown.parse(raw_content, source_path)
 
+    # A serve incremental re-parse works on the LIVE page object, and
+    # `og_image:generate` (a BeforeRender hook the incremental paths never
+    # run) previously stored the auto-OG image URL on it. Resetting
+    # page.image from front matter alone erased the og:image meta from the
+    # edited page for the rest of the session. Preserve the auto-assigned
+    # URL when the front matter still declares no image; the OG file itself
+    # is refreshed by regenerate_seo_surfaces after the re-render (or on
+    # request under lazy serve mode). On a cold build pages are fresh
+    # (page.image nil), so this is a no-op there. A front-matter image the
+    # edit just added still wins.
+    previous_image = page.image
+
     page.title = data[:title]
     page.description = data[:description]
     page.image = data[:image]
+    if data[:image].nil? && (prev = previous_image)
+      if (cfg = @config) && cfg.og.auto_image.enabled && Content::Seo::OgImage.auto_assigned?(prev, cfg.og.auto_image)
+        page.image = prev
+      end
+    end
     page.raw_content = data[:content]
     page.draft = data[:draft]
     page.template = normalize_template_name(data[:template])

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -193,9 +193,10 @@ module Hwaro::Core::Build::Phases::ParseContent
     now = Time.utc
     soon = now + 7.days
 
-    # Warn about pages expiring soon (before filtering)
+    # Warn about pages expiring soon (before filtering). all_pages so
+    # section `_index` files with an `expires` date warn too.
     if filter_expired
-      ctx.pages.each do |p|
+      ctx.all_pages.each do |p|
         if exp = p.expires
           if exp > now && exp <= soon
             Logger.warn "Page '#{p.path}' expires on #{exp.to_s("%Y-%m-%d")} (within 7 days)"
@@ -284,7 +285,15 @@ module Hwaro::Core::Build::Phases::ParseContent
   # Parse a single page: read file, parse frontmatter, assign properties
   private def parse_single_page(page : Models::Page)
     source_path = File.join("content", page.path)
-    return unless File.exists?(source_path)
+    unless File.exists?(source_path)
+      # A dangling symlink (or a file deleted mid-rebuild) must be filtered
+      # like any parse failure. Returning silently left a ghost page with
+      # url "" whose output path resolves to <output>/index.html — silently
+      # clobbering the homepage, nondeterministically under parallel render.
+      page.parse_failed = true
+      Logger.warn "Failed to parse #{page.path}: source file missing (deleted mid-build or dangling symlink)"
+      return
+    end
 
     raw_content = File.read(source_path)
     data = Processor::Markdown.parse(raw_content, source_path)

--- a/src/core/build/phases/read_content.cr
+++ b/src/core/build/phases/read_content.cr
@@ -5,7 +5,10 @@
 # raw files (JSON, XML) for later processing.
 
 module Hwaro::Core::Build::Phases::ReadContent
-  LANGUAGE_FILENAME_PATTERN = /^(.+)\.([a-z]{2,3})\.md$/
+  # Page source extensions. Must agree with the markdown processor's
+  # `extensions` declaration — a `.markdown` file the processor claims but
+  # this phase skips would silently vanish from the build.
+  PAGE_EXTENSIONS = {".md", ".markdown"}
 
   private def execute_read_content_phase(ctx : Lifecycle::BuildContext, profiler : Profiler) : Lifecycle::HookResult
     profiler.start_phase("ReadContent")
@@ -32,23 +35,23 @@ module Hwaro::Core::Build::Phases::ReadContent
       relative_path = Path[file_path].relative_to("content").to_s
       ext = Path[file_path].extension.downcase
 
-      if ext == ".md"
+      if PAGE_EXTENSIONS.includes?(ext)
         # Process markdown file
         basename = Path[relative_path].basename
-        language = extract_language_from_filename(basename, config)
+        language = extract_language_from_filename(basename, config, ext)
 
         clean_basename = if language
-                           # basename is guaranteed to end with ".<language>.md"
-                           # (extract_language_from_filename just matched it), so
-                           # plain string surgery replaces what was a per-file
-                           # interpolated Regex compile.
-                           "#{basename.rchop(".#{language}.md")}.md"
+                           # basename is guaranteed to end with
+                           # ".<language><ext>" (extract_language_from_filename
+                           # just matched it), so plain string surgery replaces
+                           # what was a per-file interpolated Regex compile.
+                           "#{basename.rchop(".#{language}#{ext}")}#{ext}"
                          else
                            basename
                          end
 
-        is_section_index = clean_basename == "_index.md"
-        is_index = clean_basename == "index.md" || is_section_index
+        is_section_index = clean_basename == "_index#{ext}"
+        is_index = clean_basename == "index#{ext}" || is_section_index
 
         if is_section_index
           page = Models::Section.new(relative_path)
@@ -82,16 +85,24 @@ module Hwaro::Core::Build::Phases::ReadContent
     end
   end
 
-  # Extract language code from filename if it matches configured languages
-  private def extract_language_from_filename(basename : String, config : Models::Config?) : String?
+  # Extract the language code from a filename (`about.ko.md` -> "ko",
+  # `_index.zh-tw.md` -> "zh-tw"). The candidate is whatever sits between
+  # the last two dots and is matched against the DECLARED language codes
+  # (plus the default) — not a fixed `[a-z]{2,3}` alphabet, which silently
+  # read `about.zh-tw.md` as a regular page published at /about.zh-tw/.
+  # An undeclared suffix still means "no language" (regular page).
+  private def extract_language_from_filename(basename : String, config : Models::Config?, ext : String = ".md") : String?
     return unless config
     return unless config.multilingual?
+    return unless basename.size > ext.size && basename[-ext.size..].downcase == ext
 
-    # Match pattern: filename.lang.md (e.g., "about.ko.md" -> "ko", "_index.ko.md" -> "ko")
-    if match = basename.match(LANGUAGE_FILENAME_PATTERN)
-      lang_code = match[2]
-      return lang_code if config.languages.has_key?(lang_code) || lang_code == config.default_language
-    end
+    stem = basename[0, basename.size - ext.size]
+    idx = stem.rindex('.')
+    # idx > 0: a non-empty base name must remain (".ko.md" is not a translation)
+    return unless idx && idx > 0
+    lang_code = stem[(idx + 1)..]
+    return if lang_code.empty?
+    return lang_code if config.languages.has_key?(lang_code) || lang_code == config.default_language
 
     nil
   end

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -297,7 +297,7 @@ module Hwaro::Core::Build::Phases::Render
     pages.select do |page|
       source_path, output_path = cache_paths_for(page, output_dir)
       fmt_paths = format_output_paths(page, output_dir, effective_output_formats(page, site.config))
-      next true if cache.changed?(source_path, output_path || "", page.cascade_fingerprint, page_template_hash(page, templates, site), extra_outputs: fmt_paths)
+      next true if cache.changed?(source_path, output_path || "", page.cascade_fingerprint, page_template_hash(page, templates, site), extra_outputs: fmt_paths, assets_hash: page_assets_hash(page))
       # Page's own source is unchanged: only re-render it if a set it depends on
       # changed. Skip the (cheap) marker scan entirely when nothing moved.
       next false unless page_set_changed || section_set_changed
@@ -460,54 +460,108 @@ module Hwaro::Core::Build::Phases::Render
   end
 
   # Fingerprint the global page set — the content-page metadata that listing
-  # pages render (membership, urls, titles, dates, weights, draft, section).
+  # pages render (membership, urls, titles, dates, updated, weights, draft,
+  # toc, section, image, series, authors, tags, bundle assets).
   #
   # `fields` widens the digest to cover `[extra]` and the content-derived
   # values (`summary`, `word_count`, `reading_time`) when the site's listing
   # templates actually read them. Without that, editing a post's body or its
   # `[extra]` re-rendered only the post itself: every listing showing its
   # excerpt, word count or badge kept the previous build's value forever.
+  # Every field is folded length-prefixed (see DigestUtils), and every
+  # list/map is size-prefixed, so adjacent values can never alias across
+  # boundaries: the previous bare `,`/`;`/`=` joins made `tags = ["a,b"]`
+  # and `tags = ["a", "b"]` fingerprint identically, hiding the edit from
+  # every listing.
   private def compute_page_set_fingerprint(pages : Array(Models::Page), fields : Builder::ListingPageFields) : String
-    Digest::MD5.hexdigest(String.build do |io|
-      pages.each do |p|
-        io << p.path << '\u0001' << p.url << '\u0001' << p.title << '\u0001'
-        io << (p.description || "") << '\u0001'
-        io << (p.date.try(&.to_unix) || 0_i64) << '\u0001' << p.weight << '\u0001'
-        io << (p.draft ? '1' : '0') << '\u0001' << p.section << '\u0001'
-        io << p.tags.join(',') << '\u0001'
-        p.taxonomies.keys.sort!.each { |k| io << k << '=' << p.taxonomies[k].join(',') << ';' }
-        p.menus.keys.sort!.each { |k| io << k << '=' << menu_registration_fp(p.menus[k]) << ';' }
-        io << extra_fp(p.extra) << '\u0001' if fields.extra
-        if fields.content_derived
-          io << (p.summary || "") << '\u0001' << p.word_count << '\u0001' << p.reading_time << '\u0001'
-        end
-        io << '\u0002'
+    digest = Digest::MD5.new
+    pages.each do |p|
+      fp_value(digest, p.path)
+      fp_value(digest, p.url)
+      fp_value(digest, p.title)
+      fp_value(digest, p.description || "")
+      fp_value(digest, (p.date.try(&.to_unix) || 0_i64).to_s)
+      fp_value(digest, (p.updated.try(&.to_unix) || 0_i64).to_s)
+      fp_value(digest, p.weight.to_s)
+      fp_value(digest, p.draft ? "1" : "0")
+      fp_value(digest, p.toc ? "1" : "0")
+      fp_value(digest, p.section)
+      fp_value(digest, p.image || "")
+      fp_value(digest, p.series || "")
+      fp_list(digest, p.authors)
+      fp_list(digest, p.tags)
+      fp_list(digest, p.assets.sort)
+      fp_value(digest, "t#{p.taxonomies.size}")
+      p.taxonomies.keys.sort!.each do |k|
+        fp_value(digest, k)
+        fp_list(digest, p.taxonomies[k])
       end
-    end)
+      fp_menus(digest, p.menus)
+      fp_value(digest, extra_fp(p.extra)) if fields.extra
+      if fields.content_derived
+        fp_value(digest, p.summary || "")
+        fp_value(digest, p.word_count.to_s)
+        fp_value(digest, p.reading_time.to_s)
+      end
+    end
+    digest.final.hexstring
   end
 
-  # Fingerprint the section set — the metadata nav/menus render.
-  # No `fields` parameter: the `site.sections`/`get_section()` Crinja hash
-  # exposes no `extra` key at all, so a section's `[extra]` is unreachable
-  # from any section-set listing. Fingerprinting it could only ever cause
-  # spurious invalidation, never fix staleness.
+  # Fingerprint the section set — the metadata nav/menus and section-set
+  # consumers render: identity fields plus `date`, `sort_by`, `reverse`,
+  # `transparent`, `paginate` and the section's bundle assets, all of which
+  # the `site.sections`/`get_section()` Crinja hash exposes.
+  # No `fields` parameter: that hash exposes no `extra` key at all, so a
+  # section's `[extra]` is unreachable from any section-set listing.
+  # Fingerprinting it could only ever cause spurious invalidation, never
+  # fix staleness.
   private def compute_section_set_fingerprint(sections : Array(Models::Section)) : String
-    Digest::MD5.hexdigest(String.build do |io|
-      sections.each do |s|
-        io << s.path << '\u0001' << s.url << '\u0001' << s.title << '\u0001'
-        io << (s.description || "") << '\u0001' << (s.draft ? '1' : '0') << '\u0001' << s.weight << '\u0001'
-        s.menus.keys.sort!.each { |k| io << k << '=' << menu_registration_fp(s.menus[k]) << ';' }
-        io << '\u0002'
-      end
-    end)
+    digest = Digest::MD5.new
+    sections.each do |s|
+      fp_value(digest, s.path)
+      fp_value(digest, s.url)
+      fp_value(digest, s.title)
+      fp_value(digest, s.description || "")
+      fp_value(digest, (s.date.try(&.to_unix) || 0_i64).to_s)
+      fp_value(digest, s.draft ? "1" : "0")
+      fp_value(digest, s.weight.to_s)
+      fp_value(digest, s.sort_by || "-")
+      reverse = s.reverse
+      fp_value(digest, reverse.nil? ? "-" : (reverse ? "1" : "0"))
+      fp_value(digest, s.transparent ? "1" : "0")
+      fp_value(digest, s.paginate.try(&.to_s) || "-")
+      fp_list(digest, s.assets.sort)
+      fp_menus(digest, s.menus)
+    end
+    digest.final.hexstring
   end
 
-  # Serializes a single front-matter menu registration for the page/section
-  # set fingerprints above. Any field change (including a page newly
-  # gaining/losing a registration) must bust the cache for pages whose
-  # template calls `get_menu` / `site.menus`.
-  private def menu_registration_fp(reg : Models::MenuRegistration) : String
-    "name=#{reg.name},weight=#{reg.weight},parent=#{reg.parent},identifier=#{reg.identifier}"
+  # Length-prefixed field fold for the set fingerprints (one scheme with
+  # every other fingerprint site — see DigestUtils).
+  private def fp_value(digest : ::Digest, value : String) : Nil
+    Utils::DigestUtils.update_length_prefixed(digest, value)
+  end
+
+  # Size-prefixed, element-length-prefixed list fold: `["a,b"]` and
+  # `["a", "b"]` must digest differently.
+  private def fp_list(digest : ::Digest, values : Array(String)) : Nil
+    Utils::DigestUtils.update_length_prefixed(digest, "a#{values.size}")
+    values.each { |v| Utils::DigestUtils.update_length_prefixed(digest, v) }
+  end
+
+  # Front-matter menu registrations for the set fingerprints. Any field
+  # change (including a page newly gaining/losing a registration) must bust
+  # the cache for pages whose template calls `get_menu` / `site.menus`.
+  private def fp_menus(digest : ::Digest, menus : Hash(String, Models::MenuRegistration)) : Nil
+    Utils::DigestUtils.update_length_prefixed(digest, "m#{menus.size}")
+    menus.keys.sort!.each do |k|
+      reg = menus[k]
+      fp_value(digest, k)
+      fp_value(digest, reg.name || "-")
+      fp_value(digest, reg.weight.try(&.to_s) || "-")
+      fp_value(digest, reg.parent || "-")
+      fp_value(digest, reg.identifier || "-")
+    end
   end
 
   # Template closure fingerprint stored in this page's cache entry. With
@@ -619,7 +673,18 @@ module Hwaro::Core::Build::Phases::Render
     # up-to-date would let filter_changed_pages skip it forever.
     return unless output_path
     fmt_paths = format_output_paths(page, output_dir, effective_output_formats(page, site.config))
-    cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site), output_paths: fmt_paths)
+    cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site), output_paths: fmt_paths, assets_hash: page_assets_hash(page))
+  end
+
+  # Fingerprint of a page bundle's colocated asset names (see
+  # CacheEntry#assets_hash). Sorted and length-prefixed; "" for pages with
+  # no assets so legacy cache entries (which default to "") don't force a
+  # one-time rebuild of every asset-less page.
+  private def page_assets_hash(page : Models::Page) : String
+    return "" if page.assets.empty?
+    digest = Digest::MD5.new
+    page.assets.sort.each { |a| Utils::DigestUtils.update_length_prefixed(digest, a) }
+    digest.final.hexstring
   end
 
   private def process_files_parallel(

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1530,6 +1530,12 @@ module Hwaro::Core::Build::Phases::Render
     # Build template variables — reuse prebuilt_vars if available (shortcode path)
     vars = if pv = prebuilt_vars
              update_content_vars(pv, content, section_list, toc, toc_headers, pagination, pagination_seo_links)
+             # The prebuilt hash is the shortcode pre-render context, built
+             # with content="" — its per-fence copy probe saw nothing. Re-run
+             # it against the FINAL rendered content, otherwise a
+             # `{copy=true}` fence on any page that also uses a shortcode
+             # ships no copy runtime.
+             inject_per_fence_copy_runtime(pv, site.config, content)
              pv
            else
              build_template_variables(page, site, content, section_list, toc, toc_headers, pagination, page_url_override, paginator, global_vars, pagination_seo_links: pagination_seo_links,
@@ -1730,9 +1736,18 @@ module Hwaro::Core::Build::Phases::Render
     pages.each do |page|
       cached_page_crinja_value(page, default_lang)
 
-      ancestors_key = {page.section, page.language}
-      unless @ancestors_crinja_cache.has_key?(ancestors_key)
-        @ancestors_crinja_cache[ancestors_key] = build_ancestors_crinja(page)
+      # Member pages sharing {section, language} have identical ancestors,
+      # so one cache entry serves them all. Section-index pages must NOT
+      # share it: their ancestors exclude themselves (transform.cr), so a
+      # shared key either put a section into its own breadcrumb or stripped
+      # the section from every member page — whichever prewarmed first won.
+      # Sections bypass the cache (see build_template_variables): each one
+      # renders exactly once, so caching buys nothing.
+      unless page.is_a?(Models::Section)
+        ancestors_key = {page.section, page.language}
+        unless @ancestors_crinja_cache.has_key?(ancestors_key)
+          @ancestors_crinja_cache[ancestors_key] = build_ancestors_crinja(page)
+        end
       end
 
       unless page.section.empty?
@@ -1819,9 +1834,13 @@ module Hwaro::Core::Build::Phases::Render
   ) : Array(Crinja::Value)
     pages = site.pages_for_section(section_name, language)
 
-    # Use section's sort_by setting if available, otherwise sort by title
+    # Use section's sort_by setting if available, otherwise sort by date
+    # (newest first) — the SAME default the paginator (paginator.cr) and the
+    # prev/next navigation (transform.cr) use, and the one the docs promise.
+    # A "title" fallback here made `get_section(...).pages` and member-page
+    # `section.pages` disagree with the section template's own listing order.
     section = site.section_for(section_name, language)
-    sort_by = section.try(&.sort_by) || "title"
+    sort_by = section.try(&.sort_by) || "date"
     reverse = section.try(&.reverse) || false
     pages = Utils::SortUtils.sort_pages(pages, sort_by, reverse)
 
@@ -2385,13 +2404,20 @@ module Hwaro::Core::Build::Phases::Render
     lower_obj = page.lower.try { |l| cached_page_crinja_value(l, default_lang) }
     higher_obj = page.higher.try { |h| cached_page_crinja_value(h, default_lang) }
 
-    # Build ancestors array (cached per section+language — pages in the same
-    # section AND language share ancestors). The language is part of the key
-    # because a multilingual section has per-language ancestors; omitting it
-    # served whichever language rendered first to every language (mirrors the
-    # section_pages cache key).
+    # Build ancestors array (cached per section+language — MEMBER pages in
+    # the same section AND language share ancestors). The language is part of
+    # the key because a multilingual section has per-language ancestors;
+    # omitting it served whichever language rendered first to every language
+    # (mirrors the section_pages cache key). Section-index pages bypass the
+    # cache entirely: their ancestors EXCLUDE themselves (transform.cr) while
+    # member pages' ancestors include the section, so sharing the key let the
+    # first writer poison the other kind — a section listing itself in its
+    # own breadcrumb, or members losing their parent. Each section renders
+    # once, so building directly costs nothing.
     ancestors_cache_key = {page.section, page.language}
-    ancestors_array = if @crinja_caches_frozen
+    ancestors_array = if page.is_a?(Models::Section)
+                        build_ancestors_crinja(page)
+                      elsif @crinja_caches_frozen
                         if cached = @ancestors_crinja_cache[ancestors_cache_key]?
                           @cache_manager.record_hit("ancestors_crinja")
                           cached
@@ -2547,13 +2573,17 @@ module Hwaro::Core::Build::Phases::Render
       paginate_path_var = page.paginate_path
       redirect_to_var = page.redirect_to || ""
 
-      # Build subsections array
+      # Build subsections array. `Models::Section#pages` is NEVER populated
+      # by the build pipeline (it stays []) — the live page list is the
+      # per-section Crinja cache, the same source `get_section(...).pages`
+      # uses in build_global_vars. Reading `sub.pages.size` here reported 0
+      # for every subsection.
       subsections_array = page.subsections.map do |sub|
         Crinja::Value.new({
           "title"       => Crinja::Value.new(sub.title),
           "description" => Crinja::Value.new(sub.description || ""),
           "url"         => Crinja::Value.new(sub.url),
-          "pages_count" => Crinja::Value.new(sub.pages.size),
+          "pages_count" => Crinja::Value.new(cached_section_pages_crinja(sub.section, sub.language, site).size),
         })
       end
 
@@ -2774,23 +2804,38 @@ module Hwaro::Core::Build::Phases::Render
     gv = global_vars || build_global_vars(site)
     gv.each { |k, v| vars[k] = v unless vars.has_key?(k) }
 
-    # Per-fence copy opt-in (`{copy=true}`) with the global `[highlight]
-    # copy` default off: the site-wide `highlight_js` (computed once in
-    # build_global_vars) ships no copy runtime, so a page whose rendered
-    # body carries an opted-in block appends it here — after the merge, so
-    # the page-level value wins. The probe can't false-positive on fenced
-    # documentation examples: the escape pipeline turns their `"` into
-    # `&quot;`. With the global flag ON the runtime is already in `gv`.
-    if config.highlight.enabled && !config.highlight.copy && content.includes?(%(data-copy="true"))
-      snippet = Models::HighlightConfig::COPY_SNIPPET
-      base_js = vars["highlight_js"]?.try(&.raw).as?(String) || ""
-      js = base_js.empty? ? snippet : "#{base_js}\n#{snippet}"
-      vars["highlight_js"] = Crinja::Value.new(js)
-      base_css = vars["highlight_css"]?.try(&.raw).as?(String) || ""
-      vars["highlight_tags"] = Crinja::Value.new(base_css.empty? ? js : "#{base_css}\n#{js}")
-    end
+    # Per-fence copy opt-in probe — NOTE: for pages WITH shortcodes this
+    # hash is built as the shortcode pre-render context with content="",
+    # so apply_template re-runs the probe against the FINAL rendered
+    # content (see inject_per_fence_copy_runtime).
+    inject_per_fence_copy_runtime(vars, config, content)
 
     vars
+  end
+
+  # Per-fence copy opt-in (`{copy=true}`) with the global `[highlight]
+  # copy` default off: the site-wide `highlight_js` (computed once in
+  # build_global_vars) ships no copy runtime, so a page whose rendered
+  # body carries an opted-in block appends it here — after the global-vars
+  # merge, so the page-level value wins. The probe can't false-positive on
+  # fenced documentation examples: the escape pipeline turns their `"` into
+  # `&quot;`. With the global flag ON the runtime is already in the global
+  # vars. Idempotent: a hash that already carries the snippet (a prebuilt
+  # vars hash reused across passes) is left untouched.
+  private def inject_per_fence_copy_runtime(
+    vars : Hash(String, Crinja::Value),
+    config : Models::Config,
+    content : String,
+  ) : Nil
+    return if !config.highlight.enabled || config.highlight.copy
+    return unless content.includes?(%(data-copy="true"))
+    snippet = Models::HighlightConfig::COPY_SNIPPET
+    base_js = vars["highlight_js"]?.try(&.raw).as?(String) || ""
+    return if base_js.includes?(snippet)
+    js = base_js.empty? ? snippet : "#{base_js}\n#{snippet}"
+    vars["highlight_js"] = Crinja::Value.new(js)
+    base_css = vars["highlight_css"]?.try(&.raw).as?(String) || ""
+    vars["highlight_tags"] = Crinja::Value.new(base_css.empty? ? js : "#{base_css}\n#{js}")
   end
 
   private def build_jsonld_vars(
@@ -2866,7 +2911,19 @@ module Hwaro::Core::Build::Phases::Render
 
   private def warn_hugo_shortcode_syntax(raw : String, path : String) : Nil
     names = Set(String).new
-    raw.scan(HUGO_SHORTCODE_RE) { |m| names << m[1] }
+    # Only `{{<` OUTSIDE fenced code blocks and inline code spans reaches
+    # Markdown as live (escaped) text — fenced examples are the documented
+    # way to SHOW Hugo syntax and must not warn. Reuse the same
+    # FenceTracker + inline-code masking the shortcode pre-filter uses
+    # (content_may_contain_shortcodes?) so the two can't disagree about
+    # what is fenced.
+    tracker = Content::Processors::FenceTracker.new
+    raw.each_line(chomp: false) do |line|
+      next if tracker.fence_line?(line)
+      next unless line.includes?("{{<")
+      scan_line = line.includes?('`') ? mask_inline_code(line)[0] : line
+      scan_line.scan(HUGO_SHORTCODE_RE) { |m| names << m[1] }
+    end
     return if names.empty?
     sorted = names.to_a.sort
     Logger.warn "Hugo-style shortcode syntax `{{< … >}}` is not supported and will render as literal text in #{path}. " \

--- a/src/core/build/phases/transform.cr
+++ b/src/core/build/phases/transform.cr
@@ -265,12 +265,22 @@ module Hwaro::Core::Build::Phases::Transform
   private def collect_assets(ctx : Lifecycle::BuildContext)
     content_files = ctx.config.try(&.content_files)
 
+    # Content-relative directories that host their own bundle index,
+    # INCLUDING language-suffixed variants (`photos/index.ko.md`) — the
+    # on-disk probe in Page#nested_bundle? only sees literal
+    # index.md/_index.md, so a translated-only bundle's assets were also
+    # collected (and published) by every ancestor bundle.
+    bundle_dirs = Set(String).new
+    ctx.all_pages.each do |p|
+      bundle_dirs << Path[p.path].dirname.to_s if p.is_index
+    end
+
     ctx.sections.each do |section|
-      section.collect_assets("content", content_files)
+      section.collect_assets("content", content_files, bundle_dirs)
     end
 
     ctx.pages.each do |page|
-      page.collect_assets("content", content_files)
+      page.collect_assets("content", content_files, bundle_dirs)
     end
   end
 
@@ -296,6 +306,10 @@ module Hwaro::Core::Build::Phases::Transform
       page.taxonomies.each do |name, terms|
         site.taxonomies[name] ||= {} of String => Array(Models::Page)
         terms.each do |term|
+          # Match the generator (Content::Taxonomies.build_taxonomy_index):
+          # an empty/whitespace term never gets a written page, so exposing
+          # it through get_taxonomy yields a 404 term link.
+          next if term.strip.empty?
           site.taxonomies[name][term] ||= [] of Models::Page
           site.taxonomies[name][term] << page
         end
@@ -404,6 +418,9 @@ module Hwaro::Core::Build::Phases::Transform
       page.taxonomies.each do |name, terms|
         site.taxonomies[name] ||= {} of String => Array(Models::Page)
         terms.each do |term|
+          # Same empty-term guard as rebuild_taxonomies — a serve-mode edit
+          # must not introduce a "" term the full rebuild would drop.
+          next if term.strip.empty?
           site.taxonomies[name][term] ||= [] of Models::Page
           site.taxonomies[name][term] << page
           affected_tax_keys << {name, term}

--- a/src/core/build/phases/write.cr
+++ b/src/core/build/phases/write.cr
@@ -76,6 +76,15 @@ module Hwaro::Core::Build::Phases::Write
         next
       end
 
+      # FileUtils.cp (and File.read) follow symlinks, so a raw-file symlink
+      # whose target escapes the project would publish a file from outside
+      # the site. Skip it — mirrors the bundle-asset guard in process_assets
+      # and the static copy guard. In-repo symlinks resolve within and pass.
+      if File.symlink?(raw_file.source_path) && !Hwaro::Utils::PathUtils.resolves_within?(raw_file.source_path, Dir.current)
+        Logger.warn "Skipping raw file symlink pointing outside the project: #{raw_file.source_path}"
+        next
+      end
+
       # Get appropriate processor
       processor = Content::Processors::Registry.for_file(raw_file.source_path).first?
 

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -38,14 +38,6 @@ module Hwaro
         # form, block_depth would never return to zero and fence protection would
         # silently break for the rest of the document.
         BLOCK_ANY_CLOSE_RE = /\{\%\s*end[\s\w\-]*\%\}/i
-        # Crinja/Jinja control-statement tags (and their `end*` forms). These
-        # legitimately appear in markdown content (e.g. `{% set x = 1 %}`,
-        # `{% if c %}…{% endif %}`) and must NOT count toward block-shortcode
-        # depth — otherwise an unbalanced `{% set %}` would pin block_depth > 0
-        # and permanently disable fenced-code-block protection in the outer loop.
-        # `\b` keeps shortcodes that merely start with a keyword (e.g. `setup`,
-        # `endorsement`) from matching.
-        CRINJA_CONTROL_TAG_RE = /\A\{\%-?\s*(?:if|elif|else|endif|for|endfor|set|endset|with|endwith|raw|endraw|filter|endfilter|block|endblock|macro|endmacro|call|endcall|autoescape|endautoescape|trans|endtrans|pluralize|comment|endcomment|include|import|from|extends|do)\b/i
 
         # Placeholder left in the content stream for each rendered shortcode
         # before Markdown runs. HTML-comment form so CommonMark treats it as
@@ -153,16 +145,20 @@ module Hwaro
               # control tags (`{% set %}`, `{% if %}`/`{% endif %}`, …) are
               # ignored — counting them would desync the depth (an unbalanced
               # `{% set %}` would pin depth > 0 and break fence protection).
+              # Classification is EXACT-keyword (control_tag_open? /
+              # shortcode_closer?), the same rules as the block parser below —
+              # the prefix regex previously used here treated `-`/`(` as word
+              # boundaries, so a shortcode named `include-code` counted as a
+              # control tag and its fenced body split at the fence line.
               # Inline code spans are masked first for the same reason: a
               # literal `{% alert %}` in backticks must not count.
               scan_line = line.includes?('`') ? mask_inline_code(line)[0] : line
               scan_line.scan(BLOCK_OPEN_RE) do |m|
-                tag = m[0]
-                next if CRINJA_CONTROL_TAG_RE.matches?(tag) || BLOCK_ANY_CLOSE_RE.matches?(tag)
+                next if control_tag_open?(m) || BLOCK_ANY_CLOSE_RE.matches?(m[0])
                 block_depth += 1
               end
               scan_line.scan(BLOCK_ANY_CLOSE_RE) do |m|
-                next if CRINJA_CONTROL_TAG_RE.matches?(m[0])
+                next unless shortcode_closer?(m[0])
                 block_depth -= 1 if block_depth > 0
               end
 
@@ -243,6 +239,19 @@ module Hwaro
           end
         end
 
+        # True when a BLOCK_ANY_CLOSE_RE match closes a shortcode block rather
+        # than a Jinja control structure (`{% endif %}`, `{% endfor %}`, …).
+        # Bare `{% end %}` is always a shortcode closer; named closers are
+        # classified against CRINJA_CONTROL_KEYWORDS exactly, mirroring
+        # normalize_named_closers.
+        private def shortcode_closer?(tag : String) : Bool
+          if m = NAMED_CLOSER_RE.match(tag)
+            !CRINJA_CONTROL_KEYWORDS.includes?(m[1].downcase)
+          else
+            true
+          end
+        end
+
         # True when `text` carries at least one shortcode named closer (i.e.
         # one that `normalize_named_closers` would actually rewrite).
         private def named_closer?(text : String) : Bool
@@ -288,10 +297,14 @@ module Hwaro
           # 1. Block shortcodes
           processed = process_block_shortcodes(normalized, templates, context, shortcode_results, crinja_env_override, template_cache_override, depth, spans, warnings)
 
-          # 2. Explicit call: {{ shortcode("name", args) }}
-          processed = processed.gsub(/\{\{\s*shortcode\s*\(\s*"([^"]+)"(?:\s*,\s*(.*?))?\s*\)\s*\}\}/) do |match|
-            args = $2?.try { |a| unmask_inline_code(a, spans) }
-            render_shortcode_result($1, args, templates, context, shortcode_results, match, warn_missing: true, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, warnings: warnings)
+          # 2. Explicit call: {{ shortcode("name", args) }} — the name accepts
+          # either quote style, matching the argument syntax docs; the
+          # single-quoted form previously fell through to the direct-call pass
+          # as a shortcode literally named "shortcode" and was warned+dropped.
+          processed = processed.gsub(/\{\{\s*shortcode\s*\(\s*(?:"([^"]+)"|'([^']+)')(?:\s*,\s*(.*?))?\s*\)\s*\}\}/) do |match|
+            name = $1? || $2? || ""
+            args = $3?.try { |a| unmask_inline_code(a, spans) }
+            render_shortcode_result(name, args, templates, context, shortcode_results, match, warn_missing: true, crinja_env_override: crinja_env_override, template_cache_override: template_cache_override, warnings: warnings)
           end
 
           # 3. Direct call: {{ name(args) }}
@@ -305,11 +318,12 @@ module Hwaro
           end
         end
 
-        # Jinja/Crinja control keywords, for exact-name matching in the block
-        # parser. Deliberately NOT the prefix-based CRINJA_CONTROL_TAG_RE: its
-        # `\b` treats a hyphen as a boundary, so a user shortcode named
-        # `include-code` (or `if-banner`, `do-not-translate`, …) would be
-        # misclassified as a control tag and silently stop expanding.
+        # Jinja/Crinja control keywords, for exact-name matching everywhere a
+        # tag must be classified (block parser AND the outer fence-loop depth
+        # scan). Deliberately not a prefix regex with `\b`: a word boundary at
+        # a hyphen means a user shortcode named `include-code` (or
+        # `if-banner`, `do-not-translate`, …) would be misclassified as a
+        # control tag and silently stop expanding.
         CRINJA_CONTROL_KEYWORDS = Set{
           "if", "elif", "else", "endif", "for", "endfor", "set", "endset",
           "with", "endwith", "raw", "endraw", "filter", "endfilter",

--- a/src/core/build/template_deps.cr
+++ b/src/core/build/template_deps.cr
@@ -233,9 +233,13 @@ module Hwaro
           if normalized == reference
             # No template extension was stripped. A basename that still
             # carries an extension names a file outside the snapshot glob.
-            # (Extension-less refs resolve against the literal file just as
-            # they always did — leave them alone.)
             return false if File.basename(reference).includes?('.')
+            # Extension-less ref: when the snapshot is known and lacks the
+            # key, the loader serves a literal extension-less file
+            # (templates/partials/nav) from DISK — content this graph never
+            # hashed. Mark it escaping; refs to genuinely missing templates
+            # error at render anyway, so over-invalidation is safe.
+            return false if !template_paths.empty? && !template_paths.has_key?(normalized)
           elsif path = template_paths[normalized]?
             return false unless path == File.join("templates", reference)
           end

--- a/src/core/build/template_deps.cr
+++ b/src/core/build/template_deps.cr
@@ -48,6 +48,18 @@ module Hwaro
         # Bare names of user shortcode templates (templates/shortcodes/*).
         getter shortcode_names : Array(String)
 
+        # Literal references the snapshot loader cannot serve — `./`-prefixed
+        # names, names that keep a non-template extension (never loadable by
+        # the snapshot glob), and exact-extension refs to a shadowed variant
+        # (`foo.j2` while `foo.html` won the snapshot slot). The render reads
+        # these files from DISK via the loader fallback, so their edits are
+        # invisible to both the snapshot templates hash and this graph. The
+        # graph is marked dynamic whenever this set is non-empty; the builder
+        # additionally folds these files' disk contents into the global
+        # templates checksum so editing one invalidates the cache (see
+        # `fold_snapshot_escaping_refs` in phases/initialize.cr).
+        getter snapshot_escaping_refs : Set(String)
+
         @direct : Hash(String, Set(String))
         @content_hashes : Hash(String, String)
         @closures : Hash(String, Set(String))
@@ -58,13 +70,18 @@ module Hwaro
         # unsynchronized Hash insert under -Dpreview_mt.
         @lazy_mutex : Mutex
 
-        def initialize(templates : Hash(String, String))
+        # `template_paths` maps each snapshot name to the source file that
+        # won its slot ("partials/nav" => "templates/partials/nav.html");
+        # it's what detects shadowed-variant references. Callers without a
+        # snapshot (tests) may omit it — shadow detection is then skipped.
+        def initialize(templates : Hash(String, String), template_paths : Hash(String, String) = {} of String => String)
           @direct = {} of String => Set(String)
           @content_hashes = {} of String => String
           @closures = {} of String => Set(String)
           @closure_hashes = {} of String => String
           @lazy_mutex = Mutex.new
           @dynamic = false
+          @snapshot_escaping_refs = Set(String).new
 
           @shortcode_names = templates.keys
             .select(&.starts_with?("shortcodes/"))
@@ -93,7 +110,15 @@ module Hwaro
                         else                           FROM_ARG_RE.match(match[2])
                         end
               if literal
-                deps << normalize(literal[1]? || literal[2]? || "")
+                reference = literal[1]? || literal[2]? || ""
+                deps << normalize(reference)
+                unless snapshot_resolvable?(reference, template_paths)
+                  # The reference resolves through the loader's DISK
+                  # fallback, whose content this graph cannot hash — degrade
+                  # to whole-site invalidation (correctness over cleverness).
+                  @dynamic = true
+                  @snapshot_escaping_refs << reference
+                end
               else
                 @dynamic = true
               end
@@ -188,6 +213,34 @@ module Hwaro
 
         private def normalize(reference : String) : String
           reference.sub(Builder::TEMPLATE_EXTENSION_REGEX, "")
+        end
+
+        # True when the snapshot loader can serve `reference` from the same
+        # source this graph hashed. Three ways it cannot (see
+        # SnapshotTemplateLoader#get_source, which falls back to disk):
+        #   (i)   `./`-prefixed refs never match a snapshot key;
+        #   (ii)  a name that keeps a non-template extension after
+        #         normalization ("foo.txt") was never loadable by the
+        #         snapshot glob;
+        #   (iii) an exact-extension ref whose snapshot slot was won by a
+        #         DIFFERENT file (`include "foo.j2"` while foo.html won) —
+        #         the loader reads foo.j2 from disk but this graph hashed
+        #         foo.html.
+        private def snapshot_resolvable?(reference : String, template_paths : Hash(String, String)) : Bool
+          return false if reference.starts_with?("./")
+
+          normalized = normalize(reference)
+          if normalized == reference
+            # No template extension was stripped. A basename that still
+            # carries an extension names a file outside the snapshot glob.
+            # (Extension-less refs resolve against the literal file just as
+            # they always did — leave them alone.)
+            return false if File.basename(reference).includes?('.')
+          elsif path = template_paths[normalized]?
+            return false unless path == File.join("templates", reference)
+          end
+
+          true
         end
       end
     end

--- a/src/core/lifecycle/manager.cr
+++ b/src/core/lifecycle/manager.cr
@@ -63,7 +63,13 @@ module Hwaro
         # Hook Execution API
         # ========================================
 
-        # Trigger all hooks at a specific point
+        # Trigger all hooks at a specific point.
+        #
+        # `Skip` is scoped to the CURRENT hook point (see HookResult's doc:
+        # "skip remaining hooks in current phase"): the remaining hooks at
+        # this point don't run, but the result is Continue so the phase body
+        # and subsequent phases proceed. Only `Abort` (or a raised
+        # HwaroError) terminates the build.
         def trigger(point : HookPoint, context : BuildContext) : HookResult
           hooks = @hooks[point]
           return HookResult::Continue if hooks.empty?
@@ -86,8 +92,8 @@ module Hwaro
 
               case result
               when HookResult::Skip
-                Logger.info "  ⏭ Phase skipped by hook: #{hook.name}" if @debug
-                return result
+                Logger.info "  ⏭ Remaining hooks at #{point} skipped by hook: #{hook.name}" if @debug
+                return HookResult::Continue
               when HookResult::Abort
                 Logger.error "  ✖ Build aborted by hook: #{hook.name}"
                 return result

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -276,7 +276,11 @@ module Hwaro
       #      its own `index.md`/`_index.md` is a different page and publishes
       #      its own assets; descending into it made every ancestor index
       #      re-copy the same files.
-      def collect_assets(content_dir : String, content_files : ContentFilesConfig? = nil) : Array(String)
+      # `bundle_dirs` (content-relative directories that host their own bundle
+      # index, computed by Transform#collect_assets from the page set) extends
+      # nested-bundle detection to language-suffixed indexes
+      # (`photos/index.ko.md`) that the literal on-disk probe cannot see.
+      def collect_assets(content_dir : String, content_files : ContentFilesConfig? = nil, bundle_dirs : Set(String)? = nil) : Array(String)
         # Assets are only collected for page bundles (directories)
         # This usually means the page is an index.md (either _index.md or index.md)
         return [] of String unless @is_index
@@ -290,7 +294,7 @@ module Hwaro
         @assets = Dir.glob(File.join(page_dir, "**", "*")).compact_map do |file|
           next unless File.file?(file)
           next if file.ends_with?(".md") || file.ends_with?(".markdown")
-          next if nested_bundle?(page_dir, file)
+          next if nested_bundle?(page_dir, file, content_dir, bundle_dirs)
 
           relative = Path[file].relative_to(content_dir).to_s
           # Honor [content.files] allow/disallow rules when configured so the
@@ -304,14 +308,20 @@ module Hwaro
       end
 
       # True when `file` sits under a subdirectory of `page_dir` that carries
-      # its own `index.md`/`_index.md` — i.e. it is another page's asset, not
-      # this bundle's. Walks the intermediate directories from the bundle root
-      # down to the file's own directory.
-      private def nested_bundle?(page_dir : String, file : String) : Bool
+      # its own bundle index — i.e. it is another page's asset, not this
+      # bundle's. Walks the intermediate directories from the bundle root
+      # down to the file's own directory. Beyond the literal
+      # `index.md`/`_index.md` probe, `bundle_dirs` membership catches
+      # translated-only bundles (`index.ko.md`) whose assets would otherwise
+      # be re-published by every ancestor bundle.
+      private def nested_bundle?(page_dir : String, file : String, content_dir : String, bundle_dirs : Set(String)?) : Bool
         dir = File.dirname(file)
         while dir != page_dir && dir.size > page_dir.size
           return true if File.exists?(File.join(dir, "index.md")) ||
                          File.exists?(File.join(dir, "_index.md"))
+          if bundle_dirs
+            return true if bundle_dirs.includes?(Path[dir].relative_to(content_dir).to_s)
+          end
           parent = File.dirname(dir)
           break if parent == dir
           dir = parent

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -280,26 +280,38 @@ module Hwaro
         redirects
       end
 
+      # Page extensions mirror Core::Build::Phases::ReadContent::PAGE_EXTENSIONS
+      # so alias generation sees exactly the pages the build publishes.
+      PAGE_EXTENSIONS = {".md", ".markdown"}
+
       private def scan_content_for_aliases(dir : String, redirects : Array(Tuple(String, String)))
         Dir.each_child(dir) do |entry|
           path = File.join(dir, entry)
           if File.directory?(path)
             scan_content_for_aliases(path, redirects)
-          elsif entry.ends_with?(".md")
+          elsif PAGE_EXTENSIONS.includes?(Path[entry].extension.downcase)
             extract_aliases_from_file(path, redirects)
           end
         end
       end
 
-      LANGUAGE_FILENAME_PATTERN = /^(.+)\.([a-z]{2,3})\.md$/
-
+      # Mirror of ReadContent#extract_language_from_filename: the suffix
+      # between the last two dots is matched against DECLARED language codes
+      # (plus the default), so declared keys like `zh-tw`/`pt-BR` route the
+      # same way here as in the build.
       private def extract_language_from_filename(basename : String) : String?
         return unless @config.multilingual?
 
-        if match = basename.match(LANGUAGE_FILENAME_PATTERN)
-          lang_code = match[2]
-          return lang_code if @config.languages.has_key?(lang_code) || lang_code == @config.default_language
-        end
+        ext = Path[basename].extension.downcase
+        return unless PAGE_EXTENSIONS.includes?(ext)
+        return unless basename.size > ext.size
+
+        stem = basename[0, basename.size - ext.size]
+        idx = stem.rindex('.')
+        return unless idx && idx > 0
+        lang_code = stem[(idx + 1)..]
+        return if lang_code.empty?
+        return lang_code if @config.languages.has_key?(lang_code) || lang_code == @config.default_language
 
         nil
       end

--- a/src/services/server/live_reload_handler.cr
+++ b/src/services/server/live_reload_handler.cr
@@ -252,6 +252,18 @@ module Hwaro
           return
         end
 
+        # A non-canonical path (`//` or `/./` segments — `/guide//index.html`)
+        # is answered by HTTP::StaticFileHandler with a canonicalising 302,
+        # and the base-path mount pre-empts the same redirect. Serving it
+        # here with a 200 (DevPath.safe_relative collapses those segments)
+        # made dev accept URLs production redirects or 404s. Defer to the
+        # next handler so the request gets the same treatment as everywhere
+        # else in the chain.
+        if noncanonical_request?(path)
+          call_next(context)
+          return
+        end
+
         # Resolve strictly (see DevPath): routing through the lenient
         # `sanitize_path` made `/a%5Cb.html` and `/%2Fa%2Fb.html` serve pages
         # that every static host 404s.
@@ -293,6 +305,22 @@ module Hwaro
         context.response.content_length = injected.bytesize
         return if method == "HEAD"
         context.response.print(injected)
+      end
+
+      # Mirrors HTTP::StaticFileHandler's own canonicalisation test (decode
+      # once, `Path.posix(...).expand("/")`, compare as Path) — the same
+      # shape as BasePathHandler#noncanonical_target — so this defers when
+      # and only when stdlib would redirect. Unservable paths are refused
+      # upstream (and `Path.posix` raises on NUL), so they are excluded
+      # before anything here can raise.
+      private def noncanonical_request?(path : String) : Bool
+        return false if DevPath.unservable?(path)
+
+        decoded = URI.decode(path)
+        return false unless decoded.valid_encoding?
+
+        request_path = Path.posix(decoded)
+        request_path != request_path.expand("/")
       end
 
       def inject_script(html : String) : String

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -510,8 +510,14 @@ module Hwaro
         # freshness bookkeeping is needed here. `partial: true`: a
         # single-page call must not truncate every other page's manifest
         # entry.
+        # The advertised URL carries the collision-disambiguated slug that
+        # assign_lazy_urls computed against the FULL page set — pass it
+        # through, because a single-page generate() call would recompute
+        # the slug with fresh collision state and collapse colliding pages
+        # (/posts/foo/ vs /posts-foo/) onto the same unsuffixed file.
+        slug = File.basename(sanitized, File.extname(sanitized))
         @mutex.synchronize do
-          Content::Seo::OgImage.generate([page], config, @output_dir, partial: true, parallel: false)
+          Content::Seo::OgImage.generate([page], config, @output_dir, partial: true, parallel: false, forced_slug: slug)
         rescue ex
           Logger.warn "On-demand OG image generation failed for #{url_path}: #{ex.message}"
         end

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -464,6 +464,78 @@ module Hwaro
       end
     end
 
+    # Dev-only on-demand OG image generation for `[og.auto_image]
+    # lazy_generate = true` under `hwaro serve`.
+    #
+    # Lazy serve builds assign each eligible page its predicted og:image URL
+    # without rendering the file (OgImage.assign_lazy_urls) — this handler
+    # fulfills the promised "generated on first request" contract that
+    # previously didn't exist (the URLs 404'd all session). A request for a
+    # path under the OG output directory generates the owning page's image,
+    # then falls through to the static file handler to serve it from disk.
+    #
+    # Only ever mounted in the dev handler chain; a no-op unless the current
+    # config enables auto-OG with lazy_generate.
+    class OgLazyImageHandler
+      include HTTP::Handler
+
+      def initialize(@builder : Core::Build::Builder, @output_dir : String)
+        @mutex = Mutex.new
+      end
+
+      def call(context)
+        method = context.request.method
+        return call_next(context) unless method == "GET" || method == "HEAD"
+
+        config = @builder.config
+        site = @builder.site
+        return call_next(context) unless config && site
+        ai = config.og.auto_image
+        return call_next(context) unless ai.enabled && ai.lazy_generate
+
+        sanitized = DevPath.safe_relative(context.request.path)
+        return call_next(context) if sanitized.nil? || sanitized.empty?
+        return call_next(context) unless sanitized.starts_with?("#{ai.output_dir.strip("/")}/")
+        return call_next(context) unless sanitized.ends_with?(".png") || sanitized.ends_with?(".svg")
+
+        url_path = "/#{sanitized}"
+        page = site.pages.find { |p| p.image == url_path } ||
+               site.sections.find { |s| s.image == url_path }
+        return call_next(context) unless page
+
+        # Serialize generation: the og:image and twitter:image fetches of one
+        # link preview land together and must not render the file twice.
+        # generate() is manifest-cached — when the file exists and the page
+        # hash matches, a repeat request costs a hash + stat, so no extra
+        # freshness bookkeeping is needed here. `partial: true`: a
+        # single-page call must not truncate every other page's manifest
+        # entry.
+        @mutex.synchronize do
+          Content::Seo::OgImage.generate([page], config, @output_dir, partial: true, parallel: false)
+        rescue ex
+          Logger.warn "On-demand OG image generation failed for #{url_path}: #{ex.message}"
+        end
+
+        # PNG rendering can fall back to SVG (no usable font). The advertised
+        # .png path then has no backing file, but the page's updated image
+        # URL does — serve those bytes under the requested path (dev-only
+        # pragmatism: the preview still shows an image).
+        requested = File.join(@output_dir, sanitized)
+        if !File.exists?(requested) && (fallback = page.image) && fallback != url_path
+          fallback_path = File.join(@output_dir, fallback.lchop('/'))
+          if File.exists?(fallback_path) && Utils::OutputGuard.within_output_dir?(fallback_path, @output_dir)
+            data = File.read(fallback_path)
+            context.response.content_type = fallback.ends_with?(".svg") ? "image/svg+xml" : "image/png"
+            context.response.content_length = data.bytesize
+            context.response.print(data) unless method == "HEAD"
+            return
+          end
+        end
+
+        call_next(context)
+      end
+    end
+
     # Categorised set of file-system changes detected by the watcher.
     #
     # Changes are split into five buckets so the server can pick the
@@ -1090,6 +1162,10 @@ module Hwaro
         end
         handlers << IndexRewriteHandler.new(output_dir)
         handlers << inject_handler if inject_handler
+        # Just above the static handler: generates a lazily-deferred OG image
+        # on first request, then lets StaticFileHandler serve it from disk.
+        # A no-op unless [og.auto_image] lazy_generate is enabled.
+        handlers << OgLazyImageHandler.new(@builder, output_dir)
         handlers << HTTP::StaticFileHandler.new(output_dir, directory_listing: false, fallthrough: true)
         handlers << not_found
         handlers
@@ -1513,6 +1589,14 @@ module Hwaro
       private def copy_static(changeset : ChangeSet, build_options : Config::Options::BuildOptions) : Bool
         output_dir = sanitize_output_dir(build_options.output_dir)
         @builder.copy_changed_static(changeset.modified_static, output_dir, build_options.verbose)
+        # Changed image BYTES need their resized variants/LQIP regenerated
+        # too — the resize hook only runs on full builds, so the copy above
+        # alone left variants stale for the whole serve session (A12).
+        unless build_options.skip_image_processing
+          if config = @builder.config
+            Hwaro::Content::Hooks::ImageHooks.reprocess_changed_images(changeset.modified_static, config, output_dir)
+          end
+        end
         # SCSS sources never publish verbatim — when one changed, recompile
         # the entries instead. A partial edit must rebuild every entry that
         # imports it, and there is no dependency graph, so the whole tree
@@ -1546,6 +1630,15 @@ module Hwaro
       private def copy_content_files(changeset : ChangeSet, build_options : Config::Options::BuildOptions)
         output_dir = sanitize_output_dir(build_options.output_dir)
         @builder.copy_changed_content_files(changeset.modified_content_files, output_dir, build_options.verbose)
+        # Mirror copy_static: modified image bytes under content/ (published
+        # via [content.files] or as page-bundle assets) must refresh their
+        # resized variants/LQIP too (A12).
+        unless build_options.skip_image_processing
+          if config = @builder.config
+            pages = @builder.site.try { |s| (s.pages + s.sections).as(Array(Models::Page)) }
+            Hwaro::Content::Hooks::ImageHooks.reprocess_changed_images(changeset.modified_content_files, config, output_dir, pages: pages)
+          end
+        end
       end
 
       # Allowlist for URLs handed to the OS opener. Serve's own URLs can

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -701,6 +701,12 @@ module Hwaro
       # overlay the live-reload client draws from an `error:` push kept
       # appearing for users who had explicitly turned overlays off.
       @error_overlay : Bool = true
+      # Watcher baseline captured BEFORE the initial build (and before any
+      # --fast-start deferred render). The watcher used to take its first
+      # snapshot only when its loop started — after both — so any edit made
+      # during that window was absorbed into the baseline and never rebuilt.
+      # Consumed once by the watch loop; nil afterwards.
+      @watch_baseline : Hash(String, FileStamp)? = nil
 
       # Extensions whose served bytes are UTF-8 text, each with the base type to
       # assume when the platform's MIME database has no opinion.
@@ -800,6 +806,11 @@ module Hwaro
         # Start anyway: @rebuild_failed forces the first watch rebuild to be
         # a full one, and the error is replayed to the first live-reload
         # client so the browser shows the overlay instead of a bare 404.
+        # Snapshot the watcher baseline BEFORE the initial build: edits saved
+        # while the build (or the fast-start deferred render) runs must land
+        # in the watcher's first diff instead of vanishing into it.
+        capture_watch_baseline
+
         initial_error : String? = nil
         begin
           unless @builder.run(build_options)
@@ -925,8 +936,14 @@ module Hwaro
         # to run — TCP connects succeeded (OS-level backlog) but HTTP
         # responses sat indefinitely.
         listen_done = Channel(Nil).new
+        # Captured from the listen fiber so a crashed accept loop can't turn
+        # into a clean exit: `ensure` alone closed the channel and the main
+        # fiber returned normally — exit 0 — with the server dead.
+        listen_error : Exception? = nil
         spawn do
           server.listen
+        rescue error
+          listen_error = error
         ensure
           listen_done.close
         end
@@ -980,6 +997,18 @@ module Hwaro
         # Block the main fiber on the listen fiber's completion so the
         # process stays alive for the lifetime of the server.
         listen_done.receive?
+
+        # The listen fiber died with an exception — serve must exit nonzero,
+        # matching how a bind failure is reported (a classified HwaroError
+        # that the CLI runner maps to a failure exit code).
+        if failure = listen_error
+          classified = failure.as?(Hwaro::HwaroError) || Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_IO,
+            message: "Dev server stopped unexpectedly: #{failure.message}",
+            hint: "This is likely a bug or an OS-level socket failure — rerun `hwaro serve` and report the error if it persists.",
+          )
+          raise classified
+        end
       end
 
       # Path component of `base_url`, mirroring `Models::Config#base_path`
@@ -1142,9 +1171,24 @@ module Hwaro
         normalized
       end
 
+      # Snapshot the watcher baseline. Called by run_with_options BEFORE the
+      # initial build so files edited while it runs still diff as changed.
+      private def capture_watch_baseline
+        @watch_baseline = scan_mtimes
+      end
+
+      # The mtime snapshot the watch loop starts from: the pre-build baseline
+      # when one was captured (consumed here — it is only valid once), a
+      # fresh scan otherwise.
+      private def initial_watch_mtimes : Hash(String, FileStamp)
+        baseline = @watch_baseline
+        @watch_baseline = nil
+        baseline || scan_mtimes
+      end
+
       private def watch_for_changes(build_options : Config::Options::BuildOptions)
         # Watched roots are shown in the serve receipt's "watch" row.
-        last_mtimes = scan_mtimes
+        last_mtimes = initial_watch_mtimes
 
         loop do
           sleep POLL_INTERVAL
@@ -1166,8 +1210,13 @@ module Hwaro
                 changeset, last_mtimes = debounce_changes(changeset, last_mtimes)
 
                 begin
+                  # apply_changeset owns the @rebuild_failed reset: it clears
+                  # the flag only after a SUCCESSFUL rebuild. Resetting here
+                  # unconditionally used to clobber the flag apply_changeset
+                  # had just set for a Bool-failure build (pre-hook failure /
+                  # phase abort return false without raising), breaking the
+                  # full-rebuild-recovery contract for that path.
                   apply_changeset(changeset, build_options)
-                  @rebuild_failed = false
                 rescue ex
                   # Surface the failure both in the terminal and the
                   # browser. Without the WS push the developer sees the
@@ -1360,7 +1409,6 @@ module Hwaro
                     @builder.run_incremental_then_rerender(changeset.modified_content, build_options)
                   when :static
                     copy_static(changeset, build_options)
-                    true
                   when :content_files
                     copy_content_files(changeset, build_options)
                     true
@@ -1380,6 +1428,11 @@ module Hwaro
           return
         end
 
+        # Clear the failure escalation HERE, where success is actually known.
+        # The watch loop must not reset it — apply_changeset returns normally
+        # after a Bool-failure build too (see the `unless success` guard).
+        @rebuild_failed = false
+
         # A config edit rebuilt the site with the new values, but [serve.*]
         # keys were consumed at startup — warn instead of silently looking
         # like they applied.
@@ -1387,7 +1440,11 @@ module Hwaro
 
         # Copy static files if they changed alongside content/template changes
         if strategy != :static && strategy != :full && !changeset.modified_static.empty?
-          copy_static(changeset, build_options)
+          unless copy_static(changeset, build_options)
+            @rebuild_failed = true
+            push_build_error("Build failed — check the terminal for details.")
+            return
+          end
         end
 
         # Republish non-Markdown content assets whenever they accompany any
@@ -1399,6 +1456,16 @@ module Hwaro
           copy_content_files(changeset, build_options)
         end
 
+        # The stale list was mapped through the PRE-rebuild site, but a
+        # single changeset can delete one source and re-create the same URL
+        # from another (foo.md removed + foo/index.md added). The rebuild
+        # just wrote that output for the NEW owner — deleting it here would
+        # 404 the page until an unrelated rebuild. Skip anything the rebuilt
+        # site still claims.
+        unless stale_outputs.empty?
+          owned = @builder.owned_output_paths(output_dir)
+          stale_outputs = stale_outputs.reject { |path| owned.includes?(path) }
+        end
         remove_stale_outputs(stale_outputs, output_dir)
 
         @live_reload_handler.try(&.notify_reload)
@@ -1441,7 +1508,9 @@ module Hwaro
         end
       end
 
-      private def copy_static(changeset : ChangeSet, build_options : Config::Options::BuildOptions)
+      # Returns false when an escalated re-render failed (bundle fingerprint
+      # moved and the page re-render below reported failure); true otherwise.
+      private def copy_static(changeset : ChangeSet, build_options : Config::Options::BuildOptions) : Bool
         output_dir = sanitize_output_dir(build_options.output_dir)
         @builder.copy_changed_static(changeset.modified_static, output_dir, build_options.verbose)
         # SCSS sources never publish verbatim — when one changed, recompile
@@ -1450,9 +1519,28 @@ module Hwaro
         # recompiles (cheap at static-site scale). Compile errors raise and
         # reach the watcher rescue → browser overlay. The predicate is the
         # same one the copy paths use, so the gate can't drift.
+        bundles_changed = false
         if (config = @builder.config) && changeset.modified_static.any? { |p| config.sass_source?(p) }
-          @builder.recompile_sass(output_dir)
+          bundles_changed = @builder.recompile_sass(output_dir)
+        elsif changeset.modified_static.any? { |p| @builder.asset_bundle_source?(p) }
+          # Plain (non-Sass) CSS/JS bundle sources only ever rebuilt inside
+          # the full-build asset pipeline — a static-only save left the
+          # fingerprinted bundle stale for the whole serve session.
+          bundles_changed = @builder.reprocess_asset_bundles(output_dir)
         end
+
+        # A changed fingerprint means every page referencing the bundle via
+        # `asset()` still points at the OLD hash — rebuild so the HTML on
+        # disk picks the new path up (covers the Sass path too). A full
+        # rebuild, not run_rerender: templates are byte-identical here, so
+        # the rerender's selective path would (correctly, by its own
+        # contract) re-render nothing. Correctness over cleverness — the
+        # rebuild reuses the same options the watcher's :full strategy runs.
+        if bundles_changed
+          Logger.info "  Asset bundle fingerprints changed — rebuilding pages to update references."
+          return @builder.run(build_options)
+        end
+        true
       end
 
       private def copy_content_files(changeset : ChangeSet, build_options : Config::Options::BuildOptions)
@@ -1460,12 +1548,20 @@ module Hwaro
         @builder.copy_changed_content_files(changeset.modified_content_files, output_dir, build_options.verbose)
       end
 
-      private def open_browser_url(url : String)
-        unless url.starts_with?("http://") || url.starts_with?("https://")
-          return
-        end
+      # Allowlist for URLs handed to the OS opener. Serve's own URLs can
+      # carry bracketed IPv6 hosts (`http://[::1]:3000`, from `-b ::1`) and
+      # percent-encoded path bytes (`/my%20blog/` base paths), so `[`, `]`
+      # and `%` are part of the safe set alongside host/path characters.
+      protected def url_openable?(url : String) : Bool
+        (url.starts_with?("http://") || url.starts_with?("https://")) &&
+          url.matches?(/\Ahttps?:\/\/[a-zA-Z0-9.:\/\-_\[\]%]+\z/)
+      end
 
-        unless url.matches?(/\Ahttps?:\/\/[a-zA-Z0-9.:\/\-_]+\z/)
+      private def open_browser_url(url : String)
+        unless url_openable?(url)
+          # Say why nothing opened instead of silently returning — the user
+          # asked for --open and got no browser.
+          Logger.debug "Not opening browser: URL contains characters outside the safe allowlist: #{url}"
           return
         end
 

--- a/src/utils/html_minifier.cr
+++ b/src/utils/html_minifier.cr
@@ -48,18 +48,20 @@ module Hwaro
       #     after the last inline child.
       # Anything not listed here is treated as inline, where whitespace
       # between siblings collapses to a single rendered space and must
-      # therefore be kept as one literal space.
+      # therefore be kept as one literal space. Replaced elements that
+      # default to display:inline (iframe, video, audio, canvas, embed,
+      # object) are deliberately NOT listed: whitespace adjacent to them
+      # renders as a visible space and must be preserved.
       BLOCK_TAGS = Set{
         "address", "article", "aside", "base", "blockquote", "body",
         "caption", "col", "colgroup", "dd", "details", "dialog",
         "div", "dl", "dt", "fieldset", "figcaption", "figure",
         "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6",
-        "head", "header", "hgroup", "hr", "html", "iframe",
+        "head", "header", "hgroup", "hr", "html",
         "li", "link", "main", "menu", "meta", "nav", "noscript",
         "ol", "p", "picture", "pre", "script", "section",
         "source", "style", "summary", "table", "tbody", "td",
         "tfoot", "th", "thead", "title", "tr", "track", "ul",
-        "video", "audio", "canvas",
       }
 
       # Tags whose content must be preserved verbatim. Extracted into

--- a/src/utils/js_minifier.cr
+++ b/src/utils/js_minifier.cr
@@ -119,14 +119,37 @@ module Hwaro
               end
 
               if next_c == '*'
-                # Multi-line comment
+                # Multi-line comment. Removing it must leave a separator
+                # behind: a comment is a token boundary (`return/*x*/g`
+                # must not fuse into `returng`), and a comment containing
+                # a line terminator counts as one for automatic semicolon
+                # insertion (`return /*\n*/ 42` must keep the line break).
+                prev_char = i > 0 ? chars[i - 1] : nil
                 i += 2
+                had_newline = false
                 while i + 1 < len
                   if chars[i] == '*' && chars[i + 1] == '/'
                     i += 2
                     break
                   end
+                  had_newline = true if chars[i] == '\n' || chars[i] == '\r'
                   i += 1
+                end
+                if had_newline
+                  # Always re-emit the line break: adjacent spaces do not
+                  # preserve ASI semantics. The later per-line cleanup
+                  # rstrips and drops blank lines but never joins lines,
+                  # so the separation survives.
+                  io << '\n'
+                else
+                  # A single space, and only when both neighbours are
+                  # non-whitespace tokens that would otherwise fuse — this
+                  # keeps output byte-identical for the common
+                  # `a = /* c */ 1` shape where separation already exists.
+                  next_char = i < len ? chars[i] : nil
+                  if prev_char && next_char && !prev_char.whitespace? && !next_char.whitespace?
+                    io << ' '
+                  end
                 end
                 next
               end


### PR DESCRIPTION
## Summary

A structured audit of the `build` and `serve` commands: two collection rounds (5 area agents + 1 asset/output sweep), an adversarial verification round on every high/med finding, four fix batches (each defect proven with a regression spec that fails pre-fix), and a fresh-reviewer adversarial pass over the resulting diff whose findings are also fixed here.

**52 defects fixed** across 5 commits; 2 findings were refuted during verification/fix (`--jobs` forwarding, taxonomy lang slugs — pin specs added instead).

### Highlights (high severity)
- `--full` was a no-op and `serve_mode` never reached hooks: the `Builder#run(options)` overload dropped both while re-packing options (now the real implementation uses the incoming struct verbatim)
- `--cache` staleness cluster: page/section-set fingerprints missed `image`/`updated`/`authors`/`series`/`toc`/assets/section sort options; bundle-asset changes were in no cache key; snapshot-escaping template refs (shadowed `.j2`, `./`-prefixed, non-template extensions) were invisible to invalidation; fingerprints rewritten to length-prefixed streaming MD5
- A dangling symlink (or file deleted mid-rebuild) in `content/` became a ghost page with an empty URL that silently clobbered `public/index.html`
- JS minifier fused tokens when removing block comments (`return/*#__PURE__*/g(1)` → `returng(1)`), breaking prebuilt vendor JS
- serve: plain CSS/JS edits to fingerprinted asset bundles never reprocessed the bundle (stale all session); PWA sw.js was generated before the files it precaches existed (clean/warm nondeterminism)
- multilingual section feeds interleaved every language

### Other clusters
- serve recovery: `@rebuild_failed` clobbered on Bool-failure builds; post-rebuild stale pruning deleting freshly re-created outputs; watcher baseline absorbing edits made during startup builds
- front matter: thematic-break `---` blocks no longer swallow the first content block; bodies starting with `{{`/`{%`/`{:` no longer abort as JSON front matter
- shortcodes: keyword-exact fence protection (`include-code` class), single-quoted explicit calls, builtin alert/callout markdownify
- i18n: hyphenated language codes (`zh-tw`, `pt-BR`), `.markdown` as a first-class page extension (incl. translation linking), translated-only bundle asset double-publish
- OG/image/PWA under serve: incremental edits keep auto-OG images and regenerate assets; `lazy_generate` now has the promised on-request dev handler (collision-safe); changed image bytes re-run resize/LQIP; sw.js regenerates on incremental paths
- SEO: sitemap/search/llms collision winner unified with render's path-sort-first rule; hreflang excludes `render=false`; RSS honors `feeds.truncate` (escaped); feed `<updated>` normalized before max
- symlink-escape guards added to the two remaining copy paths (serve static republish, raw content files)
- `HookResult::Skip` no longer silently terminates the whole build with exit 0

### Verification
- Every fix has a regression spec proven failing pre-fix; ~90 new examples across 6 new spec files + extensions
- Full suites green: unit 6872, functional 578, 0 failures; `crystal tool format` + ameba clean
- Release-binary smoke: init/build/cache-warm/`--full` on a multilingual blog scaffold behave correctly (warm = 0 rendered, `--full` = full re-render)

### Deferred (documented, intentionally unfixed)
WS broadcast liveness (needs ping/timeout design), cache-entry pruning for deleted content, `object_id` memo ABA, mtime-preserving-writer detection, unclosed-shortcode blast radius, case-only output collisions, aliases racing derived outputs, section-feed global-enabled gating (spec-pinned as intended), extension-less-template edge already mitigated via dynamic marking.