### PR TITLE
feat(sass): framework compatibility — @extend, lazy if(), calc/var interpolation, meta host functions

### DIFF
--- a/docs/content/features/sass.ko.md
+++ b/docs/content/features/sass.ko.md
@@ -75,9 +75,11 @@ Hwaro는 실용적인 SCSS 부분집합을 구현합니다 — 직접 작성하�
 | `@import`(Sass 파일) | ✅ 클래식 전역 병합 시맨틱, 순수 CSS 형태는 그대로 통과 |
 | `@mixin` / `@include` | ✅ 기본값, 키워드 인자, 가변 인자 `$args...`, 스프레드, `@content` 블록 |
 | `@function` / `@return` | ✅ 값 안에서 호출 가능한 사용자 함수, 기본값/키워드/가변 인자, 재귀 |
+| `@extend` + `%placeholder` | ✅ 단순 셀렉터 타깃, 컴파운드 통합, `!optional`. 확장되지 않은 플레이스홀더는 출력되지 않음 — 차이점 참고 |
+| SassScript의 `&` | ✅ `if(&, "&", "")` 패턴 — 부모 셀렉터를 값으로, 루트에서는 `null` |
 | 제어 흐름 | ✅ `@if` / `@else if` / `@else`, `@each`(구조 분해 포함), `@for`(`through`/`to`, 내림차순), `@while` |
 | SassScript 표현식 | ✅ 산술(`+ - * %`), 비교, `and`/`or`/`not`, 문자열, 리스트, 맵 — `/`는 차이점 참고 |
-| 내장 함수 | ✅ `sass:math`, `sass:string`, `sass:list`, `sass:map`, `sass:meta`, `sass:color` 부분집합 + 레거시 전역 이름(`map-get`, `nth`, `darken`, `if()` 등) |
+| 내장 함수 | ✅ `sass:math`, `sass:string`, `sass:list`(`zip` 포함), `sass:map`(`set` / `deep-merge` 포함), `sass:meta`(`variable-exists` / `function-exists` / `mixin-exists` / `content-exists` / `get-function` / `call` 포함), `sass:color` 부분집합 + 레거시 전역 이름(`map-get`, `nth`, `darken`, `if()` 등) |
 | `@debug` / `@warn` / `@error` | ✅ `@error`는 위치 정보가 담긴 메시지로 빌드를 실패시킴 |
 | `@at-root` | ✅ 셀렉터 형태와 블록 형태(`with:`/`without:` 쿼리는 제외) |
 | 규칙 안의 `@media` / `@supports` | ✅ 중첩 밖으로 자동 버블링, 피처 값에서 표현식 평가 |
@@ -111,7 +113,7 @@ $breakpoints: (sm: 640px, md: 768px, lg: 1024px);
 
 ### 색상
 
-색상 함수는 hex 리터럴(`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`)과 CSS 색상 키워드(`red`, `rebeccapurple`, `transparent`)에 동작합니다.
+색상 함수는 hex 리터럴(`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`), CSS 색상 키워드(`red`, `rebeccapurple`, `transparent`), 그리고 레거시 콤마 철자 `rgb(…)` / `rgba(…)` / `hsl(…)` / `hsla(…)`에 동작합니다. `hsl()`로 만든 색상은 선언된 색조/채도를 기억하므로 `hue(hsl(221, 14%, 100%))`는 `221deg`를 답합니다.
 
 ```scss
 $brand: #336699;
@@ -145,14 +147,26 @@ $brand: #336699;
 
 두 색상이 색상으로서 비교되는 것은 색상 함수가 만들어낸 값일 때뿐입니다. 리터럴끼리의 `#ffffff == #FFF`는 여전히 일반 텍스트 비교이므로 false입니다. `==`가 모든 리터럴을 파싱하게 만들면 지금 잘 컴파일되는 스타일시트의 `@if` 분기가 뒤집히는데, 순수 CSS 보장이 이를 허용하지 않습니다.
 
+### @extend
+
+`@extend`는 단순 셀렉터 타깃(클래스, `%placeholder`, id, 요소, 의사 클래스)에 동작합니다 — Bootstrap을 포함한 실제 스타일시트의 사용 방식을 전부 커버합니다. 타깃이 속한 컴파운드는 확장자의 마지막 컴파운드와 통합되고, 조상 컴파운드는 앞에 붙으며, 확장되지 않은 `%placeholder` 규칙은 출력에 등장하지 않습니다.
+
+```scss
+%visually-hidden { position: absolute; clip: rect(0 0 0 0); }
+.sr-only { @extend %visually-hidden; }
+// → .sr-only { position: absolute; clip: rect(0 0 0 0); }
+```
+
+타깃을 찾지 못하면 위치 정보가 담긴 오류로 빌드가 실패합니다. `!optional`을 붙이면 허용됩니다. dart-sass의 전체 extend 알고리즘과의 차이는 아래 차이점 목록을 참고하세요.
+
 ### 미지원 (아직)
 
-`@extend`, 단위 변환(`px`↔`cm`), `@at-root (with: ...)` 쿼리, `@forward ... with (...)`, `@content(args)` / `using`, `math.random` / `unique-id()`(빌드는 결정적이어야 합니다), 중첩 속성(`font: { family: ... }`), 들여쓰기 방식의 `.sass` 문법, 소스맵은 지원하지 않습니다.
+단위 변환(`px`↔`cm`), `@at-root (with: ...)` 쿼리, `@forward ... with (...)`, `@content(args)` / `using`, `math.random` / `unique-id()`(빌드는 결정적이어야 합니다), 중첩 속성(`font: { family: ... }`), 들여쓰기 방식의 `.sass` 문법, 소스맵은 지원하지 않습니다.
 
 **미지원 지시문은 위치 정보가 담긴 오류와 함께 빌드를 실패시킵니다** — Hwaro는 조용히 깨진 CSS를 내보내지 않습니다.
 
 ```
-Error [HWARO_E_CONTENT]: Sass: static/css/style.scss:14:3: @extend is not supported by hwaro's Sass subset (yet)
+Error [HWARO_E_CONTENT]: Sass: static/css/style.scss:14:3: @content arguments are not supported
 ```
 
 ### 표현식 시맨틱
@@ -169,9 +183,11 @@ Error [HWARO_E_CONTENT]: Sass: static/css/style.scss:14:3: @extend is not suppor
 - 단위 산술은 동일 단위이거나 한쪽이 단위 없는 경우만 지원합니다. `px`↔`in` 변환 테이블은 없습니다.
 - *값* 위치의 `and`/`or`는 실제 불리언에만 동작합니다 — `font-family: Franklin and Marshall`은 텍스트로 남습니다. 조건식에서는 Sass의 완전한 truthiness를 따릅니다.
 - 전역 `min()`/`max()`/`round()`/`abs()`는 모든 인자가 정적으로 비교 가능한 숫자일 때만 평가됩니다. CSS 형태(`min(5vw, 100px)`, `round(up, 101px, 10px)`)는 그대로 통과합니다.
-- `rgb()`/`rgba()`/`hsl()`/`hsla()`는 CSS 형태 그대로 두고 접지 **않습니다**. dart-sass는 `rgb(0, 0, 0)`을 `black`으로 내보내지만 여기서는 원문이 유지됩니다. 유효한 CSS가 아닌 Sass 전용 `rgba($color, $alpha)` 철자만 평가됩니다. 마찬가지로 `grayscale()`, `invert()`, `saturate()`, `opacity()`는 색상을 받으면 색상 함수, 숫자를 받으면 순수 CSS 필터로 취급됩니다(`filter: grayscale(50%)`는 그대로 통과).
+- `rgb()`/`rgba()`/`hsl()`/`hsla()`는 CSS 형태 그대로 두고 접지 **않습니다**. dart-sass는 `rgb(0, 0, 0)`을 `black`으로 내보내지만 여기서는 원문이 유지됩니다(색상 *함수*가 그런 리터럴을 받으면 색상으로 읽기는 합니다). 유효한 CSS가 아닌 Sass 전용 `rgba($color, $alpha)` 철자만 평가됩니다. 마찬가지로 `grayscale()`, `invert()`, `saturate()`, `opacity()`는 색상을 받으면 색상 함수, 숫자를 받으면 순수 CSS 필터로 취급됩니다(`filter: grayscale(50%)`는 그대로 통과).
+- 계산된 색상은 정수 채널의 hex/`rgba()`로 직렬화됩니다. dart-sass 1.79+는 소수 채널(`rgb(38.25, 76.5, 114.75)`)을 유지합니다. 채널당 최대 1 차이입니다.
 - 대부분의 내장 함수는 위치 인자만 받습니다. 키워드 호출(`list.append($l, x, $separator: comma)`)은 평가되지 않고 원문 그대로 남습니다. **색상** 함수는 예외로, 문서화된 키워드 이름을 받습니다(`darken($c, $amount: 10%)`, `mix($a, $b, $weight: 25%)`, `scale-color($c, $lightness: 60%)`). `adjust`/`scale`/`change`는 `$lightness` 같은 키워드 인자가 유일한 호출 방법이기 때문입니다. 사용자 정의 `@mixin`/`@function`의 키워드 인자는 정상 동작합니다.
-- `if()`는 두 분기를 모두 즉시 평가합니다(부수 효과가 없으므로, 선택되지 않은 분기의 `@error`로만 관찰 가능합니다).
+- `@extend`는 dart-sass 알고리즘의 실용적 부분집합입니다: 타깃은 단순 셀렉터여야 하고, 확장은 문서 전역에 적용되며(dart-sass는 모듈 단위로 스코프를 나누고 `@media` 경계를 넘는 확장을 금지), 확장 대상과 확장자 양쪽에 조상 컴파운드가 있으면 첫 번째 접두 순서만 출력합니다(dart-sass는 두 순서를 모두 "위빙"). 공유하는 선행 접두는 병합됩니다(`.nav %p`를 `.nav > .c`로 확장 → `.nav > .c`).
+- `calc()` 내용은 절대 단순화하지 않습니다 — dart-sass는 `calc(9 / 21 * 100%)`를 `42.86%`로 접지만 여기서는 쓴 그대로 남습니다. 브라우저 계산 결과는 동일합니다.
 - at-규칙 서두와 값 안의 변수는 직접 치환됩니다(`@media (min-width: $bp)` 동작). 셀렉터와 속성 이름에는 `#{...}` 보간이 필요합니다(dart-sass와 동일).
 - at-규칙 서두에서는 `(feature: value)` 구간 안에서만 표현식이 평가됩니다. 쿼리 구조 자체는 원문 그대로 유지됩니다.
 - `@media` 안에 중첩된 `@media`는 문자 그대로 중첩된 블록으로 출력됩니다(dart-sass는 조건을 병합).

--- a/docs/content/features/sass.md
+++ b/docs/content/features/sass.md
@@ -75,9 +75,11 @@ Hwaro implements a practical SCSS subset — the features hand-written site styl
 | `@import` (Sass files) | ✅ classic global-merge semantics; plain-CSS forms pass through |
 | `@mixin` / `@include` | ✅ default values, keyword arguments, variadic `$args...`, spreads, `@content` blocks |
 | `@function` / `@return` | ✅ user functions callable in values, defaults/keywords/variadic, recursion |
+| `@extend` + `%placeholders` | ✅ simple-selector targets, compound unification, `!optional`; un-extended placeholders never emit — see deviations |
+| `&` in SassScript | ✅ `if(&, "&", "")` and friends — the parent selector as a value, `null` at the root |
 | Control flow | ✅ `@if` / `@else if` / `@else`, `@each` (with destructuring), `@for` (`through`/`to`, descending), `@while` |
 | SassScript expressions | ✅ arithmetic (`+ - * %`), comparisons, `and`/`or`/`not`, strings, lists, maps — see deviations for `/` |
-| Built-in functions | ✅ `sass:math`, `sass:string`, `sass:list`, `sass:map`, `sass:meta`, `sass:color` subset + legacy global names (`map-get`, `nth`, `darken`, `if()`, …) |
+| Built-in functions | ✅ `sass:math`, `sass:string`, `sass:list` (incl. `zip`), `sass:map` (incl. `set` / `deep-merge`), `sass:meta` (incl. `variable-exists` / `function-exists` / `mixin-exists` / `content-exists` / `get-function` / `call`), `sass:color` subset + legacy global names (`map-get`, `nth`, `darken`, `if()`, …) |
 | `@debug` / `@warn` / `@error` | ✅ `@error` fails the build with a located message |
 | `@at-root` | ✅ selector and block forms (no `with:`/`without:` queries) |
 | `@media` / `@supports` in rules | ✅ bubbled out of nesting automatically; feature values evaluate expressions |
@@ -111,7 +113,7 @@ $breakpoints: (sm: 640px, md: 768px, lg: 1024px);
 
 ### Colors
 
