### PR TITLE
feat(docs): richer landing animations and motion polish

### DIFF
--- a/docs/static/assets/css/04-content.css
+++ b/docs/static/assets/css/04-content.css
@@ -62,6 +62,40 @@
     margin-top: var(--space-4);
     border-radius: 999px;
     background: var(--spark);
+    transform-origin: left center;
+}
+
+/* Entrance — one quiet rise for the content column and a drawn-in ember
+   rule under the title. CSS-only (runs without JS), once per navigation,
+   and skipped entirely under prefers-reduced-motion. */
+@media (prefers-reduced-motion: no-preference) {
+    .docs-main {
+        animation: docs-enter 0.45s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .docs-main > h1:first-of-type::after {
+        animation: docs-rule 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.15s backwards;
+    }
+}
+
+@keyframes docs-enter {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+@keyframes docs-rule {
+    from {
+        transform: scaleX(0);
+    }
+    to {
+        transform: scaleX(1);
+    }
 }
 
 /* Page description directly under the title reads as a standfirst. */

--- a/docs/static/assets/css/07-landing.css
+++ b/docs/static/assets/css/07-landing.css
@@ -59,15 +59,24 @@
     left: 0;
     right: 0;
     height: 64px;
-    background: var(--glass);
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
-    border-bottom: 1px solid var(--border-subtle);
+    background: transparent;
+    border-bottom: 1px solid transparent;
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 0 var(--space-5);
     z-index: 100;
+    transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+/* Once the page scrolls, the header picks up its glass. Without JS the
+   is-scrolled hook never lands, so keep the glass as the no-JS default. */
+html:not(.js) .landing-header,
+.landing-header.is-scrolled {
+    background: var(--glass);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    border-bottom-color: var(--border-subtle);
 }
 
 .landing-header .logo {
@@ -141,11 +150,17 @@
 .btn-primary {
     background: var(--heading);
     color: var(--bg);
+    transition:
+        background var(--transition),
+        color var(--transition),
+        box-shadow 0.3s ease,
+        transform 0.1s ease;
 }
 
 .btn-primary:hover {
     background: #ffffff;
     color: var(--bg);
+    box-shadow: 0 0 28px color-mix(in srgb, var(--primary) 35%, transparent);
 }
 
 /* =============================================================================
@@ -167,6 +182,10 @@
     inset: 0;
     pointer-events: none;
     z-index: 0;
+    /* Pointer parallax targets, driven by a lerped rAF loop in the page
+       script. Zero without JS or under reduced motion. */
+    --par-x: 0px;
+    --par-y: 0px;
 }
 
 /* Toned-down fire cover as an immersive backdrop. The pseudo-element is
@@ -181,7 +200,8 @@
     left: 50%;
     width: min(1240px, 94vw);
     aspect-ratio: 16 / 9;
-    transform: translate(-50%, -50%);
+    transform: translate(calc(-50% + var(--par-x)), calc(-50% + var(--par-y)));
+    will-change: transform;
     background-image:
         radial-gradient(
             ellipse 68% 60% at 50% 50%,
@@ -206,6 +226,37 @@
         rgba(0, 0, 0, 0.5) 58%,
         transparent 88%
     );
+}
+
+/* A slow breathing glow behind the brazier — the fire's light on the room.
+   Pure opacity animation on a composited layer, so it costs nothing. */
+.hero-bg::after {
+    content: "";
+    position: absolute;
+    top: 52%;
+    left: 50%;
+    width: min(1100px, 100vw);
+    aspect-ratio: 16 / 10;
+    transform: translate(calc(-50% + var(--par-x) * 1.6), calc(-50% + var(--par-y) * 1.6));
+    background: radial-gradient(
+        ellipse 50% 42% at 50% 55%,
+        color-mix(in srgb, var(--primary) 14%, transparent),
+        rgba(255, 140, 60, 0.05) 45%,
+        transparent 72%
+    );
+    mix-blend-mode: screen;
+    opacity: 0.7;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .hero-bg::after {
+        animation: hero-breathe 5.5s ease-in-out infinite;
+    }
+}
+
+@keyframes hero-breathe {
+    0%, 100% { opacity: 0.55; }
+    50% { opacity: 0.95; }
 }
 
 #ember-canvas {
@@ -242,6 +293,35 @@
 
 .hero-content .highlight {
     color: var(--primary);
+    /* Ember gradient sweep across the second line. Browsers without
+       background-clip:text keep the solid color above. */
+    background: linear-gradient(
+        100deg,
+        var(--rule-from) 0%,
+        var(--rule-to) 34%,
+        #ffb864 50%,
+        var(--rule-from) 66%,
+        var(--rule-to) 100%
+    );
+    background-size: 240% 100%;
+    background-position: 100% 0;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    /* the h1 shadow would bleed through a transparent fill */
+    text-shadow: none;
+    filter: drop-shadow(0 2px 18px rgba(0, 0, 0, 0.55));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .hero-content .highlight {
+        animation: ember-sheen 9s ease-in-out 1.4s infinite;
+    }
+}
+
+@keyframes ember-sheen {
+    0%, 68%, 100% { background-position: 100% 0; }
+    18%, 50% { background-position: 0% 0; }
 }
 
 .hero-sub {
@@ -289,22 +369,33 @@
     color: var(--text);
 }
 
-/* Entry - a single quiet rise, only when motion is welcome. */
+/* Entry - a cinematic rise out of soft focus, only when motion is welcome. */
 @media (prefers-reduced-motion: no-preference) {
     .hero-content h1,
     .hero-content .hero-sub,
     .hero-content .hero-actions {
         opacity: 0;
-        transform: translateY(14px);
-        animation: lp-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+        transform: translateY(22px) scale(0.985);
+        filter: blur(6px);
+        animation: lp-rise 0.9s cubic-bezier(0.16, 1, 0.3, 1) forwards;
     }
 
     .hero-content .hero-sub {
-        animation-delay: 0.1s;
+        animation-delay: 0.15s;
     }
 
     .hero-content .hero-actions {
-        animation-delay: 0.2s;
+        animation-delay: 0.3s;
+    }
+
+    .hero-bg {
+        opacity: 0;
+        animation: lp-fade 1.4s ease 0.1s forwards;
+    }
+
+    .hero-scroll-cue {
+        opacity: 0;
+        animation: lp-fade 0.8s ease 1.1s forwards;
     }
 }
 
@@ -312,7 +403,47 @@
     to {
         opacity: 1;
         transform: none;
+        filter: none;
     }
+}
+
+@keyframes lp-fade {
+    to {
+        opacity: 1;
+    }
+}
+
+/* Scroll cue — a quiet pulse at the fold's edge. */
+.hero-scroll-cue {
+    position: absolute;
+    bottom: var(--space-5);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2;
+    display: flex;
+    color: var(--text-muted);
+    padding: var(--space-2);
+    transition: color var(--transition), opacity 0.3s ease;
+}
+
+.hero-scroll-cue:hover {
+    color: var(--primary);
+}
+
+.hero-scroll-cue svg {
+    width: 22px;
+    height: 22px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .hero-scroll-cue svg {
+        animation: cue-drift 2.2s ease-in-out infinite;
+    }
+}
+
+@keyframes cue-drift {
+    0%, 100% { transform: translateY(0); opacity: 0.7; }
+    50% { transform: translateY(6px); opacity: 1; }
 }
 
 /* =============================================================================
@@ -338,6 +469,30 @@
     text-wrap: balance;
 }
 
+/* Ember rule under each section title, drawn in as the section reveals. */
+.section-header h2::after,
+.speed-header h2::after {
+    content: "";
+    display: block;
+    width: 44px;
+    height: 3px;
+    border-radius: 999px;
+    margin-top: var(--space-3);
+    background: var(--spark);
+    transform-origin: left center;
+}
+
+html.js .reveal .section-header h2::after,
+html.js .reveal .speed-header h2::after {
+    transform: scaleX(0);
+    transition: transform 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.25s;
+}
+
+html.js .reveal.is-visible .section-header h2::after,
+html.js .reveal.is-visible .speed-header h2::after {
+    transform: scaleX(1);
+}
+
 .section-header p,
 .speed-header p {
     margin: 0;
@@ -358,9 +513,60 @@ html.js .reveal.is-visible {
     transform: none;
 }
 
+/* Child cascade — cards inside a revealed section rise one after another.
+   The section itself still fades as a unit; children add a second beat.
+   Everything is scoped to :not(.is-settled): once the entrance has played,
+   these rules vanish entirely so hover transforms win again. */
+html.js .reveal:not(.is-settled) .bento-cell,
+html.js .reveal:not(.is-settled) .speed-modes li,
+html.js .reveal:not(.is-settled) .showcase-card,
+html.js .reveal:not(.is-settled) .scaffold-card {
+    opacity: 0;
+    transform: translateY(18px);
+    transition:
+        opacity 0.55s ease,
+        transform 0.55s cubic-bezier(0.16, 1, 0.3, 1);
+    transition-delay: calc(0.08s + var(--stagger, 0) * 0.07s);
+}
+
+html.js .reveal.is-visible:not(.is-settled) .bento-cell,
+html.js .reveal.is-visible:not(.is-settled) .speed-modes li,
+html.js .reveal.is-visible:not(.is-settled) .showcase-card,
+html.js .reveal.is-visible:not(.is-settled) .scaffold-card {
+    opacity: 1;
+    transform: none;
+}
+
+.bento-cell:nth-child(1), .speed-modes li:nth-child(1),
+.showcase-card:nth-child(1), .scaffold-card:nth-child(1) { --stagger: 0; }
+.bento-cell:nth-child(2), .speed-modes li:nth-child(2),
+.showcase-card:nth-child(2), .scaffold-card:nth-child(2) { --stagger: 1; }
+.bento-cell:nth-child(3), .speed-modes li:nth-child(3),
+.showcase-card:nth-child(3), .scaffold-card:nth-child(3) { --stagger: 2; }
+.bento-cell:nth-child(4), .showcase-card:nth-child(4),
+.scaffold-card:nth-child(4) { --stagger: 3; }
+.bento-cell:nth-child(5), .showcase-card:nth-child(5),
+.scaffold-card:nth-child(5) { --stagger: 4; }
+.bento-cell:nth-child(6), .showcase-card:nth-child(6) { --stagger: 5; }
+
 @media (prefers-reduced-motion: reduce) {
     html.js .reveal {
         opacity: 1;
+        transform: none;
+        transition: none;
+    }
+
+    html.js .reveal:not(.is-settled) .bento-cell,
+    html.js .reveal:not(.is-settled) .speed-modes li,
+    html.js .reveal:not(.is-settled) .showcase-card,
+    html.js .reveal:not(.is-settled) .scaffold-card {
+        opacity: 1;
+        transform: none;
+        transition: none;
+    }
+
+    html.js .reveal .section-header h2::after,
+    html.js .reveal .speed-header h2::after {
         transform: none;
         transition: none;
     }
@@ -398,6 +604,28 @@ html.js .reveal.is-visible {
 
 .speed-stage.is-done .speed-number {
     color: var(--primary);
+}
+
+/* Finish beat — the number pops and the bar flashes when the build lands. */
+@media (prefers-reduced-motion: no-preference) {
+    .speed-stage.is-done .speed-figure {
+        animation: speed-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+
+    .speed-stage.is-done .speed-fill {
+        animation: speed-flash 0.7s ease-out;
+    }
+}
+
+@keyframes speed-pop {
+    0% { transform: scale(1); }
+    35% { transform: scale(1.06); }
+    100% { transform: scale(1); }
+}
+
+@keyframes speed-flash {
+    0% { box-shadow: 0 0 24px 4px color-mix(in srgb, var(--primary) 65%, transparent); }
+    100% { box-shadow: 0 0 0 0 transparent; }
 }
 
 .speed-track {
@@ -499,6 +727,7 @@ html.js .speed-fill {
 }
 
 .bento-cell {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
@@ -506,6 +735,48 @@ html.js .speed-fill {
     padding: var(--space-5);
     border: 1px solid var(--border);
     border-radius: var(--radius);
+    overflow: hidden;
+    transition: border-color 0.3s ease, transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Pointer spotlight — a soft ember glow that follows the cursor. The page
+   script feeds --mx/--my; without JS the layer simply never lights up. */
+.bento-cell::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+        320px circle at var(--mx, 50%) var(--my, 50%),
+        color-mix(in srgb, var(--primary) 10%, transparent),
+        transparent 70%
+    );
+    opacity: 0;
+    transition: opacity 0.35s ease;
+}
+
+.bento-cell:hover {
+    border-color: color-mix(in srgb, var(--primary) 35%, var(--border));
+    transform: translateY(-2px);
+}
+
+.bento-cell:hover::before {
+    opacity: 1;
+}
+
+.bento-cell > * {
+    position: relative;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .bento-cell,
+    .bento-cell::before {
+        transition: none;
+    }
+
+    .bento-cell:hover {
+        transform: none;
+    }
 }
 
 .bento-cell h3 {
@@ -544,6 +815,26 @@ html.js .speed-fill {
     border-radius: var(--radius-sm);
     border: 1px solid var(--border);
     box-shadow: var(--shadow);
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* The fan spreads a touch wider when the cell is hovered. */
+.cell-seo:hover .og-fan img:nth-child(1) {
+    transform: rotate(-7.5deg) translate(-4%, -3%);
+}
+
+.cell-seo:hover .og-fan img:nth-child(2) {
+    transform: rotate(1.5deg) translateY(-6%);
+}
+
+.cell-seo:hover .og-fan img:nth-child(3) {
+    transform: rotate(8.5deg) translate(4%, -3%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .og-fan img {
+        transition: none;
+    }
 }
 
 .og-fan img:nth-child(1) {
@@ -626,6 +917,22 @@ html.js .speed-fill {
     border-radius: var(--radius);
     border: 1px solid var(--border);
     box-shadow: var(--shadow);
+    transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.3s ease;
+}
+
+.scaffold-card:hover img {
+    transform: translateY(-4px);
+    border-color: color-mix(in srgb, var(--primary) 40%, var(--border));
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .scaffold-card img {
+        transition: none;
+    }
+
+    .scaffold-card:hover img {
+        transform: none;
+    }
 }
 
 .scaffold-card figcaption {
@@ -849,6 +1156,18 @@ html.js .speed-fill {
     color: var(--text);
     white-space: nowrap;
     overflow-x: auto;
+}
+
+/* Tab switches swap the command with a quick dissolve. */
+@media (prefers-reduced-motion: no-preference) {
+    .install-cmd code.is-swapping {
+        animation: cmd-swap 0.28s ease;
+    }
+}
+
+@keyframes cmd-swap {
+    0% { opacity: 0; transform: translateY(4px); }
+    100% { opacity: 1; transform: none; }
 }
 
 .install-copy {

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -81,6 +81,9 @@
                         </button>
                     </div>
                 </div>
+                <a href="#speed" class="hero-scroll-cue" aria-label="{{ "landing.speed_title" | t }}">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+                </a>
             </section>
 
             <!-- ============================================================
@@ -365,7 +368,9 @@
         </main>
         {{ auto_includes_js }}
         <script>
-        // Ember particles rising from the hero art. Skipped entirely under
+        // Ember particles rising from the hero art. Two depth layers, a
+        // per-ember flicker, and the occasional bright spark. Spawn is
+        // biased toward the brazier at center. Skipped entirely under
         // prefers-reduced-motion; rAF pauses on hidden tabs by itself.
         (function() {
             var reduce = window.matchMedia &&
@@ -375,32 +380,59 @@
             var ctx = canvas.getContext('2d');
             var host = canvas.parentElement;
             var embers = [];
-            var MAX = 40;
+            var dpr = Math.min(window.devicePixelRatio || 1, 2);
+            var W = 0, H = 0;
+            var MAX = Math.min(64, Math.max(36, Math.round(window.innerWidth / 24)));
 
             function resize() {
-                canvas.width = host.offsetWidth;
-                canvas.height = host.offsetHeight;
+                W = host.offsetWidth;
+                H = host.offsetHeight;
+                canvas.width = W * dpr;
+                canvas.height = H * dpr;
+                canvas.style.width = W + 'px';
+                canvas.style.height = H + 'px';
+                ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
             }
             resize();
             window.addEventListener('resize', resize);
 
+            // Center-biased x: the average of two rolls clusters around the
+            // brazier; the far layer spreads wider than the near one.
+            function biasedX(spread) {
+                var r = (Math.random() + Math.random()) / 2;
+                return W * (0.5 + (r - 0.5) * spread);
+            }
+
             function Ember() {
                 this.reset();
-                this.y = Math.random() * canvas.height;
+                this.y = Math.random() * H;
+                this.life = Math.random();
             }
 
             Ember.prototype.reset = function() {
-                this.x = Math.random() * canvas.width;
-                this.y = canvas.height + 4;
-                this.r = Math.random() * 2.2 + 0.8;
-                this.vx = (Math.random() - 0.5) * 0.6;
-                this.vy = -(Math.random() * 1.2 + 0.4);
+                // ~1/4 far (small, slow, dim), ~3/4 near; 1 in 18 is a spark.
+                this.far = Math.random() < 0.28;
+                this.spark = !this.far && Math.random() < 0.055;
+                this.x = biasedX(this.far ? 1.7 : 1.1);
+                this.y = H + 4;
+                this.r = this.far
+                    ? Math.random() * 1.1 + 0.5
+                    : Math.random() * 2.2 + 0.9;
+                if (this.spark) this.r += 0.8;
+                var speed = this.far ? 0.5 : 1.0;
+                this.vx = (Math.random() - 0.5) * 0.6 * speed;
+                this.vy = -(Math.random() * 1.3 + 0.45) * speed;
+                if (this.spark) this.vy *= 1.6;
                 this.life = 1;
-                this.decay = Math.random() * 0.008 + 0.003;
-                this.drift = Math.random() * 0.3 + 0.1;
+                this.decay = (Math.random() * 0.008 + 0.003) * (this.far ? 1.25 : 1);
+                this.drift = (Math.random() * 0.3 + 0.1) * speed;
                 this.wobble = Math.random() * Math.PI * 2;
+                this.flicker = Math.random() * Math.PI * 2;
+                this.flickerSpeed = Math.random() * 0.25 + 0.08;
                 var hue = Math.random();
-                if (hue < 0.5) {
+                if (this.spark) {
+                    this.color = [255, 235 + Math.random() * 20 | 0, 150 + Math.random() * 60 | 0];
+                } else if (hue < 0.5) {
                     this.color = [255, 160 + Math.random() * 60 | 0, 30 + Math.random() * 30 | 0];
                 } else if (hue < 0.8) {
                     this.color = [255, 80 + Math.random() * 60 | 0, 20 + Math.random() * 20 | 0];
@@ -411,21 +443,24 @@
 
             Ember.prototype.update = function() {
                 this.wobble += 0.04;
+                this.flicker += this.flickerSpeed;
                 this.x += this.vx + Math.sin(this.wobble) * this.drift;
                 this.y += this.vy;
                 this.life -= this.decay;
-                if (this.life <= 0 || this.y < -10 || this.x < -10 || this.x > canvas.width + 10) {
+                if (this.life <= 0 || this.y < -10 || this.x < -10 || this.x > W + 10) {
                     this.reset();
                 }
             };
 
             Ember.prototype.draw = function(ctx) {
-                var a = this.life * 0.65;
+                var base = this.far ? 0.4 : 0.68;
+                var a = this.life * base * (0.75 + Math.sin(this.flicker) * 0.25);
+                if (a <= 0.01) return;
                 ctx.beginPath();
                 ctx.arc(this.x, this.y, this.r * this.life, 0, Math.PI * 2);
                 ctx.fillStyle = 'rgba(' + this.color[0] + ',' + this.color[1] + ',' + this.color[2] + ',' + a + ')';
-                ctx.shadowColor = 'rgba(' + this.color[0] + ',' + this.color[1] + ',' + this.color[2] + ',' + (a * 0.5) + ')';
-                ctx.shadowBlur = this.r * 5;
+                ctx.shadowColor = 'rgba(' + this.color[0] + ',' + this.color[1] + ',' + this.color[2] + ',' + (a * 0.55) + ')';
+                ctx.shadowBlur = this.r * (this.spark ? 8 : 5);
                 ctx.fill();
             };
 
@@ -434,7 +469,7 @@
             }
 
             function loop() {
-                ctx.clearRect(0, 0, canvas.width, canvas.height);
+                ctx.clearRect(0, 0, W, H);
                 for (var i = 0; i < embers.length; i++) {
                     embers[i].update();
                     embers[i].draw(ctx);
@@ -444,6 +479,74 @@
                 requestAnimationFrame(loop);
             }
             loop();
+        })();
+        </script>
+        <script>
+        // Hero pointer parallax (fine pointers only) + bento spotlight +
+        // header glass on scroll. All rAF-throttled, all skipped under
+        // prefers-reduced-motion where they would move things.
+        (function() {
+            var reduce = window.matchMedia &&
+                window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+            // Header picks up its glass once the page leaves the very top.
+            var header = document.querySelector('.landing-header');
+            if (header) {
+                var scrolled = null;
+                function onScroll() {
+                    var now = window.scrollY > 12;
+                    if (now !== scrolled) {
+                        scrolled = now;
+                        header.classList.toggle('is-scrolled', now);
+                    }
+                }
+                window.addEventListener('scroll', onScroll, { passive: true });
+                onScroll();
+            }
+
+            // Bento spotlight follows the cursor inside each cell.
+            var cells = document.querySelectorAll('.bento-cell');
+            for (var i = 0; i < cells.length; i++) {
+                cells[i].addEventListener('mousemove', function(e) {
+                    var b = this.getBoundingClientRect();
+                    this.style.setProperty('--mx', (e.clientX - b.left) + 'px');
+                    this.style.setProperty('--my', (e.clientY - b.top) + 'px');
+                });
+            }
+
+            // Pointer parallax: the brazier drifts a few px against the
+            // cursor; the glow layer moves a little more (CSS multiplies).
+            if (reduce) return;
+            var fine = window.matchMedia && window.matchMedia('(pointer: fine)').matches;
+            var bg = document.querySelector('.hero-bg');
+            var hero = document.querySelector('.hero');
+            if (!fine || !bg || !hero) return;
+            var tx = 0, ty = 0, cx = 0, cy = 0, raf = null;
+
+            function tick() {
+                cx += (tx - cx) * 0.06;
+                cy += (ty - cy) * 0.06;
+                bg.style.setProperty('--par-x', cx.toFixed(2) + 'px');
+                bg.style.setProperty('--par-y', cy.toFixed(2) + 'px');
+                if (Math.abs(tx - cx) > 0.05 || Math.abs(ty - cy) > 0.05) {
+                    raf = requestAnimationFrame(tick);
+                } else {
+                    raf = null;
+                }
+            }
+
+            hero.addEventListener('mousemove', function(e) {
+                var b = hero.getBoundingClientRect();
+                tx = ((e.clientX - b.left) / b.width - 0.5) * -14;
+                ty = ((e.clientY - b.top) / b.height - 0.5) * -8;
+                if (!raf) raf = requestAnimationFrame(tick);
+            });
+
+            hero.addEventListener('mouseleave', function() {
+                tx = 0;
+                ty = 0;
+                if (!raf) raf = requestAnimationFrame(tick);
+            });
         })();
         </script>
         <script>
@@ -496,6 +599,9 @@
                     }
                     this.setAttribute('aria-selected', 'true');
                     cmdEl.textContent = this.getAttribute('data-command');
+                    cmdEl.classList.remove('is-swapping');
+                    void cmdEl.offsetWidth; /* restart the dissolve */
+                    cmdEl.classList.add('is-swapping');
                 });
             }
 
@@ -564,6 +670,11 @@
             function show(el) {
                 el.classList.add('is-visible');
                 if (el.classList.contains('speed')) runSpeed(el);
+                // Once the child cascade has played out, drop the stagger
+                // delays so hover transitions respond instantly.
+                setTimeout(function() {
+                    el.classList.add('is-settled');
+                }, 1100);
             }
 
             if (reduce || !('IntersectionObserver' in window)) {


### PR DESCRIPTION
## Summary

Design pass over the docs site with a focus on a more dynamic, animated landing page.

### Landing
- **Hero**: ember gradient sheen on the highlight line, blur-rise entry, breathing glow behind the brazier art, pointer parallax, and a pulsing scroll cue
- **Ember canvas**: DPR-aware (sharp on retina), two depth layers, per-ember flicker, occasional bright sparks, center-biased spawn
- **Scroll narrative**: staggered child cascade on section reveals (bento / speed modes / scaffolds / showcase), section-title ember rule draw-in
- **Speed section**: finish beat — number pop + track glow flash
- **Header**: transparent at top, picks up glass on scroll (no-JS keeps glass)
- **Micro-interactions**: bento pointer spotlight + lift, OG fan hover spread, scaffold card lift, primary button ember glow, install command swap dissolve

### Docs
- Content column entrance fade + page title ember rule draw-in (CSS-only)

### Accessibility / robustness
- Every animation is gated behind `prefers-reduced-motion`
- Progressive enhancement: no-JS visitors see all content at full opacity
- Parallax only on fine pointers; rAF loops idle out when settled

## Test Plan
- [x] `bin/hwaro build -i docs` passes (140 pages)
- [x] Visually verified hero, speed, bento, scaffolds, OG marquee, showcase, closer, and a docs page at localhost