### PR TITLE
feat(sass): dart-sass differential audit — division, units, output order, module gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Sass: classic `/` division (dart-sass 1.x rule) — `$w/2`, `(1/3)`, `percentage(1/4)` and `12 / 4 * 3` now divide, while literal-only slashes (`font: 12px/30px`, `grid-area: 1 / 2`) stay verbatim
 - Sass: unit conversion within the standard groups (`1in + 72pt`, `1in == 96px`, `math.min(1in, 50px)`, `math.compatible(1px, 1in)`)
 - Sass: nested properties (`font: 12px serif { family: sans; }`), `@content(args)` / `@include … using (...)`, `@at-root (with: ...)` / `(without: ...)` queries
-- Sass: variadic keyword arguments — extra keywords bind into `meta.keywords($args)` and forward through `@include inner($args...)`
+- Sass: variadic keyword arguments — extra keywords bind into `meta.keywords($args)` and forward through `@include inner($args...)`; unused extra keywords (typos like `$colour`) error unless `keywords()` reads them
 - Sass: the `sass:selector` module (`parse` / `nest` / `append` / `unify` / `is-superselector`, string-level) plus the legacy global spellings
 - Sass: `math.log` / `math.hypot` / trigonometry, `string.insert` / `string.split`, `list.set-nth` / `list.slash` / `list.is-bracketed`, `color.channel` / `color.hwb` / `ie-hex-str`
 - Sass: a single `@charset "UTF-8";` is prepended when the compiled CSS contains non-ASCII (source `@charset` lines are dropped, so a merged sheet no longer carries one per imported file)
@@ -40,6 +40,11 @@
 - **Release binaries could hang forever at exit.** `-Dpreview_mt` is deprecated in Crystal 1.21 and its legacy MT scheduler spins in the event loop's spin lock at process exit, so `hwaro build` never returned (measured 4/120 short-lived runs under CPU oversubscription). Parallelism now comes from Crystal's execution contexts, sized in `src/main.cr`
 - Sass grouping parentheses no longer leak into declaration values (`width: (10px / 2)`, `margin: (1px 2px)`); a failing namespaced reference (`math.div(…)`) now warns with a `path:line:col` location instead of silently emitting invalid CSS
 - Sass output-order fixes matching dart-sass: selector lists resolve parent-major (`a, b { c, d {} }` → `a c, a d, b c, b d`), declarations after a nested rule reopen the parent selector instead of being hoisted above it (cascade order), and `@media` nested in `@media` merges into `screen and (min-width: …)` at the top level (comma lists cross-multiply; `not`/`@supports`-interrupted nestings stay literal)