-Color functions operate on hex literals (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`) and the CSS color keywords (`red`, `rebeccapurple`, `transparent`):
+Color functions operate on hex literals (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`), the CSS color keywords (`red`, `rebeccapurple`, `transparent`), and the legacy comma spellings `rgb(…)` / `rgba(…)` / `hsl(…)` / `hsla(…)` — a color built from `hsl()` remembers its declared hue/saturation, so `hue(hsl(221, 14%, 100%))` answers `221deg`:
 
 ```scss
 $brand: #336699;
@@ -145,14 +147,26 @@ A computed color serializes as `#rrggbb` when opaque and `rgba(r, g, b, a)` othe
 
 Two colors are only compared as colors once a color function has produced them; `#ffffff == #FFF` between two literals is still the generic text comparison and is false. Teaching `==` to parse every literal would flip `@if` branches in stylesheets that compile today, which the plain-CSS guarantee rules out.
 
+### @extend
+
+`@extend` works on simple-selector targets — a class, `%placeholder`, id, element, or pseudo — which covers how real stylesheets (Bootstrap included) use it. The target's compound is unified with the extender's final compound, ancestor compounds are prepended, and un-extended `%placeholder` rules never reach the output:
+
+```scss
+%visually-hidden { position: absolute; clip: rect(0 0 0 0); }
+.sr-only { @extend %visually-hidden; }
+// → .sr-only { position: absolute; clip: rect(0 0 0 0); }
+```
+
+A missing target fails the build with a located error; append `!optional` to tolerate it. See the deviations list for how the subset differs from dart-sass's full extend algorithm.
+
 ### Not supported (yet)
 
-`@extend`, unit conversion (`px`↔`cm`), `@at-root (with: ...)` queries, `@forward ... with (...)`, `@content(args)` / `using`, `math.random` / `unique-id()` (builds must stay deterministic), nested properties (`font: { family: ... }`), the indented `.sass` syntax, and source maps.
+Unit conversion (`px`↔`cm`), `@at-root (with: ...)` queries, `@forward ... with (...)`, `@content(args)` / `using`, `math.random` / `unique-id()` (builds must stay deterministic), nested properties (`font: { family: ... }`), the indented `.sass` syntax, and source maps.
 
 **Unsupported directives fail the build with a located error** — Hwaro never emits silently broken CSS:
 
 ```
-Error [HWARO_E_CONTENT]: Sass: static/css/style.scss:14:3: @extend is not supported by hwaro's Sass subset (yet)
+Error [HWARO_E_CONTENT]: Sass: static/css/style.scss:14:3: @content arguments are not supported
 ```
 
 ### Expression semantics
@@ -169,9 +183,11 @@ The compiler's first duty is the plain-CSS guarantee, so expressions follow a tw
 - Unit arithmetic requires identical units or one unitless side; there is no `px`↔`in` conversion table.
 - `and`/`or` in *value* positions only operate on real booleans — `font-family: Franklin and Marshall` stays text. Conditions have full Sass truthiness.
 - Global `min()`/`max()`/`round()`/`abs()` evaluate only when all arguments are statically comparable numbers; CSS forms (`min(5vw, 100px)`, `round(up, 101px, 10px)`) pass through.
-- `rgb()`/`rgba()`/`hsl()`/`hsla()` are **not** folded in their CSS forms: `rgb(0, 0, 0)` stays verbatim where dart-sass would emit `black`. Only the Sass-only `rgba($color, $alpha)` spelling — which is not valid CSS — evaluates. Likewise `grayscale()`, `invert()`, `saturate()` and `opacity()` are color functions when handed a color and plain CSS filters when handed a number (`filter: grayscale(50%)` passes through).
+- `rgb()`/`rgba()`/`hsl()`/`hsla()` are **not** folded in their CSS forms: `rgb(0, 0, 0)` stays verbatim where dart-sass would emit `black` (a color *function* handed such a literal still reads it as a color). Only the Sass-only `rgba($color, $alpha)` spelling — which is not valid CSS — evaluates. Likewise `grayscale()`, `invert()`, `saturate()` and `opacity()` are color functions when handed a color and plain CSS filters when handed a number (`filter: grayscale(50%)` passes through).
+- A computed color serializes as hex/`rgba()` with integer channels; dart-sass 1.79+ keeps fractional channels (`rgb(38.25, 76.5, 114.75)`). Off by at most one per channel.
 - Most built-in functions take positional arguments only. A keyword call (`list.append($l, x, $separator: comma)`) doesn't evaluate and keeps its verbatim text. The **color** functions are the exception — they accept their documented keyword names (`darken($c, $amount: 10%)`, `mix($a, $b, $weight: 25%)`, `scale-color($c, $lightness: 60%)`), since `$lightness`-style arguments are the only way to call `adjust`/`scale`/`change`. User-defined `@mixin`/`@function` keyword arguments work normally.
-- `if()` evaluates both branches eagerly (no side effects exist, so this is observable only via `@error` in the untaken branch).
+- `@extend` is a practical subset of dart-sass's algorithm: targets must be simple selectors, extends apply document-wide (dart-sass scopes them per module and forbids crossing `@media` boundaries), and when both the extended selector and the extender have ancestor compounds only the first prefix order is emitted (dart-sass "weaves" both). Shared leading prefixes merge (`.nav %p` extended by `.nav > .c` → `.nav > .c`).
+- `calc()` contents are never simplified — `calc(9 / 21 * 100%)` stays as written where dart-sass folds it to `42.86%`. Browsers compute both identically.
 - Variables in at-rule preludes and values substitute directly (`@media (min-width: $bp)` works); selectors and property names require `#{...}` interpolation (same as dart-sass).
 - At-rule preludes evaluate expressions only inside `(feature: value)` spans; the query structure itself stays verbatim.
 - `@media` nested inside `@media` emits literally nested blocks (dart-sass merges the conditions).

--- a/spec/unit/sass/compile_spec.cr
+++ b/spec/unit/sass/compile_spec.cr
@@ -301,8 +301,8 @@ describe Hwaro::Assets::Sass do
     # =========================================================================
     # Unsupported directives fail loudly
     # =========================================================================
-    it "rejects @extend with a located error" do
-      ex = expect_raises(Hwaro::Assets::Sass::SyntaxError, /@extend is not supported/) do
+    it "rejects @extend of a missing target with a located error" do
+      ex = expect_raises(Hwaro::Assets::Sass::SyntaxError, /@extend target ".b" was not found/) do
         compile(".a { @extend .b; }", path: "d.scss")
       end
       ex.location.should eq("d.scss:1:6")

--- a/spec/unit/sass/extend_spec.cr
+++ b/spec/unit/sass/extend_spec.cr
@@ -1,0 +1,152 @@
+require "../../spec_helper"
+require "../../../src/assets/sass"
+
+private def compile(scss : String, path : String = "test.scss") : String
+  Hwaro::Assets::Sass.compile(scss, path)
+end
+
+describe "Sass @extend" do
+  # ===========================================================================
+  # Placeholder selectors
+  # ===========================================================================
+  it "never emits un-extended placeholder rules" do
+    css = compile("%btn { color: red; }\n.a { b: 1; }")
+    css.should_not contain("%btn")
+    css.should_not contain("color: red")
+    css.should contain(".a {")
+  end
+
+  it "drops placeholder members from selector lists but keeps the rest" do
+    css = compile("%p, .real { color: red; }")
+    css.should_not contain("%p")
+    css.should contain(".real {\n  color: red;")
+  end
+
+  it "drops nested rules whose resolved selector contains a placeholder" do
+    css = compile("%btn { color: red; &:hover { color: blue; } }")
+    css.should_not contain("%btn")
+    css.should_not contain(":hover")
+  end
+
+  it "does not treat keyframe percentages as placeholders" do
+    css = compile("@keyframes spin { 50% { opacity: 0.5; } }")
+    css.should contain("50% {")
+  end
+
+  # ===========================================================================
+  # Basic extension
+  # ===========================================================================
+  it "extends a class selector" do
+    css = compile(".error { border: red; }\n.fatal { @extend .error; font-weight: bold; }")
+    css.should contain(".error,\n.fatal {\n  border: red;")
+    css.should contain(".fatal {\n  font-weight: bold;")
+  end
+
+  it "extends a placeholder and scrubs it" do
+    css = compile("%vh { position: absolute; }\n.sr-only { @extend %vh; }")
+    css.should contain(".sr-only {\n  position: absolute;")
+    css.should_not contain("%vh")
+  end
+
+  it "extends every rule containing the target, compounds included" do
+    css = compile(<<-SCSS)
+      .b.c { x: 1; }
+      .b:hover { y: 2; }
+      a.b { z: 3; }
+      .a { @extend .b; }
+      SCSS
+    css.should contain(".a.c")
+    css.should contain(".a:hover")
+    css.should contain("a.a")
+  end
+
+  it "keeps the element selector first when unifying" do
+    css = compile("a.b { z: 3; }\n.c { @extend .b; }")
+    css.should contain("a.c")
+    css.should_not contain(".ca")
+  end
+
+  it "skips unification when element selectors conflict" do
+    css = compile("div.b { z: 3; }\nspan.x { @extend .b; }")
+    css.should contain("div.b {")
+    css.should_not contain("divspan")
+    css.should_not contain("spandiv")
+  end
+
+  it "prepends the extender's ancestor compounds" do
+    css = compile(".t { c: red; }\n.x .y { @extend .t; }")
+    css.should contain(".t,\n.x .y {")
+  end
+
+  it "merges a shared leading prefix instead of duplicating it" do
+    # The Bootstrap navbar shape: a placeholder nested under .navbar,
+    # extended from `.navbar > .container`.
+    css = compile(<<-SCSS)
+      .navbar {
+        %flex { display: flex; }
+        > .container { @extend %flex; }
+      }
+      SCSS
+    css.should contain(".navbar > .container {\n  display: flex;")
+    css.should_not contain(".navbar .navbar")
+  end
+
+  it "extends rules inside at-rules" do
+    css = compile("@media print { .b { x: 1; } }\n.a { @extend .b; }")
+    css.should contain("@media print {\n  .b,\n  .a {")
+  end
+
+  it "supports comma-separated targets" do
+    css = compile(".x { a: 1; }\n.y { b: 2; }\n.z { @extend .x, .y; }")
+    css.should contain(".x,\n.z {")
+    css.should contain(".y,\n.z {")
+  end
+
+  it "resolves chained extends through placeholders" do
+    css = compile("%x { a: 1; }\n%y { @extend %x; b: 2; }\n.z { @extend %y; }")
+    css.should contain(".z {\n  a: 1;")
+    css.should contain(".z {\n  b: 2;")
+    css.should_not contain("%")
+  end
+
+  it "applies extends recorded in @use'd modules" do
+    loader = Hwaro::Assets::Sass::MemoryLoader.new({
+      "_lib.scss" => "%base { margin: 0; }\n.card { @extend %base; }",
+    })
+    css = Hwaro::Assets::Sass.compile("@use \"lib\";", path: "main.scss", loader: loader)
+    css.should contain(".card {\n  margin: 0;")
+    css.should_not contain("%base")
+  end
+
+  # ===========================================================================
+  # Errors & !optional
+  # ===========================================================================
+  it "errors on a missing target with a located message" do
+    ex = expect_raises(Hwaro::Assets::Sass::SyntaxError, /@extend target ".nope" was not found/) do
+      compile(".a { @extend .nope; }", path: "e.scss")
+    end
+    ex.location.should eq("e.scss:1:6")
+  end
+
+  it "tolerates a missing target with !optional" do
+    css = compile(".a { @extend .nope !optional; b: 1; }")
+    css.should contain(".a {\n  b: 1;")
+  end
+
+  it "rejects @extend outside a style rule" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /may only be used within style rules/) do
+      compile("@extend .a;")
+    end
+  end
+
+  it "rejects @extend inside @keyframes" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /may only be used within style rules/) do
+      compile(".a { c: red; }\n@keyframes k { 50% { @extend .a; } }")
+    end
+  end
+
+  it "supports interpolation in the target" do
+    css = compile(".item-2 { c: red; }\n.a { @extend .item-\#{1 + 1}; }")
+    css.should contain(".item-2,\n.a {")
+  end
+end

--- a/spec/unit/sass/framework_compat_spec.cr
+++ b/spec/unit/sass/framework_compat_spec.cr
@@ -1,0 +1,346 @@
+# Regression specs for the framework-compatibility batch: every case here
+# is minimized from a real Bootstrap 5.3 / Bulma 1.0 failure.
+
+require "../../spec_helper"
+require "../../../src/assets/sass"
+
+private def compile(scss : String, path : String = "test.scss") : String
+  Hwaro::Assets::Sass.compile(scss, path)
+end
+
+describe "Sass framework compatibility" do
+  # ===========================================================================
+  # CSS-owned spans with dynamic pieces in strict contexts
+  # ===========================================================================
+  it "evaluates calc() with interpolation in @return (Bootstrap add())" do
+    css = compile(<<-'SCSS')
+      @function add($a, $b) { @return calc(#{$a} + #{$b}); }
+      .x { height: add(1em, 2px); }
+      SCSS
+    css.should contain("height: calc(1em + 2px);")
+  end
+
+  it "evaluates url()-style spans with $var pieces in @return" do
+    css = compile("@function f($a) { @return calc(100% - $a); }\n.x { w: f(10px); }")
+    css.should contain("w: calc(100% - 10px);")
+  end
+
+  it "evaluates var() with interpolation in @return (Bulma getVar())" do
+    css = compile("@function cv($n) { @return var(\#{$n}); }\n.x { c: cv(--foo); }")
+    css.should contain("c: var(--foo);")
+  end
+
+  it "keeps plain var()/calc() values verbatim" do
+    css = compile(".a { width: var( --x , 10px ); height: calc(100% -  10px); }")
+    css.should contain("width: var( --x , 10px );")
+    css.should contain("height: calc(100% - 10px);")
+  end
+
+  it "evaluates known function calls inside a var() fallback" do
+    css = compile(<<-'SCSS')
+      @function esc($s) { @return "<#{$s}>"; }
+      .b { content: var(--divider, esc("/")); }
+      SCSS
+    css.should contain(%(content: var(--divider, "</>");))
+  end
+
+  it "lexes strings with consecutive interpolations in @return (Bulma buildVarName())" do
+    css = compile(<<-'SCSS')
+      @function n($a, $b) { @return "--x-#{$a}#{$b}"; }
+      .x { c: n(p, q); }
+      SCSS
+    css.should contain("c: \"--x-pq\";")
+  end
+
+  it "converts an unlexable strict expression into a located error" do
+    ex = expect_raises(Hwaro::Assets::Sass::SyntaxError, /invalid expression/) do
+      compile("@function f() { @return ~~~; }\n.x { c: f(); }\n@if f() { .y { a: 1 } }", path: "l.scss")
+    end
+    ex.location.should_not be_nil
+  end
+
+  # ===========================================================================
+  # Lazy if()
+  # ===========================================================================
+  it "evaluates only the taken branch of if() (Bootstrap shift-color())" do
+    css = compile(<<-SCSS)
+      @function shift($c, $w) { @return if($w > 0, mix(black, $c, $w), mix(white, $c, -$w)); }
+      .a { color: shift(#0d6efd, -20%); }
+      SCSS
+    css.should contain("color: #3d8bfd;")
+  end
+
+  it "does not raise @error from the untaken if() branch" do
+    css = compile(<<-SCSS)
+      @function boom() { @error "untaken"; }
+      .a { w: if(true, 1px, boom()); }
+      SCSS
+    css.should contain("w: 1px;")
+  end
+
+  # ===========================================================================
+  # !important as a SassScript value (Bootstrap utilities API)
+  # ===========================================================================
+  it "supports !important through if() in values" do
+    css = compile(<<-SCSS)
+      $enable: true;
+      .m-0 { margin: 0 if($enable, !important, null); }
+      .m-1 { margin: 1px if(not $enable, !important, null); }
+      SCSS
+    css.should contain("margin: 0 !important;")
+    css.should contain("margin: 1px;\n")
+  end
+
+  # ===========================================================================
+  # & as a SassScript value (Bootstrap form-validation-state-selector)
+  # ===========================================================================
+  it "evaluates & as null at the root and the selector list inside a rule" do
+    css = compile(<<-'SCSS')
+      @mixin sel($s) { #{if(&, "&", "")}.is-#{$s} { color: red; } }
+      .form { @include sel(bad); }
+      @include sel(ok);
+      SCSS
+    css.should contain(".form.is-bad {")
+    css.should contain("\n.is-ok {")
+  end
+
+  # ===========================================================================
+  # meta host functions
+  # ===========================================================================
+  it "answers the *-exists meta functions" do
+    css = compile(<<-SCSS)
+      $x: 1;
+      @mixin m {}
+      @function f() { @return 1; }
+      .a {
+        a: variable-exists(x);
+        b: variable-exists(nope);
+        c: mixin-exists(m);
+        d: function-exists(f);
+        e: function-exists(map-get);
+        f: function-exists(zzz);
+      }
+      SCSS
+    css.should contain("a: true;")
+    css.should contain("b: false;")
+    css.should contain("c: true;")
+    css.should contain("d: true;")
+    css.should contain("e: true;")
+    css.should contain("f: false;")
+  end
+
+  it "supports variable-exists inside a value guard (Bootstrap grid mixin)" do
+    css = compile(<<-SCSS)
+      $box: true;
+      .col { box-sizing: if(variable-exists(box) and $box, border-box, null); }
+      .col2 { box-sizing: if(variable-exists(nope), border-box, content-box); }
+      SCSS
+    css.should contain("box-sizing: border-box;")
+    css.should contain("box-sizing: content-box;")
+  end
+
+  it "invokes functions through get-function and call (Bootstrap map-loop)" do
+    css = compile(<<-SCSS)
+      @use "sass:meta";
+      @function double($x) { @return $x * 2; }
+      $args: (5px,);
+      .a {
+        w: meta.call(meta.get-function("double"), 4px);
+        x: call(get-function("double"), $args...);
+        y: meta.call(meta.get-function("str-length"), "abc");
+      }
+      SCSS
+    css.should contain("w: 8px;")
+    css.should contain("x: 10px;")
+    css.should contain("y: 3;")
+  end
+
+  # ===========================================================================
+  # New builtins
+  # ===========================================================================
+  it "zips lists (Bootstrap utility values)" do
+    css = compile(<<-'SCSS')
+      $m: zip((a b c), (1 2 3));
+      @each $k, $v in $m { .z-#{$k} { n: $v; } }
+      SCSS
+    css.should contain(".z-a {\n  n: 1;")
+    css.should contain(".z-c {\n  n: 3;")
+  end
+
+  it "sets map keys with map.set, nested included (Bulma shades)" do
+    css = compile(<<-SCSS)
+      @use "sass:map";
+      $m: (a: 1);
+      $m: map.set($m, b, 2);
+      $m: map.set($m, c, d, 3);
+      .a { x: map.get($m, b); y: map.get($m, c, d); z: inspect($m); }
+      SCSS
+    css.should contain("x: 2;")
+    css.should contain("y: 3;")
+    css.should contain("z: (a: 1, b: 2, c: (d: 3));")
+  end
+
+  it "deep-merges maps" do
+    css = compile(<<-SCSS)
+      @use "sass:map";
+      .a { m: inspect(map.deep-merge((a: (b: 1)), (a: (c: 2)))); }
+      SCSS
+    css.should contain("m: (a: (b: 1, c: 2));")
+  end
+
+  # ===========================================================================
+  # Value-model fixes
+  # ===========================================================================
+  it "parses bracketed space lists element-wise" do
+    css = compile("@use \"sass:list\";\n.a { n: list.length([1 2 3]); i: inspect([1 2]); }")
+    css.should contain("n: 3;")
+    css.should contain("i: [1 2];")
+  end
+
+  it "round-trips single-element comma lists" do
+    css = compile("@use \"sass:list\";\n.a { i: inspect((1,)); s: list.separator((1,)); n: list.length((1,)); }")
+    css.should contain("i: (1,);")
+    css.should contain("s: comma;")
+    css.should contain("n: 1;")
+  end
+
+  it "propagates null through bare-variable arguments (Bulma palette)" do
+    css = compile(<<-SCSS)
+      @mixin pal($light: null, $dark: null) {
+        .pal { both: if($light and $dark, yes, no); }
+      }
+      $light: null;
+      $dark: null;
+      @include pal($light, $dark);
+      SCSS
+    css.should contain("both: no;")
+  end
+
+  it "lets !default overwrite a null value (Bootstrap dark-mode maps)" do
+    css = compile(<<-'SCSS')
+      $map: null !default;
+      @if true { $map: (a: 1) !default; }
+      @each $k, $v in $map { .e-#{$k} { n: $v; } }
+      SCSS
+    css.should contain(".e-a {\n  n: 1;")
+  end
+
+  it "renders nested-list variables without structural parens" do
+    css = compile(<<-'SCSS')
+      $shadow: inset 0 1px 0 rgba(#fff, 0.15), 0 1px 1px rgba(#000, 0.075);
+      .btn { box-shadow: $shadow; --shadow: #{$shadow}; }
+      SCSS
+    css.should contain("box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 1px 1px rgba(0, 0, 0, 0.075);")
+    css.should_not contain("(inset")
+  end
+
+  it "always evaluates map literals so structure survives argument passing" do
+    css = compile(<<-'SCSS')
+      $family: "A B", "C D", serif;
+      @mixin reg($vars) { @each $k, $v in $vars { .r-#{$k} { v: $v; } } }
+      @include reg(("family": $family, "delta": -5%));
+      SCSS
+    css.should contain(%(v: "A B", "C D", serif;))
+    css.should contain("v: -5%;")
+  end
+
+  it "compares raw function results with typed numbers (Bootstrap RFS)" do
+    css = compile(<<-'SCSS')
+      @function ident($x) { @return #{$x}; }
+      .a { eq: if(ident(1rem) == 1rem, same, different); }
+      SCSS
+    css.should contain("eq: same;")
+  end
+
+  # ===========================================================================
+  # Colors
+  # ===========================================================================
+  it "reads hsl()/hsla() literals as colors in color functions (Bulma)" do
+    css = compile(".a { r: red(hsl(0, 100%, 50%)); d: darken(hsl(120deg, 50%, 50%), 10%); a: alpha(hsla(0, 0%, 0%, 0.5)); }")
+    css.should contain("r: 255;")
+    css.should contain("d: #339933;")
+    css.should contain("a: 0.5;")
+  end
+
+  it "remembers declared hsl components through the RGB round trip" do
+    css = compile(".a { h: hue(hsl(221, 14%, 100%)); s: saturation(hsl(221, 14%, 100%)); }")
+    css.should contain("h: 221deg;")
+    css.should contain("s: 14%;")
+  end
+
+  # ===========================================================================
+  # Comment interpolation
+  # ===========================================================================
+  it "resolves interpolation inside loud comments (Bootstrap banner)" do
+    css = compile("$v: \"5.3.3\";\n/*! Library v\#{$v} */\n.a { b: 1; }")
+    css.should contain("/*! Library v5.3.3 */")
+  end
+
+  it "leaves comments without interpolation untouched" do
+    css = compile("/*! plain $var \\ */\n.a { b: 1; }")
+    css.should contain("/*! plain $var \\ */")
+  end
+
+  # ===========================================================================
+  # Review-batch regressions
+  # ===========================================================================
+  it "does not scrub selectors with an escaped percent" do
+    css = compile(".sale\\%-badge { color: red; }")
+    css.should contain(".sale\\%-badge {\n  color: red;")
+  end
+
+  it "keeps commented-out Sass with unresolvable interpolation verbatim" do
+    css = compile("/* was: color: \#{$old-brand} */\n.a { b: 1; }")
+    css.should contain("/* was: color: \#{$old-brand} */")
+  end
+
+  it "renders single-element comma lists as their bare value in every output path" do
+    css = compile(<<-'SCSS')
+      $x: append((), 10px, comma);
+      .a { margin: $x; pad: #{$x}; }
+      @media (max-width: $x) { .b { c: 1; } }
+      SCSS
+    css.should contain("margin: 10px;")
+    css.should contain("pad: 10px;")
+    css.should contain("@media (max-width: 10px)")
+    css.should_not contain("(10px,)")
+  end
+
+  it "re-resolves a function reference that round-tripped through a variable" do
+    css = compile(<<-SCSS)
+      $f: get-function("darken");
+      .a { c: call($f, #336699, 10%); }
+      SCSS
+    css.should contain("c: #264d73;")
+  end
+
+  it "answers $module-scoped meta introspection" do
+    css = compile(<<-SCSS)
+      @use "sass:meta";
+      @use "sass:color";
+      .a { b: meta.function-exists("adjust", $module: "color"); c: meta.function-exists("nope", $module: "color"); }
+      SCSS
+    css.should contain("b: true;")
+    css.should contain("c: false;")
+  end
+
+  it "extends targets inside :is()/:where() arguments" do
+    css = compile(".x :is(.b) { q: 1; }\n.c { @extend .b; }")
+    css.should contain(":is(.b, .c)")
+  end
+
+  it "keeps declared hsl components through alpha-only derivations" do
+    css = compile(".a { h: hue(transparentize(hsl(221, 14%, 100%), 0.2)); }")
+    css.should contain("h: 221deg;")
+  end
+
+  it "counts the meta host functions in function-exists and get-function" do
+    css = compile(<<-SCSS)
+      $g: get-function("variable-exists");
+      .a { a: function-exists("get-function"); b: call($g, "g"); c: call($g, "nope"); }
+      SCSS
+    css.should contain("a: true;")
+    css.should contain("b: true;")
+    css.should contain("c: false;")
+  end
+end

--- a/src/assets/sass.cr
+++ b/src/assets/sass.cr
@@ -4,11 +4,14 @@
 # partials via @use (namespaces, `with (...)` configuration) / @forward /
 # @import (classic merge), @mixin / @include with defaults, keyword and
 # variadic args and @content, @function / @return, control flow
-# (@if/@else/@each/@for/@while), @debug/@warn/@error, @at-root, `#{...}`
-# interpolation, @media/@supports bubbling through nesting, SassScript
-# expressions (arithmetic, comparisons, string/list/map values), and a
-# curated built-in function set (`sass:math`, `sass:string`, `sass:list`,
-# `sass:map`, `sass:meta`, `sass:color` + the legacy global names).
+# (@if/@else/@each/@for/@while), @extend with %placeholders (simple-
+# selector targets), @debug/@warn/@error, @at-root, `#{...}`
+# interpolation (loud comments included), @media/@supports bubbling
+# through nesting, SassScript expressions (arithmetic, comparisons,
+# string/list/map values, `&`, lazy `if()`), and a curated built-in
+# function set (`sass:math`, `sass:string`, `sass:list`, `sass:map`,
+# `sass:meta` incl. get-function/call and the *-exists family,
+# `sass:color` + the legacy global names).
 #
 # Two invariants shape the design:
 # - Valid plain CSS compiles to itself (whitespace-normalized): value
@@ -26,6 +29,7 @@ require "./sass/ast"
 require "./sass/parser"
 require "./sass/environment"
 require "./sass/css"
+require "./sass/extend"
 require "./sass/importer"
 require "./sass/evaluator"
 

--- a/src/assets/sass/ast.cr
+++ b/src/assets/sass/ast.cr
@@ -233,6 +233,17 @@ module Hwaro
           end
         end
 
+        # `@extend .target [!optional];` — extends the enclosing rule's
+        # selectors onto every rule matching the target selector(s).
+        class ExtendNode < Node
+          getter selector : TextTemplate
+          getter optional : Bool
+
+          def initialize(@selector, @optional, line, column)
+            super(line, column)
+          end
+        end
+
         # `@at-root { ... }` / `@at-root .sel { ... }` — evaluates its
         # body outside the current style-rule nesting (but inside any
         # surrounding at-rule).
@@ -268,11 +279,15 @@ module Hwaro
           end
         end
 
-        # Loud comment kept at statement position.
+        # Loud comment kept at statement position. `template` is set when
+        # the comment contains `#{...}` interpolation (dart-sass resolves
+        # interpolation inside loud comments — the `/*! Library v#{$ver} */`
+        # banner idiom).
         class CommentNode < Node
           getter text : String
+          getter template : TextTemplate?
 
-          def initialize(@text, line, column)
+          def initialize(@text, line, column, @template = nil)
             super(line, column)
           end
         end

--- a/src/assets/sass/color.cr
+++ b/src/assets/sass/color.cr
@@ -124,7 +124,14 @@ module Hwaro
         end
 
         def with_alpha(alpha : Float64) : ColorV
-          ColorV.new(@red, @green, @blue, alpha)
+          color = ColorV.new(@red, @green, @blue, alpha)
+          # RGB is unchanged, so the declared HSL components survive an
+          # alpha-only derivation (transparentize/opacify/rgba($c, $a)) —
+          # otherwise `hue(transparentize(hsl(221, 14%, 100%), .2))` would
+          # forget the hue that from_hsl just preserved.
+          h, s, l = to_hsl
+          color.preset_hsl(h, s, l)
+          color
         end
 
         # ---------------------------------------------------------------
@@ -194,19 +201,31 @@ module Hwaro
           s = saturation.clamp(0.0, 100.0) / 100.0
           l = lightness.clamp(0.0, 100.0) / 100.0
 
-          if s == 0.0
-            gray = l * 255.0
-            return new(gray, gray, gray, alpha)
-          end
+          color =
+            if s == 0.0
+              gray = l * 255.0
+              new(gray, gray, gray, alpha)
+            else
+              q = l < 0.5 ? l * (1.0 + s) : l + s - l * s
+              p = 2.0 * l - q
+              new(
+                hue_to_rgb(p, q, h + 1.0 / 3.0) * 255.0,
+                hue_to_rgb(p, q, h) * 255.0,
+                hue_to_rgb(p, q, h - 1.0 / 3.0) * 255.0,
+                alpha
+              )
+            end
+          # Remember the DECLARED components: the RGB round trip collapses
+          # hue/saturation at the extremes (white/black/grays), but
+          # `hue(hsl(221, 14%, 100%))` must answer 221deg, not 0deg
+          # (dart-sass colors remember their construction space).
+          color.preset_hsl(h * 360.0, s * 100.0, l * 100.0)
+          color
+        end
 
-          q = l < 0.5 ? l * (1.0 + s) : l + s - l * s
-          p = 2.0 * l - q
-          new(
-            hue_to_rgb(p, q, h + 1.0 / 3.0) * 255.0,
-            hue_to_rgb(p, q, h) * 255.0,
-            hue_to_rgb(p, q, h - 1.0 / 3.0) * 255.0,
-            alpha
-          )
+        # :nodoc: — see from_hsl.
+        protected def preset_hsl(h : Float64, s : Float64, l : Float64) : Nil
+          @hsl = {h, s, l}
         end
 
         private def self.hue_to_rgb(p : Float64, q : Float64, t : Float64) : Float64
@@ -233,7 +252,7 @@ module Hwaro
           stripped = text.strip
           return if stripped.empty?
           return parse_hex?(stripped) if stripped[0] == '#'
-          named?(stripped) || parse_rgb_call?(stripped)
+          named?(stripped) || parse_rgb_call?(stripped) || parse_hsl_call?(stripped)
         end
 
         # Parses the `rgb(…)` / `rgba(…)` spelling.
@@ -266,6 +285,32 @@ module Hwaro
           end
           return unless channels.all?(&.finite?) && alpha.finite?
           new(channels[0], channels[1], channels[2], alpha, lexeme: text)
+        end
+
+        # The `hsl(…)` / `hsla(…)` legacy comma spelling, same rationale as
+        # `parse_rgb_call?`: a color function handed an hsl literal (or an
+        # hsl round-tripped through variable storage) must read it as a
+        # color. Saturation and lightness require `%`; hue accepts a bare
+        # number or `deg`. Modern space/slash syntax stays untouched.
+        private def self.parse_hsl_call?(text : String) : ColorV?
+          return unless match = text.match(/\A hsla? \( ([^()]*) \) \z/xi)
+          parts = match[1].split(',').map(&.strip)
+          return unless parts.size == 3 || parts.size == 4
+          return if parts.any?(&.empty?)
+
+          hue_text = parts[0]
+          hue_text = hue_text[0...-3] if hue_text.ends_with?("deg")
+          return unless hue = hue_text.to_f?
+          return unless parts[1].ends_with?('%') && parts[2].ends_with?('%')
+          return unless saturation = number_value?(parts[1])
+          return unless lightness = number_value?(parts[2])
+          alpha = 1.0
+          if raw_alpha = parts[3]?
+            return unless parsed = number_value?(raw_alpha)
+            alpha = raw_alpha.ends_with?('%') ? parsed / 100.0 : parsed
+          end
+          return unless hue.finite? && saturation.finite? && lightness.finite? && alpha.finite?
+          from_hsl(hue, saturation, lightness, alpha)
         end
 
         # An RGB channel: `0`..`255`, or a percentage of 255.

--- a/src/assets/sass/environment.cr
+++ b/src/assets/sass/environment.cr
@@ -30,6 +30,26 @@ module Hwaro
       # A callable function: a user closure or a built-in proc.
       alias SassFn = FunctionClosure | Builtins::Fn
 
+      # First-class function reference: produced by `meta.get-function`,
+      # consumed by `meta.call`. Lives only within a single expression
+      # evaluation — the string storage model can't round-trip it, so a
+      # reference assigned to a variable degrades to its `to_css` text.
+      class FnRefV < Value
+        getter name : String
+        getter fn : SassFn
+
+        def initialize(@name : String, @fn : SassFn)
+        end
+
+        def to_css : String
+          "get-function(\"#{@name}\")"
+        end
+
+        def eq?(other : Value) : Bool
+          other.is_a?(FnRefV) && name == other.name
+        end
+      end
+
       # A loaded `@use` module: its root-scope members (plus anything it
       # `@forward`s). Module-private state stays in the closed-over
       # environments.
@@ -98,7 +118,10 @@ module Hwaro
 
         # Assignment semantics (dart-sass-flavored):
         # - `!global` writes the root scope (skipped by `!default` when set).
-        # - `!default` is a no-op when the name resolves anywhere in scope.
+        # - `!default` is a no-op when the name resolves anywhere in scope
+        #   to a non-null value; a null still takes the default (dart-sass:
+        #   the `$map: null !default; @if ... { $map: (...) !default; }`
+        #   guard idiom depends on it).
         # - Otherwise the innermost non-root scope already declaring the
         #   name is updated; failing that, the name is declared here —
         #   which shadows a root/global variable rather than mutating it.
@@ -108,11 +131,11 @@ module Hwaro
         def assign_var(name : String, value : String, default : Bool, global : Bool) : Nil
           name = Sass.normalize_ident(name)
           if global
-            return if default && root.variables.has_key?(name)
+            return if default && non_null?(root.variables[name]?)
             root.variables[name] = value
             return
           end
-          return if default && lookup_var(name)
+          return if default && non_null?(lookup_var(name))
           env : Environment? = self
           transparent = true # all frames walked so far are flow-control
           while env
@@ -125,6 +148,12 @@ module Hwaro
             env = env.parent
           end
           @variables[name] = value
+        end
+
+        # "null" is the storage spelling of a real null (Value#inspect_css)
+        # — the one value `!default` may overwrite.
+        private def non_null?(value : String?) : Bool
+          !value.nil? && value != "null"
         end
 
         def lookup_mixin(name : String) : MixinClosure?

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -20,6 +20,7 @@ require "./importer"
 require "./parser"
 require "./value"
 require "./expr"
+require "./extend"
 require "./functions"
 require "../../utils/logger"
 
@@ -107,6 +108,9 @@ module Hwaro
           @forward_variables = {} of String => String
           @forward_mixins = {} of String => MixinClosure
           @forward_functions = {} of String => SassFn
+          # @extend requests, applied document-wide as a post-pass —
+          # deliberately NOT saved/restored around module loads.
+          @extends = [] of Extend::Request
         end
 
         # Registers the entry file's canonical path so a self-import cycle
@@ -117,6 +121,8 @@ module Hwaro
 
         def evaluate(sheet : Ast::Stylesheet) : Array(Css::Node)
           eval_nodes(sheet.children)
+          apply_extends
+          Extend.scrub_placeholders(@sink)
           @sink
         end
 
@@ -169,6 +175,8 @@ module Hwaro
             eval_message(node)
           when Ast::AtRootNode
             eval_at_root(node)
+          when Ast::ExtendNode
+            eval_extend(node)
           when Ast::UseNode
             eval_use(node)
           when Ast::ImportNode
@@ -178,8 +186,23 @@ module Hwaro
           when Ast::RawAtRuleNode
             eval_at_rule(node)
           when Ast::CommentNode
-            emit_comment(node.text)
+            emit_comment(comment_text(node))
           end
+        end
+
+        # Comments are the most lenient context of all: a `#{...}` that
+        # fails to resolve (undefined variable in commented-out Sass, a
+        # `#{...}` that was never meant as interpolation) keeps the
+        # comment byte-identical instead of failing the build.
+        private def comment_text(node : Ast::CommentNode) : String
+          if template = node.template
+            begin
+              return resolve_template(template, allow_vars: true)
+            rescue SyntaxError
+              # fall through to the verbatim text
+            end
+          end
+          node.text
         end
 
         # ---------------------------------------------------------------
@@ -861,6 +884,86 @@ module Hwaro
         end
 
         # ---------------------------------------------------------------
+        # @extend
+        # ---------------------------------------------------------------
+
+        # Records the enclosing rule's selectors as extenders of each
+        # target; application happens document-wide after evaluation, once
+        # every rule (own file, @use'd modules, @imports) is in the sink.
+        private def eval_extend(node : Ast::ExtendNode) : Nil
+          rule = @current_rule
+          if rule.nil? || @in_keyframes
+            error_at(node.line, node.column, "@extend may only be used within style rules")
+          end
+          text = resolve_template(node.selector, allow_vars: false)
+          targets = Parser.split_top_level_commas(text).map { |s| collapse_ws(s) }.reject(&.empty?)
+          error_at(node.line, node.column, "expected selector after @extend") if targets.empty?
+          # Snapshot the selectors: the apply pass appends to rule selector
+          # arrays, and a request must not iterate an extender list that is
+          # growing under it (self-extension aliases the two). Chains still
+          # resolve through the per-rule fixpoint.
+          extenders = rule.selectors.dup
+          targets.each do |target|
+            @extends << Extend::Request.new(extenders, target, node.optional,
+              @path, node.line, node.column)
+          end
+        end
+
+        private def apply_extends : Nil
+          return if @extends.empty?
+          matched = Array(Bool).new(@extends.size, false)
+          extend_nodes(@sink, matched)
+          @extends.each_with_index do |req, i|
+            next if req.optional || matched[i]
+            raise SyntaxError.new(
+              "@extend target #{req.target.inspect} was not found " \
+              "(add \"!optional\" to tolerate a missing target)",
+              req.path, req.line, req.column)
+          end
+        end
+
+        private def extend_nodes(nodes : Array(Css::Node), matched : Array(Bool)) : Nil
+          nodes.each do |node|
+            case node
+            when Css::Rule
+              extend_rule(node, matched)
+            when Css::AtRule
+              extend_nodes(node.children, matched) unless keyframes?(node.name)
+            end
+          end
+        end
+
+        # Grows the rule's selector list to a local fixpoint: selectors a
+        # request adds are themselves candidates for other requests, which
+        # is what makes chained extends (`.c {@extend .b} .b {@extend .a}`)
+        # resolve. Terminates because additions are deduplicated and capped.
+        private def extend_rule(rule : Css::Rule, matched : Array(Bool)) : Nil
+          selectors = rule.selectors
+          seen = selectors.to_set
+          i = 0
+          while i < selectors.size
+            sel = selectors[i]
+            @extends.each_with_index do |req, ri|
+              results = Extend.extend_selector(sel, req.target, req.extenders)
+              next unless results
+              matched[ri] = true
+              results.each do |added|
+                next if seen.includes?(added)
+                seen << added
+                selectors << added
+                if selectors.size > MAX_RULE_SELECTORS
+                  raise SyntaxError.new(
+                    "@extend expanded a rule to more than #{MAX_RULE_SELECTORS} selectors " \
+                    "(mutually recursive extends?)",
+                    req.path, req.line, req.column)
+                end
+              end
+            end
+            i += 1
+          end
+        end
+
+        # ---------------------------------------------------------------
         # Functions
         # ---------------------------------------------------------------
 
@@ -1184,6 +1287,14 @@ module Hwaro
         # calls), evaluate it; otherwise — and on any soft failure — the
         # legacy verbatim path keeps output byte-identical.
         private def resolve_value(template : Ast::TextTemplate) : String
+          # A bare `$var` propagates its storage text EXACTLY: "null" must
+          # stay "null" (argument passing and `@if $x` depend on it — the
+          # splicing path below elides null, which turned a null argument
+          # into a truthy empty string), and structural parens of nested
+          # lists must survive for later coercion.
+          if template.pieces.size == 1 && (ref = template.pieces[0].as?(Ast::VarRef))
+            return lookup_var_ref(ref)
+          end
           if node = Expr.parse(template)
             if Expr.computes?(node, self)
               begin
@@ -1337,7 +1448,10 @@ module Hwaro
 
           text = String.build do |io|
             segments.each do |is_value, sub|
-              io << (is_value ? resolve_value(sub) : resolve_template(sub, allow_vars: true))
+              # Feature values render like declaration values (CSS text,
+              # not storage text) — the storage spellings `(10px,)` and
+              # `(a b), (c d)` must not leak into a media query.
+              io << (is_value ? resolve_decl_value(sub).text : resolve_template(sub, allow_vars: true))
             end
           end
           collapse_ws(text)
@@ -1372,9 +1486,31 @@ module Hwaro
         end
 
         # :nodoc:
+        def expr_parent_selectors : Array(String)?
+          @parent_selectors
+        end
+
+        # sass:meta functions that need evaluator state (scopes, mixins,
+        # @content) and therefore can't live in the static builtin tables.
+        META_HOST_FNS = %w[variable-exists global-variable-exists
+          function-exists mixin-exists content-exists get-function call]
+
+        # :nodoc:
         def expr_call(ns : String?, name : String, args : Array(Value),
                       kwargs : Hash(String, Value)) : Value?
           norm = Sass.normalize_ident(name)
+          if host_meta_fn?(ns, norm)
+            begin
+              return call_meta_host_fn(norm, args, kwargs)
+            rescue ex : NamespacedEvalError
+              raise ex
+            rescue ex : SoftEvalError
+              # Same policy as every other namespaced builtin: a failure
+              # inside `meta.…` must not fall back to verbatim CSS.
+              raise NamespacedEvalError.new(ex.message || "call failed") if ns
+              raise ex
+            end
+          end
           if ns
             mod = @env.module?(ns)
             raise NamespacedEvalError.new("there is no module namespace \"#{ns}\"") unless mod
@@ -1418,7 +1554,145 @@ module Hwaro
           # or function then soft-fails (lenient: verbatim, strict: loud).
           return true if ns
           norm = Sass.normalize_ident(name)
-          !@env.lookup_function(norm).nil? || Builtins::GLOBAL_FNS.has_key?(norm)
+          !@env.lookup_function(norm).nil? || Builtins::GLOBAL_FNS.has_key?(norm) ||
+            META_HOST_FNS.includes?(norm)
+        end
+
+        # True when this call resolves to a host-backed sass:meta function:
+        # the legacy global spelling (unless shadowed by a user @function)
+        # or a namespaced call whose namespace is the built-in meta module.
+        private def host_meta_fn?(ns : String?, norm : String) : Bool
+          return false unless META_HOST_FNS.includes?(norm)
+          if ns
+            mod = @env.module?(ns)
+            !mod.nil? && mod.same?(BUILTIN_MODULES["meta"]?)
+          else
+            @env.lookup_function(norm).nil?
+          end
+        end
+
+        private def call_meta_host_fn(norm : String, args : Array(Value),
+                                      kwargs : Hash(String, Value)) : Value
+          case norm
+          when "content-exists"
+            unless args.empty? && kwargs.empty?
+              raise SoftEvalError.new("content-exists() takes no arguments")
+            end
+            return BoolV.new(!@content.nil?)
+          when "get-function"
+            return meta_get_function(args, kwargs)
+          when "call"
+            return meta_call(args, kwargs)
+          end
+          raise SoftEvalError.new("#{norm}() takes one argument, $name") unless args.size <= 1
+          kwargs.each_key do |key|
+            next if key == "name"
+            next if key == "module" && norm != "variable-exists"
+            raise SoftEvalError.new("#{norm}(): no parameter named $#{key}")
+          end
+          value = args[0]? || kwargs["name"]?
+          member =
+            case value
+            when Str then value.text
+            when Raw then value.text
+            else
+              raise SoftEvalError.new("#{norm}() expects a string, got #{value.try(&.to_css).inspect}")
+            end
+          member = Sass.normalize_ident(member.lchop('$'))
+          if mod_arg = kwargs["module"]?
+            mod = @env.module?(module_arg_text(mod_arg))
+            raise SoftEvalError.new("#{norm}(): no module named #{mod_arg.to_css.inspect}") unless mod
+            exists =
+              case norm
+              when "global-variable-exists" then mod.variables.has_key?(member)
+              when "function-exists"        then mod.functions.has_key?(member)
+              else # mixin-exists
+                mod.mixins.has_key?(member)
+              end
+            return BoolV.new(exists)
+          end
+          exists =
+            case norm
+            when "variable-exists"
+              !@env.lookup_var(member).nil?
+            when "global-variable-exists"
+              @env.root.variables.has_key?(member)
+            when "function-exists"
+              !named_function(member).nil?
+            else # mixin-exists
+              !@env.lookup_mixin(member).nil?
+            end
+          BoolV.new(exists)
+        end
+
+        # Resolves a function name the way a call site would: user
+        # @functions win, then the host-backed meta functions (wrapped so
+        # they are first-class values for get-function/call), then the
+        # global builtins.
+        private def named_function(norm : String) : SassFn?
+          if fn = @env.lookup_function(norm)
+            return fn
+          end
+          if META_HOST_FNS.includes?(norm)
+            return Builtins::Fn.new { |a, k| call_meta_host_fn(norm, a, k) }
+          end
+          Builtins::GLOBAL_FNS[norm]?
+        end
+
+        private def meta_get_function(args : Array(Value), kwargs : Hash(String, Value)) : Value
+          if kwargs["css"]?.try(&.truthy?)
+            raise SoftEvalError.new("get-function($css: true) is not supported")
+          end
+          value = args[0]? || kwargs["name"]?
+          name =
+            case value
+            when Str then value.text
+            when Raw then value.text
+            else
+              raise SoftEvalError.new("get-function() expects a function name string")
+            end
+          norm = Sass.normalize_ident(name)
+          fn = if mod_name = kwargs["module"]?
+                 mod = @env.module?(module_arg_text(mod_name))
+                 raise SoftEvalError.new("get-function(): no module named #{mod_name.to_css.inspect}") unless mod
+                 mod.functions[norm]?
+               else
+                 named_function(norm)
+               end
+          raise SoftEvalError.new("get-function(): no function named #{name.inspect}") unless fn
+          FnRefV.new(norm, fn)
+        end
+
+        private def module_arg_text(value : Value) : String
+          value.is_a?(Str) ? value.text : value.to_css
+        end
+
+        private def meta_call(args : Array(Value), kwargs : Hash(String, Value)) : Value
+          ref = args[0]?
+          raise SoftEvalError.new("call() expects a function reference") unless ref
+          rest = args[1..]
+          name =
+            case ref
+            when FnRefV
+              return invoke_fn(ref.fn, ref.name, rest, kwargs)
+            when Str
+              # Legacy spelling: call("name", args...).
+              ref.text
+            when Raw
+              # A reference that round-tripped through string storage
+              # degrades to its `get-function("name")` spelling
+              # (`$f: get-function("darken"); call($f, …)`) — re-resolve
+              # it by name.
+              match = ref.text.match(/\Aget-function\(\s*"([^"]*)"\s*\)\z/)
+              raise SoftEvalError.new("call() expects a function reference, got #{ref.to_css.inspect}") unless match
+              match[1]
+            else
+              raise SoftEvalError.new("call() expects a function reference, got #{ref.to_css.inspect}")
+            end
+          norm = Sass.normalize_ident(name)
+          fn = named_function(norm)
+          raise SoftEvalError.new("call(): no function named #{name.inspect}") unless fn
+          invoke_fn(fn, norm, rest, kwargs)
         end
 
         # :nodoc:
@@ -1447,7 +1721,7 @@ module Hwaro
                   # optional-modifier idiom `.btn#{$mod}` with `$mod: null`
                   # has to yield `.btn`, not `.btnnull`.
                   var_text = lookup_var_ref(piece)
-                  io << var_text unless var_text == "null"
+                  io << var_display_text(var_text) unless var_text == "null"
                 end
               in Ast::Interp
                 io << unquote_interp(resolve_interp(piece.inner))
@@ -1494,6 +1768,26 @@ module Hwaro
             i += 1
           end
           inner
+        end
+
+        # Storage text is `inspect_css` — nested unbracketed lists carry
+        # structural parens (`(inset 0 1px #fff), (0 1px #000)`) and a
+        # single-element comma list spells itself `(10px,)` so they
+        # survive the string round-trip. Those spellings are NOT valid
+        # CSS, so a verbatim `$var` substitution must render such values
+        # with `to_css` instead. Every other storage text (including
+        # verbatim never-computed source) passes through untouched, which
+        # is what keeps plain-CSS output byte-identical.
+        private def var_display_text(storage : String) : String
+          return storage unless storage.includes?('(')
+          value = Expr.coerce(storage)
+          if value.is_a?(ListV) &&
+             (value.items.any? { |i| i.is_a?(ListV) && !i.bracketed } ||
+             (value.sep == ListV::Sep::Comma && value.items.size == 1))
+            value.to_css
+          else
+            storage
+          end
         end
 
         private def lookup_var_ref(ref : Ast::VarRef) : String

--- a/src/assets/sass/expr.cr
+++ b/src/assets/sass/expr.cr
@@ -131,6 +131,26 @@ module Hwaro
           end
         end
 
+        # A CSS-owned function span (`calc(...)`, `var(...)`, `url(...)`)
+        # whose argument text is interrupted by interpolation or `$var`
+        # pieces: `calc(#{$a} + 2px)`, `var(--#{$prefix}x)`. The span is
+        # never evaluated as Sass — the dynamic pieces resolve to text and
+        # splice back into the verbatim span (dart-sass treats these spans
+        # as unparsed too). Templates in `parts` are either a real `#{...}`
+        # body or a synthesized single-`$var` template.
+        class RawSpanE < Node
+          getter parts : Array(String | Ast::TextTemplate)
+
+          def initialize(@parts)
+          end
+        end
+
+        # `&` as a SassScript value: the parent selector as a comma list,
+        # or null at the root (dart-sass semantics). What makes the
+        # `#{if(&, "&", "")}` mixin idiom work.
+        class AmpE < Node
+        end
+
         # ---------------------------------------------------------------
         # Tokens
         # ---------------------------------------------------------------
@@ -143,7 +163,9 @@ module Hwaro
           Str
           Var
           Interp
-          Raw # hex colors, u+ranges, url(...)/calc(...) spans
+          Raw     # hex colors, u+ranges, url(...)/calc(...) spans
+          RawSpan # url(...)/calc(...) span with interpolation/$var pieces
+          Amp     # `&` parent-selector reference
           LParen
           RParen
           LBracket
@@ -206,8 +228,12 @@ module Hwaro
         # ---------------------------------------------------------------
 
         # Function names whose parenthesized span belongs to CSS and must
-        # pass through verbatim, never parsed as Sass arguments.
-        RAW_SPAN_FNS = %w[url var env attr counter counters expression format local]
+        # pass through verbatim, never parsed as Sass arguments. `var()` is
+        # deliberately NOT here: dart-sass parses its fallback argument as
+        # SassScript (`var(--x, escape-svg($d))` must call the function),
+        # and the computes? gate still passes plain `var(--x, 10px)`
+        # through verbatim.
+        RAW_SPAN_FNS = %w[url env attr counter counters expression format local]
 
         # :nodoc:
         class Lexer
@@ -355,16 +381,25 @@ module Hwaro
             buf = String::Builder.new
             loop do
               if eop?
-                # The string continues past this piece: an Interp piece
-                # follows, then a String piece with the rest.
+                # The string continues past this piece: one or more Interp
+                # pieces follow (`"--#{$a}#{$b}rest"`), then a String piece
+                # with the rest.
                 parts << buf.to_s
                 buf = String::Builder.new
-                nxt = @pieces[@piece_i + 1]?
-                fail unless nxt.is_a?(Ast::Interp)
-                parts << nxt.inner
-                @piece_i += 2
-                @char_i = 0
-                fail unless current_piece.is_a?(String)
+                loop do
+                  @piece_i += 1
+                  @char_i = 0
+                  nxt = current_piece
+                  fail unless nxt
+                  case nxt
+                  in String
+                    break
+                  in Ast::Interp
+                    parts << nxt.inner
+                  in Ast::VarRef
+                    fail # `$var` is literal inside strings; never a piece here
+                  end
+                end
                 next
               end
               c = advance
@@ -439,32 +474,71 @@ module Hwaro
           end
 
           # Balanced-paren verbatim span starting at `start` (cursor on
-          # the opening paren). Interpolation inside would have split the
-          # piece — that shape is unlexable and falls back.
+          # the opening paren). Interpolation or `$var` pieces inside the
+          # span (`calc(#{$a} + 2px)`, `var(--#{$p}x)`) split the String
+          # piece; the span then continues across those pieces and lexes
+          # as a RawSpan token whose dynamic parts resolve at eval time.
           private def lex_raw_span(start : Int32) : Nil
+            space = @space
+            parts = [] of String | Ast::TextTemplate
+            buf = String::Builder.new
+            buf << text[start...@char_i] # function name (cursor on '(')
             depth = 0
-            loop do
-              fail if eop?
+            done = false
+            until done
+              if eop?
+                # The span continues in the next piece(s): flush the text
+                # run and absorb dynamic pieces until text resumes.
+                flushed = buf.to_s
+                parts << flushed unless flushed.empty?
+                buf = String::Builder.new
+                loop do
+                  @piece_i += 1
+                  @char_i = 0
+                  piece = current_piece
+                  fail unless piece # unterminated span at template end
+                  case piece
+                  in String
+                    break
+                  in Ast::Interp
+                    parts << piece.inner
+                  in Ast::VarRef
+                    parts << Ast::TextTemplate.new(
+                      Array(Ast::Piece){piece}, piece.line, piece.column)
+                  end
+                end
+                next
+              end
               c = advance
-              if c == '"' || c == '\''
+              buf << c
+              case c
+              when '"', '\''
                 quote = c
                 loop do
-                  fail if eop?
+                  fail if eop? # interpolation inside a quoted span string
                   sc = advance
+                  buf << sc
                   if sc == '\\'
-                    advance unless eop?
+                    buf << advance unless eop?
                   elsif sc == quote
                     break
                   end
                 end
-              elsif c == '('
+              when '('
                 depth += 1
-              elsif c == ')'
+              when ')'
                 depth -= 1
-                break if depth == 0
+                done = true if depth == 0
               end
             end
-            push(Tok.new(TokKind::Raw, text[start...@char_i], @space))
+            tail = buf.to_s
+            parts << tail unless tail.empty?
+            if parts.size == 1 && (only = parts[0]).is_a?(String)
+              @toks << Tok.new(TokKind::Raw, only, space)
+            else
+              @toks << Tok.new(TokKind::RawSpan, "", space, str_parts: parts)
+            end
+            @space = false
           end
 
           private def lex_operator(c : Char) : Nil
@@ -501,6 +575,9 @@ module Hwaro
             when '%'
               advance
               push(Tok.new(TokKind::Percent, "%", @space))
+            when '&'
+              advance
+              push(Tok.new(TokKind::Amp, "&", @space))
             when '='
               advance
               fail unless peek == '='
@@ -508,9 +585,23 @@ module Hwaro
               push(Tok.new(TokKind::EqEq, "==", @space))
             when '!'
               advance
-              fail unless peek == '='
-              advance
-              push(Tok.new(TokKind::NotEq, "!=", @space))
+              if peek == '='
+                advance
+                push(Tok.new(TokKind::NotEq, "!=", @space))
+              else
+                # `!important` as a SassScript value (dart-sass
+                # ImportantExpression) — the utilities-API idiom
+                # `$value if($enable-important, !important, null)`.
+                # (A trailing `!important` flag never reaches this lexer;
+                # the statement parser strips it first.)
+                off = 0
+                while peek(off).try(&.ascii_whitespace?)
+                  off += 1
+                end
+                fail unless word_at?(off, "important")
+                (off + 9).times { advance }
+                push(Tok.new(TokKind::Ident, "!important", @space))
+              end
             when '<'
               advance
               if peek == '='
@@ -574,12 +665,23 @@ module Hwaro
             @space = false
           end
 
+          # Case-insensitive keyword match at `offset` chars ahead, ending
+          # at a non-ident boundary.
+          private def word_at?(offset : Int32, word : String) : Bool
+            word.each_char_with_index do |wc, i|
+              c = peek(offset + i)
+              return false unless c && c.downcase == wc
+            end
+            !ident_char?(peek(offset + word.size))
+          end
+
           private def prev_operand? : Bool
             last = @toks.last?
             return false unless last
             case last.kind
             when TokKind::Number, TokKind::Ident, TokKind::Str, TokKind::Var,
-                 TokKind::Interp, TokKind::Raw, TokKind::RParen, TokKind::RBracket
+                 TokKind::Interp, TokKind::Raw, TokKind::RawSpan, TokKind::Amp,
+                 TokKind::RParen, TokKind::RBracket
               true
             else
               false
@@ -693,8 +795,8 @@ module Hwaro
             return false unless tok
             case tok.kind
             when TokKind::Number, TokKind::Ident, TokKind::QualIdent, TokKind::Str,
-                 TokKind::Var, TokKind::Interp, TokKind::Raw, TokKind::LParen,
-                 TokKind::LBracket
+                 TokKind::Var, TokKind::Interp, TokKind::Raw, TokKind::RawSpan,
+                 TokKind::Amp, TokKind::LParen, TokKind::LBracket
               true
             when TokKind::Minus, TokKind::Plus
               # `a -b` starts a new item; `a - b` is subtraction and was
@@ -838,7 +940,8 @@ module Hwaro
             case tok.kind
             when TokKind::Interp
               true
-            when TokKind::Number, TokKind::Ident, TokKind::Str, TokKind::Var, TokKind::Raw
+            when TokKind::Number, TokKind::Ident, TokKind::Str, TokKind::Var,
+                 TokKind::Raw, TokKind::RawSpan
               # Only join runs that involve interpolation; `10px 5px`
               # spacing errors and the like should fail-fast instead.
               @toks[@pos - 1].kind.interp?
@@ -867,6 +970,13 @@ module Hwaro
             when TokKind::Raw
               @pos += 1
               Lit.new(Raw.new(tok.text))
+            when TokKind::RawSpan
+              @pos += 1
+              parts = tok.str_parts || fail
+              RawSpanE.new(parts)
+            when TokKind::Amp
+              @pos += 1
+              AmpE.new
             when TokKind::Ident, TokKind::QualIdent
               parse_ident_primary
             when TokKind::LParen
@@ -966,17 +1076,22 @@ module Hwaro
             sep = ListV::Sep::Space
             unless match?(TokKind::RBracket)
               first = parse_slash
-              items << first
               if match?(TokKind::Comma)
+                items << first
                 sep = ListV::Sep::Comma
                 while accept(TokKind::Comma)
                   break if match?(TokKind::RBracket)
                   items << parse_slash
                 end
+              elsif first.is_a?(ListE) && !first.bracketed
+                # parse_slash already consumed the whole space/slash run as
+                # one inner list — its items ARE the bracketed list's items
+                # (`[1 2 3]` is a 3-element bracketed space list, not a
+                # 1-element list holding `(1 2 3)`).
+                items = first.items
+                sep = first.sep
               else
-                while !match?(TokKind::RBracket) && !eof?
-                  items << parse_slash
-                end
+                items << first
               end
             end
             fail unless accept(TokKind::RBracket)
@@ -1006,12 +1121,21 @@ module Hwaro
           nil
         end
 
-        # Strict parse for control-flow contexts.
+        # Strict parse for control-flow contexts. Every ParseFailure —
+        # the lexer's included — must convert to SoftEvalError here: a raw
+        # ParseFailure escaping the compiler bypasses error classification
+        # entirely and surfaces as an unlocated crash.
         def self.parse!(template : Ast::TextTemplate) : Node
-          toks = Lexer.new(template).lex
+          toks = begin
+            Lexer.new(template).lex
+          rescue ParseFailure
+            raise SoftEvalError.new("invalid expression")
+          end
           raise SoftEvalError.new("expected expression") if toks.empty?
           begin
             Parser.new(toks).parse
+          rescue ex : DepthExceeded
+            raise SoftEvalError.new(ex.message || "invalid expression")
           rescue ParseFailure
             raise SoftEvalError.new("invalid expression")
           end
@@ -1036,7 +1160,12 @@ module Hwaro
           when ListE
             node.items.any? { |i| computes?(i, host) }
           when MapE
-            node.pairs.any? { |pair| computes?(pair.key, host) || computes?(pair.value, host) }
+            # Map literals ALWAYS count as work, same rationale as ParenE:
+            # `(a: b)` is Sass-only syntax with no CSS meaning. The verbatim
+            # path also corrupts them — substituting a comma-list variable
+            # into the map's text splices the list into the map's own comma
+            # structure, and the storage round-trip no longer parses.
+            true
           when ParenE
             # Grouping parens ALWAYS count as work, even around a bare literal
             # or a slash/space list: they are Sass syntax with no meaning in
@@ -1047,6 +1176,10 @@ module Hwaro
           when ConcatE
             node.parts.any? { |p| computes?(p, host) }
           else
+            # RawSpanE and AmpE deliberately don't compute: a lone
+            # `calc(#{$a})` value or a bare `&` resolves identically via
+            # the verbatim path, which keeps existing output
+            # byte-identical.
             false
           end
         end
@@ -1063,6 +1196,8 @@ module Hwaro
           abstract def expr_known_fn?(ns : String?, name : String) : Bool
           # Resolves an interpolation template to (unquoted) text.
           abstract def expr_interp(template : Ast::TextTemplate) : String
+          # Enclosing rule's resolved selectors for `&` (nil at root).
+          abstract def expr_parent_selectors : Array(String)?
         end
 
         # Coerces stored text back into a typed value ("1px" -> Number,
@@ -1099,6 +1234,10 @@ module Hwaro
           def expr_interp(template : Ast::TextTemplate) : String
             raise SoftEvalError.new("no interpolation in stored values")
           end
+
+          def expr_parent_selectors : Array(String)?
+            nil
+          end
         end
 
         # ---------------------------------------------------------------
@@ -1120,6 +1259,14 @@ module Hwaro
             when VarE    then Expr.coerce(@host.expr_var(node.name, node.ns))
             when InterpE then Expr.coerce(@host.expr_interp(node.template))
             when StrE    then eval_str(node)
+            when RawSpanE
+              Raw.new(node.parts.join { |p| p.is_a?(String) ? p : @host.expr_interp(p) })
+            when AmpE
+              if parents = @host.expr_parent_selectors
+                ListV.new(parents.map { |p| Str.new(p, quoted: false).as(Value) }, ListV::Sep::Comma)
+              else
+                NullV.new
+              end
             when ConcatE then Raw.new(node.parts.map { |p| eval(p).to_css }.join)
             when ParenE  then eval(node.inner)
             when ListE   then ListV.new(node.items.map { |i| eval(i).as(Value) }, node.sep, node.bracketed)
@@ -1185,9 +1332,9 @@ module Hwaro
               boolish!(left)
               left.truthy? ? eval(node.right) : left
             when :eq
-              BoolV.new(eval(node.left).eq?(eval(node.right)))
+              BoolV.new(loose_eq(eval(node.left), eval(node.right)))
             when :neq
-              BoolV.new(!eval(node.left).eq?(eval(node.right)))
+              BoolV.new(!loose_eq(eval(node.left), eval(node.right)))
             when :lt, :gt, :le, :ge
               compare(node.op, eval(node.left), eval(node.right))
             when :plus
@@ -1201,6 +1348,17 @@ module Hwaro
             else
               raise SoftEvalError.new("unsupported operator")
             end
+          end
+
+          # `==` with Raw normalization: a value that reaches comparison as
+          # unmodeled text (a function's raw return, a concat result) still
+          # compares equal to its typed twin — `1rem == 1rem` must not
+          # depend on which evaluation path each side took.
+          private def loose_eq(left : Value, right : Value) : Bool
+            return true if left.eq?(right)
+            l = left.is_a?(Raw) ? Expr.coerce(left.text) : left
+            r = right.is_a?(Raw) ? Expr.coerce(right.text) : right
+            l.eq?(r)
           end
 
           private def compare(op : Symbol, left : Value, right : Value) : Value
@@ -1269,6 +1427,10 @@ module Hwaro
           end
 
           private def eval_call(node : CallE) : Value
+            if node.ns.nil? && node.spread.nil? && node.kwargs.empty? &&
+               node.args.size == 3 && Sass.normalize_ident(node.name) == "if"
+              return eval(node.args[0]).truthy? ? eval(node.args[1]) : eval(node.args[2])
+            end
             args = node.args.map { |a| eval(a) }
             if spread = node.spread
               spread_val = eval(spread)

--- a/src/assets/sass/extend.cr
+++ b/src/assets/sass/extend.cr
@@ -1,0 +1,379 @@
+# @extend support: selector-level extension applied as a post-pass over
+# the flat CSS tree, plus %placeholder scrubbing.
+#
+# Subset semantics (documented in features/sass.md):
+# - Targets must be simple selectors (`.class`, `%placeholder`, `#id`,
+#   `tag`, `:pseudo`); a compound or complex target never matches.
+# - Extension removes the target from its compound and unifies the
+#   extender's final compound with what remains; the extender's ancestor
+#   compounds are prepended after the extended selector's own prefix.
+#   dart-sass additionally "weaves" both prefix orders — hwaro emits the
+#   first order only.
+# - Extends apply document-wide. dart-sass scopes them per module and
+#   forbids crossing @media boundaries; hand-written stylesheets don't
+#   hit the difference, and erring on the side of applying keeps the
+#   extended styles present rather than silently absent.
+#
+# Selector text here is fully resolved output text (interpolation and `&`
+# already substituted), so parsing is a light tokenization — compounds
+# split on combinators/whitespace, simple selectors split on sigils —
+# with quotes, attribute brackets, and pseudo-class parens consumed as
+# units.
+
+require "./css"
+require "./parser"
+
+module Hwaro
+  module Assets
+    module Sass
+      module Extend
+        extend self
+
+        # One `@extend` directive: the extending rule's resolved selectors,
+        # one target selector, and the location for error reporting.
+        record Request, extenders : Array(String), target : String,
+          optional : Bool, path : String, line : Int32, column : Int32
+
+        # One parsed piece of a complex selector.
+        record Compound, simples : Array(String)
+        record Combinator, text : String
+        alias Item = Compound | Combinator
+
+        # nil when `selector` does not contain `target` as a complete
+        # simple selector; otherwise every extension of `selector` by
+        # `extenders` (possibly empty when no extender unifies — the
+        # target still counts as found).
+        def extend_selector(selector : String, target : String,
+                            extenders : Array(String)) : Array(String)?
+          items = parse_items(selector)
+          return unless items
+          found = false
+          results = [] of String
+          items.each_with_index do |item, idx|
+            next unless item.is_a?(Compound)
+            if slot = item.simples.index(target)
+              found = true
+              rest = item.simples.dup
+              rest.delete_at(slot)
+              extenders.each do |ext_sel|
+                ext_items = parse_items(ext_sel)
+                next unless ext_items
+                last = ext_items.last?
+                next unless last.is_a?(Compound)
+                merged = unify_compound(last.simples, rest)
+                next unless merged
+                prefix = merge_prefixes(items[0...idx], ext_items[0...-1])
+                new_items = prefix + [Compound.new(merged).as(Item)] + items[idx + 1..]
+                results << serialize_items(new_items)
+              end
+            end
+            # A target inside a selector pseudo-class argument
+            # (`:is(.b)`, `:not(.b)`) extends the argument list itself:
+            # `:is(.b)` extended by `.c` → `:is(.b, .c)` (dart-sass
+            # semantics for selector pseudos).
+            item.simples.each_with_index do |simple, si|
+              extended = extend_pseudo_args(simple, target, extenders)
+              next unless extended
+              found = true
+              next if extended == simple
+              new_simples = item.simples.dup
+              new_simples[si] = extended
+              new_items = items.dup
+              new_items[idx] = Compound.new(new_simples)
+              results << serialize_items(new_items)
+            end
+          end
+          found ? results : nil
+        end
+
+        # nil when `simple` is not a pseudo whose argument list contains
+        # the target; otherwise the pseudo with every extension appended
+        # to its argument list (unchanged text when nothing unified).
+        private def extend_pseudo_args(simple : String, target : String,
+                                       extenders : Array(String)) : String?
+          return unless simple.starts_with?(':')
+          open = simple.index('(')
+          return unless open && simple.ends_with?(')')
+          inner = simple[(open + 1)...-1]
+          args = Parser.split_top_level_commas(inner).map(&.strip).reject(&.empty?)
+          found = false
+          additions = [] of String
+          args.each do |arg|
+            results = extend_selector(arg, target, extenders)
+            next unless results
+            found = true
+            results.each do |sel|
+              additions << sel unless args.includes?(sel) || additions.includes?(sel)
+            end
+          end
+          return unless found
+          simple[0..open] + (args + additions).join(", ") + ")"
+        end
+
+        # Combines the extended selector's prefix with the extender's
+        # ancestors. When one is a leading subsequence of the other they
+        # merge instead of concatenating — extending `%p` in `.nav %p`
+        # by `.nav > .c` must yield `.nav > .c`, not `.nav .nav > .c`
+        # (the head of dart-sass's prefix weave).
+        private def merge_prefixes(own : Array(Item), ext : Array(Item)) : Array(Item)
+          if leading?(own, ext)
+            ext
+          elsif leading?(ext, own)
+            own
+          else
+            own + ext
+          end
+        end
+
+        private def leading?(head : Array(Item), full : Array(Item)) : Bool
+          head.size <= full.size && full[0...head.size] == head
+        end
+
+        # Merges the extender's final compound with what remains of the
+        # extended compound: element selector first, then the other simple
+        # selectors, pseudo-classes/-elements last. nil when the two need
+        # different element selectors (`div` vs `span` can't both match).
+        def unify_compound(ext : Array(String), rest : Array(String)) : Array(String)?
+          ext_elem = ext.find { |s| element?(s) }
+          rest_elem = rest.find { |s| element?(s) }
+          if ext_elem && rest_elem && ext_elem != rest_elem
+            return unless ext_elem == "*" || rest_elem == "*"
+          end
+          elem =
+            if ext_elem && rest_elem
+              ext_elem == "*" ? rest_elem : ext_elem
+            else
+              ext_elem || rest_elem
+            end
+          merged = [] of String
+          merged << elem if elem
+          (ext + rest).each do |s|
+            next if element?(s) || pseudo?(s)
+            merged << s unless merged.includes?(s)
+          end
+          (ext + rest).each do |s|
+            next unless pseudo?(s)
+            merged << s unless merged.includes?(s)
+          end
+          merged
+        end
+
+        # True when the selector references a `%placeholder` outside
+        # quotes and attribute brackets — such selectors never reach the
+        # output (dart-sass emits nothing for un-extended placeholders).
+        def placeholder?(selector : String) : Bool
+          chars = selector.chars
+          i = 0
+          while i < chars.size
+            case chars[i]
+            when '\\'
+              # An escaped character is literal — `.sale\%-badge` is a
+              # plain CSS class, not a placeholder.
+              i += 2
+            when '"', '\''
+              j = skip_string(chars, i)
+              return false unless j
+              i = j
+            when '['
+              j = skip_bracket(chars, i)
+              return false unless j
+              i = j
+            when '%'
+              n = chars[i + 1]?
+              return true if n && (n.ascii_letter? || n == '_' || n == '-' || n.ord > 0x7F)
+              i += 1
+            else
+              i += 1
+            end
+          end
+          false
+        end
+
+        # Removes placeholder selectors from every rule (recursively,
+        # skipping @keyframes bodies) and drops rules with none left.
+        def scrub_placeholders(nodes : Array(Css::Node)) : Nil
+          nodes.reject! do |node|
+            case node
+            when Css::Rule
+              node.selectors.reject! { |s| placeholder?(s) }
+              node.selectors.empty?
+            when Css::AtRule
+              scrub_placeholders(node.children) unless keyframes_name?(node.name)
+              false
+            else
+              false
+            end
+          end
+        end
+
+        def keyframes_name?(name : String) : Bool
+          name == "keyframes" || name.ends_with?("-keyframes")
+        end
+
+        # Parses a complex selector into compounds and combinators; nil
+        # when the text is too exotic to model (unbalanced quotes/spans).
+        def parse_items(selector : String) : Array(Item)?
+          items = [] of Item
+          chars = selector.chars
+          i = 0
+          while i < chars.size
+            c = chars[i]
+            if c.ascii_whitespace?
+              i += 1
+            elsif c == '>' || c == '+' || c == '~'
+              items << Combinator.new(c.to_s)
+              i += 1
+            else
+              stop = scan_compound(chars, i)
+              return if stop.nil? || stop <= i
+              simples = split_compound(selector[i...stop])
+              return unless simples
+              items << Compound.new(simples)
+              i = stop
+            end
+          end
+          items
+        end
+
+        # Advances past one compound selector (stops at whitespace or a
+        # top-level combinator); nil on an unbalanced span.
+        private def scan_compound(chars : Array(Char), start : Int32) : Int32?
+          i = start
+          while i < chars.size
+            c = chars[i]
+            break if c.ascii_whitespace? || c == '>' || c == '+' || c == '~'
+            case c
+            when '['
+              j = skip_bracket(chars, i)
+              return unless j
+              i = j
+            when '('
+              j = skip_paren(chars, i)
+              return unless j
+              i = j
+            when '"', '\''
+              return # a bare string is not a selector we model
+            else
+              i += 1
+            end
+          end
+          i
+        end
+
+        # Splits one compound into simple selectors (`.a:hover::before` →
+        # [".a", ":hover", "::before"]).
+        private def split_compound(text : String) : Array(String)?
+          simples = [] of String
+          chars = text.chars
+          i = 0
+          start = 0
+          while i < chars.size
+            case c = chars[i]
+            when '['
+              j = skip_bracket(chars, i)
+              return unless j
+              if i > start
+                simples << text[start...i]
+              end
+              simples << text[i...j]
+              start = j
+              i = j
+            when '('
+              j = skip_paren(chars, i)
+              return unless j
+              i = j
+            when '.', '#', '%', ':', '&'
+              # The second colon of `::element` continues the previous
+              # simple selector instead of starting a new one.
+              if i > start && !(c == ':' && chars[i - 1] == ':')
+                simples << text[start...i]
+                start = i
+              end
+              i += 1
+            else
+              i += 1
+            end
+          end
+          simples << text[start...chars.size] if start < chars.size
+          simples
+        end
+
+        private def serialize_items(items : Array(Item)) : String
+          items.join(" ") do |item|
+            case item
+            in Compound   then item.simples.join
+            in Combinator then item.text
+            end
+          end
+        end
+
+        private def element?(simple : String) : Bool
+          first = simple[0]?
+          return false unless first
+          first != '.' && first != '#' && first != '%' && first != ':' &&
+            first != '[' && first != '&'
+        end
+
+        private def pseudo?(simple : String) : Bool
+          simple.starts_with?(':')
+        end
+
+        private def skip_string(chars : Array(Char), start : Int32) : Int32?
+          quote = chars[start]
+          i = start + 1
+          while i < chars.size
+            c = chars[i]
+            if c == '\\'
+              i += 2
+            elsif c == quote
+              return i + 1
+            else
+              i += 1
+            end
+          end
+          nil
+        end
+
+        private def skip_bracket(chars : Array(Char), start : Int32) : Int32?
+          i = start + 1
+          while i < chars.size
+            case chars[i]
+            when '"', '\''
+              j = skip_string(chars, i)
+              return unless j
+              i = j
+            when ']'
+              return i + 1
+            else
+              i += 1
+            end
+          end
+          nil
+        end
+
+        private def skip_paren(chars : Array(Char), start : Int32) : Int32?
+          depth = 0
+          i = start
+          while i < chars.size
+            case chars[i]
+            when '"', '\''
+              j = skip_string(chars, i)
+              return unless j
+              i = j
+            when '('
+              depth += 1
+              i += 1
+            when ')'
+              depth -= 1
+              i += 1
+              return i if depth == 0
+            else
+              i += 1
+            end
+          end
+          nil
+        end
+      end
+    end
+  end
+end

--- a/src/assets/sass/functions.cr
+++ b/src/assets/sass/functions.cr
@@ -517,6 +517,16 @@ module Hwaro
             bracketed = base.is_a?(ListV) && base.bracketed
             ListV.new(list_of(base) + list_of(args[1]), sep_from(args[2]?, sep), bracketed)
           end,
+          "zip" => Fn.new do |args, kwargs|
+            no_kwargs!("list.zip", kwargs)
+            arity!("zip", args, 1, Int32::MAX)
+            lists = args.map { |a| list_of(a) }
+            size = lists.min_of(&.size)
+            items = (0...size).map do |i|
+              ListV.new(lists.map { |l| l[i] }, ListV::Sep::Space).as(Value)
+            end
+            ListV.new(items, ListV::Sep::Comma)
+          end,
           "separator" => Fn.new do |args, kwargs|
             no_kwargs!("list.separator", kwargs)
             arity!("list-separator", args, 1)
@@ -602,7 +612,54 @@ module Hwaro
             keys = args[1..]
             MapV.new(base.entries.reject { |e| keys.any?(&.eq?(e.key)) })
           end,
+          "set" => Fn.new do |args, kwargs|
+            no_kwargs!("map.set", kwargs)
+            arity!("map.set", args, 3, Int32::MAX)
+            # Intermediate keys drill into (or create) nested maps.
+            map_set(map!("map.set", args[0]), args[1...-1], args[-1])
+          end,
+          "deep-merge" => Fn.new do |args, kwargs|
+            no_kwargs!("map.deep-merge", kwargs)
+            arity!("map.deep-merge", args, 2)
+            map_deep_merge(map!("map.deep-merge", args[0]), map!("map.deep-merge", args[1]))
+          end,
         }
+
+        private def self.map_set(map : MapV, keys : Array(Value), value : Value) : MapV
+          key = keys[0]
+          entries = map.entries.dup
+          replacement =
+            if keys.size == 1
+              value
+            else
+              inner = map[key]?
+              inner_map = inner.as?(MapV) ||
+                          (inner.is_a?(Raw) ? Expr.coerce(inner.text).as?(MapV) : nil) ||
+                          MapV.new([] of MapEntry)
+              map_set(inner_map, keys[1..], value)
+            end
+          if idx = entries.index(&.key.eq?(key))
+            entries[idx] = MapEntry.new(key, replacement)
+          else
+            entries << MapEntry.new(key, replacement)
+          end
+          MapV.new(entries)
+        end
+
+        private def self.map_deep_merge(base : MapV, overlay : MapV) : MapV
+          entries = base.entries.dup
+          overlay.entries.each do |entry|
+            idx = entries.index(&.key.eq?(entry.key))
+            if idx && (existing = entries[idx].value.as?(MapV)) && (incoming = entry.value.as?(MapV))
+              entries[idx] = MapEntry.new(entry.key, map_deep_merge(existing, incoming))
+            elsif idx
+              entries[idx] = entry
+            else
+              entries << entry
+            end
+          end
+          MapV.new(entries)
+        end
 
         # ---------------------------------------------------------------
         # sass:meta
@@ -945,6 +1002,7 @@ module Hwaro
           "index"          => LIST_FNS["index"],
           "append"         => LIST_FNS["append"],
           "join"           => LIST_FNS["join"],
+          "zip"            => LIST_FNS["zip"],
           "list-separator" => LIST_FNS["separator"],
           "map-get"        => MAP_FNS["get"],
           "map-has-key"    => MAP_FNS["has-key"],

--- a/src/assets/sass/parser.cr
+++ b/src/assets/sass/parser.cr
@@ -19,10 +19,6 @@ module Hwaro
   module Assets
     module Sass
       class Parser
-        # Sass directives outside the supported subset. Rejected loudly with
-        # a located error — never silently emitted as broken CSS.
-        UNSUPPORTED_DIRECTIVES = %w[extend]
-
         private record TemplateScan,
           template : Ast::TextTemplate,
           terminator : Char?,
@@ -125,7 +121,10 @@ module Hwaro
         private def parse_statements(top_level : Bool) : Array(Ast::Node)
           nodes = [] of Ast::Node
           loop do
-            @s.skip_ws { |text, line, col| nodes << Ast::CommentNode.new(text, line, col) }
+            @s.skip_ws do |text, line, col|
+              template = text.includes?("\#{") ? Parser.comment_template(text, @s.path, line, col) : nil
+              nodes << Ast::CommentNode.new(text, line, col, template)
+            end
             break if @s.eof?
             case @s.peek
             when '}'
@@ -190,10 +189,6 @@ module Hwaro
           name = @s.read_ident
           @s.error("expected at-rule name after \"@\"", line, column) if name.empty?
 
-          if UNSUPPORTED_DIRECTIVES.includes?(name)
-            @s.error("@#{name} is not supported by hwaro's Sass subset (yet)", line, column)
-          end
-
           case name
           when "use"
             nodes << parse_use(line, column)
@@ -225,6 +220,8 @@ module Hwaro
             nodes << parse_message(:error, line, column)
           when "at-root"
             nodes << parse_at_root(line, column)
+          when "extend"
+            nodes << parse_extend(line, column)
           when "forward"
             nodes << parse_forward(line, column)
           when "content"
@@ -445,6 +442,18 @@ module Hwaro
             @s.error("expected selector or \"{\" after @at-root", line, column) if selector.empty?
             Ast::AtRootNode.new(selector, parse_block, line, column)
           end
+        end
+
+        # `@extend .target[, .other] [!optional];` — the selector template
+        # may contain interpolation (`.item-#{$i}`) but, like rule
+        # selectors, no bare `$var` substitution.
+        private def parse_extend(line : Int32, column : Int32) : Ast::Node
+          scan = read_template(stops: ";}", value_vars: false)
+          template, flags = strip_flags(scan.template, {"optional"})
+          template = trim_template(template)
+          @s.error("expected selector after @extend", line, column) if template.empty?
+          @s.advance if scan.terminator == ';'
+          Ast::ExtendNode.new(template, flags.includes?("optional"), line, column)
         end
 
         private def parse_forward(line : Int32, column : Int32) : Ast::Node
@@ -1051,6 +1060,34 @@ module Hwaro
               buf << @s.advance
             end
           end
+        end
+
+        # Splits a loud comment's text into literal runs and `#{...}`
+        # interpolations. Positions inside the returned template are
+        # relative to the comment body, so errors carry the comment's own
+        # location instead. nil when the text doesn't parse as a template
+        # (a literal `#{` with no closing brace) — plain-CSS comments must
+        # keep passing through verbatim, never become parse errors.
+        def self.comment_template(text : String, path : String,
+                                  line : Int32, column : Int32) : Ast::TextTemplate?
+          new(text, path).scan_comment_template(line, column)
+        rescue SyntaxError
+          nil
+        end
+
+        protected def scan_comment_template(line : Int32, column : Int32) : Ast::TextTemplate
+          pieces = [] of Ast::Piece
+          buf = Buf.new
+          until @s.eof?
+            if @s.peek == '#' && @s.peek(1) == '{'
+              buf.flush_into(pieces)
+              pieces << parse_interp
+            else
+              buf << @s.advance
+            end
+          end
+          buf.flush_into(pieces)
+          Ast::TextTemplate.new(pieces, line, column)
         end
 
         # `#{ ... }` (cursor on '#').

--- a/src/assets/sass/value.cr
+++ b/src/assets/sass/value.cr
@@ -229,6 +229,16 @@ module Hwaro
         # sublists so nesting survives a storage round-trip.
         def inspect_css : String
           return "()" if @items.empty?
+          if @sep == Sep::Comma && @items.size == 1 && !@bracketed
+            # A single-element comma list has no comma to reveal its
+            # separator — dart-sass spells it `(1,)`, which is also the
+            # only spelling that survives a storage round-trip without
+            # degrading into a plain value.
+            item = @items[0]
+            text = item.inspect_css
+            text = "(#{text})" if item.is_a?(ListV) && !item.bracketed
+            return "(#{text},)"
+          end
           joiner =
             case @sep
             in Sep::Space then " "


### PR DESCRIPTION
## Summary

Makes the built-in Sass compiler compile real-world frameworks: **Bootstrap 5.3.3 and Bulma 1.0.2 now compile end-to-end**, with output semantically equivalent to dart-sass 1.80 (rule-level differential comparison; residual diffs are documented cosmetic deviations — fractional rgb channels, nested-`@media` not merged, `calc()` not simplified).

### New capabilities
- **`@extend` + `%placeholder`** (new `src/assets/sass/extend.cr` post-pass): simple-selector targets, compound unification, ancestor-prefix merging, extension inside `:is()/:where()/:not()` arguments, chained extends, `!optional`, located missing-target errors. Un-extended placeholders no longer leak into output.
- **Expression layer**: `calc(#{$a} + 2px)` / `var(--#{$p}x)` spans lex across template pieces instead of crashing strict contexts with an unlocated `unlexable`; `Expr.parse!` converts lexer failures into located errors; `&` as a SassScript value (`if(&, "&", "")`); `!important` as an expression value; **lazy `if()`**; `var()` fallback arguments evaluate known function calls.
- **Builtins**: `list.zip`, `map.set` / `map.deep-merge`, host-backed `sass:meta` functions (`variable-exists` family with `$module`, `get-function` / `call` via first-class function references).
- **Colors**: `hsl()`/`hsla()` comma literals parse as colors in color functions; colors built from hsl (and alpha-only derivations) remember declared hue/saturation.
- **Loud comments** resolve `#{...}` (the `/*! Lib v#{$v} */` banner idiom), falling back to verbatim on any failure.

### Latent bugs fixed (each with a minimized regression spec, all failing pre-fix)
- Null variable passed as a bare argument became a truthy empty string → flipped `@if` branches (Bulma palette emitted `lightness()` with empty args).
- Verbatim map storage corrupted comma-list member values → map literals now always evaluate.
- `!default` did not overwrite null (`$m: null !default; @if … { $m: (…) !default; }` guard never took).
- Structural storage spellings (`(a b), (c d)` nested-list parens, `(x,)` single-comma list) leaked into emitted CSS via `$var` substitution, interpolation, and at-rule preludes.
- `[1 2 3]` parsed as one element; `(1,)` lost its separator; `==` missed equal values across raw/typed evaluation paths; escaped `\%` in plain CSS selectors was scrubbed as a placeholder.

### Review
An adversarial review pass on this branch confirmed 10 defects (escaped-`%` scrub, `(x,)` leak, comment-eval build failures, FnRef storage round-trip, namespaced meta error policy, `@extend` inside pseudo args, `with_alpha` HSL loss, meta introspection blind spots); all fixed here with probes + specs. Two findings assessed as intended behavior: color-arg dispatch for `grayscale()` etc. matches dart-sass on non-CSS input, and unquoted-`"null"`-text classification is a documented limit of the text storage model.

## Verification
- `crystal spec`: **7795 examples, 0 failures** (84 new: `extend_spec` + `framework_compat_spec`; 44/48 of the initial batch fail on `main`)
- Bootstrap + Bulma compile with 0 errors; differential vs dart-sass 1.80 clean modulo documented deviations
- Old-vs-new binary `diff -r` on a sass-enabled site: **byte-identical** (plain-CSS/lenient-fallback invariant preserved)
- `crystal tool format --check` + ameba clean
- Docs (`features/sass.md`, `sass.ko.md`) updated: support matrix, @extend section, deviations