+- Sass media merge no longer duplicates ancestor conditions in ≥3-deep `@media` nesting, and treats `Not`/`NOT` like `not` instead of silently dropping that branch
+- Sass `@at-root (with: all)` keeps media and selector nesting (a no-op, matching dart-sass) instead of escaping both
+- Sass `list.slash(...)` stored in a variable round-trips as a slash list (`list.length`/`nth`/`separator` work), and maps whose keys collide after unit conversion (`1in` vs `96px`) error as Duplicate key
+- Sass variadic mixins/functions reject unused extra keyword arguments unless `meta.keywords($args)` reads them or `$args...` forwards them
+- Sass `sass:selector` keeps whitespace inside attribute selectors and `:is()`/`:not()` arguments instead of fragmenting them
 - Sass: `12 / 4 * 3` no longer mangles into the meaning-changing `12 / 12`; `+$a` evaluates; `1 + "a"` keeps the quote; `red == #f00` compares colors by channel; a spread space list keeps its separator in a variadic `$rest`; `@at-root #{&}__suffix` resolves instead of erroring
 - GFM tables with short alignment delimiters (`|:--|--:|`, `|:-:|`, `| - |`) render as tables; the delimiter cell now matches GFM's `:?-+:?` instead of requiring three hyphens
 - `hwaro tool check-links` stops reporting valid links as dead: angle-bracket destinations (`[t](</about/>)`, including ones containing spaces) and destinations with balanced parentheses (`/docs/foo_(bar)`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+- Sass: classic `/` division (dart-sass 1.x rule) — `$w/2`, `(1/3)`, `percentage(1/4)` and `12 / 4 * 3` now divide, while literal-only slashes (`font: 12px/30px`, `grid-area: 1 / 2`) stay verbatim
+- Sass: unit conversion within the standard groups (`1in + 72pt`, `1in == 96px`, `math.min(1in, 50px)`, `math.compatible(1px, 1in)`)
+- Sass: nested properties (`font: 12px serif { family: sans; }`), `@content(args)` / `@include … using (...)`, `@at-root (with: ...)` / `(without: ...)` queries
+- Sass: variadic keyword arguments — extra keywords bind into `meta.keywords($args)` and forward through `@include inner($args...)`
+- Sass: the `sass:selector` module (`parse` / `nest` / `append` / `unify` / `is-superselector`, string-level) plus the legacy global spellings
+- Sass: `math.log` / `math.hypot` / trigonometry, `string.insert` / `string.split`, `list.set-nth` / `list.slash` / `list.is-bracketed`, `color.channel` / `color.hwb` / `ie-hex-str`
+- Sass: a single `@charset "UTF-8";` is prepended when the compiled CSS contains non-ASCII (source `@charset` lines are dropped, so a merged sheet no longer carries one per imported file)
+
 ### Fixed
 - **`hwaro tool list` and `hwaro tool stats` disagreed with `hwaro build` about what is published.** Both called every non-draft file "published", while a default build also drops future-dated pages (`date` in the future), expired ones (`expires` in the past), and pages a parent section marked draft via `[cascade]` — so the tool that answers "what will ship?" listed files that would not. `list` now reports `[pub]` / `[draft]` / `[future]` / `[expired]` (with a matching `status` field in `--json`), `list published` returns exactly the build's published set, and `stats` counts `future` / `expired` separately instead of folding them into `published`. Cascade resolution matches the build's: the nearest section wins (so a nested `[cascade] draft = false` un-drafts what an ancestor cascaded) and the language must match
 - `hwaro tool stats` and `hwaro tool validate` read tags declared in a `[taxonomies]` table — the shape hwaro's own scaffolds and every Zola-style site use. The tag distribution came back EMPTY for those sites and the mixed-case tag check never ran; `stats` also ignored JSON front matter entirely
@@ -30,6 +39,8 @@
 - `get_taxonomy_url` on a multilingual site links to that language's term page (`/ko/tags/foo/`) when one exists — a term appearing only in non-default-language content previously linked to a root page that was never written
 - **Release binaries could hang forever at exit.** `-Dpreview_mt` is deprecated in Crystal 1.21 and its legacy MT scheduler spins in the event loop's spin lock at process exit, so `hwaro build` never returned (measured 4/120 short-lived runs under CPU oversubscription). Parallelism now comes from Crystal's execution contexts, sized in `src/main.cr`
 - Sass grouping parentheses no longer leak into declaration values (`width: (10px / 2)`, `margin: (1px 2px)`); a failing namespaced reference (`math.div(…)`) now warns with a `path:line:col` location instead of silently emitting invalid CSS
+- Sass output-order fixes matching dart-sass: selector lists resolve parent-major (`a, b { c, d {} }` → `a c, a d, b c, b d`), declarations after a nested rule reopen the parent selector instead of being hoisted above it (cascade order), and `@media` nested in `@media` merges into `screen and (min-width: …)` at the top level (comma lists cross-multiply; `not`/`@supports`-interrupted nestings stay literal)
+- Sass: `12 / 4 * 3` no longer mangles into the meaning-changing `12 / 12`; `+$a` evaluates; `1 + "a"` keeps the quote; `red == #f00` compares colors by channel; a spread space list keeps its separator in a variadic `$rest`; `@at-root #{&}__suffix` resolves instead of erroring
 - GFM tables with short alignment delimiters (`|:--|--:|`, `|:-:|`, `| - |`) render as tables; the delimiter cell now matches GFM's `:?-+:?` instead of requiring three hyphens
 - `hwaro tool check-links` stops reporting valid links as dead: angle-bracket destinations (`[t](</about/>)`, including ones containing spaces) and destinations with balanced parentheses (`/docs/foo_(bar)`)
 - An oversized `[image_processing] widths` entry no longer aborts the build with a bare `OverflowError`; the variant is declined by the existing pixel-count guard instead

--- a/docs/content/features/sass.md
+++ b/docs/content/features/sass.md
@@ -73,16 +73,18 @@ Hwaro implements a practical SCSS subset — the features hand-written site styl
 | Partials + `@use` | ✅ namespaces (`colors.$primary`), `as x`, `as *`, load-once, `with (...)` configuration |
 | `@forward` | ✅ `show` / `hide` filters, `as prefix-*` |
 | `@import` (Sass files) | ✅ classic global-merge semantics; plain-CSS forms pass through |
-| `@mixin` / `@include` | ✅ default values, keyword arguments, variadic `$args...`, spreads, `@content` blocks |
+| `@mixin` / `@include` | ✅ default values, keyword arguments, variadic `$args...` (extra keywords land in `meta.keywords()`), spreads (keywords forward through `$args...`), `@content` blocks with arguments (`@content(1px)` / `@include m using ($a)`) |
 | `@function` / `@return` | ✅ user functions callable in values, defaults/keywords/variadic, recursion |
 | `@extend` + `%placeholders` | ✅ simple-selector targets, compound unification, `!optional`; un-extended placeholders never emit — see deviations |
 | `&` in SassScript | ✅ `if(&, "&", "")` and friends — the parent selector as a value, `null` at the root |
 | Control flow | ✅ `@if` / `@else if` / `@else`, `@each` (with destructuring), `@for` (`through`/`to`, descending), `@while` |
-| SassScript expressions | ✅ arithmetic (`+ - * %`), comparisons, `and`/`or`/`not`, strings, lists, maps — see deviations for `/` |
-| Built-in functions | ✅ `sass:math`, `sass:string`, `sass:list` (incl. `zip`), `sass:map` (incl. `set` / `deep-merge`), `sass:meta` (incl. `variable-exists` / `function-exists` / `mixin-exists` / `content-exists` / `get-function` / `call`), `sass:color` subset + legacy global names (`map-get`, `nth`, `darken`, `if()`, …) |
+| SassScript expressions | ✅ arithmetic (`+ - * / %`, classic slash-division rule), comparisons, `and`/`or`/`not`, strings, lists, maps — see deviations for `/` |
+| Unit conversion | ✅ `px`/`cm`/`mm`/`q`/`in`/`pt`/`pc`, `deg`/`grad`/`rad`/`turn`, `s`/`ms`, `Hz`/`kHz`, `dpi`/`dpcm`/`dppx` convert in arithmetic, comparisons, `==`, and `math.*` |
+| Nested properties | ✅ `font: 12px serif { family: sans; }` → `font`, `font-family` (recursive) |
+| Built-in functions | ✅ `sass:math` (incl. `log` / `hypot` / trigonometry), `sass:string` (incl. `insert` / `split`), `sass:list` (incl. `zip` / `set-nth` / `slash` / `is-bracketed`), `sass:map` (incl. `set` / `deep-merge`), `sass:meta` (incl. `keywords` / `variable-exists` / `function-exists` / `mixin-exists` / `content-exists` / `get-function` / `call`), `sass:selector` (string-level `parse` / `nest` / `append` / `unify` / `is-superselector`), `sass:color` subset (incl. `channel` / `hwb` / `ie-hex-str`) + legacy global names (`map-get`, `nth`, `darken`, `if()`, …) |
 | `@debug` / `@warn` / `@error` | ✅ `@error` fails the build with a located message |
-| `@at-root` | ✅ selector and block forms (no `with:`/`without:` queries) |
-| `@media` / `@supports` in rules | ✅ bubbled out of nesting automatically; feature values evaluate expressions |
+| `@at-root` | ✅ selector and block forms, `#{&}` suffixing, `(with: ...)` / `(without: ...)` queries |
+| `@media` / `@supports` in rules | ✅ bubbled out of nesting automatically; nested `@media` merge with `and` (comma lists cross-multiply); feature values evaluate expressions |
 | `@keyframes`, `@font-face`, custom properties | ✅ pass through correctly |
 | Plain CSS | ✅ any valid `.css` compiles to itself (whitespace-normalized) |
 
@@ -134,7 +136,8 @@ $brand: #336699;
 | Blending | `mix`, `invert` |
 | Alpha | `rgba($color, $alpha)`, `opacify` / `fade-in`, `transparentize` / `fade-out` |
 | Compound | `adjust-color`, `scale-color`, `change-color` |
-| Components | `red`, `green`, `blue`, `hue`, `saturation`, `lightness`, `alpha` / `opacity` |
+| Components | `red`, `green`, `blue`, `hue`, `saturation`, `lightness`, `alpha` / `opacity`, `color.channel` |
+| Misc | `ie-hex-str`, `color.hwb` |
 
 The same functions are available under `sass:color` with the modern names — `color.adjust`, `color.scale`, `color.change`, `color.mix`, `color.complement`, `color.grayscale`, `color.invert`, and the component getters:
 
@@ -145,7 +148,7 @@ The same functions are available under `sass:color` with the modern names — `c
 
 A computed color serializes as `#rrggbb` when opaque and `rgba(r, g, b, a)` otherwise. A color you *don't* modify keeps the exact spelling you wrote — `#FFF` stays `#FFF`.
 
-Two colors are only compared as colors once a color function has produced them; `#ffffff == #FFF` between two literals is still the generic text comparison and is false. Teaching `==` to parse every literal would flip `@if` branches in stylesheets that compile today, which the plain-CSS guarantee rules out.
+Colors compare by channel across spellings: `#ffffff == #FFF`, `red == #f00`, and `rgb(255, 0, 0) == #ff0000` are all true (dart-sass semantics).
 
 ### @extend
 
@@ -161,12 +164,12 @@ A missing target fails the build with a located error; append `!optional` to tol
 
 ### Not supported (yet)
 
-Unit conversion (`px`↔`cm`), `@at-root (with: ...)` queries, `@forward ... with (...)`, `@content(args)` / `using`, `math.random` / `unique-id()` (builds must stay deterministic), nested properties (`font: { family: ... }`), the indented `.sass` syntax, and source maps.
+Compound units (`px*em`, `px/s` — multiplication/division that would need numerator/denominator unit lists), `calc()` simplification, `@forward ... with (...)`, `math.random` / `unique-id()` (builds must stay deterministic), the indented `.sass` syntax, and source maps.
 
 **Unsupported directives fail the build with a located error** — Hwaro never emits silently broken CSS:
 
 ```
-Error [HWARO_E_CONTENT]: Sass: static/css/style.scss:14:3: @content arguments are not supported
+Error [HWARO_E_CONTENT]: Sass: static/css/style.scss:14:3: @forward ... with (...) is not supported
 ```
 
 ### Expression semantics
@@ -178,9 +181,9 @@ The compiler's first duty is the plain-CSS guarantee, so expressions follow a tw
 
 ### Deviations from dart-sass
 
-- `/` is **never** division — `font: 12px/1.5` and `grid-area: 1 / 2` stay verbatim. Use `math.div()` (this matches dart-sass 2.0, which removed slash-division).
+- `/` follows the classic Sass division rule (dart-sass 1.x): it divides when an operand is a variable, a known function call, or parenthesized, or when the slash sits in a computing context (adjacent arithmetic, a Sass function argument, a variable declaration, interpolation, control flow). Literal-only slashes (`font: 12px/1.5`, `grid-area: 1 / 2`) stay verbatim **with the author's spacing** — dart-sass reprints them compacted (`1/2`).
 - Values are stored as CSS text between evaluations; types are re-derived on use. An unquoted string that *looks* like a list (`"a, b"` unquoted) is treated as one.
-- Unit arithmetic requires identical units or one unitless side; there is no `px`↔`in` conversion table.
+- Unit arithmetic converts within the standard groups (length, angle, time, frequency, resolution), the left operand's unit winning. Compound units (`1px * 1em`, `math.div(1px, 1s)`) are not modeled and fall back to verbatim text.
 - `and`/`or` in *value* positions only operate on real booleans — `font-family: Franklin and Marshall` stays text. Conditions have full Sass truthiness.
 - Global `min()`/`max()`/`round()`/`abs()` evaluate only when all arguments are statically comparable numbers; CSS forms (`min(5vw, 100px)`, `round(up, 101px, 10px)`) pass through.
 - `rgb()`/`rgba()`/`hsl()`/`hsla()` are **not** folded in their CSS forms: `rgb(0, 0, 0)` stays verbatim where dart-sass would emit `black` (a color *function* handed such a literal still reads it as a color). Only the Sass-only `rgba($color, $alpha)` spelling — which is not valid CSS — evaluates. Likewise `grayscale()`, `invert()`, `saturate()` and `opacity()` are color functions when handed a color and plain CSS filters when handed a number (`filter: grayscale(50%)` passes through).
@@ -190,12 +193,12 @@ The compiler's first duty is the plain-CSS guarantee, so expressions follow a tw
 - `calc()` contents are never simplified — `calc(9 / 21 * 100%)` stays as written where dart-sass folds it to `42.86%`. Browsers compute both identically.
 - Variables in at-rule preludes and values substitute directly (`@media (min-width: $bp)` works); selectors and property names require `#{...}` interpolation (same as dart-sass).
 - At-rule preludes evaluate expressions only inside `(feature: value)` spans; the query structure itself stays verbatim.
-- `@media` nested inside `@media` emits literally nested blocks (dart-sass merges the conditions).
+- `@media` nested inside `@media` merges the conditions with `and` (comma lists cross-multiply outer-major; type-conflicting pairs are dropped). Queries the merge can't express (`not …`) and nestings interrupted by another at-rule (`@supports`) keep the literal nested form — valid modern CSS — where dart-sass drops or rewrites them.
 - `&` substitution is textual — `&__elem` concatenates without validating the compound selector.
 - Custom property values are verbatim: `$var` stays literal, only `#{...}` interpolates (dart-sass semantics), but leading/trailing whitespace is trimmed.
 - `@import` of the same file re-emits its CSS each time (classic Sass behavior); `@use` loads once.
 - Configuring a module that itself uses `@forward` (`@use "lib" with (...)`) is an error rather than silently ignored.
-- Declarations placed *after* a nested rule merge into the parent's single output block (`.a { color: red; .b {} color: blue; }` emits one `.a` block); dart-sass splits them in source order. Avoid relying on cascade order between a parent's trailing declarations and its nested rules.
+- Output with non-ASCII content gets a single leading `@charset "UTF-8";`; source `@charset` declarations are dropped (dart-sass behavior).
 - Values are substituted as text: interpolating a variable whose value contains an unbalanced quote character can confuse downstream whitespace/quote handling. Keep quote characters inside quoted strings.
 - Only lowercase `.scss` extensions are treated as Sass sources; other casings publish verbatim like any static file.
 

--- a/spec/unit/sass/audit_fixes_spec.cr
+++ b/spec/unit/sass/audit_fixes_spec.cr
@@ -1,0 +1,335 @@
+# Regression specs for the 2026-08 dart-sass differential audit.
+#
+# Each group pins one fixed defect cluster against the behavior verified
+# with dart-sass 1.103. Expected values here come from actual dart-sass
+# output, not from reading our own implementation.
+
+require "../../spec_helper"
+
+private def compile(source : String) : String
+  Hwaro::Assets::Sass.compile(source)
+end
+
+describe "Sass division (classic slash rule)" do
+  it "divides when an operand is a variable" do
+    compile("$a: 10;\no { q: $a/2; }").should contain("q: 5;")
+  end
+
+  it "divides when an operand is a function call" do
+    compile("@function r() { @return 20; }\no { q: r()/2; }").should contain("q: 10;")
+  end
+
+  it "divides inside parentheses" do
+    compile("o { q: (1/4); }").should contain("q: 0.25;")
+  end
+
+  it "divides when adjacent to other arithmetic" do
+    css = compile("o { a: 1/2 + 1/2; b: 12 / 4 * 3; }")
+    css.should contain("a: 1;")
+    css.should contain("b: 9;")
+  end
+
+  it "divides inside Sass function arguments" do
+    compile("o { q: percentage(1/4); }").should contain("q: 25%;")
+  end
+
+  it "divides in variable declarations, so the stored value is the quotient" do
+    compile("$x: 1/2;\no { v: $x; }").should contain("v: 0.5;")
+  end
+
+  it "divides in interpolation" do
+    compile("o { v: \#{1/2}; }").should contain("v: 0.5;")
+  end
+
+  it "keeps a literal slash between plain literals" do
+    css = compile("o { font: 12px/30px serif; grid-area: 1 / 2 / 3 / 4; }")
+    css.should contain("font: 12px/30px serif;")
+    css.should contain("grid-area: 1 / 2 / 3 / 4;")
+  end
+
+  it "keeps a literal slash in unknown function arguments" do
+    compile("o { q: foo(1/2) 1px; }").should contain("q: foo(1/2) 1px;")
+  end
+
+  it "keeps a literal slash under a lone unary minus" do
+    compile("o { q: -1/2 1px; }").should contain("q: -1/2 1px;")
+  end
+
+  it "binds the slash tighter than a space list" do
+    compile("$a: 10;\no { q: $a /2 em; }").should contain("q: 5 em;")
+  end
+
+  it "cancels convertible units" do
+    compile("o { q: (1in / 96px); }").should contain("q: 1;")
+  end
+end
+
+describe "Sass unit conversion" do
+  it "adds and subtracts across convertible units, left unit winning" do
+    css = compile("o { a: 1in + 72pt; b: 1cm + 10mm; c: 100ms + 1s; d: 90deg + 0.5turn; }")
+    css.should contain("a: 2in;")
+    css.should contain("b: 2cm;")
+    css.should contain("c: 1100ms;")
+    css.should contain("d: 270deg;")
+  end
+
+  it "compares across convertible units" do
+    css = compile("o { a: 1in == 96px; b: 2cm > 19mm; }")
+    css.should contain("a: true;")
+    css.should contain("b: true;")
+  end
+
+  it "reports convertible units as compatible" do
+    compile(%(@use "sass:math";\no { c: math.compatible(1px, 1in); })).should contain("c: true;")
+  end
+
+  it "converts in math.div and min/max" do
+    css = compile(%(@use "sass:math";\no { a: math.div(1in, 96px); b: math.min(1in, 50px); c: math.max(1s, 500ms); }))
+    css.should contain("a: 1;")
+    css.should contain("b: 50px;")
+    css.should contain("c: 1s;")
+  end
+
+  it "still refuses unconvertible unit pairs" do
+    compile("o { q: 1px + 1s; }").should contain("q: 1px + 1s;") # verbatim fallback
+  end
+end
+
+describe "Sass math module additions" do
+  it "computes log, hypot and trigonometry" do
+    css = compile(<<-SCSS)
+      @use "sass:math";
+      o {
+        a: math.log(math.$e);
+        b: math.log(8, 2);
+        c: math.hypot(3, 4);
+        d: math.cos(0);
+        e: math.atan2(1, 1);
+        f: math.asin(1);
+      }
+      SCSS
+    css.should contain("a: 1;")
+    css.should contain("b: 3;")
+    css.should contain("c: 5;")
+    css.should contain("d: 1;")
+    css.should contain("e: 45deg;")
+    css.should contain("f: 90deg;")
+  end
+
+  it "keeps units in hypot and converts angle units in sin" do
+    css = compile(%(@use "sass:math";\no { a: math.hypot(3px, 4px); b: math.sin(90deg); }))
+    css.should contain("a: 5px;")
+    css.should contain("b: 1;")
+  end
+end
+
+describe "Sass string/list function additions" do
+  it "inserts with positive, zero, and negative indices" do
+    css = compile(<<-SCSS)
+      @use "sass:string";
+      o {
+        a: string.insert("abc", "X", -1);
+        b: string.insert("abc", "X", -2);
+        c: string.insert("abc", "X", 0);
+        d: string.insert("abc", "X", 2);
+      }
+      SCSS
+    css.should contain(%(a: "abcX";))
+    css.should contain(%(b: "abXc";))
+    css.should contain(%(c: "Xabc";))
+    css.should contain(%(d: "aXbc";))
+  end
+
+  it "splits strings into a bracketed comma list" do
+    css = compile(%(@use "sass:string";\no { a: inspect(string.split("a,b,c", ",")); }))
+    css.should contain(%(a: ["a", "b", "c"];))
+  end
+
+  it "supports set-nth, list.slash and list.is-bracketed" do
+    css = compile(<<-SCSS)
+      @use "sass:list";
+      o {
+        a: set-nth(1 2 3, 2, X);
+        b: inspect(list.slash(1, 2, 3));
+        c: list.is-bracketed([1 2]);
+        d: list.nth(list.slash(1, 2, 3), 2);
+      }
+      SCSS
+    css.should contain("a: 1 X 3;")
+    css.should contain("b: 1 / 2 / 3;")
+    css.should contain("c: true;")
+    css.should contain("d: 2;")
+  end
+end
+
+describe "Sass color additions" do
+  it "reads channels via color.channel" do
+    css = compile(<<-SCSS)
+      @use "sass:color";
+      o {
+        r: color.channel(rgba(10, 20, 30, 0.5), "red");
+        h: color.channel(#f00, "hue", $space: hsl);
+        l: color.channel(#f00, "lightness", $space: hsl);
+      }
+      SCSS
+    css.should contain("r: 10;")
+    css.should contain("h: 0deg;")
+    css.should contain("l: 50%;")
+  end
+
+  it "formats ie-hex-str" do
+    css = compile("o { a: ie-hex-str(#abcdef); b: ie-hex-str(rgba(255, 0, 0, 0.5)); }")
+    css.should contain("a: #FFABCDEF;")
+    css.should contain("b: #80FF0000;")
+  end
+
+  it "builds colors from hwb channels" do
+    # hwb(0, 0%, 0%) is pure red.
+    compile(%(@use "sass:color";\no { c: color.hwb(0 0% 0%); })).should contain("c: #ff0000;")
+  end
+
+  it "compares colors by value across spellings" do
+    css = compile("o { a: red == #f00; b: rgb(255, 0, 0) == #ff0000; }")
+    css.should contain("a: true;")
+    css.should contain("b: true;")
+  end
+end
+
+describe "Sass selector module" do
+  it "unifies compound selectors with elements first" do
+    css = compile(%(@use "sass:selector";\no { a: selector.unify(".wrapper .field", "input"); b: selector.unify(".a.b", ".b.c"); c: if(selector.unify("a.x", "b") == null, none, some); }))
+    css.should contain("a: .wrapper input.field;")
+    css.should contain("b: .a.b.c;")
+    css.should contain("c: none;")
+  end
+
+  it "nests and appends selector lists" do
+    css = compile(%(@use "sass:selector";\no { a: selector.nest(".a, .b", ".c", ".d &"); b: selector.append(".a", "__b", "-c"); }))
+    css.should contain("a: .d .a .c, .d .b .c;")
+    css.should contain("b: .a__b-c;")
+  end
+
+  it "answers is-superselector" do
+    css = compile(%(@use "sass:selector";\no { a: selector.is-superselector(".a", ".a.b"); b: selector.is-superselector(".a", ".b"); }))
+    css.should contain("a: true;")
+    css.should contain("b: false;")
+  end
+
+  it "works with & through interpolation in @at-root" do
+    css = compile(<<-'SCSS')
+      @use "sass:selector";
+      @mixin unify-parent($child) {
+        @at-root #{selector.unify(&, $child)} { @content; }
+      }
+      .wrapper .field { @include unify-parent("input") { color: red; } }
+      SCSS
+    css.should contain(".wrapper input.field {\n  color: red;")
+    css.should_not contain(".wrapper .field .wrapper")
+  end
+end
+
+describe "Sass variadic keyword arguments" do
+  it "collects extra keyword arguments into meta.keywords" do
+    css = compile(<<-SCSS)
+      @use "sass:meta";
+      @mixin m($args...) { x: inspect(meta.keywords($args)); n: length($args); }
+      a { @include m(1, $a: 2, $b: c); }
+      SCSS
+    css.should contain("x: (a: 2, b: c);")
+    css.should contain("n: 1;")
+  end
+
+  it "forwards keywords through a spread" do
+    css = compile(<<-SCSS)
+      @use "sass:meta";
+      @mixin m($args...) { x: inspect(meta.keywords($args)); }
+      @mixin fwd($args...) { @include m($args...); }
+      b { @include fwd(9, $z: 8); }
+      SCSS
+    css.should contain("x: (z: 8);")
+  end
+
+  it "preserves the spread list's separator in the rest arglist" do
+    css = compile(<<-SCSS)
+      @mixin n($a, $rest...) { w: $rest; s: list-separator($rest); }
+      $lst: 4 5 6;
+      b { @include n($lst...); }
+      c { @include n(1, 2, 3); }
+      SCSS
+    css.should contain("w: 5 6;")
+    css.should contain("s: space;")
+    css.should contain("w: 2, 3;")
+    css.should contain("s: comma;")
+  end
+end
+
+describe "Sass output structure" do
+  it "resolves selector lists parent-major" do
+    css = compile("a, b { c, d { x: 1; } }")
+    css.should contain("a c,\na d,\nb c,\nb d {")
+  end
+
+  it "keeps mixed parent-referencing parts in parent-major order" do
+    css = compile("a, b { c, &:hover, d { x: 1; } }")
+    css.should contain("a c,\na:hover,\na d,\nb c,\nb:hover,\nb d {")
+  end
+
+  it "reopens a rule for declarations that follow a nested rule" do
+    css = compile("a { color: red; b { x: 1; } margin: 0; }")
+    css.index!("color: red").should be < css.index!("x: 1")
+    css.index!("x: 1").should be < css.index!("margin: 0")
+    css.scan(/^a \{$/m).size.should eq(2)
+  end
+
+  it "does not reopen when declarations precede nested rules" do
+    css = compile("a { color: red; margin: 0; b { x: 1; } }")
+    css.scan(/^a \{$/m).size.should eq(1)
+  end
+
+  it "merges nested @media through style rules and reopens the outer block" do
+    css = compile("@media screen { c { x: 1; @media (min-width: 200px) { y: 2; } z: 3; } d { w: 4; } }")
+    css.should contain("@media screen and (min-width: 200px) {\n  c {\n    y: 2;")
+    # z stays with x (the c rule was still last in the outer block) …
+    css.should contain("x: 1;\n    z: 3;")
+    # … while d reopens a fresh `@media screen` after the merged block.
+    merged = css.index!("@media screen and")
+    css.index!("w: 4").should be > merged
+  end
+
+  it "cross-multiplies comma-separated media queries outer-major, dropping type conflicts" do
+    css = compile("@media (min-width: 10px), print { a { @media (max-width: 20px), screen { x: 1; } } }")
+    css.should contain("@media (min-width: 10px) and (max-width: 20px), screen and (min-width: 10px), print and (max-width: 20px) {")
+  end
+
+  it "resolves @at-root \#{&} without re-nesting" do
+    css = compile(".block { @at-root \#{&}__direct { color: blue; } }")
+    css.should contain(".block__direct {\n  color: blue;")
+    css.should_not contain(".block .block__direct")
+  end
+
+  it "prepends @charset when the output contains non-ASCII" do
+    compile(%(a { content: "한글"; })).should start_with(%(@charset "UTF-8";\n))
+  end
+
+  it "does not double a source @charset" do
+    css = compile(%(@charset "UTF-8";\na { content: "한글"; }))
+    css.scan("@charset").size.should eq(1)
+  end
+
+  it "leaves ASCII-only output without @charset" do
+    compile("a { color: red; }").should_not contain("@charset")
+  end
+end
+
+describe "Sass expression polish" do
+  it "evaluates unary plus" do
+    compile("$a: 5;\no { y: +$a; }").should contain("y: 5;")
+  end
+
+  it "quotes number + quoted-string concatenation" do
+    css = compile(%(o { a: 1 + "a"; b: "a" + 1; c: a + "b"; }))
+    css.should contain(%(a: "1a";))
+    css.should contain(%(b: "a1";))
+    css.should contain("c: ab;")
+  end
+end

--- a/spec/unit/sass/audit_fixes_spec.cr
+++ b/spec/unit/sass/audit_fixes_spec.cr
@@ -79,6 +79,12 @@ describe "Sass unit conversion" do
     css.should contain("b: true;")
   end
 
+  it "rejects maps whose keys collide after unit conversion" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /Duplicate key/) do
+      compile(%(@use "sass:map"; $m: (1in: a, 96px: b); o { x: map.get($m, 96px); }))
+    end
+  end
+
   it "reports convertible units as compatible" do
     compile(%(@use "sass:math";\no { c: math.compatible(1px, 1in); })).should contain("c: true;")
   end
@@ -160,6 +166,17 @@ describe "Sass string/list function additions" do
     css.should contain("c: true;")
     css.should contain("d: 2;")
   end
+
+  it "round-trips a slash list through a variable" do
+    css = compile(<<-SCSS)
+      @use "sass:list";
+      $l: list.slash(4, 5, 6);
+      a { n: list.length($l); s: list.separator($l); b: list.nth($l, 2); }
+      SCSS
+    css.should contain("n: 3;")
+    css.should contain("s: slash;")
+    css.should contain("b: 5;")
+  end
 end
 
 describe "Sass color additions" do
@@ -215,6 +232,18 @@ describe "Sass selector module" do
     css.should contain("b: false;")
   end
 
+  it "keeps whitespace inside attribute selectors and :is() when appending/nesting" do
+    css = compile(<<-SCSS)
+      @use "sass:selector";
+      o {
+        a: selector.append('[title="a b"]', ".x");
+        b: selector.nest(":is(a > b)", ".c");
+      }
+      SCSS
+    css.should contain(%(a: [title="a b"].x;))
+    css.should contain("b: :is(a > b) .c;")
+  end
+
   it "works with & through interpolation in @at-root" do
     css = compile(<<-'SCSS')
       @use "sass:selector";
@@ -239,6 +268,13 @@ describe "Sass variadic keyword arguments" do
     css.should contain("n: 1;")
   end
 
+  it "warns when namespaced meta.keywords is not given an argument list" do
+    log = with_captured_log do
+      compile(%(@use "sass:meta"; $x: 1; .a { x: meta.keywords($x); }))
+    end
+    log.should match(/not an argument list/)
+  end
+
   it "forwards keywords through a spread" do
     css = compile(<<-SCSS)
       @use "sass:meta";
@@ -247,6 +283,24 @@ describe "Sass variadic keyword arguments" do
       b { @include fwd(9, $z: 8); }
       SCSS
     css.should contain("x: (z: 8);")
+  end
+
+  it "errors on a misspelled keyword even when the mixin is variadic" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /no parameter named \$colour/) do
+      compile(<<-SCSS)
+        @mixin theme($color: red, $args...) { color: $color; }
+        a { @include theme($colour: blue); }
+        SCSS
+    end
+  end
+
+  it "accepts extra keywords when meta.keywords reads them" do
+    css = compile(<<-SCSS)
+      @use "sass:meta";
+      @mixin theme($color: red, $args...) { x: inspect(meta.keywords($args)); }
+      a { @include theme($colour: blue); }
+      SCSS
+    css.should contain("x: (colour: blue);")
   end
 
   it "preserves the spread list's separator in the rest arglist" do
@@ -299,6 +353,22 @@ describe "Sass output structure" do
   it "cross-multiplies comma-separated media queries outer-major, dropping type conflicts" do
     css = compile("@media (min-width: 10px), print { a { @media (max-width: 20px), screen { x: 1; } } }")
     css.should contain("@media (min-width: 10px) and (max-width: 20px), screen and (min-width: 10px), print and (max-width: 20px) {")
+  end
+
+  it "does not duplicate ancestor conditions in triple-nested @media" do
+    css = compile("@media (min-width: 1px) { @media (min-width: 2px) { @media (min-width: 3px) { a { x: 1 } } } }")
+    css.should contain("@media (min-width: 1px) and (min-width: 2px) and (min-width: 3px) {")
+    css.should_not contain("(min-width: 1px) and (min-width: 1px)")
+  end
+
+  it "keeps nested form for uppercase NOT media queries the same as lowercase" do
+    lower = compile("@media not print, screen { .a { @media (min-width: 10px) { x: 1; } } }")
+    upper = compile("@media Not print, screen { .a { @media (min-width: 10px) { x: 1; } } }")
+    lower.should contain("@media not print, screen")
+    lower.should contain("@media (min-width: 10px)")
+    upper.should contain("@media Not print, screen")
+    upper.should contain("@media (min-width: 10px)")
+    upper.should_not contain("@media screen and (min-width: 10px)")
   end
 
   it "resolves @at-root \#{&} without re-nesting" do

--- a/spec/unit/sass/color_spec.cr
+++ b/spec/unit/sass/color_spec.cr
@@ -301,14 +301,16 @@ describe "Sass colors" do
       css.should contain("b: yes;")
     end
 
-    # Documented deviation: `==` between two *literals* is still the
-    # generic text comparison, because colors are only parsed when a color
-    # function asks for one. Teaching `==` to parse would flip `@if`
-    # branches in stylesheets that compile today, which the plain-CSS
-    # guarantee rules out. See docs/content/features/sass.md.
-    it "compares two color literals as text" do
+    # `==` compares colors by channel across spellings (dart-sass
+    # semantics): `#ffffff`, `#FFF` and `white` are one value.
+    it "compares two color literals by channel" do
       css = compile(".a { b: if(#ffffff == #FFF, yes, no); }")
-      css.should contain("b: no;")
+      css.should contain("b: yes;")
+    end
+
+    it "compares a named color against a hex literal" do
+      css = compile(".a { b: if(red == #f00, yes, no); }")
+      css.should contain("b: yes;")
     end
 
     it "works through variables and user functions" do

--- a/spec/unit/sass/compile_spec.cr
+++ b/spec/unit/sass/compile_spec.cr
@@ -113,10 +113,19 @@ describe Hwaro::Assets::Sass do
       css.should contain(".link:focus::before")
     end
 
-    it "errors on nested properties" do
-      expect_raises(Hwaro::Assets::Sass::SyntaxError, /nested properties are not supported/) do
-        compile(".a { font: { family: serif; } }")
-      end
+    it "expands nested properties" do
+      css = compile(".a { font: 12px serif { family: serif; weight: bold; } margin: auto { top: 1px; } }")
+      css.should contain("font: 12px serif;")
+      css.should contain("font-family: serif;")
+      css.should contain("font-weight: bold;")
+      css.should contain("margin: auto;")
+      css.should contain("margin-top: 1px;")
+    end
+
+    it "expands recursively nested properties without a value" do
+      css = compile(".a { grid: { template: { columns: 1fr; } } }")
+      css.should contain("grid-template-columns: 1fr;")
+      css.should_not contain("grid:;")
     end
 
     # =========================================================================
@@ -201,9 +210,15 @@ describe Hwaro::Assets::Sass do
       css.should contain("@supports (display: grid) {\n  .a {\n    display: grid;")
     end
 
-    it "nests @media inside @media literally" do
+    it "merges @media nested inside @media" do
       css = compile("@media screen { @media (min-width: 5px) { .a { color: red; } } }")
-      css.should contain("@media screen {\n  @media (min-width: 5px) {")
+      css.should contain("@media screen and (min-width: 5px) {")
+      css.should_not contain("@media screen {\n  @media")
+    end
+
+    it "keeps unmergeable nested @media literal" do
+      css = compile("@media screen { @media not print { .a { color: red; } } }")
+      css.should contain("@media screen {\n  @media not print {")
     end
 
     it "does not join @keyframes frame selectors with outer rules" do
@@ -229,7 +244,9 @@ describe Hwaro::Assets::Sass do
         @font-face { font-family: "X"; src: url(x.woff2) format("woff2"); }
         .grid { background: url(data:image/png;base64,AAA/BBB==); }
         SCSS
-      css.should contain(%q(@charset "utf-8";))
+      # A source @charset is dropped for ASCII-only output (the serializer
+      # re-emits a single UTF-8 one only when the bytes need it).
+      css.should_not contain("@charset")
       css.should contain("--brand: #f00;")
       css.should contain("--gap: 4px   8px;")
       css.should contain(%q(src: url(x.woff2) format("woff2");))

--- a/spec/unit/sass/control_flow_spec.cr
+++ b/spec/unit/sass/control_flow_spec.cr
@@ -265,6 +265,11 @@ describe "Sass control flow" do
     css = compile("@media screen { .e { @at-root (with: rule) { .g { color: blue; } } } }")
     css.should contain(".e .g {\n  color: blue;")
   end
+
+  it "treats (with: all) as a no-op that keeps media and selector nesting" do
+    css = compile("@media screen { .e { @at-root (with: all) { .f { color: red; } } } }")
+    css.should contain("@media screen {\n  .e .f {\n    color: red;")
+  end
 end
 
 describe "Sass loop budget" do

--- a/spec/unit/sass/control_flow_spec.cr
+++ b/spec/unit/sass/control_flow_spec.cr
@@ -255,10 +255,15 @@ describe "Sass control flow" do
     css.should contain("@media print {\n  .q {\n    color: red;")
   end
 
-  it "rejects with/without queries" do
-    expect_raises(Hwaro::Assets::Sass::SyntaxError, /queries are not supported/) do
-      compile(".a { @at-root (without: media) { color: red; } }")
-    end
+  it "escapes @media but keeps selector nesting with (without: media)" do
+    css = compile("@media screen { .e { @at-root (without: media) { .f { color: red; } } } }")
+    css.should contain(".e .f {\n  color: red;")
+    css.should_not contain("@media screen {\n  .e .f")
+  end
+
+  it "escapes at-rules but keeps rules with (with: rule)" do
+    css = compile("@media screen { .e { @at-root (with: rule) { .g { color: blue; } } } }")
+    css.should contain(".e .g {\n  color: blue;")
   end
 end
 

--- a/spec/unit/sass/expressions_spec.cr
+++ b/spec/unit/sass/expressions_spec.cr
@@ -180,9 +180,10 @@ describe "Sass grouping parentheses" do
   # around a bare literal or a slash/space list computes nothing — so the
   # parens were emitted into the stylesheet as part of the declaration
   # value, which no browser accepts.
-  it "does not leak parentheses around a slash list" do
+  it "divides a parenthesized slash expression" do
+    # Parens force `/` division (classic Sass rule, dart-sass parity).
     css = Hwaro::Assets::Sass.compile("a { width: (10px / 2); }")
-    css.should contain("width: 10px / 2;")
+    css.should contain("width: 5px;")
     css.should_not contain("(10px")
   end
 

--- a/spec/unit/sass/functions_spec.cr
+++ b/spec/unit/sass/functions_spec.cr
@@ -123,11 +123,8 @@ describe "Sass functions" do
   end
 
   it "rejects unknown built-in modules" do
-    # `sass:selector` is a real dart-sass module this subset doesn't
-    # implement. (`sass:color` used to stand in here, before the color
-    # functions landed.)
     expect_raises(Hwaro::Assets::Sass::SyntaxError, /unknown built-in module/) do
-      compile(%q(@use "sass:selector";))
+      compile(%q(@use "sass:no-such-module";))
     end
   end
 

--- a/spec/unit/sass/mixins_spec.cr
+++ b/spec/unit/sass/mixins_spec.cr
@@ -198,8 +198,18 @@ describe "Hwaro::Assets::Sass mixins" do
     end
   end
 
-  it "rejects @include using clauses" do
-    expect_raises(Hwaro::Assets::Sass::SyntaxError, /using \(\.\.\.\) is not supported/) do
+  it "binds @content arguments to @include using parameters" do
+    css = compile("@mixin m { @content(4px); }\n.x { @include m using ($a) { width: $a; } }")
+    css.should contain("width: 4px;")
+  end
+
+  it "applies using parameter defaults when @content passes fewer arguments" do
+    css = compile("@mixin m { @content(1px); }\n.x { @include m using ($a, $b: 2px) { margin: $a $b; } }")
+    css.should contain("margin: 1px 2px;")
+  end
+
+  it "errors when @content omits a required using parameter" do
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /missing argument \$a/) do
       compile("@mixin m { @content; }\n.x { @include m using ($a) { width: $a; } }")
     end
   end

--- a/src/assets/sass/ast.cr
+++ b/src/assets/sass/ast.cr
@@ -277,7 +277,7 @@ module Hwaro
           def escapes_rules? : Bool
             case mode
             when :without then names.includes?("rule") || names.includes?("all")
-            else               !names.includes?("rule")
+            else               !(names.includes?("rule") || names.includes?("all"))
             end
           end
 
@@ -285,7 +285,7 @@ module Hwaro
           def escapes_at?(at_name : String) : Bool
             case mode
             when :without then names.includes?(at_name) || names.includes?("all")
-            else               !names.includes?(at_name)
+            else               !(names.includes?(at_name) || names.includes?("all"))
             end
           end
         end

--- a/src/assets/sass/ast.cr
+++ b/src/assets/sass/ast.cr
@@ -121,13 +121,38 @@ module Hwaro
           getter namespace : String?
           getter args : Array(Arg)
           getter body : Array(Node)?
+          # `@include m using ($a, $b: 1) { ... }` — parameters the mixin's
+          # `@content(...)` arguments bind to. Empty without `using`.
+          getter using_params : Array(Param)
 
-          def initialize(@name, @namespace, @args, @body, line, column)
+          def initialize(@name, @namespace, @args, @body, line, column,
+                         @using_params = [] of Param)
             super(line, column)
           end
         end
 
         class ContentNode < Node
+          # `@content(1, 2)` arguments, evaluated in the mixin body's scope
+          # and bound to the include's `using` parameters.
+          getter args : Array(Arg)
+
+          def initialize(line, column, @args = [] of Arg)
+            super(line, column)
+          end
+        end
+
+        # `font: 12px serif { family: sans; }` — a declaration with a
+        # nested property block. Inner declarations emit with the outer
+        # name as a `-` prefix (`font-family`).
+        class NestedPropsNode < Node
+          getter name : TextTemplate
+          getter value : TextTemplate?
+          getter important : Bool
+          getter children : Array(Node)
+
+          def initialize(@name, @value, @important, @children, line, column)
+            super(line, column)
+          end
         end
 
         # One `$name: value` entry of `@use ... with (...)`.
@@ -244,14 +269,37 @@ module Hwaro
           end
         end
 
+        # `(with: media supports)` / `(without: media)` — which contexts an
+        # `@at-root` body keeps. `names` are at-rule names plus the special
+        # "rule" (style rules) and "all".
+        record AtRootQuery, mode : Symbol, names : Array(String) do
+          # True when style-rule nesting is escaped.
+          def escapes_rules? : Bool
+            case mode
+            when :without then names.includes?("rule") || names.includes?("all")
+            else               !names.includes?("rule")
+            end
+          end
+
+          # True when the named at-rule context is escaped.
+          def escapes_at?(at_name : String) : Bool
+            case mode
+            when :without then names.includes?(at_name) || names.includes?("all")
+            else               !names.includes?(at_name)
+            end
+          end
+        end
+
         # `@at-root { ... }` / `@at-root .sel { ... }` — evaluates its
         # body outside the current style-rule nesting (but inside any
-        # surrounding at-rule).
+        # surrounding at-rule). A query (`(without: media)`) picks which
+        # contexts are escaped instead of the default `(without: rule)`.
         class AtRootNode < Node
           getter selector : TextTemplate?
           getter children : Array(Node)
+          getter query : AtRootQuery?
 
-          def initialize(@selector, @children, line, column)
+          def initialize(@selector, @children, line, column, @query = nil)
             super(line, column)
           end
         end

--- a/src/assets/sass/css.cr
+++ b/src/assets/sass/css.cr
@@ -56,10 +56,24 @@ module Hwaro
           extend self
 
           def serialize(nodes : Array(Node)) : String
-            out = String.build do |io|
+            # Source `@charset` declarations are dropped (a merged sheet
+            # can carry one per imported file); the single output charset
+            # is decided below from the bytes actually emitted.
+            nodes = nodes.reject { |n| charset?(n) }
+            text = String.build do |io|
               write_nodes(io, hoist_statements(nodes), 0)
             end
-            out.empty? ? out : out.chomp + "\n"
+            return text if text.empty?
+            text = text.chomp + "\n"
+            # Non-ASCII output needs an encoding declaration or browsers
+            # fall back to the response/platform charset and garble it
+            # (dart-sass emits this too).
+            text = "@charset \"UTF-8\";\n" + text unless text.ascii_only?
+            text
+          end
+
+          private def charset?(node : Node) : Bool
+            node.is_a?(Raw) && node.text.lstrip.starts_with?("@charset")
           end
 
           # Plain-CSS `@import` (and `@charset`) are only honoured before any

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -136,6 +136,10 @@ module Hwaro
           # @extend requests, applied document-wide as a post-pass —
           # deliberately NOT saved/restored around module loads.
           @extends = [] of Extend::Request
+          # Rest-parameter names whose `meta.keywords($args)` store was
+          # read (or forwarded via `$args...`) during the current mixin /
+          # function / @content body. Unused extra keywords error.
+          @keywords_accessed = Set(String).new
         end
 
         # Registers the entry file's canonical path so a self-import cycle
@@ -528,7 +532,11 @@ module Hwaro
           container = @sink
           if node.name == "media" && !@at_frames.empty? &&
              @at_frames.all? { |f| f.at.name == "media" }
-            if merged = merge_media_queries(@at_frames.map(&.at.prelude), prelude)
+            # Only fold the innermost enclosing prelude: intermediate
+            # frames already store their merged query, so folding every
+            # ancestor would duplicate the outer conditions
+            # (`(min-width: 1px) and (min-width: 1px) and …`).
+            if merged = merge_media_pair(@at_frames.last.at.prelude, prelude)
               prelude = merged
               container = @at_frames[0].container
             end
@@ -589,19 +597,6 @@ module Hwaro
           @env = saved_env
         end
 
-        # Merges enclosing @media preludes with a nested one into a single
-        # query list, or nil when the combination can't be expressed
-        # (`not` operands, conflicting media types). Comma lists cross-
-        # multiply, outer-major; type-conflicting pairs are dropped
-        # (dart-sass semantics).
-        private def merge_media_queries(outers : Array(String), inner : String) : String?
-          merged = inner
-          outers.reverse_each do |outer|
-            merged = merge_media_pair(outer, merged) || return
-          end
-          merged
-        end
-
         private def merge_media_pair(outer : String, inner : String) : String?
           outer_qs = Parser.split_top_level_commas(outer).map { |q| collapse_ws(q) }.reject(&.empty?)
           inner_qs = Parser.split_top_level_commas(inner).map { |q| collapse_ws(q) }.reject(&.empty?)
@@ -611,14 +606,20 @@ module Hwaro
             inner_qs.each do |iq|
               if q = merge_media_query(oq, iq)
                 combined << q
-              elsif oq.starts_with?("not ") || iq.starts_with?("not ")
+              elsif media_query_negated?(oq) || media_query_negated?(iq)
                 # `not` can't be distributed over `and`; keep nesting.
+                # Case-insensitive: CSS media types/keywords are ASCII
+                # case-insensitive (`Not print` is the same as `not print`).
                 return
               end
               # A plain type conflict (screen × print) drops the pair.
             end
           end
           combined.empty? ? nil : combined.join(", ")
+        end
+
+        private def media_query_negated?(query : String) : Bool
+          parse_media_query(query).try(&.[:negated]) || false
         end
 
         # One query each side: `[only|not] [type] [and (feature)...]`.
@@ -740,7 +741,7 @@ module Hwaro
 
           call_env = Environment.new(closure.env)
           positional, kwargs, rest_sep = collect_args(node.args, "mixin #{node.name}", node.line, node.column)
-          bind_params(closure.node.params, positional, kwargs, call_env,
+          extra = bind_params(closure.node.params, positional, kwargs, call_env,
             "mixin #{node.name}", node.line, node.column, rest_sep: rest_sep)
 
           content =
@@ -759,15 +760,20 @@ module Hwaro
           saved_env = @env
           saved_content = @content
           saved_path = @path
+          saved_kw = @keywords_accessed
           @env = call_env
           @content = content
           @path = closure.path
+          @keywords_accessed = Set(String).new
           begin
             eval_nodes(closure.node.body)
+            reject_unused_kwargs(extra, closure.node.params, "mixin #{node.name}",
+              node.line, node.column)
           ensure
             @env = saved_env
             @content = saved_content
             @path = saved_path
+            @keywords_accessed = saved_kw
             @include_depth -= 1
           end
         end
@@ -807,7 +813,10 @@ module Hwaro
               # semantics). The keywords live in the hidden side-channel
               # the variadic binding wrote.
               if (pieces = arg.value.pieces).size == 1 && (ref = pieces[0].as?(Ast::VarRef)) && ref.namespace.nil?
-                if stored = @env.lookup_var(KEYWORDS_VAR_PREFIX + Sass.normalize_ident(ref.name))
+                rest_name = Sass.normalize_ident(ref.name)
+                if stored = @env.lookup_var(KEYWORDS_VAR_PREFIX + rest_name)
+                  # Forwarding `$args...` counts as using the extra keywords.
+                  @keywords_accessed << rest_name
                   if map = Expr.coerce(stored).as?(MapV)
                     map.entries.each do |entry|
                       key = entry.key
@@ -875,7 +884,7 @@ module Hwaro
         private def bind_params(params : Array(Ast::Param), positional : Array(String),
                                 kwargs : Hash(String, String), call_env : Environment,
                                 what : String, line : Int32, column : Int32,
-                                soft : Bool = false, rest_sep : ListV::Sep? = nil) : Nil
+                                soft : Bool = false, rest_sep : ListV::Sep? = nil) : Hash(String, String)
           param_names = params.map { |p| Sass.normalize_ident(p.name) }
           variadic = params.last?.try(&.variadic) || false
           fixed = variadic ? params.size - 1 : params.size
@@ -935,6 +944,18 @@ module Hwaro
               end
             call_env.variables[param_name] = value
           end
+          extra_kwargs
+        end
+
+        private def reject_unused_kwargs(extra : Hash(String, String), params : Array(Ast::Param),
+                                         what : String, line : Int32, column : Int32,
+                                         soft : Bool = false) : Nil
+          return if extra.empty?
+          rest = params.last?
+          return unless rest && rest.variadic
+          rest_name = Sass.normalize_ident(rest.name)
+          return if @keywords_accessed.includes?(rest_name)
+          bind_error("no parameter named $#{extra.keys.first} in #{what}", soft, line, column)
         end
 
         private def bind_error(message : String, soft : Bool, line : Int32, column : Int32) : NoReturn
@@ -986,24 +1007,29 @@ module Hwaro
           # and bind to the include's `using (...)` parameters in the
           # content block's scope (dart-sass semantics).
           content_env = Environment.new(block.env)
+          extra = {} of String => String
           if !node.args.empty? || !block.params.empty?
             positional, kwargs, rest_sep = collect_args(node.args, "@content", node.line, node.column)
-            bind_params(block.params, positional, kwargs, content_env,
+            extra = bind_params(block.params, positional, kwargs, content_env,
               "the content block", node.line, node.column, rest_sep: rest_sep)
           end
 
           saved_env = @env
           saved_content = @content
           saved_path = @path
+          saved_kw = @keywords_accessed
           @env = content_env
           @content = block.outer
           @path = block.path
+          @keywords_accessed = Set(String).new
           begin
             eval_nodes(block.nodes)
+            reject_unused_kwargs(extra, block.params, "the content block", node.line, node.column)
           ensure
             @env = saved_env
             @content = saved_content
             @path = saved_path
+            @keywords_accessed = saved_kw
           end
         end
 
@@ -1256,6 +1282,19 @@ module Hwaro
             elsif parents.nil?
               error_at(node.line, node.column, "top-level selectors may not contain \"&\"")
             else
+              if amps <= MAX_PARENT_REF_SLOTS
+                projected = 1_i64
+                amps.times do
+                  projected *= parents.size
+                  break if projected > MAX_RULE_SELECTORS
+                end
+                if projected > MAX_RULE_SELECTORS
+                  error_at(node.line, node.column,
+                    "selector expands to more than #{MAX_RULE_SELECTORS} selectors " \
+                    "(#{parents.size} parent selectors, #{amps} \"&\" references); " \
+                    "reduce the nesting or the comma-separated parent list")
+                end
+              end
               combos =
                 if amps <= MAX_PARENT_REF_SLOTS
                   parent_combinations(parents, amps)
@@ -1451,24 +1490,29 @@ module Hwaro
             positional = args.map { |a| value_storage(a) }
             kw = {} of String => String
             kwargs.each { |k, v| kw[k] = value_storage(v) }
-            bind_params(closure.node.params, positional, kw, call_env,
+            extra = bind_params(closure.node.params, positional, kw, call_env,
               "function #{name}", closure.node.line, closure.node.column, soft: true)
 
             saved_env = @env
             saved_path = @path
             saved_in_function = @in_function
+            saved_kw = @keywords_accessed
             @env = call_env
             @path = closure.path
             @in_function = true
+            @keywords_accessed = Set(String).new
             begin
               eval_nodes(closure.node.body)
               raise SoftEvalError.new("function #{name} finished without @return")
             rescue ex : ReturnSignal
+              reject_unused_kwargs(extra, closure.node.params, "function #{name}",
+                closure.node.line, closure.node.column, soft: true)
               ex.value
             ensure
               @env = saved_env
               @path = saved_path
               @in_function = saved_in_function
+              @keywords_accessed = saved_kw
             end
           ensure
             @call_depth -= 1
@@ -1761,6 +1805,8 @@ module Hwaro
                 return value_storage(Expr::Evaluator.new(self, force_div: true).eval(node))
               rescue ex : NamespacedEvalError
                 warn_namespaced(template, ex)
+              rescue ex : DuplicateKeyError
+                error_at(template.line, template.column, ex.message || "Duplicate key")
               rescue SoftEvalError
                 # fall through to the verbatim path
               end
@@ -1782,6 +1828,8 @@ module Hwaro
                 return ResolvedValue.new(value.to_css, value.is_a?(NullV))
               rescue ex : NamespacedEvalError
                 warn_namespaced(template, ex)
+              rescue ex : DuplicateKeyError
+                error_at(template.line, template.column, ex.message || "Duplicate key")
               rescue SoftEvalError
                 # fall through to the verbatim path
               end
@@ -1965,6 +2013,7 @@ module Hwaro
           unless stored
             raise SoftEvalError.new("keywords(): $#{name} is not an argument list")
           end
+          @keywords_accessed << norm
           Expr.coerce(stored).as?(MapV) || MapV.new([] of MapEntry)
         end
 

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -68,20 +68,38 @@ module Hwaro
 
         # A `{ ... }` block passed to `@include`; evaluated at `@content`
         # with the caller's variable scope (dart-sass lexical semantics).
+        # `params` are the `using ($a, $b: 1)` parameters that
+        # `@content(...)` arguments bind to.
         # :nodoc:
         class ContentBlock
           getter nodes : Array(Ast::Node)
           getter env : Environment
           getter outer : ContentBlock?
           getter path : String
+          getter params : Array(Ast::Param)
 
-          def initialize(@nodes, @env, @outer, @path)
+          def initialize(@nodes, @env, @outer, @path, @params = [] of Ast::Param)
+          end
+        end
+
+        # An at-rule the evaluator is currently writing into, with the sink
+        # that CONTAINS it. Needed to reopen the at-rule when later content
+        # arrives after something else (a merged nested @media) was emitted
+        # beside it, and to find enclosing @media preludes for merging.
+        # :nodoc:
+        class AtFrame
+          property at : Css::AtRule
+          getter container : Array(Css::Node)
+
+          def initialize(@at, @container)
           end
         end
 
         @env : Environment
         @sink : Array(Css::Node)
         @current_rule : Css::Rule?
+        @current_rule_sink : Array(Css::Node)?
+        @at_frames : Array(AtFrame)
         @current_at : Css::AtRule?
         @parent_selectors : Array(String)?
         @content : ContentBlock?
@@ -101,6 +119,13 @@ module Hwaro
           @include_depth = 0
           @loop_iterations = 0_i64
           @path = path
+          # Sink the current rule was emitted into; when it is no longer
+          # the sink's last node (a nested rule was emitted after it),
+          # later declarations reopen a fresh rule with the same selectors
+          # to preserve cascade order (dart-sass behavior).
+          @current_rule_sink = nil
+          # Enclosing at-rule stack (innermost last) — see AtFrame.
+          @at_frames = [] of AtFrame
           @loaded_modules = {} of String => SassModule
           @load_stack = [] of String
           @in_function = false
@@ -156,10 +181,12 @@ module Hwaro
             eval_rule(node)
           when Ast::DeclarationNode
             eval_declaration(node)
+          when Ast::NestedPropsNode
+            eval_nested_props(node)
           when Ast::IncludeNode
             eval_include(node)
           when Ast::ContentNode
-            eval_content
+            eval_content(node)
           when Ast::IfNode
             eval_if(node)
           when Ast::EachNode
@@ -216,67 +243,117 @@ module Hwaro
 
           selectors = @in_keyframes ? parts : combine_selectors(parts, node)
           rule = Css::Rule.new(selectors)
-          @sink << rule
+          emit(rule)
 
           saved_rule = @current_rule
+          saved_rule_sink = @current_rule_sink
           saved_parents = @parent_selectors
           saved_env = @env
           @current_rule = rule
+          @current_rule_sink = @sink
           @parent_selectors = selectors
           @env = Environment.new(saved_env) # each block is a variable scope
           eval_nodes(node.children)
           @current_rule = saved_rule
+          @current_rule_sink = saved_rule_sink
           @parent_selectors = saved_parents
           @env = saved_env
         end
 
+        # Emits a node into the current sink, reopening the innermost
+        # enclosing at-rule first when something else (a bubbled/merged
+        # @media) was emitted beside it in the meantime — later content
+        # must not serialize above it, or cascade order flips
+        # (dart-sass reopens the block the same way).
+        private def emit(node : Css::Node) : Nil
+          if (frame = @at_frames.last?) && @sink.same?(frame.at.children) &&
+             !frame.container.last?.same?(frame.at)
+            stale = frame.at
+            fresh = Css::AtRule.new(stale.name, stale.prelude)
+            frame.container << fresh
+            frame.at = fresh
+            @sink = fresh.children
+            @current_at = fresh if @current_at.same?(stale)
+          end
+          @sink << node
+        end
+
         private def combine_selectors(parts : Array(String), node : Ast::RuleNode) : Array(String)
           parents = @parent_selectors
-          result = [] of String
-          parts.each do |part|
-            amps = count_parent_refs(part)
-            if parents.nil?
-              if amps > 0
+          if parents.nil?
+            parts.each do |part|
+              if count_parent_refs(part) > 0
                 error_at(node.line, node.column, "top-level selectors may not contain \"&\"")
               end
-              result << part
-            elsif amps > 0
-              # Cost-check BEFORE building the cross-product: materializing it
-              # first is exactly the allocation this guard exists to prevent.
-              # Past MAX_PARENT_REF_SLOTS there is no cross-product to size —
-              # `parent_combinations` already degrades to a single combo — and
-              # the running product is capped rather than raised to a power so
-              # the check itself can't overflow.
-              if amps <= MAX_PARENT_REF_SLOTS
-                projected = 1_i64
-                amps.times do
-                  projected *= parents.size
-                  break if projected > MAX_RULE_SELECTORS
-                end
-                if projected > MAX_RULE_SELECTORS
-                  error_at(node.line, node.column,
-                    "selector expands to more than #{MAX_RULE_SELECTORS} selectors " \
-                    "(#{parents.size} parent selectors, #{amps} \"&\" references); " \
-                    "reduce the nesting or the comma-separated parent list")
-                end
-              end
-              parent_combinations(parents, amps).each do |combo|
-                result << substitute_parent(part, combo)
-              end
-            else
-              parents.each { |parent| result << "#{parent} #{part}" }
             end
-            if result.size > MAX_RULE_SELECTORS
+            return parts
+          end
+
+          amps_by_part = parts.map { |part| count_parent_refs(part) }
+          amps_by_part.each do |amps|
+            next unless amps > 0
+            # Cost-check BEFORE building the cross-product: materializing it
+            # first is exactly the allocation this guard exists to prevent.
+            # Past MAX_PARENT_REF_SLOTS there is no cross-product to size —
+            # `parent_combinations` already degrades to a single combo — and
+            # the running product is capped rather than raised to a power so
+            # the check itself can't overflow.
+            next unless amps <= MAX_PARENT_REF_SLOTS
+            projected = 1_i64
+            amps.times do
+              projected *= parents.size
+              break if projected > MAX_RULE_SELECTORS
+            end
+            if projected > MAX_RULE_SELECTORS
               error_at(node.line, node.column,
-                "selector expands to more than #{MAX_RULE_SELECTORS} selectors; " \
+                "selector expands to more than #{MAX_RULE_SELECTORS} selectors " \
+                "(#{parents.size} parent selectors, #{amps} \"&\" references); " \
                 "reduce the nesting or the comma-separated parent list")
+            end
+          end
+
+          # Parent-major ordering (dart-sass): `a, b { c, d {} }` resolves
+          # to `a c, a d, b c, b d` — the parent varies slowest. For a
+          # multi-`&` part the FIRST `&` slot is the one aligned with the
+          # parent loop; the remaining slots run the full parent list.
+          result = [] of String
+          parents.each_with_index do |parent, parent_i|
+            parts.each_with_index do |part, pi|
+              amps = amps_by_part[pi]
+              if amps == 0
+                result << "#{parent} #{part}"
+              elsif amps > MAX_PARENT_REF_SLOTS
+                # Degraded single-combo expansion; emit once, on the first
+                # parent pass, mirroring parent_combinations' fallback.
+                result << substitute_parent(part, parents) if parent_i == 0
+              else
+                parent_combinations(parents, amps - 1).each do |combo|
+                  result << substitute_parent(part, [parent] + combo)
+                end
+              end
+              if result.size > MAX_RULE_SELECTORS
+                error_at(node.line, node.column,
+                  "selector expands to more than #{MAX_RULE_SELECTORS} selectors; " \
+                  "reduce the nesting or the comma-separated parent list")
+              end
             end
           end
           result
         end
 
         private def template_has_parent_ref?(template : Ast::TextTemplate) : Bool
-          template.pieces.any? { |piece| piece.is_a?(String) && piece.includes?('&') }
+          template.pieces.any? do |piece|
+            case piece
+            when String
+              piece.includes?('&')
+            when Ast::Interp
+              # `@at-root #{&}__suffix` — the `&` lives inside the
+              # interpolation body (the standard BEM idiom).
+              template_has_parent_ref?(piece.inner)
+            else
+              false
+            end
+          end
         end
 
         # Every assignment of `parents` to `slots` independent `&` slots,
@@ -390,7 +467,7 @@ module Hwaro
             return
           end
           decl = Css::Decl.new(name, value, node.important)
-          if rule = @current_rule
+          if rule = open_rule
             rule.items << decl
           elsif at = @current_at
             at.items << decl
@@ -399,13 +476,29 @@ module Hwaro
           end
         end
 
+        # The rule new declarations belong to. When nested rules were
+        # emitted after the current rule in the same sink, a declaration
+        # arriving now must NOT be hoisted back into it — that flips
+        # cascade order against source order. Reopen a fresh rule with the
+        # same selectors instead (dart-sass behavior).
+        private def open_rule : Css::Rule?
+          rule = @current_rule
+          return unless rule
+          sink = @current_rule_sink
+          return rule if sink.nil? || sink.last?.same?(rule)
+          fresh = Css::Rule.new(rule.selectors)
+          sink << fresh
+          @current_rule = fresh
+          fresh
+        end
+
         private def emit_comment(text : String) : Nil
-          if rule = @current_rule
+          if rule = open_rule
             rule.items << Css::Comment.new(text)
           elsif at = @current_at
             at.items << Css::Comment.new(text)
           else
-            @sink << Css::Comment.new(text)
+            emit(Css::Comment.new(text))
           end
         end
 
@@ -419,15 +512,38 @@ module Hwaro
           children = node.children
           unless children
             text = prelude.empty? ? "@#{node.name};" : "@#{node.name} #{prelude};"
-            @sink << Css::Raw.new(text)
+            emit(Css::Raw.new(text))
             return
           end
 
+          # `@media` nested inside `@media` merges into one query and
+          # bubbles beside the OUTERMOST enclosing media block, matching
+          # dart-sass output (`screen` + `(min-width: x)` →
+          # `screen and (min-width: x)` at the top level). Queries the
+          # string merge can't express (`not …`) keep the nested form —
+          # valid modern CSS — instead of being dropped.
+          # Only merge when every enclosing at-rule is a @media: with a
+          # @supports (or unknown at-rule) in between, bubbling past it
+          # would silently drop that condition — keep the nested form.
+          container = @sink
+          if node.name == "media" && !@at_frames.empty? &&
+             @at_frames.all? { |f| f.at.name == "media" }
+            if merged = merge_media_queries(@at_frames.map(&.at.prelude), prelude)
+              prelude = merged
+              container = @at_frames[0].container
+            end
+          end
+
           at = Css::AtRule.new(node.name, prelude)
-          @sink << at
+          if container.same?(@sink)
+            emit(at)
+          else
+            container << at
+          end
 
           saved_sink = @sink
           saved_rule = @current_rule
+          saved_rule_sink = @current_rule_sink
           saved_at = @current_at
           saved_parents = @parent_selectors
           saved_keyframes = @in_keyframes
@@ -438,6 +554,7 @@ module Hwaro
           @env = Environment.new(saved_env)
           if keyframes?(node.name)
             @current_rule = nil
+            @current_rule_sink = nil
             @parent_selectors = nil
             @in_keyframes = true
           elsif (rule = saved_rule) && conditional_group?(node.name)
@@ -450,18 +567,143 @@ module Hwaro
             synthetic = Css::Rule.new(rule.selectors)
             at.children << synthetic
             @current_rule = synthetic
+            @current_rule_sink = at.children
           else
             @current_rule = nil
+            @current_rule_sink = nil
           end
 
-          eval_nodes(children)
+          @at_frames << AtFrame.new(at, container)
+          begin
+            eval_nodes(children)
+          ensure
+            @at_frames.pop
+          end
 
           @sink = saved_sink
           @current_rule = saved_rule
+          @current_rule_sink = saved_rule_sink
           @current_at = saved_at
           @parent_selectors = saved_parents
           @in_keyframes = saved_keyframes
           @env = saved_env
+        end
+
+        # Merges enclosing @media preludes with a nested one into a single
+        # query list, or nil when the combination can't be expressed
+        # (`not` operands, conflicting media types). Comma lists cross-
+        # multiply, outer-major; type-conflicting pairs are dropped
+        # (dart-sass semantics).
+        private def merge_media_queries(outers : Array(String), inner : String) : String?
+          merged = inner
+          outers.reverse_each do |outer|
+            merged = merge_media_pair(outer, merged) || return
+          end
+          merged
+        end
+
+        private def merge_media_pair(outer : String, inner : String) : String?
+          outer_qs = Parser.split_top_level_commas(outer).map { |q| collapse_ws(q) }.reject(&.empty?)
+          inner_qs = Parser.split_top_level_commas(inner).map { |q| collapse_ws(q) }.reject(&.empty?)
+          return if outer_qs.empty? || inner_qs.empty?
+          combined = [] of String
+          outer_qs.each do |oq|
+            inner_qs.each do |iq|
+              if q = merge_media_query(oq, iq)
+                combined << q
+              elsif oq.starts_with?("not ") || iq.starts_with?("not ")
+                # `not` can't be distributed over `and`; keep nesting.
+                return
+              end
+              # A plain type conflict (screen × print) drops the pair.
+            end
+          end
+          combined.empty? ? nil : combined.join(", ")
+        end
+
+        # One query each side: `[only|not] [type] [and (feature)...]`.
+        private def merge_media_query(outer : String, inner : String) : String?
+          o = parse_media_query(outer)
+          i = parse_media_query(inner)
+          return unless o && i
+          return if o[:negated] || i[:negated]
+          type =
+            if (ot = o[:type]) && (it = i[:type])
+              return unless ot == it && o[:modifier] == i[:modifier]
+              o[:modifier] + ot
+            else
+              side = o[:type] ? o : i
+              (t = side[:type]) ? side[:modifier] + t : nil
+            end
+          parts = [] of String
+          parts << type if type
+          parts.concat(o[:features])
+          parts.concat(i[:features])
+          return if parts.empty?
+          parts.join(" and ")
+        end
+
+        # Splits a single media query into modifier/type/features; nil when
+        # it doesn't fit the simple shape (`not (...)`, level-4 syntax).
+        private def parse_media_query(query : String)
+          words = split_media_words(query)
+          return if words.empty?
+          modifier = ""
+          negated = false
+          idx = 0
+          case words[0].downcase
+          when "only"
+            modifier = "only "
+            idx = 1
+          when "not"
+            negated = true
+            idx = 1
+          end
+          type = nil
+          features = [] of String
+          expect_and = false
+          while idx < words.size
+            word = words[idx]
+            if word.starts_with?('(')
+              features << word
+            elsif word.downcase == "and"
+              idx += 1
+              next
+            elsif type.nil? && features.empty? && !expect_and
+              type = word
+            else
+              return
+            end
+            expect_and = true
+            idx += 1
+          end
+          return if negated && !features.empty? && type.nil?
+          {modifier: modifier, negated: negated, type: type, features: features}
+        end
+
+        # Media query words: feature parens are single words.
+        private def split_media_words(query : String) : Array(String)
+          words = [] of String
+          buf = String::Builder.new
+          depth = 0
+          query.each_char do |c|
+            if c == '('
+              depth += 1
+              buf << c
+            elsif c == ')'
+              depth -= 1
+              buf << c
+            elsif c.ascii_whitespace? && depth == 0
+              word = buf.to_s
+              words << word unless word.empty?
+              buf = String::Builder.new
+            else
+              buf << c
+            end
+          end
+          word = buf.to_s
+          words << word unless word.empty?
+          words
         end
 
         private def keyframes?(name : String) : Bool
@@ -497,9 +739,9 @@ module Hwaro
           end
 
           call_env = Environment.new(closure.env)
-          positional, kwargs = collect_args(node.args, "mixin #{node.name}", node.line, node.column)
+          positional, kwargs, rest_sep = collect_args(node.args, "mixin #{node.name}", node.line, node.column)
           bind_params(closure.node.params, positional, kwargs, call_env,
-            "mixin #{node.name}", node.line, node.column)
+            "mixin #{node.name}", node.line, node.column, rest_sep: rest_sep)
 
           content =
             if body = node.body
@@ -511,7 +753,7 @@ module Hwaro
                 error_at(node.line, node.column,
                   "mixin #{node.name} doesn't accept a content block (no @content in its body)")
               end
-              ContentBlock.new(body, @env, @content, @path)
+              ContentBlock.new(body, @env, @content, @path, node.using_params)
             end
 
           saved_env = @env
@@ -544,16 +786,37 @@ module Hwaro
 
         # Resolves call-site arguments (in the caller's scope) into
         # positional strings and keyword strings; `$value...` spreads
-        # lists into positionals and maps into keywords.
+        # lists into positionals and maps into keywords. The third result
+        # is the separator of a spread list, so a variadic parameter that
+        # absorbs it keeps the original separator (`$lst: 4 5 6` spread
+        # into `$rest...` must stay space-separated).
         private def collect_args(args : Array(Ast::Arg), what : String,
-                                 line : Int32, column : Int32) : {Array(String), Hash(String, String)}
+                                 line : Int32, column : Int32) : {Array(String), Hash(String, String), ListV::Sep?}
           positional = [] of String
           kwargs = {} of String => String
+          rest_sep = nil.as(ListV::Sep?)
 
           args.each do |arg|
             value = resolve_value(arg.value) # evaluated in the caller's scope
             if arg.spread
-              spread_into(value, positional, kwargs, line, column)
+              if sep = spread_into(value, positional, kwargs, line, column)
+                rest_sep = sep
+              end
+              # Spreading a variadic arglist onward forwards its keyword
+              # arguments too (`@include inner($args...)` — dart-sass
+              # semantics). The keywords live in the hidden side-channel
+              # the variadic binding wrote.
+              if (pieces = arg.value.pieces).size == 1 && (ref = pieces[0].as?(Ast::VarRef)) && ref.namespace.nil?
+                if stored = @env.lookup_var(KEYWORDS_VAR_PREFIX + Sass.normalize_ident(ref.name))
+                  if map = Expr.coerce(stored).as?(MapV)
+                    map.entries.each do |entry|
+                      key = entry.key
+                      next unless key.is_a?(Str)
+                      kwargs[Sass.normalize_ident(key.text)] ||= value_storage(entry.value)
+                    end
+                  end
+                end
+              end
             elsif name = arg.name
               name = Sass.normalize_ident(name)
               if kwargs.has_key?(name)
@@ -567,11 +830,12 @@ module Hwaro
               positional << value
             end
           end
-          {positional, kwargs}
+          {positional, kwargs, rest_sep}
         end
 
+        # Returns the spread list's separator (nil for maps/scalars).
         private def spread_into(value : String, positional : Array(String),
-                                kwargs : Hash(String, String), line : Int32, column : Int32) : Nil
+                                kwargs : Hash(String, String), line : Int32, column : Int32) : ListV::Sep?
           spread = Expr.coerce(value)
           case spread
           when MapV
@@ -582,16 +846,19 @@ module Hwaro
               end
               kwargs[Sass.normalize_ident(key.text)] = value_storage(entry.value)
             end
+            nil
           when ListV
             unless kwargs.empty?
               error_at(line, column, "positional arguments must precede keyword arguments")
             end
             spread.items.each { |item| positional << value_storage(item) }
+            spread.sep
           else
             unless kwargs.empty?
               error_at(line, column, "positional arguments must precede keyword arguments")
             end
             positional << value
+            nil
           end
         end
 
@@ -599,17 +866,30 @@ module Hwaro
         # `soft: true` raises SoftEvalError instead of located errors —
         # function calls happen inside expression evaluation, where
         # lenient contexts fall back and strict contexts add locations.
+        # Hidden variable prefix carrying a variadic parameter's keyword
+        # arguments (`meta.keywords($args)` / spread forwarding). `@` can
+        # never appear in a user identifier, so the side-channel is
+        # unreachable from stylesheet code.
+        KEYWORDS_VAR_PREFIX = "@kw:"
+
         private def bind_params(params : Array(Ast::Param), positional : Array(String),
                                 kwargs : Hash(String, String), call_env : Environment,
                                 what : String, line : Int32, column : Int32,
-                                soft : Bool = false) : Nil
+                                soft : Bool = false, rest_sep : ListV::Sep? = nil) : Nil
           param_names = params.map { |p| Sass.normalize_ident(p.name) }
           variadic = params.last?.try(&.variadic) || false
           fixed = variadic ? params.size - 1 : params.size
 
-          kwargs.each_key do |name|
+          # Keyword arguments no fixed parameter declares flow into the
+          # variadic arglist's keyword store (dart-sass semantics) — only
+          # a non-variadic signature rejects them.
+          extra_kwargs = {} of String => String
+          kwargs.each do |name, value|
             unless param_names.includes?(name)
-              bind_error("no parameter named $#{name} in #{what}", soft, line, column)
+              unless variadic
+                bind_error("no parameter named $#{name} in #{what}", soft, line, column)
+              end
+              extra_kwargs[name] = value
             end
           end
           if variadic && kwargs.has_key?(param_names.last)
@@ -623,7 +903,14 @@ module Hwaro
             param_name = param_names[i]
             if param.variadic
               rest = positional.size > fixed ? positional[fixed..] : [] of String
-              call_env.variables[param_name] = rest.empty? ? "()" : rest.join(", ")
+              joiner =
+                case rest_sep
+                in nil, ListV::Sep::Comma then ", "
+                in ListV::Sep::Space      then " "
+                in ListV::Sep::Slash      then " / "
+                end
+              call_env.variables[param_name] = rest.empty? ? "()" : rest.join(joiner)
+              call_env.variables[KEYWORDS_VAR_PREFIX + param_name] = keywords_storage(extra_kwargs)
               next
             end
             value =
@@ -655,6 +942,14 @@ module Hwaro
           error_at(line, column, message)
         end
 
+        # Serializes leftover keyword arguments as a map storage string.
+        # Values containing top-level commas wrap in structural parens so
+        # they survive the map's own comma separators on re-parse.
+        private def keywords_storage(kwargs : Hash(String, String)) : String
+          return "()" if kwargs.empty?
+          "(" + kwargs.map { |k, v| "#{k}: #{v.includes?(',') ? "(#{v})" : v}" }.join(", ") + ")"
+        end
+
         # True when the mixin body can reach `@content`: a lexically nested
         # `@content` anywhere except inside a nested `@mixin` definition
         # (whose `@content` belongs to that inner mixin — dart-sass scoping).
@@ -683,14 +978,24 @@ module Hwaro
           end
         end
 
-        private def eval_content : Nil
+        private def eval_content(node : Ast::ContentNode) : Nil
           block = @content
           return unless block # @include without a body: @content emits nothing
+
+          # `@content(args)` arguments evaluate in the MIXIN body's scope
+          # and bind to the include's `using (...)` parameters in the
+          # content block's scope (dart-sass semantics).
+          content_env = Environment.new(block.env)
+          if !node.args.empty? || !block.params.empty?
+            positional, kwargs, rest_sep = collect_args(node.args, "@content", node.line, node.column)
+            bind_params(block.params, positional, kwargs, content_env,
+              "the content block", node.line, node.column, rest_sep: rest_sep)
+          end
 
           saved_env = @env
           saved_content = @content
           saved_path = @path
-          @env = Environment.new(block.env)
+          @env = content_env
           @content = block.outer
           @path = block.path
           begin
@@ -700,6 +1005,50 @@ module Hwaro
             @content = saved_content
             @path = saved_path
           end
+        end
+
+        # Nested property block: `font: 12px serif { family: sans; }`
+        # emits `font: 12px serif` plus `font-family: sans`, prefixing
+        # recursively. Only declarations (and nested blocks/comments) may
+        # appear inside — anything else is an error, matching dart-sass.
+        private def eval_nested_props(node : Ast::NestedPropsNode) : Nil
+          if value = node.value
+            eval_declaration(Ast::DeclarationNode.new(
+              node.name, value, node.important, false, node.line, node.column))
+          end
+          node.children.each do |child|
+            case child
+            when Ast::DeclarationNode
+              eval_declaration(Ast::DeclarationNode.new(
+                prefix_property(node.name, child.name), child.value,
+                child.important, child.custom_property, child.line, child.column))
+            when Ast::NestedPropsNode
+              eval_nested_props(Ast::NestedPropsNode.new(
+                prefix_property(node.name, child.name), child.value,
+                child.important, child.children, child.line, child.column))
+            when Ast::CommentNode
+              emit_comment(comment_text(child))
+            when Ast::VarDeclNode, Ast::MessageNode
+              eval_node(child)
+            else
+              # Control flow / includes inside a nested property block
+              # would emit their declarations WITHOUT the prefix — a
+              # silent misrender. Refuse instead.
+              error_at(child.line, child.column,
+                "only declarations are allowed inside a nested property block")
+            end
+          end
+        end
+
+        # `font` + `family` → `font-family`, preserving interpolation in
+        # either template.
+        private def prefix_property(outer : Ast::TextTemplate, inner : Ast::TextTemplate) : Ast::TextTemplate
+          pieces = outer.pieces + [dash_piece] + inner.pieces
+          Ast::TextTemplate.new(pieces, inner.line, inner.column)
+        end
+
+        private def dash_piece : Ast::Piece
+          "-".as(Ast::Piece)
         end
 
         # ---------------------------------------------------------------
@@ -842,7 +1191,7 @@ module Hwaro
         end
 
         private def message_text(template : Ast::TextTemplate) : String
-          value = Expr::Evaluator.new(self, strict: true).eval(Expr.parse!(template))
+          value = Expr::Evaluator.new(self, strict: true, force_div: true).eval(Expr.parse!(template))
           value.is_a?(Str) ? value.text : Builtins.inspect_value(value)
         rescue SoftEvalError
           resolve_value(template)
@@ -850,8 +1199,14 @@ module Hwaro
 
         # `@at-root` re-evaluates its body outside style-rule nesting but
         # inside any surrounding at-rule (the flat sink makes that the
-        # natural behavior).
+        # natural behavior). A query picks which contexts are escaped:
+        # `(without: media)` keeps selector nesting but hoists out of
+        # `@media`, `(with: rule)` keeps rules and escapes all at-rules.
         private def eval_at_root(node : Ast::AtRootNode) : Nil
+          if query = node.query
+            eval_at_root_query(node, query)
+            return
+          end
           saved_rule = @current_rule
           saved_parents = @parent_selectors
           @current_rule = nil
@@ -860,11 +1215,12 @@ module Hwaro
             if selector = node.selector
               # `&` in an `@at-root` selector still refers to the enclosing
               # rule (`.parent { @at-root .child & { } }` → `.child
-              # .parent`). Expose the parents only when the selector
-              # actually uses `&` — otherwise `@at-root .child` would be
-              # nested under them, the opposite of what @at-root means.
+              # .parent`, `@at-root #{&}__suffix` → `.parent__suffix`) —
+              # expose the parents for resolution. But the result is a
+              # TOP-LEVEL rule: a selector without `&` left in it must not
+              # be re-nested under the parents.
               @parent_selectors = saved_parents if template_has_parent_ref?(selector)
-              eval_rule(Ast::RuleNode.new(selector, node.children, node.line, node.column))
+              eval_at_root_rule(selector, node, saved_parents)
             else
               # A plain block scope, not `scoped`: `@at-root` is not a
               # flow-control rule, so assignments inside it must not write
@@ -880,6 +1236,110 @@ module Hwaro
           ensure
             @current_rule = saved_rule
             @parent_selectors = saved_parents
+          end
+        end
+
+        # The `@at-root .sel { }` rule: literal `&` substitutes the parent
+        # selectors, but the resolved parts stand at the root as-is —
+        # unlike a nested rule, a part without `&` takes no parent prefix.
+        private def eval_at_root_rule(selector : Ast::TextTemplate, node : Ast::AtRootNode,
+                                      parents : Array(String)?) : Nil
+          text = resolve_template(selector, allow_vars: false)
+          parts = Parser.split_top_level_commas(text).map { |s| collapse_ws(s) }.reject(&.empty?)
+          error_at(node.line, node.column, "expected selector") if parts.empty?
+
+          selectors = [] of String
+          parts.each do |part|
+            amps = count_parent_refs(part)
+            if amps == 0
+              selectors << part
+            elsif parents.nil?
+              error_at(node.line, node.column, "top-level selectors may not contain \"&\"")
+            else
+              combos =
+                if amps <= MAX_PARENT_REF_SLOTS
+                  parent_combinations(parents, amps)
+                else
+                  [parents.dup]
+                end
+              combos.each { |combo| selectors << substitute_parent(part, combo) }
+            end
+            if selectors.size > MAX_RULE_SELECTORS
+              error_at(node.line, node.column,
+                "selector expands to more than #{MAX_RULE_SELECTORS} selectors; " \
+                "reduce the comma-separated parent list")
+            end
+          end
+
+          rule = Css::Rule.new(selectors)
+          emit(rule)
+          saved_rule = @current_rule
+          saved_rule_sink = @current_rule_sink
+          saved_parents = @parent_selectors
+          saved_env = @env
+          @current_rule = rule
+          @current_rule_sink = @sink
+          @parent_selectors = selectors
+          @env = Environment.new(saved_env)
+          begin
+            eval_nodes(node.children)
+          ensure
+            @current_rule = saved_rule
+            @current_rule_sink = saved_rule_sink
+            @parent_selectors = saved_parents
+            @env = saved_env
+          end
+        end
+
+        # `@at-root (with: ...)` / `(without: ...)`. Escaped at-rule
+        # contexts are left by re-targeting the sink at the container of
+        # the outermost escaped frame; kept style-rule nesting means the
+        # parent selectors stay visible so nested rules resolve normally.
+        private def eval_at_root_query(node : Ast::AtRootNode, query : Ast::AtRootQuery) : Nil
+          target_sink = @sink
+          kept_frames = @at_frames
+          if idx = @at_frames.index { |frame| query.escapes_at?(frame.at.name) }
+            target_sink = @at_frames[idx].container
+            kept_frames = @at_frames[0...idx]
+          end
+
+          saved_sink = @sink
+          saved_frames = @at_frames
+          saved_rule = @current_rule
+          saved_rule_sink = @current_rule_sink
+          saved_parents = @parent_selectors
+          saved_at = @current_at
+          saved_env = @env
+
+          @sink = target_sink
+          @at_frames = kept_frames
+          @current_at = kept_frames.last?.try(&.at)
+          @current_rule = nil
+          @current_rule_sink = nil
+          @parent_selectors = query.escapes_rules? ? nil : saved_parents
+          @env = Environment.new(saved_env)
+          begin
+            if query.escapes_rules? || saved_parents.nil?
+              eval_nodes(node.children)
+            else
+              # Rules kept: re-wrap the body in the enclosing selectors so
+              # declarations keep their rule (`e { @at-root (without:
+              # media) { f {} } }` → `e f` outside the media).
+              rule = Css::Rule.new(saved_parents)
+              emit(rule)
+              @current_rule = rule
+              @current_rule_sink = @sink
+              @parent_selectors = saved_parents
+              eval_nodes(node.children)
+            end
+          ensure
+            @sink = saved_sink
+            @at_frames = saved_frames
+            @current_rule = saved_rule
+            @current_rule_sink = saved_rule_sink
+            @parent_selectors = saved_parents
+            @current_at = saved_at
+            @env = saved_env
           end
         end
 
@@ -971,7 +1431,7 @@ module Hwaro
         # failure is a located error.
         private def eval_expr!(template : Ast::TextTemplate) : Value
           node = Expr.parse!(template)
-          Expr::Evaluator.new(self, strict: true).eval(node)
+          Expr::Evaluator.new(self, strict: true, force_div: true).eval(node)
         rescue ex : SoftEvalError
           error_at(template.line, template.column, ex.message || "invalid expression")
         end
@@ -1296,9 +1756,9 @@ module Hwaro
             return lookup_var_ref(ref)
           end
           if node = Expr.parse(template)
-            if Expr.computes?(node, self)
+            if Expr.computes?(node, self, force_div: true)
               begin
-                return value_storage(Expr::Evaluator.new(self).eval(node))
+                return value_storage(Expr::Evaluator.new(self, force_div: true).eval(node))
               rescue ex : NamespacedEvalError
                 warn_namespaced(template, ex)
               rescue SoftEvalError
@@ -1338,9 +1798,9 @@ module Hwaro
         # text exactly as today when nothing computes).
         private def resolve_interp(template : Ast::TextTemplate) : String
           if node = Expr.parse(template)
-            if Expr.computes?(node, self)
+            if Expr.computes?(node, self, force_div: true)
               begin
-                return Expr::Evaluator.new(self).eval(node).to_css
+                return Expr::Evaluator.new(self, force_div: true).eval(node).to_css
               rescue ex : NamespacedEvalError
                 warn_namespaced(template, ex)
               rescue SoftEvalError
@@ -1493,7 +1953,20 @@ module Hwaro
         # sass:meta functions that need evaluator state (scopes, mixins,
         # @content) and therefore can't live in the static builtin tables.
         META_HOST_FNS = %w[variable-exists global-variable-exists
-          function-exists mixin-exists content-exists get-function call]
+          function-exists mixin-exists content-exists get-function call keywords]
+
+        # :nodoc: — see Expr::Host#expr_keywords.
+        def expr_keywords(name : String, var_ns : String?, call_ns : String?) : Value?
+          return if var_ns # a module variable is never an arglist
+          norm = Sass.normalize_ident(name)
+          # Only when the call actually resolves to the meta built-in.
+          return unless host_meta_fn?(call_ns, "keywords")
+          stored = @env.lookup_var(KEYWORDS_VAR_PREFIX + norm)
+          unless stored
+            raise SoftEvalError.new("keywords(): $#{name} is not an argument list")
+          end
+          Expr.coerce(stored).as?(MapV) || MapV.new([] of MapEntry)
+        end
 
         # :nodoc:
         def expr_call(ns : String?, name : String, args : Array(Value),
@@ -1583,6 +2056,10 @@ module Hwaro
             return meta_get_function(args, kwargs)
           when "call"
             return meta_call(args, kwargs)
+          when "keywords"
+            # The VarE fast path in Expr's eval_call handles the real
+            # `keywords($args)` shape; anything else isn't an arglist.
+            raise SoftEvalError.new("keywords() expects an argument-list variable ($args)")
           end
           raise SoftEvalError.new("#{norm}() takes one argument, $name") unless args.size <= 1
           kwargs.each_key do |key|

--- a/src/assets/sass/expr.cr
+++ b/src/assets/sass/expr.cr
@@ -12,9 +12,13 @@
 #   @use ... with) parse with `Expr.parse!` and surface every failure as
 #   a located SyntaxError.
 #
-# `/` is never division (dart-sass 2.0 semantics): it builds a
-# slash-separated list, which is what keeps CSS shorthands like
-# `font: 12px/1.5` and `grid-area: 1 / 2` safe. Division is `math.div`.
+# `/` follows the classic Sass division rule (dart-sass 1.x semantics):
+# it divides when either operand is "computed" (a variable, a known
+# function call, parenthesized) or when the slash itself sits in a
+# computing context (an operand of other arithmetic, a Sass function
+# argument, a variable declaration, interpolation, control flow).
+# Otherwise the operands render joined by a literal `/`, which is what
+# keeps CSS shorthands like `font: 12px/1.5` and `grid-area: 1 / 2` safe.
 #
 # CSS-owned function spans (`url(...)`, `calc(...)`, `var(...)`, ...)
 # lex as verbatim raw tokens and are never evaluated.
@@ -112,7 +116,7 @@ module Hwaro
         end
 
         class Binary < Node
-          getter op : Symbol # :or, :and, :eq, :neq, :lt, :gt, :le, :ge, :plus, :minus, :times, :mod
+          getter op : Symbol # :or, :and, :eq, :neq, :lt, :gt, :le, :ge, :plus, :minus, :times, :div, :mod
           getter left : Node
           getter right : Node
 
@@ -694,9 +698,11 @@ module Hwaro
         # ---------------------------------------------------------------
 
         # Grammar, loosest first:
-        #   comma-list > slash-list > space-list > or > and >
-        #   equality > relational > additive > multiplicative >
+        #   comma-list > space-list > or > and >
+        #   equality > relational > additive > multiplicative (*, /, %) >
         #   unary (-, +, not) > concat/primary
+        # `/` parses at multiplicative precedence (dart-sass): whether it
+        # divides or renders as a literal slash is decided at eval time.
         # :nodoc:
         class Parser
           # Cap on expression nesting depth. This is a recursive-descent
@@ -759,24 +765,14 @@ module Hwaro
           end
 
           private def parse_comma : Node
-            first = parse_slash
+            first = parse_space
             return first unless match?(TokKind::Comma)
             items = [first]
             while accept(TokKind::Comma)
               break if eof? # trailing comma
-              items << parse_slash
-            end
-            ListE.new(items, ListV::Sep::Comma)
-          end
-
-          private def parse_slash : Node
-            first = parse_space
-            return first unless match?(TokKind::Slash)
-            items = [first]
-            while accept(TokKind::Slash)
               items << parse_space
             end
-            ListE.new(items, ListV::Sep::Slash)
+            ListE.new(items, ListV::Sep::Comma)
           end
 
           private def parse_space : Node
@@ -891,6 +887,8 @@ module Hwaro
             loop do
               if accept(TokKind::Star)
                 left = Binary.new(:times, left, parse_unary)
+              elsif accept(TokKind::Slash)
+                left = Binary.new(:div, left, parse_unary)
               elsif (tok = peek) && tok.kind.percent?
                 @pos += 1
                 left = Binary.new(:mod, left, parse_unary)
@@ -1019,9 +1017,9 @@ module Hwaro
               if (v = peek) && v.kind.var? && @toks[@pos + 1]?.try(&.kind.colon?)
                 kw = advance.text
                 advance # ':'
-                kwargs << KwargE.new(kw, parse_slash)
+                kwargs << KwargE.new(kw, parse_space)
               else
-                value = parse_slash
+                value = parse_space
                 if accept(TokKind::Ellipsis)
                   fail unless kwargs.empty?
                   spread = value
@@ -1041,16 +1039,16 @@ module Hwaro
             advance # '('
             return Lit.new(ListV.new(Array(Value).new, ListV::Sep::Space)) if accept(TokKind::RParen)
 
-            first = parse_slash
+            first = parse_space
             if accept(TokKind::Colon)
-              first_val = parse_slash
+              first_val = parse_space
               pairs = Array(MapPair).new
               pairs << MapPair.new(first, first_val)
               while accept(TokKind::Comma)
                 break if match?(TokKind::RParen) # trailing comma
-                key = parse_slash
+                key = parse_space
                 fail unless accept(TokKind::Colon)
-                pairs << MapPair.new(key, parse_slash)
+                pairs << MapPair.new(key, parse_space)
               end
               fail unless accept(TokKind::RParen)
               return MapE.new(pairs)
@@ -1060,7 +1058,7 @@ module Hwaro
               items = [first]
               while accept(TokKind::Comma)
                 break if match?(TokKind::RParen) # trailing comma
-                items << parse_slash
+                items << parse_space
               end
               fail unless accept(TokKind::RParen)
               return ListE.new(items, ListV::Sep::Comma)
@@ -1075,16 +1073,16 @@ module Hwaro
             items = [] of Node
             sep = ListV::Sep::Space
             unless match?(TokKind::RBracket)
-              first = parse_slash
+              first = parse_space
               if match?(TokKind::Comma)
                 items << first
                 sep = ListV::Sep::Comma
                 while accept(TokKind::Comma)
                   break if match?(TokKind::RBracket)
-                  items << parse_slash
+                  items << parse_space
                 end
               elsif first.is_a?(ListE) && !first.bracketed
-                # parse_slash already consumed the whole space/slash run as
+                # parse_space already consumed the whole space run as
                 # one inner list — its items ARE the bracketed list's items
                 # (`[1 2 3]` is a 3-element bracketed space list, not a
                 # 1-element list holding `(1 2 3)`).
@@ -1141,24 +1139,66 @@ module Hwaro
           end
         end
 
+        # True when this node, used as a `/` operand, forces the slash to
+        # divide (the classic Sass rule): a variable reference, a function
+        # call, or grouping parens. Unary wrappers force iff their operand
+        # does (`-1/2` stays literal, `-$a/2` divides — dart-sass parity).
+        def self.div_operand_forces?(node : Node) : Bool
+          case node
+          when VarE, CallE, ParenE
+            true
+          when Unary
+            div_operand_forces?(node.operand)
+          when Binary
+            # A nested arithmetic result is a computed value.
+            node.op != :div || div_operand_forces?(node.left) || div_operand_forces?(node.right)
+          else
+            false
+          end
+        end
+
+        # Division with the math.div unit rules plus convertible-group
+        # cancelling: same units (or convertible ones) cancel, a unitless
+        # divisor keeps the numerator's unit.
+        def self.divide_numbers(ln : Number, rn : Number) : {Float64, String}
+          if ln.unit == rn.unit
+            {ln.value / rn.value, ""}
+          elsif rn.unit.empty?
+            {ln.value / rn.value, ln.unit}
+          elsif ln.unit.empty?
+            raise SoftEvalError.new("can't divide unitless by #{rn.to_css}")
+          elsif factor = Number.conversion_factor(rn.unit, ln.unit)
+            {ln.value / (rn.value * factor), ""}
+          else
+            raise SoftEvalError.new("incompatible units: #{ln.to_css} and #{rn.to_css}")
+          end
+        end
+
         # True when evaluating the tree would do real work: any operator,
         # `not`, or a call that resolves to a known (user or built-in)
         # function. Bare literals/variables/lists resolve identically via
         # the legacy path, so they don't count — that is what keeps
         # existing output byte-identical.
-        def self.computes?(node : Node, host : Host) : Bool
+        #
+        # `force_div` marks a division-forcing context (variable values,
+        # interpolation): there a literal-operand `/` counts as work too.
+        def self.computes?(node : Node, host : Host, force_div : Bool = false) : Bool
           case node
           when Binary
-            true
+            return true unless node.op == :div
+            force_div || div_operand_forces?(node.left) || div_operand_forces?(node.right) ||
+              computes?(node.left, host, force_div) || computes?(node.right, host, force_div)
           when Unary
-            node.op == :not || computes?(node.operand, host)
+            # Even a plain `-$a` / `+$a` counts: the verbatim path renders
+            # `+5` for `+$a` where dart-sass emits the evaluated `5`.
+            true
           when CallE
             return true if host.expr_known_fn?(node.ns, node.name)
-            node.args.any? { |a| computes?(a, host) } ||
-              node.kwargs.any? { |kw| computes?(kw.value, host) } ||
-              node.spread.try { |s| computes?(s, host) } || false
+            node.args.any? { |a| computes?(a, host, force_div) } ||
+              node.kwargs.any? { |kw| computes?(kw.value, host, force_div) } ||
+              node.spread.try { |s| computes?(s, host, force_div) } || false
           when ListE
-            node.items.any? { |i| computes?(i, host) }
+            node.items.any? { |i| computes?(i, host, force_div) }
           when MapE
             # Map literals ALWAYS count as work, same rationale as ParenE:
             # `(a: b)` is Sass-only syntax with no CSS meaning. The verbatim
@@ -1198,6 +1238,13 @@ module Hwaro
           abstract def expr_interp(template : Ast::TextTemplate) : String
           # Enclosing rule's resolved selectors for `&` (nil at root).
           abstract def expr_parent_selectors : Array(String)?
+
+          # `meta.keywords($args)` — the keyword arguments captured by the
+          # variadic parameter `$name`, as a map; nil when the call does
+          # not resolve to the built-in (the normal call path then runs).
+          def expr_keywords(name : String, var_ns : String?, call_ns : String?) : Value?
+            nil
+          end
         end
 
         # Coerces stored text back into a typed value ("1px" -> Number,
@@ -1250,7 +1297,14 @@ module Hwaro
           # `Franklin and Marshall` font stack must fall back to verbatim
           # text, never evaluate to one operand. Strict contexts
           # (@if/@while conditions) keep full Sass truthiness.
-          def initialize(@host : Host, @strict : Bool = false)
+          #
+          # `force_div` starts the evaluation in a division-forcing context
+          # (variable declarations, interpolation, strict contexts): every
+          # `/` in the tree divides. When it starts false (declaration
+          # values), a `/` divides only when an operand is computed or the
+          # slash sits under other arithmetic / a Sass function call — the
+          # classic Sass division rule.
+          def initialize(@host : Host, @strict : Bool = false, @force_div : Bool = false)
           end
 
           def eval(node : Node) : Value
@@ -1268,7 +1322,7 @@ module Hwaro
                 NullV.new
               end
             when ConcatE then Raw.new(node.parts.map { |p| eval(p).to_css }.join)
-            when ParenE  then eval(node.inner)
+            when ParenE  then eval_forced(node.inner) # parens force `/` division (Sass rule)
             when ListE   then ListV.new(node.items.map { |i| eval(i).as(Value) }, node.sep, node.bracketed)
             when MapE    then eval_map(node)
             when Unary   then eval_unary(node)
@@ -1332,21 +1386,52 @@ module Hwaro
               boolish!(left)
               left.truthy? ? eval(node.right) : left
             when :eq
-              BoolV.new(loose_eq(eval(node.left), eval(node.right)))
+              BoolV.new(loose_eq(eval_forced(node.left), eval_forced(node.right)))
             when :neq
-              BoolV.new(!loose_eq(eval(node.left), eval(node.right)))
+              BoolV.new(!loose_eq(eval_forced(node.left), eval_forced(node.right)))
             when :lt, :gt, :le, :ge
-              compare(node.op, eval(node.left), eval(node.right))
+              compare(node.op, eval_forced(node.left), eval_forced(node.right))
             when :plus
-              add(eval(node.left), eval(node.right))
+              add(eval_forced(node.left), eval_forced(node.right))
             when :minus
-              arith(:minus, eval(node.left), eval(node.right))
+              arith(:minus, eval_forced(node.left), eval_forced(node.right))
             when :times
-              multiply(eval(node.left), eval(node.right))
+              multiply(eval_forced(node.left), eval_forced(node.right))
+            when :div
+              eval_div(node)
             when :mod
-              arith(:mod, eval(node.left), eval(node.right))
+              arith(:mod, eval_forced(node.left), eval_forced(node.right))
             else
               raise SoftEvalError.new("unsupported operator")
+            end
+          end
+
+          # Evaluates a subexpression in division-forcing position (an
+          # arithmetic/comparison operand or a Sass function argument).
+          private def eval_forced(node : Node) : Value
+            saved = @force_div
+            @force_div = true
+            begin
+              eval(node)
+            ensure
+              @force_div = saved
+            end
+          end
+
+          # The classic Sass `/` rule: divide when forced by context or by
+          # a computed operand; otherwise render the operands joined by a
+          # literal slash (`font: 12px/30px` territory).
+          private def eval_div(node : Binary) : Value
+            if @force_div || Expr.div_operand_forces?(node.left) || Expr.div_operand_forces?(node.right)
+              ln = number!(eval_forced(node.left), "division")
+              rn = number!(eval_forced(node.right), "division")
+              raise SoftEvalError.new("division by zero") if rn.value == 0
+              value, unit = Expr.divide_numbers(ln, rn)
+              Number.new(value, unit)
+            else
+              left = eval(node.left)
+              right = eval(node.right)
+              Raw.new("#{left.to_css}/#{right.to_css}")
             end
           end
 
@@ -1358,7 +1443,14 @@ module Hwaro
             return true if left.eq?(right)
             l = left.is_a?(Raw) ? Expr.coerce(left.text) : left
             r = right.is_a?(Raw) ? Expr.coerce(right.text) : right
-            l.eq?(r)
+            return true if l.eq?(r)
+            # Colors compare by channel across spellings: `red == #f00`.
+            # Neither side coerces to ColorV via Expr.coerce (colors are
+            # only produced on demand), so ask the color parser directly.
+            if (lc = ColorV.coerce?(l)) && (rc = ColorV.coerce?(r))
+              return lc.eq?(rc)
+            end
+            false
           end
 
           private def compare(op : Symbol, left : Value, right : Value) : Value
@@ -1367,12 +1459,13 @@ module Hwaro
             unless ln.compatible_unit?(rn)
               raise SoftEvalError.new("can't compare #{ln.to_css} with #{rn.to_css} (incompatible units)")
             end
+            rv = ln.unit.empty? ? rn.value : ln.coerce_value(rn)
             result =
               case op
-              when :lt then ln.value < rn.value
-              when :gt then ln.value > rn.value
-              when :le then ln.value <= rn.value
-              else          ln.value >= rn.value
+              when :lt then ln.value < rv
+              when :gt then ln.value > rv
+              when :le then ln.value <= rv
+              else          ln.value >= rv
               end
             BoolV.new(result)
           end
@@ -1382,13 +1475,13 @@ module Hwaro
               return arith_numbers(:plus, ln, rn)
             end
             # String concatenation; quotedness follows the left operand
-            # (dart-sass semantics).
+            # when it IS a string, otherwise the right one (dart-sass:
+            # `"a" + b` is quoted, `a + "b"` is not, `1 + "a"` is).
             if left.is_a?(Str) || right.is_a?(Str)
               lt = left.is_a?(Str) ? left.text : left.to_css
               rt = right.is_a?(Str) ? right.text : right.to_css
-              quoted = left.is_a?(Str) && left.quoted
-              quote = left.is_a?(Str) ? left.quote_char : '"'
-              return Str.new(lt + rt, quoted: quoted, quote_char: quote)
+              lead = left.is_a?(Str) ? left : right.as(Str)
+              return Str.new(lt + rt, quoted: lead.quoted, quote_char: lead.quote_char)
             end
             raise SoftEvalError.new("can't add #{left.to_css} and #{right.to_css}")
           end
@@ -1404,13 +1497,16 @@ module Hwaro
               raise SoftEvalError.new("incompatible units: #{ln.to_css} and #{rn.to_css}")
             end
             unit = ln.result_unit(rn)
+            # The left operand's unit wins; a convertible right operand is
+            # re-expressed in it (`1in + 72pt` is `2in`, dart-sass parity).
+            rv = ln.unit.empty? ? rn.value : ln.coerce_value(rn)
             value =
               case op
-              when :plus  then ln.value + rn.value
-              when :minus then ln.value - rn.value
+              when :plus  then ln.value + rv
+              when :minus then ln.value - rv
               when :mod
-                raise SoftEvalError.new("modulo by zero") if rn.value == 0
-                ln.value % rn.value
+                raise SoftEvalError.new("modulo by zero") if rv == 0
+                ln.value % rv
               else
                 raise SoftEvalError.new("unsupported arithmetic")
               end
@@ -1426,14 +1522,35 @@ module Hwaro
             Number.new(ln.value * rn.value, ln.unit.empty? ? rn.unit : ln.unit)
           end
 
+          # Built-ins that shadow real CSS functions. Their argument lists
+          # may be plain CSS (`rgb(255 0 0 / 0.5)`, `min(10px, 5%/2)`), so
+          # a `/` inside must stay literal — forcing division there would
+          # corrupt the reconstructed passthrough.
+          SHADOWED_CSS_FNS = %w[rgb rgba hsl hsla hwb min max clamp round abs
+            invert grayscale greyscale opacity saturate]
+
           private def eval_call(node : CallE) : Value
             if node.ns.nil? && node.spread.nil? && node.kwargs.empty? &&
                node.args.size == 3 && Sass.normalize_ident(node.name) == "if"
-              return eval(node.args[0]).truthy? ? eval(node.args[1]) : eval(node.args[2])
+              return eval_forced(node.args[0]).truthy? ? eval_forced(node.args[1]) : eval_forced(node.args[2])
             end
-            args = node.args.map { |a| eval(a) }
+            # `meta.keywords($args)` needs the VARIABLE, not its value —
+            # the keyword store is a side channel of the variadic binding
+            # that doesn't survive evaluation of `$args` into a list.
+            if Sass.normalize_ident(node.name) == "keywords" && node.kwargs.empty? &&
+               node.spread.nil? && node.args.size == 1 && (ref = node.args[0]).is_a?(VarE)
+              if result = @host.expr_keywords(ref.name, ref.ns, node.ns)
+                return result
+              end
+            end
+            # Arguments of a known Sass function are a SassScript context:
+            # `/` divides there (`percentage(1/4)` is `25%`). Unknown-
+            # function arguments are CSS and keep the literal slash.
+            force_args = @host.expr_known_fn?(node.ns, node.name) &&
+                         !(node.ns.nil? && SHADOWED_CSS_FNS.includes?(Sass.normalize_ident(node.name)))
+            args = node.args.map { |a| force_args ? eval_forced(a) : eval(a) }
             if spread = node.spread
-              spread_val = eval(spread)
+              spread_val = force_args ? eval_forced(spread) : eval(spread)
               case spread_val
               when ListV
                 args.concat(spread_val.items)
@@ -1445,7 +1562,7 @@ module Hwaro
             node.kwargs.each do |kw|
               key = Sass.normalize_ident(kw.name)
               raise SoftEvalError.new("duplicate argument $#{kw.name}") if kwargs.has_key?(key)
-              kwargs[key] = eval(kw.value)
+              kwargs[key] = force_args ? eval_forced(kw.value) : eval(kw.value)
             end
             if result = @host.expr_call(node.ns, node.name, args, kwargs)
               result

--- a/src/assets/sass/expr.cr
+++ b/src/assets/sass/expr.cr
@@ -1337,7 +1337,7 @@ module Hwaro
             entries = Array(MapEntry).new
             node.pairs.each do |pair|
               key = eval(pair.key)
-              if entries.any? { |entry| entry.key.eq?(key) }
+              if entries.any?(&.key.eq?(key))
                 raise DuplicateKeyError.new("Duplicate key")
               end
               entries << MapEntry.new(key, eval(pair.value))

--- a/src/assets/sass/expr.cr
+++ b/src/assets/sass/expr.cr
@@ -1335,7 +1335,13 @@ module Hwaro
 
           private def eval_map(node : MapE) : Value
             entries = Array(MapEntry).new
-            node.pairs.each { |pair| entries << MapEntry.new(eval(pair.key), eval(pair.value)) }
+            node.pairs.each do |pair|
+              key = eval(pair.key)
+              if entries.any? { |entry| entry.key.eq?(key) }
+                raise DuplicateKeyError.new("Duplicate key")
+              end
+              entries << MapEntry.new(key, eval(pair.value))
+            end
             MapV.new(entries)
           end
 
@@ -1419,8 +1425,10 @@ module Hwaro
           end
 
           # The classic Sass `/` rule: divide when forced by context or by
-          # a computed operand; otherwise render the operands joined by a
-          # literal slash (`font: 12px/30px` territory).
+          # a computed operand; otherwise the slash is a list separator
+          # (`list.slash` round-trips through variable storage as
+          # `4 / 5 / 6`). Literal CSS slashes (`font: 12px/30px`) never
+          # reach here — `computes?` is false, so they stay verbatim.
           private def eval_div(node : Binary) : Value
             if @force_div || Expr.div_operand_forces?(node.left) || Expr.div_operand_forces?(node.right)
               ln = number!(eval_forced(node.left), "division")
@@ -1429,9 +1437,24 @@ module Hwaro
               value, unit = Expr.divide_numbers(ln, rn)
               Number.new(value, unit)
             else
-              left = eval(node.left)
-              right = eval(node.right)
-              Raw.new("#{left.to_css}/#{right.to_css}")
+              slash_list(eval(node.left), eval(node.right))
+            end
+          end
+
+          # Flattens adjacent unbracketed slash lists so `1 / 2 / 3`
+          # round-trips as one 3-element slash list, not a nested pair.
+          private def slash_list(left : Value, right : Value) : ListV
+            items = [] of Value
+            append_slash_items(items, left)
+            append_slash_items(items, right)
+            ListV.new(items, ListV::Sep::Slash)
+          end
+
+          private def append_slash_items(items : Array(Value), value : Value) : Nil
+            if value.is_a?(ListV) && value.sep == ListV::Sep::Slash && !value.bracketed
+              items.concat(value.items)
+            else
+              items << value
             end
           end
 
@@ -1539,8 +1562,17 @@ module Hwaro
             # that doesn't survive evaluation of `$args` into a list.
             if Sass.normalize_ident(node.name) == "keywords" && node.kwargs.empty? &&
                node.spread.nil? && node.args.size == 1 && (ref = node.args[0]).is_a?(VarE)
-              if result = @host.expr_keywords(ref.name, ref.ns, node.ns)
-                return result
+              begin
+                if result = @host.expr_keywords(ref.name, ref.ns, node.ns)
+                  return result
+                end
+              rescue ex : NamespacedEvalError
+                raise ex
+              rescue ex : SoftEvalError
+                # Same policy as expr_call: a namespaced `meta.keywords`
+                # failure must not fall back to verbatim CSS.
+                raise NamespacedEvalError.new(ex.message || "keywords() failed") if node.ns
+                raise ex
               end
             end
             # Arguments of a known Sass function are a SassScript context:

--- a/src/assets/sass/functions.cr
+++ b/src/assets/sass/functions.cr
@@ -27,6 +27,8 @@
 require "./value"
 require "./color"
 require "./expr"
+require "./extend"
+require "./parser"
 
 module Hwaro
   module Assets
@@ -1219,43 +1221,12 @@ module Hwaro
         # sass:selector
         #
         # String-level implementations of the selector functions: selectors
-        # are handled as comma lists of complex selectors (whitespace-
-        # separated compound words). Sound for the class/id/element/pseudo
-        # selectors frameworks feed these; the full unification semantics
-        # (combinator weaving, pseudo-element rules) are out of scope.
+        # are comma lists of complex selectors, tokenized with the same
+        # quote/bracket/paren-aware parser @extend uses. Sound for the
+        # class/id/element/pseudo/attribute selectors frameworks feed
+        # these; the full unification semantics (combinator weaving,
+        # pseudo-element rules) are out of scope.
         # ---------------------------------------------------------------
-
-        # Splits selector text on top-level commas (commas inside `(...)`
-        # and `[...]` — `:is(a, b)`, `[title="a,b"]` — don't split).
-        private def self.split_selector_commas(text : String) : Array(String)
-          parts = [] of String
-          buf = String::Builder.new
-          depth = 0
-          in_quote = '\0'
-          text.each_char do |c|
-            if in_quote != '\0'
-              buf << c
-              in_quote = '\0' if c == in_quote
-              next
-            end
-            case c
-            when '"', '\'' then in_quote = c; buf << c
-            when '(', '['  then depth += 1; buf << c
-            when ')', ']'  then depth -= 1; buf << c
-            when ','
-              if depth == 0
-                parts << buf.to_s
-                buf = String::Builder.new
-              else
-                buf << c
-              end
-            else
-              buf << c
-            end
-          end
-          parts << buf.to_s
-          parts.map(&.strip).reject(&.empty?)
-        end
 
         # A selector argument as text: strings/raw verbatim, lists joined
         # by their separator (`&` arrives as a comma list of strings).
@@ -1270,10 +1241,21 @@ module Hwaro
           end
         end
 
-        # Comma list of complex selectors, each an array of whitespace-
-        # separated words (compounds and combinators).
+        # Comma list of complex selectors, each an array of compounds and
+        # combinators. Attribute selectors and `:is()`/`:not()` parens keep
+        # their internal whitespace — naive String#split would fragment
+        # `[title="a b"]` into two tokens.
         private def self.selector_complexes(name : String, value : Value) : Array(Array(String))
-          split_selector_commas(selector_text(name, value)).map(&.split)
+          Parser.split_top_level_commas(selector_text(name, value)).map(&.strip).reject(&.empty?).map do |complex|
+            items = Extend.parse_items(complex)
+            raise SoftEvalError.new("#{name}: invalid selector #{complex.inspect}") unless items
+            items.map do |item|
+              case item
+              in Extend::Combinator then item.text
+              in Extend::Compound   then item.simples.join
+              end
+            end
+          end
         end
 
         # Splits one compound selector into its leading element (or "") and

--- a/src/assets/sass/functions.cr
+++ b/src/assets/sass/functions.cr
@@ -244,17 +244,45 @@ module Hwaro
           bound
         end
 
+        # Checks every argument is unit-compatible (identical, unitless, or
+        # convertible) and returns the first non-empty unit — the basis the
+        # min/max/clamp comparisons convert into.
         private def self.same_units!(name : String, numbers : Array(Number)) : String
           unit = ""
           numbers.each do |n|
             next if n.unit.empty?
             if unit.empty?
               unit = n.unit
-            elsif unit != n.unit
+            elsif unit != n.unit && Number.conversion_factor(n.unit, unit).nil?
               raise SoftEvalError.new("#{name}(): incompatible units #{unit} and #{n.unit}")
             end
           end
           unit
+        end
+
+        # A number's value expressed in `unit` for comparison purposes
+        # (unitless operands compare as-is — dart-sass semantics).
+        private def self.comparable_value(n : Number, unit : String) : Float64
+          return n.value if unit.empty? || n.unit.empty? || n.unit == unit
+          n.value * (Number.conversion_factor(n.unit, unit) || 1.0)
+        end
+
+        # An angle argument in degrees: bare numbers are radians for the
+        # trig functions? No — dart-sass treats a unitless angle as
+        # RADIANS for sin/cos/tan. Convertible angle units convert.
+        private def self.radians!(name : String, n : Number) : Float64
+          return n.value if n.unit.empty?
+          factor = Number.conversion_factor(n.unit, "rad")
+          raise SoftEvalError.new("#{name}() expects an angle, got #{n.to_css}") unless factor
+          n.value * factor
+        end
+
+        private def self.unitless!(name : String, value : Value) : Float64
+          n = number!(name, value)
+          unless n.unit.empty?
+            raise SoftEvalError.new("#{name}() expects a unitless number, got #{n.to_css}")
+          end
+          n.value
         end
 
         # ---------------------------------------------------------------
@@ -268,17 +296,8 @@ module Hwaro
             a = number!("math.div", args[0])
             b = number!("math.div", args[1])
             raise SoftEvalError.new("math.div(): division by zero") if b.value == 0
-            unit =
-              if a.unit == b.unit
-                "" # units cancel
-              elsif b.unit.empty?
-                a.unit
-              elsif a.unit.empty?
-                raise SoftEvalError.new("math.div(): can't divide unitless by #{b.unit}")
-              else
-                raise SoftEvalError.new("math.div(): incompatible units #{a.unit} and #{b.unit}")
-              end
-            Number.new(a.value / b.value, unit)
+            value, unit = Expr.divide_numbers(a, b)
+            Number.new(value, unit)
           end,
           "percentage" => Fn.new do |args, kwargs|
             no_kwargs!("math.percentage", kwargs)
@@ -319,31 +338,113 @@ module Hwaro
             no_kwargs!("math.min", kwargs)
             arity!("min", args, 1, Int32::MAX)
             numbers = args.map { |a| number!("min", a) }
-            same_units!("min", numbers) # unit-compatibility check only
+            base = same_units!("min", numbers)
             # Return the winning operand as-is. Stamping the first non-empty
             # unit seen across all args onto the winner fabricates a unit
             # the result never had: `min(1, 2px)` is `1`, not `1px`.
-            winner = numbers.min_by(&.value)
+            # Convertible units compare in a common basis (`min(1in, 50px)`
+            # is `50px`).
+            winner = numbers.min_by { |n| comparable_value(n, base) }
             Number.new(winner.value, winner.unit)
           end,
           "max" => Fn.new do |args, kwargs|
             no_kwargs!("math.max", kwargs)
             arity!("max", args, 1, Int32::MAX)
             numbers = args.map { |a| number!("max", a) }
-            same_units!("max", numbers) # unit-compatibility check only
-            winner = numbers.max_by(&.value)
+            base = same_units!("max", numbers)
+            winner = numbers.max_by { |n| comparable_value(n, base) }
             Number.new(winner.value, winner.unit)
           end,
           "clamp" => Fn.new do |args, kwargs|
             no_kwargs!("math.clamp", kwargs)
             arity!("math.clamp", args, 3)
             numbers = args.map { |a| number!("math.clamp", a) }
-            same_units!("math.clamp", numbers) # unit-compatibility check only
+            base = same_units!("math.clamp", numbers)
             # As with min/max, the result is whichever operand wins, unit
             # included — not the value re-stamped with a scanned unit.
             low, mid, high = numbers[0], numbers[1], numbers[2]
-            winner = mid.value < low.value ? low : (mid.value > high.value ? high : mid)
+            lv = comparable_value(low, base)
+            mv = comparable_value(mid, base)
+            hv = comparable_value(high, base)
+            winner = mv < lv ? low : (mv > hv ? high : mid)
             Number.new(winner.value, winner.unit)
+          end,
+          "log" => Fn.new do |args, kwargs|
+            no_kwargs!("math.log", kwargs)
+            arity!("math.log", args, 1, 2)
+            value = unitless!("math.log", args[0])
+            raise SoftEvalError.new("math.log() of a non-positive number") if value <= 0
+            result = Math.log(value)
+            if base_arg = args[1]?
+              base = unitless!("math.log", base_arg)
+              raise SoftEvalError.new("math.log(): invalid base #{Number.format(base)}") if base <= 0 || base == 1
+              result /= Math.log(base)
+            end
+            Number.new(result, "")
+          end,
+          "hypot" => Fn.new do |args, kwargs|
+            no_kwargs!("math.hypot", kwargs)
+            arity!("math.hypot", args, 1, Int32::MAX)
+            numbers = args.map { |a| number!("math.hypot", a) }
+            unit = numbers[0].unit
+            sum = numbers.reduce(0.0) do |acc, n|
+              v =
+                if unit.empty? || n.unit.empty? || n.unit == unit
+                  raise SoftEvalError.new("math.hypot(): mixed unit and unitless arguments") if unit.empty? != n.unit.empty?
+                  n.value
+                else
+                  factor = Number.conversion_factor(n.unit, unit)
+                  raise SoftEvalError.new("math.hypot(): incompatible units #{unit} and #{n.unit}") unless factor
+                  n.value * factor
+                end
+              acc + v * v
+            end
+            Number.new(Math.sqrt(sum), unit)
+          end,
+          "sin" => Fn.new do |args, kwargs|
+            no_kwargs!("math.sin", kwargs)
+            arity!("math.sin", args, 1)
+            Number.new(Math.sin(radians!("math.sin", number!("math.sin", args[0]))), "")
+          end,
+          "cos" => Fn.new do |args, kwargs|
+            no_kwargs!("math.cos", kwargs)
+            arity!("math.cos", args, 1)
+            Number.new(Math.cos(radians!("math.cos", number!("math.cos", args[0]))), "")
+          end,
+          "tan" => Fn.new do |args, kwargs|
+            no_kwargs!("math.tan", kwargs)
+            arity!("math.tan", args, 1)
+            Number.new(Math.tan(radians!("math.tan", number!("math.tan", args[0]))), "")
+          end,
+          "asin" => Fn.new do |args, kwargs|
+            no_kwargs!("math.asin", kwargs)
+            arity!("math.asin", args, 1)
+            v = unitless!("math.asin", args[0])
+            raise SoftEvalError.new("math.asin() argument must be within -1 and 1") if v < -1 || v > 1
+            Number.new(Math.asin(v) * 180.0 / Math::PI, "deg")
+          end,
+          "acos" => Fn.new do |args, kwargs|
+            no_kwargs!("math.acos", kwargs)
+            arity!("math.acos", args, 1)
+            v = unitless!("math.acos", args[0])
+            raise SoftEvalError.new("math.acos() argument must be within -1 and 1") if v < -1 || v > 1
+            Number.new(Math.acos(v) * 180.0 / Math::PI, "deg")
+          end,
+          "atan" => Fn.new do |args, kwargs|
+            no_kwargs!("math.atan", kwargs)
+            arity!("math.atan", args, 1)
+            Number.new(Math.atan(unitless!("math.atan", args[0])) * 180.0 / Math::PI, "deg")
+          end,
+          "atan2" => Fn.new do |args, kwargs|
+            no_kwargs!("math.atan2", kwargs)
+            arity!("math.atan2", args, 2)
+            y = number!("math.atan2", args[0])
+            x = number!("math.atan2", args[1])
+            unless y.compatible_unit?(x)
+              raise SoftEvalError.new("math.atan2(): incompatible units #{y.unit} and #{x.unit}")
+            end
+            xv = y.unit.empty? ? x.value : y.coerce_value(x)
+            Number.new(Math.atan2(y.value, xv) * 180.0 / Math::PI, "deg")
           end,
           "pow" => Fn.new do |args, kwargs|
             no_kwargs!("math.pow", kwargs)
@@ -431,6 +532,40 @@ module Hwaro
             to = end_at < 0 ? size + end_at : Math.min(end_at - 1, size - 1)
             sliced = from > to ? "" : text[from..to]
             Str.new(sliced, quoted: quoted)
+          end,
+          "insert" => Fn.new do |args, kwargs|
+            no_kwargs!("string.insert", kwargs)
+            arity!("str-insert", args, 3)
+            base = string!("str-insert", args[0])
+            insert = string!("str-insert", args[1]).text
+            index = number!("str-insert", args[2]).int_value("str-insert() index")
+            size = base.text.size
+            # 1-based; negative counts from the end where -1 inserts AT the
+            # end (dart-sass: `insert("abc", "X", -1)` is `"abcX"`).
+            index = size + index + 2 if index < 0
+            offset = (index - 1).clamp(0, size)
+            Str.new(base.text[0, offset] + insert + base.text[offset..],
+              quoted: base.quoted, quote_char: base.quote_char)
+          end,
+          "split" => Fn.new do |args, kwargs|
+            no_kwargs!("string.split", kwargs)
+            arity!("string.split", args, 2, 3)
+            text = string!("string.split", args[0]).text
+            sep = string!("string.split", args[1]).text
+            limit =
+              if (arg = args[2]?) && !arg.is_a?(NullV)
+                number!("string.split", arg).int_value("string.split() limit")
+              end
+            parts =
+              if sep.empty?
+                text.chars.map(&.to_s)
+              elsif limit
+                text.split(sep, limit + 1)
+              else
+                text.split(sep)
+              end
+            ListV.new(parts.map { |p| Str.new(p, quoted: true).as(Value) },
+              ListV::Sep::Comma, bracketed: true)
           end,
           "to-upper-case" => Fn.new do |args, kwargs|
             no_kwargs!("string.to-upper-case", kwargs)
@@ -526,6 +661,33 @@ module Hwaro
               ListV.new(lists.map { |l| l[i] }, ListV::Sep::Space).as(Value)
             end
             ListV.new(items, ListV::Sep::Comma)
+          end,
+          "set-nth" => Fn.new do |args, kwargs|
+            no_kwargs!("list.set-nth", kwargs)
+            arity!("set-nth", args, 3)
+            base = args[0]
+            items = list_of(base).dup
+            n = number!("set-nth", args[1]).int_value("set-nth() index")
+            raise SoftEvalError.new("set-nth() index may not be 0") if n == 0
+            idx = n > 0 ? n - 1 : items.size + n
+            unless 0 <= idx < items.size
+              raise SoftEvalError.new("set-nth() index #{n} is out of bounds for a #{items.size}-element list")
+            end
+            items[idx] = args[2]
+            sep = base.is_a?(ListV) ? base.sep : ListV::Sep::Space
+            bracketed = base.is_a?(ListV) && base.bracketed
+            ListV.new(items, sep, bracketed)
+          end,
+          "slash" => Fn.new do |args, kwargs|
+            no_kwargs!("list.slash", kwargs)
+            arity!("list.slash", args, 2, Int32::MAX)
+            ListV.new(args.dup, ListV::Sep::Slash)
+          end,
+          "is-bracketed" => Fn.new do |args, kwargs|
+            no_kwargs!("list.is-bracketed", kwargs)
+            arity!("is-bracketed", args, 1)
+            value = args[0]
+            BoolV.new(value.is_a?(ListV) && value.bracketed)
           end,
           "separator" => Fn.new do |args, kwargs|
             no_kwargs!("list.separator", kwargs)
@@ -961,6 +1123,81 @@ module Hwaro
           end,
         }
 
+        # `color.channel($color, $channel, $space: ...)` — the modern
+        # accessor for single components. `$space` is accepted (rgb/hsl/
+        # hwb spellings) but the channel name alone determines the answer;
+        # colors here are always RGBA underneath.
+        COLOR_FNS["channel"] = Fn.new do |args, kwargs|
+          bound = bind!("color.channel", args, kwargs, ["color", "channel", "space"], required: 2)
+          color = color!("color.channel", bound[0].as(Value))
+          channel_arg = bound[1].as(Value)
+          channel =
+            case channel_arg
+            when Str then channel_arg.text
+            else          channel_arg.to_css
+            end
+          case ascii_downcase(channel)
+          when "red"        then Number.new(color.red8.to_f)
+          when "green"      then Number.new(color.green8.to_f)
+          when "blue"       then Number.new(color.blue8.to_f)
+          when "alpha"      then Number.new(color.alpha)
+          when "hue"        then Number.new(color.hue, "deg")
+          when "saturation" then Number.new(color.saturation, "%")
+          when "lightness"  then Number.new(color.lightness, "%")
+          when "whiteness"
+            Number.new({color.red, color.green, color.blue}.min / 255.0 * 100.0, "%")
+          when "blackness"
+            Number.new((1.0 - {color.red, color.green, color.blue}.max / 255.0) * 100.0, "%")
+          else
+            raise SoftEvalError.new("color.channel(): unknown channel #{channel.inspect}")
+          end
+        end
+
+        # `color.hwb($hue $whiteness $blackness)` — the space-separated
+        # channels form. A slash-alpha (`… / 0.5`) is not modeled; use
+        # `color.change($c, $alpha: …)` instead.
+        COLOR_FNS["hwb"] = Fn.new do |args, kwargs|
+          known_kwargs!("color.hwb", kwargs, ["channels"])
+          arity!("color.hwb", args, 0, 1)
+          channels = args[0]? || kwargs["channels"]? ||
+                     raise SoftEvalError.new("color.hwb() is missing required argument $channels")
+          items =
+            case channels
+            when ListV then channels.items
+            else            raise SoftEvalError.new("color.hwb() expects a space-separated $hue $whiteness $blackness list")
+            end
+          arity!("color.hwb() channels", items, 3)
+          hue = finite!("color.hwb", number!("color.hwb", items[0]))
+          whiteness = amount!("color.hwb", items[1])
+          blackness = amount!("color.hwb", items[2])
+          Builtins.hwb_color(hue, whiteness, blackness)
+        end
+
+        # `ie-hex-str($color)` — the legacy `#AARRGGBB` spelling IE filters
+        # take.
+        IE_HEX_STR_FN = Fn.new do |args, kwargs|
+          bound = bind!("ie-hex-str", args, kwargs, ["color"], required: 1)
+          color = color!("ie-hex-str", bound[0].as(Value))
+          alpha8 = ColorV.fuzzy_round(color.alpha * 255.0)
+          Str.new("#%02X%02X%02X%02X" % {alpha8, color.red8, color.green8, color.blue8},
+            quoted: false)
+        end
+        COLOR_FNS["ie-hex-str"] = IE_HEX_STR_FN
+
+        # HWB → RGB (CSS Color 4): degenerate w+b ≥ 100 is a flat gray,
+        # otherwise the pure hue scaled between whiteness and blackness.
+        def self.hwb_color(hue : Float64, whiteness : Float64, blackness : Float64) : ColorV
+          w = whiteness / 100.0
+          b = blackness / 100.0
+          if w + b >= 1.0
+            gray = w / (w + b) * 255.0
+            return ColorV.new(gray, gray, gray)
+          end
+          pure = ColorV.from_hsl(hue, 100.0, 50.0)
+          scale = ->(channel : Float64) { (channel / 255.0 * (1.0 - w - b) + w) * 255.0 }
+          ColorV.new(scale.call(pure.red), scale.call(pure.green), scale.call(pure.blue))
+        end
+
         # `color.fade-in` / `color.fade-out` are the module spellings of
         # opacify / transparentize. dart-sass defines both, so the module
         # table needs them or `color.fade-in(...)` leaks its call text.
@@ -979,6 +1216,229 @@ module Hwaro
         end
 
         # ---------------------------------------------------------------
+        # sass:selector
+        #
+        # String-level implementations of the selector functions: selectors
+        # are handled as comma lists of complex selectors (whitespace-
+        # separated compound words). Sound for the class/id/element/pseudo
+        # selectors frameworks feed these; the full unification semantics
+        # (combinator weaving, pseudo-element rules) are out of scope.
+        # ---------------------------------------------------------------
+
+        # Splits selector text on top-level commas (commas inside `(...)`
+        # and `[...]` — `:is(a, b)`, `[title="a,b"]` — don't split).
+        private def self.split_selector_commas(text : String) : Array(String)
+          parts = [] of String
+          buf = String::Builder.new
+          depth = 0
+          in_quote = '\0'
+          text.each_char do |c|
+            if in_quote != '\0'
+              buf << c
+              in_quote = '\0' if c == in_quote
+              next
+            end
+            case c
+            when '"', '\'' then in_quote = c; buf << c
+            when '(', '['  then depth += 1; buf << c
+            when ')', ']'  then depth -= 1; buf << c
+            when ','
+              if depth == 0
+                parts << buf.to_s
+                buf = String::Builder.new
+              else
+                buf << c
+              end
+            else
+              buf << c
+            end
+          end
+          parts << buf.to_s
+          parts.map(&.strip).reject(&.empty?)
+        end
+
+        # A selector argument as text: strings/raw verbatim, lists joined
+        # by their separator (`&` arrives as a comma list of strings).
+        private def self.selector_text(name : String, value : Value) : String
+          case value
+          when Str   then value.text
+          when Raw   then value.text
+          when ListV then value.items.map { |i| selector_text(name, i) }.join(value.sep == ListV::Sep::Comma ? ", " : " ")
+          when NullV then raise SoftEvalError.new("#{name}: expected a selector, got null")
+          else
+            raise SoftEvalError.new("#{name}: expected a selector, got #{value.to_css.inspect}")
+          end
+        end
+
+        # Comma list of complex selectors, each an array of whitespace-
+        # separated words (compounds and combinators).
+        private def self.selector_complexes(name : String, value : Value) : Array(Array(String))
+          split_selector_commas(selector_text(name, value)).map(&.split)
+        end
+
+        # Splits one compound selector into its leading element (or "") and
+        # the trailing simple selectors (classes, ids, attributes, pseudos,
+        # placeholders).
+        private def self.compound_simples(compound : String) : {String, Array(String)}
+          simples = [] of String
+          element = String::Builder.new
+          i = 0
+          chars = compound.chars
+          while i < chars.size && !".#:[%".includes?(chars[i])
+            element << chars[i]
+            i += 1
+          end
+          while i < chars.size
+            start = i
+            i += 1                     # the delimiter
+            i += 1 if chars[i]? == ':' # `::pseudo-element`
+            depth = 0
+            while i < chars.size
+              c = chars[i]
+              if c == '(' || c == '['
+                depth += 1
+              elsif c == ')' || c == ']'
+                depth -= 1
+                i += 1
+                break if depth == 0 && (chars[i]?.nil? || ".#:[%".includes?(chars[i]))
+                next
+              elsif depth == 0 && ".#:[%".includes?(c) && !(c == ':' && chars[start] == ':' && i == start + 1)
+                break
+              end
+              i += 1
+            end
+            simples << chars[start...i].join
+          end
+          {element.to_s, simples}
+        end
+
+        # Merges two compound selectors into one matching both, or nil when
+        # they can't both match (two different element types).
+        private def self.unify_compounds(a : String, b : String) : String?
+          ea, sa = compound_simples(a)
+          eb, sb = compound_simples(b)
+          element =
+            if ea.empty? || ea == "*"
+              eb.empty? ? ea : eb
+            elsif eb.empty? || eb == "*"
+              ea
+            elsif ea == eb
+              ea
+            else
+              return
+            end
+          merged = sa.dup
+          sb.each { |s| merged << s unless merged.includes?(s) }
+          element + merged.join
+        end
+
+        # True when every element `sub` matches is also matched by `sup`
+        # (subset simples, compounds embedded in order, last-to-last).
+        private def self.complex_superselector?(sup : Array(String), sub : Array(String)) : Bool
+          sup_c = sup.reject { |w| w == ">" || w == "+" || w == "~" }
+          sub_c = sub.reject { |w| w == ">" || w == "+" || w == "~" }
+          return false if sup_c.empty? || sub_c.empty?
+          return false unless compound_subset?(sup_c.last, sub_c.last)
+          si = 0
+          sup_c[0...-1].each do |sc|
+            while si < sub_c.size - 1 && !compound_subset?(sc, sub_c[si])
+              si += 1
+            end
+            return false if si >= sub_c.size - 1
+            si += 1
+          end
+          true
+        end
+
+        private def self.compound_subset?(a : String, b : String) : Bool
+          ea, sa = compound_simples(a)
+          eb, sb = compound_simples(b)
+          element_ok = ea.empty? || ea == "*" || ea == eb
+          element_ok && sa.all? { |s| sb.includes?(s) }
+        end
+
+        private def self.selector_value(complexes : Array(Array(String))) : Value
+          items = complexes.map do |words|
+            ListV.new(words.map { |w| Str.new(w, quoted: false).as(Value) }, ListV::Sep::Space).as(Value)
+          end
+          ListV.new(items, ListV::Sep::Comma)
+        end
+
+        SELECTOR_FNS = {
+          "parse" => Fn.new do |args, kwargs|
+            no_kwargs!("selector.parse", kwargs)
+            arity!("selector-parse", args, 1)
+            selector_value(selector_complexes("selector.parse()", args[0]))
+          end,
+          "nest" => Fn.new do |args, kwargs|
+            no_kwargs!("selector.nest", kwargs)
+            arity!("selector-nest", args, 1, Int32::MAX)
+            result = selector_complexes("selector.nest()", args[0])
+            args[1..].each do |arg|
+              parts = selector_complexes("selector.nest()", arg)
+              grown = [] of Array(String)
+              result.each do |parent|
+                parent_text = parent.join(' ')
+                parts.each do |part|
+                  if part.any?(&.includes?('&'))
+                    grown << part.flat_map(&.gsub('&', parent_text).split)
+                  else
+                    grown << parent + part
+                  end
+                end
+              end
+              result = grown
+            end
+            selector_value(result)
+          end,
+          "append" => Fn.new do |args, kwargs|
+            no_kwargs!("selector.append", kwargs)
+            arity!("selector-append", args, 1, Int32::MAX)
+            result = selector_complexes("selector.append()", args[0])
+            args[1..].each do |arg|
+              parts = selector_complexes("selector.append()", arg)
+              grown = [] of Array(String)
+              result.each do |parent|
+                parts.each do |part|
+                  head = part[0]
+                  if [">", "+", "~"].includes?(head) || [">", "+", "~"].includes?(parent.last)
+                    raise SoftEvalError.new("selector.append(): can't append #{part.join(' ').inspect}")
+                  end
+                  grown << parent[0...-1] + [parent.last + head] + part[1..]
+                end
+              end
+              result = grown
+            end
+            selector_value(result)
+          end,
+          "unify" => Fn.new do |args, kwargs|
+            no_kwargs!("selector.unify", kwargs)
+            arity!("selector-unify", args, 2)
+            a_list = selector_complexes("selector.unify()", args[0])
+            b_list = selector_complexes("selector.unify()", args[1])
+            unified = [] of Array(String)
+            a_list.each do |a|
+              b_list.each do |b|
+                merged = unify_compounds(a.last, b.last)
+                next unless merged
+                unified << a[0...-1] + b[0...-1] + [merged]
+              end
+            end
+            next NullV.new.as(Value) if unified.empty?
+            selector_value(unified)
+          end,
+          "is-superselector" => Fn.new do |args, kwargs|
+            no_kwargs!("selector.is-superselector", kwargs)
+            arity!("is-superselector", args, 2)
+            supers = selector_complexes("is-superselector()", args[0])
+            subs = selector_complexes("is-superselector()", args[1])
+            BoolV.new(subs.all? do |sub|
+              supers.any? { |sup| complex_superselector?(sup, sub) }
+            end)
+          end,
+        }
+
+        # ---------------------------------------------------------------
         # Global names (dart-sass legacy globals) + `if()`
         # ---------------------------------------------------------------
 
@@ -995,6 +1455,7 @@ module Hwaro
           "str-length"     => STRING_FNS["length"],
           "str-index"      => STRING_FNS["index"],
           "str-slice"      => STRING_FNS["slice"],
+          "str-insert"     => STRING_FNS["insert"],
           "to-upper-case"  => STRING_FNS["to-upper-case"],
           "to-lower-case"  => STRING_FNS["to-lower-case"],
           "length"         => LIST_FNS["length"],
@@ -1003,6 +1464,8 @@ module Hwaro
           "append"         => LIST_FNS["append"],
           "join"           => LIST_FNS["join"],
           "zip"            => LIST_FNS["zip"],
+          "set-nth"        => LIST_FNS["set-nth"],
+          "is-bracketed"   => LIST_FNS["is-bracketed"],
           "list-separator" => LIST_FNS["separator"],
           "map-get"        => MAP_FNS["get"],
           "map-has-key"    => MAP_FNS["has-key"],
@@ -1047,18 +1510,26 @@ module Hwaro
           "lightness"      => COLOR_FNS["lightness"],
           "alpha"          => COLOR_FNS["alpha"],
           "opacity"        => COLOR_FNS["opacity"],
+          "ie-hex-str"     => IE_HEX_STR_FN,
           "rgba"           => RGBA_FN,
           "rgb"            => RGBA_FN,
+          # Legacy global selector functions.
+          "selector-parse"   => SELECTOR_FNS["parse"],
+          "selector-nest"    => SELECTOR_FNS["nest"],
+          "selector-append"  => SELECTOR_FNS["append"],
+          "selector-unify"   => SELECTOR_FNS["unify"],
+          "is-superselector" => SELECTOR_FNS["is-superselector"],
         }
 
         # `sass:<name>` module tables: {functions, variables}.
         MODULE_TABLES = {
-          "math"   => {MATH_FNS, MATH_VARS},
-          "string" => {STRING_FNS, {} of String => String},
-          "list"   => {LIST_FNS, {} of String => String},
-          "map"    => {MAP_FNS, {} of String => String},
-          "meta"   => {META_FNS, {} of String => String},
-          "color"  => {COLOR_FNS, {} of String => String},
+          "math"     => {MATH_FNS, MATH_VARS},
+          "string"   => {STRING_FNS, {} of String => String},
+          "list"     => {LIST_FNS, {} of String => String},
+          "map"      => {MAP_FNS, {} of String => String},
+          "meta"     => {META_FNS, {} of String => String},
+          "color"    => {COLOR_FNS, {} of String => String},
+          "selector" => {SELECTOR_FNS, {} of String => String},
         }
       end
     end

--- a/src/assets/sass/parser.cr
+++ b/src/assets/sass/parser.cr
@@ -226,11 +226,10 @@ module Hwaro
             nodes << parse_forward(line, column)
           when "content"
             @s.skip_ws
-            if @s.peek == '('
-              @s.error("@content arguments are not supported", line, column)
-            end
+            args = @s.peek == '(' ? parse_args : [] of Ast::Arg
+            @s.skip_ws
             @s.advance if @s.peek == ';'
-            nodes << Ast::ContentNode.new(line, column)
+            nodes << Ast::ContentNode.new(line, column, args)
           else
             nodes << parse_raw_at_rule(name, line, column)
           end
@@ -430,11 +429,14 @@ module Hwaro
 
         private def parse_at_root(line : Int32, column : Int32) : Ast::Node
           @s.skip_ws
+          query = nil
           if @s.peek == '('
-            @s.error("@at-root (with: ...) / (without: ...) queries are not supported", line, column)
+            query = parse_at_root_query(line, column)
+            @s.skip_ws
+            @s.error("expected \"{\" after @at-root (...)", line, column) unless @s.peek == '{'
           end
           if @s.peek == '{'
-            Ast::AtRootNode.new(nil, parse_block, line, column)
+            Ast::AtRootNode.new(nil, parse_block, line, column, query)
           else
             scan = read_template(stops: "{;}", value_vars: true)
             @s.error("expected \"{\" after @at-root", line, column) unless scan.terminator == '{'
@@ -442,6 +444,31 @@ module Hwaro
             @s.error("expected selector or \"{\" after @at-root", line, column) if selector.empty?
             Ast::AtRootNode.new(selector, parse_block, line, column)
           end
+        end
+
+        # `(with: media supports)` / `(without: media)`.
+        private def parse_at_root_query(line : Int32, column : Int32) : Ast::AtRootQuery
+          @s.advance # '('
+          @s.skip_ws
+          keyword = @s.read_ident
+          unless keyword == "with" || keyword == "without"
+            @s.error("expected \"with\" or \"without\" in @at-root query", line, column)
+          end
+          @s.skip_ws
+          @s.error("expected \":\" after @at-root (#{keyword}", line, column) unless @s.peek == ':'
+          @s.advance
+          names = [] of String
+          loop do
+            @s.skip_ws
+            break if @s.peek == ')'
+            @s.error("unterminated @at-root query", line, column) if @s.eof?
+            name = @s.read_ident
+            @s.error("expected an at-rule name in @at-root query", line, column) if name.empty?
+            names << name.downcase
+          end
+          @s.advance # ')'
+          @s.error("expected at least one name in @at-root (#{keyword}: ...)", line, column) if names.empty?
+          Ast::AtRootQuery.new(keyword == "with" ? :with : :without, names)
         end
 
         # `@extend .target[, .other] [!optional];` — the selector template
@@ -717,12 +744,21 @@ module Hwaro
           args = @s.peek == '(' ? parse_args : [] of Ast::Arg
           @s.skip_ws
           body = nil
+          using_params = [] of Ast::Param
           if @s.ident_start?(@s.peek)
             word_line = @s.line
             word_col = @s.column
             word = @s.read_ident
             if word == "using"
-              @s.error("@include ... using (...) is not supported", word_line, word_col)
+              @s.skip_ws
+              unless @s.peek == '('
+                @s.error("expected \"(\" after \"using\"", word_line, word_col)
+              end
+              using_params = parse_params
+              @s.skip_ws
+              unless @s.peek == '{'
+                @s.error("expected a content block after @include ... using (...)", word_line, word_col)
+              end
             else
               @s.error("unexpected \"#{word}\" after @include #{name}", word_line, word_col)
             end
@@ -732,7 +768,7 @@ module Hwaro
           elsif @s.peek == ';'
             @s.advance
           end
-          Ast::IncludeNode.new(name, namespace, args, body, line, column)
+          Ast::IncludeNode.new(name, namespace, args, body, line, column, using_params)
         end
 
         private def parse_args : Array(Ast::Arg)
@@ -808,23 +844,32 @@ module Hwaro
           scan = read_template(stops: "{;}", value_vars: true)
 
           if scan.terminator == '{'
-            if (colon = scan.first_decl_colon) && blank_after?(scan.template, colon)
-              cp_name = trim_template(split_at(scan.template, colon)[0])
-              if cp_name.pieces[0]?.as?(String).try(&.starts_with?("--"))
-                # `--x: { ... }` is a custom property whose value happens to
-                # be a brace block — legal CSS, since custom-property values
-                # are an almost free-form token stream. Only the
-                # `font: { family: x }` nested-property shape is unsupported,
-                # so `--` names must not be swept up by that check. The block
-                # is kept fully verbatim.
-                raw = read_raw_block
-                @s.skip_ws { }
-                @s.advance if @s.peek == ';'
-                return Ast::DeclarationNode.new(
-                  cp_name, Ast::TextTemplate.new(Array(Ast::Piece){raw}, line, column),
-                  false, true, line, column)
+            if colon = scan.first_decl_colon
+              name_t, value_t = split_at(scan.template, colon)
+              name_t = trim_template(name_t)
+              if name_t.pieces[0]?.as?(String).try(&.starts_with?("--"))
+                if blank_after?(scan.template, colon)
+                  # `--x: { ... }` is a custom property whose value happens
+                  # to be a brace block — legal CSS, since custom-property
+                  # values are an almost free-form token stream. `--` names
+                  # must not be swept up by the nested-property handling
+                  # below. The block is kept fully verbatim.
+                  raw = read_raw_block
+                  @s.skip_ws { }
+                  @s.advance if @s.peek == ';'
+                  return Ast::DeclarationNode.new(
+                    name_t, Ast::TextTemplate.new(Array(Ast::Piece){raw}, line, column),
+                    false, true, line, column)
+                end
+              elsif !name_t.empty?
+                # `font: { family: x }` / `margin: auto { top: 1px }` —
+                # a nested property block, with an optional leading value.
+                value_t, flags = strip_flags(value_t, {"important"})
+                value_t = trim_template(value_t)
+                return Ast::NestedPropsNode.new(
+                  name_t, value_t.empty? ? nil : value_t,
+                  flags.includes?("important"), parse_block, line, column)
               end
-              @s.error("nested properties are not supported", line, column)
             end
             selector = trim_template(scan.template)
             @s.error("expected selector", line, column) if selector.empty?
@@ -974,7 +1019,11 @@ module Hwaro
               if depth == 0
                 first_colon ||= {pieces.size, buf.size}
                 nxt = @s.peek(1)
-                pseudo_like = @s.ident_start?(nxt) || nxt == ':'
+                # `:#{...}` with no space counts as pseudo-like too: a
+                # dynamic pseudo selector (`.btn:#{$state} { }`) must stay
+                # a selector, not become a nested property block.
+                pseudo_like = @s.ident_start?(nxt) || nxt == ':' ||
+                              (nxt == '#' && @s.peek(2) == '{')
                 first_decl_colon ||= {pieces.size, buf.size} unless pseudo_like
               end
               buf << @s.advance

--- a/src/assets/sass/value.cr
+++ b/src/assets/sass/value.cr
@@ -113,24 +113,68 @@ module Hwaro
           s
         end
 
+        # Convertible-unit groups (dart-sass's known compatibilities):
+        # {group id, factor to the group's canonical unit}. Lookup is
+        # case-insensitive because CSS units are.
+        UNIT_CONVERSIONS = {
+          # length — canonical px
+          "px" => {0, 1.0}, "cm" => {0, 96.0 / 2.54}, "mm" => {0, 96.0 / 25.4},
+          "q" => {0, 96.0 / 101.6}, "in" => {0, 96.0}, "pt" => {0, 4.0 / 3.0},
+          "pc" => {0, 16.0},
+          # angle — canonical deg
+          "deg" => {1, 1.0}, "grad" => {1, 0.9}, "rad" => {1, 180.0 / Math::PI},
+          "turn" => {1, 360.0},
+          # time — canonical s
+          "s" => {2, 1.0}, "ms" => {2, 0.001},
+          # frequency — canonical Hz
+          "hz" => {3, 1.0}, "khz" => {3, 1000.0},
+          # resolution — canonical dppx
+          "dppx" => {4, 1.0}, "dpi" => {4, 1.0 / 96.0}, "dpcm" => {4, 2.54 / 96.0},
+        }
+
+        # Multiplier that converts a value in `from` units to `to` units;
+        # nil when the units aren't in the same convertible group.
+        def self.conversion_factor(from : String, to : String) : Float64?
+          return 1.0 if from == to
+          f = UNIT_CONVERSIONS[from.downcase]?
+          t = UNIT_CONVERSIONS[to.downcase]?
+          return unless f && t && f[0] == t[0]
+          f[1] / t[1]
+        end
+
         def eq?(other : Value) : Bool
           return false unless other.is_a?(Number)
           # Equality needs units to actually match — `1px == 1` is false.
           # `compatible_unit?` (one side unitless adopts the other's unit)
           # is the right rule for arithmetic and comparison, but using it
           # here silently picks the wrong `@if` branch and collides map
-          # keys that differ only by unit.
-          unit == other.unit && value == other.value
+          # keys that differ only by unit. Convertible units DO compare
+          # equal after conversion (`1in == 96px` is true in dart-sass).
+          return value == other.value if unit == other.unit
+          return false if unit.empty? || other.unit.empty?
+          factor = Number.conversion_factor(other.unit, unit)
+          !factor.nil? && value == other.value * factor
         end
 
-        # v1 unit model: identical units or one side unitless. No
-        # px↔cm-style conversions.
+        # Identical units, one side unitless, or units in the same
+        # convertible group (px↔in, deg↔turn, s↔ms, ...).
         def compatible_unit?(other : Number) : Bool
-          unit.empty? || other.unit.empty? || unit == other.unit
+          unit.empty? || other.unit.empty? || unit == other.unit ||
+            !Number.conversion_factor(other.unit, unit).nil?
         end
 
         def result_unit(other : Number) : String
           unit.empty? ? other.unit : unit
+        end
+
+        # The other operand's value expressed in THIS number's unit (the
+        # left operand of an arithmetic expression wins the unit, dart-sass
+        # semantics). Callers must have checked `compatible_unit?`.
+        def coerce_value(other : Number) : Float64
+          return other.value if unit.empty? || other.unit.empty? || unit == other.unit
+          factor = Number.conversion_factor(other.unit, unit)
+          raise SoftEvalError.new("incompatible units: #{to_css} and #{other.to_css}") unless factor
+          other.value * factor
         end
 
         def int_value(context : String) : Int32

--- a/src/assets/sass/value.cr
+++ b/src/assets/sass/value.cr
@@ -35,6 +35,13 @@ module Hwaro
       class NamespacedEvalError < SoftEvalError
       end
 
+      # Map construction saw two keys that `==` considers equal (`1in` and
+      # `96px` after unit conversion). dart-sass fails the compile; the
+      # lenient SoftEvalError fallback would store the map as text and
+      # later lookups would silently hit the first key.
+      class DuplicateKeyError < SoftEvalError
+      end
+
       # "This call isn't mine" — raised by a built-in whose name shadows a
       # real CSS function (`rgba()`, `grayscale()`, `saturate()`, …) when
       # the arguments are the CSS shape rather than the Sass one.


### PR DESCRIPTION
## Summary

Built-in SCSS compiler now matches dart-sass 1.103 on the clusters a 130-case corpus (plus Bootstrap/Bulma full compiles) actually failed:

- Classic `/` division rule (`$w/2`, `(1/3)`, `percentage(1/4)`, `12 / 4 * 3`) while literal CSS slashes (`font: 12px/30px`) stay verbatim
- Unit conversion within the standard groups (`1in + 72pt`, `1in == 96px`, `math.min`/`compatible`)
- Parent-major selector lists, declaration-after-nested-rule reopen, nested `@media` merge with `and`
- Nested properties, `@content(args)`/`using`, `@at-root` queries, variadic kwargs + `meta.keywords`, `sass:selector`, math/string/list/color additions, `@charset`

A follow-up commit lands review findings that were empirically confirmed against dart-sass 1.103:

- Triple-nested `@media` no longer duplicates ancestor conditions; `Not`/`NOT` keep nesting like `not`
- `@at-root (with: all)` is a no-op (keeps media + selector nesting)
- `list.slash` stored in a variable round-trips; maps with unit-colliding keys (`1in` vs `96px`) error as Duplicate key
- Unused extra kwargs on a variadic mixin/function error unless `meta.keywords()` / `$args...` consume them
- `sass:selector` keeps whitespace inside `[title="a b"]` and `:is(a > b)`

Untracked local probe scripts (`probe_c_tmp.cr`, `sass_probe2.cr`, `sass_probe_tmp.cr`) are **not** in this PR.

## Test plan

- [x] `crystal spec spec/unit/sass/*.cr spec/unit/sass_compiler_spec.cr` — 366 examples, 0 failures
- [ ] CI