### PR TITLE
feat(tool): feature-improvement batch across the tool subcommand family

### DIFF
--- a/docs/content/start/cli.ko.md
+++ b/docs/content/start/cli.ko.md
@@ -529,11 +529,19 @@ hwaro tool agents-md --write      # AGENTS.md를 파일로 쓰기
 
 # JSON 출력
 hwaro tool list all --json
+hwaro tool convert to-yaml --json
 hwaro tool stats --json
 hwaro tool validate --json
 hwaro tool unused-assets --json
 hwaro tool doctor --json
 hwaro tool check-links --json
+hwaro tool import jekyll /path --json
+hwaro tool export hugo --json
+
+# 파괴적/대량 작업을 쓰기 없이 미리보기
+hwaro tool convert to-yaml --dry-run
+hwaro tool import jekyll /path --dry-run
+hwaro tool export hugo --dry-run
 ```
 
 **서브커맨드:**
@@ -556,7 +564,7 @@ hwaro tool check-links --json
 
 | 플래그 | 설명 |
 |------|-------------|
-| -c, --content DIR | 특정 콘텐츠 디렉터리로 제한 |
+| -c, --content-dir DIR | 특정 콘텐츠 디렉터리로 제한 |
 | -j, --json | 결과를 JSON으로 출력 |
 | -h, --help | 도움말 표시 |
 

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -528,11 +528,19 @@ hwaro tool agents-md --write      # Write AGENTS.md to file
 
 # JSON output
 hwaro tool list all --json
+hwaro tool convert to-yaml --json
 hwaro tool stats --json
 hwaro tool validate --json
 hwaro tool unused-assets --json
 hwaro tool doctor --json
 hwaro tool check-links --json
+hwaro tool import jekyll /path --json
+hwaro tool export hugo --json
+
+# Preview destructive/bulk operations without writing
+hwaro tool convert to-yaml --dry-run
+hwaro tool import jekyll /path --dry-run
+hwaro tool export hugo --dry-run
 ```
 
 **Subcommands:**
@@ -555,7 +563,7 @@ hwaro tool check-links --json
 
 | Flag | Description |
 |------|-------------|
-| -c, --content DIR | Limit to specific content directory |
+| -c, --content-dir DIR | Limit to specific content directory |
 | -j, --json | Output result as JSON |
 | -h, --help | Show help |
 

--- a/docs/content/start/tools/agents-md.ko.md
+++ b/docs/content/start/tools/agents-md.ko.md
@@ -30,7 +30,7 @@ hwaro tool agents-md --write --force
 | `--local` (기본값) | 전체 내장 레퍼런스(약 260줄). 콘텐츠 형식, 템플릿 변수, 설정 레퍼런스, AI 에이전트 참고 사항 포함. 오프라인이나 로컬 LLM 환경에 적합 |
 | `--remote` | 경량 버전(약 50줄). 프로젝트 구조, 핵심 명령, 그리고 [온라인 문서](https://hwaro.hahwul.com)와 [LLM 레퍼런스](https://hwaro.hahwul.com/llms-full.txt) 링크가 담긴 AI 에이전트 참고 사항 포함 |
 
-두 모드 모두 프로젝트 고유의 규칙과 컨벤션을 적을 수 있는 **Site-Specific Instructions** 섹션을 포함합니다.
+두 모드 모두 프로젝트 고유의 규칙과 컨벤션을 적을 수 있는 **Site-Specific Instructions** 섹션을 포함합니다. `--write`로 다시 생성해도 이 섹션은 기존 파일에서 그대로 이어집니다 — 생성된 부분(모드 전환 포함)만 갱신되고 `## Site-Specific Instructions` 아래에 적은 내용은 변경 없이 보존됩니다.
 
 ## 옵션
 
@@ -42,7 +42,7 @@ hwaro tool agents-md --write --force
 | -f, --force | 기존 파일을 확인 없이 덮어쓰기 |
 | -h, --help | 도움말 표시 |
 
-기본적으로 stdout에 출력하므로 저장하기 전에 내용을 살펴볼 수 있습니다. 파일로 저장하려면 `--write`를 사용합니다. `AGENTS.md`가 이미 있으면 `--force`를 쓰지 않는 한 확인을 요청합니다.
+기본적으로 stdout에 출력하므로 저장하기 전에 내용을 살펴볼 수 있습니다. 파일로 저장하려면 `--write`를 사용합니다. `AGENTS.md`가 이미 있으면 `--force`를 쓰지 않는 한 확인을 요청합니다. 어느 쪽이든 **Site-Specific Instructions** 섹션은 다시 쓰기 과정에서 보존됩니다.
 
 ## `hwaro init`와의 관계
 

--- a/docs/content/start/tools/agents-md.ko.md
+++ b/docs/content/start/tools/agents-md.ko.md
@@ -30,7 +30,7 @@ hwaro tool agents-md --write --force
 | `--local` (기본값) | 전체 내장 레퍼런스(약 260줄). 콘텐츠 형식, 템플릿 변수, 설정 레퍼런스, AI 에이전트 참고 사항 포함. 오프라인이나 로컬 LLM 환경에 적합 |
 | `--remote` | 경량 버전(약 50줄). 프로젝트 구조, 핵심 명령, 그리고 [온라인 문서](https://hwaro.hahwul.com)와 [LLM 레퍼런스](https://hwaro.hahwul.com/llms-full.txt) 링크가 담긴 AI 에이전트 참고 사항 포함 |
 
-두 모드 모두 프로젝트 고유의 규칙과 컨벤션을 적을 수 있는 **Site-Specific Instructions** 섹션을 포함합니다. `--write`로 다시 생성해도 이 섹션은 기존 파일에서 그대로 이어집니다 — 생성된 부분(모드 전환 포함)만 갱신되고 `## Site-Specific Instructions` 아래에 적은 내용은 변경 없이 보존됩니다.
+두 모드 모두 프로젝트 고유의 규칙과 컨벤션을 적을 수 있는 **Site-Specific Instructions** 섹션을 포함합니다. `--write`로 다시 생성해도 이 섹션은 기존 파일에서 그대로 이어집니다 — 생성된 부분(모드 전환 포함)만 갱신되고 `## Site-Specific Instructions` 아래에 적은 내용은 변경 없이 보존됩니다. 보존은 정확히 이 헤딩을 기준으로 동작하므로, `## Site-Specific Instructions` 헤딩이 없는 기존 파일은 전체가 교체됩니다(실행 전에 프롬프트가, `--force`에서는 경고가 이를 알려줍니다).
 
 ## 옵션
 
@@ -39,7 +39,7 @@ hwaro tool agents-md --write --force
 | --remote | 온라인 문서 링크가 있는 경량 버전 생성 |
 | --local | 전체 내장 레퍼런스 생성 (기본값) |
 | --write | stdout 대신 AGENTS.md 파일로 저장 |
-| -f, --force | 기존 파일을 확인 없이 덮어쓰기 |
+| -f, --force | 확인 없이 기존 파일 재생성 (Site-Specific Instructions 섹션은 보존) |
 | -h, --help | 도움말 표시 |
 
 기본적으로 stdout에 출력하므로 저장하기 전에 내용을 살펴볼 수 있습니다. 파일로 저장하려면 `--write`를 사용합니다. `AGENTS.md`가 이미 있으면 `--force`를 쓰지 않는 한 확인을 요청합니다. 어느 쪽이든 **Site-Specific Instructions** 섹션은 다시 쓰기 과정에서 보존됩니다.

--- a/docs/content/start/tools/agents-md.md
+++ b/docs/content/start/tools/agents-md.md
@@ -30,7 +30,7 @@ hwaro tool agents-md --write --force
 | `--local` (default) | Full embedded reference (~260 lines). Includes content format, template variables, configuration reference, and AI agent notes. Best for offline or local LLM environments. |
 | `--remote` | Lightweight version (~50 lines). Includes project structure, essential commands, and AI agent notes with links to [online documentation](https://hwaro.hahwul.com) and [LLM reference](https://hwaro.hahwul.com/llms-full.txt). |
 
-Both modes include a **Site-Specific Instructions** section where you can add your own project rules and conventions. Regenerating with `--write` preserves that section from the existing file — the generated parts are refreshed (or switched between modes) while whatever you wrote under `## Site-Specific Instructions` is carried over unchanged.
+Both modes include a **Site-Specific Instructions** section where you can add your own project rules and conventions. Regenerating with `--write` preserves that section from the existing file — the generated parts are refreshed (or switched between modes) while whatever you wrote under `## Site-Specific Instructions` is carried over unchanged. Preservation keys on that exact heading: an existing file without a `## Site-Specific Instructions` heading is replaced entirely (the prompt — or a warning under `--force` — says so before it happens).
 
 ## Options
 
@@ -39,7 +39,7 @@ Both modes include a **Site-Specific Instructions** section where you can add yo
 | --remote | Generate lightweight version with links to online docs |
 | --local | Generate full embedded reference (default) |
 | --write | Write to AGENTS.md file instead of stdout |
-| -f, --force | Overwrite existing file without confirmation |
+| -f, --force | Regenerate an existing file without confirmation (Site-Specific Instructions still preserved) |
 | -h, --help | Show help |
 
 By default, the command prints to stdout so you can inspect the content before saving. Use `--write` to save to file. If `AGENTS.md` already exists, you'll be prompted for confirmation unless `--force` is used — and either way, your **Site-Specific Instructions** section is preserved across the rewrite.

--- a/docs/content/start/tools/agents-md.md
+++ b/docs/content/start/tools/agents-md.md
@@ -30,7 +30,7 @@ hwaro tool agents-md --write --force
 | `--local` (default) | Full embedded reference (~260 lines). Includes content format, template variables, configuration reference, and AI agent notes. Best for offline or local LLM environments. |
 | `--remote` | Lightweight version (~50 lines). Includes project structure, essential commands, and AI agent notes with links to [online documentation](https://hwaro.hahwul.com) and [LLM reference](https://hwaro.hahwul.com/llms-full.txt). |
 
-Both modes include a **Site-Specific Instructions** section where you can add your own project rules and conventions.
+Both modes include a **Site-Specific Instructions** section where you can add your own project rules and conventions. Regenerating with `--write` preserves that section from the existing file — the generated parts are refreshed (or switched between modes) while whatever you wrote under `## Site-Specific Instructions` is carried over unchanged.
 
 ## Options
 
@@ -42,7 +42,7 @@ Both modes include a **Site-Specific Instructions** section where you can add yo
 | -f, --force | Overwrite existing file without confirmation |
 | -h, --help | Show help |
 
-By default, the command prints to stdout so you can inspect the content before saving. Use `--write` to save to file. If `AGENTS.md` already exists, you'll be prompted for confirmation unless `--force` is used.
+By default, the command prints to stdout so you can inspect the content before saving. Use `--write` to save to file. If `AGENTS.md` already exists, you'll be prompted for confirmation unless `--force` is used — and either way, your **Site-Specific Instructions** section is preserved across the rewrite.
 
 ## Relation to `hwaro init`
 

--- a/docs/content/start/tools/check-links.ko.md
+++ b/docs/content/start/tools/check-links.ko.md
@@ -18,6 +18,9 @@ hwaro tool check-links --timeout 30 --concurrency 4
 # 외부 또는 내부 링크만 검사
 hwaro tool check-links --external-only
 hwaro tool check-links --internal-only
+
+# 알려진 불안정 호스트 무시, 봇 차단 상태 코드 허용
+hwaro tool check-links --ignore-url twitter.com --allow-status 403,429
 ```
 
 ## 옵션
@@ -29,17 +32,33 @@ hwaro tool check-links --internal-only
 | --concurrency N | 최대 동시 요청 수 (기본값: 8) |
 | --external-only | 외부 링크만 검사 |
 | --internal-only | 내부 링크만 검사 |
+| --ignore-url PATTERN | URL이 PATTERN과 일치하는 링크는 건너뜀 (반복 가능) |
+| --allow-status CODES | 나열한 HTTP 상태 코드를 정상으로 취급 (쉼표 구분) |
 | -j, --json | 결과를 JSON으로 출력 |
 | -h, --help | 도움말 표시 |
+
+`--ignore-url`은 소스에 적힌 URL을 부분 문자열로 매칭합니다 —
+`--ignore-url twitter.com`은 `twitter.com`이 포함된 모든 링크를 건너뛰고,
+`*`는 임의 문자열과 매칭됩니다(`--ignore-url 'https://example.com/*'`).
+여러 번 전달할 수 있으며, 매칭된 링크에는 요청 자체를 보내지 않고 스캔
+라인에 무시된 개수를 표시합니다.
+
+`--allow-status`는 브라우저에는 정상 응답하면서 링크 검사기에는 `403`/`429`를
+돌려주는 호스트를 위한 것으로, 나열된 상태 코드는 CI를 실패시키지 않습니다.
 
 ## 동작 방식
 
 1. `content/` 디렉터리의 모든 마크다운 파일을 스캔
 2. 외부 URL(http/https 링크)과 내부 링크(상대/절대 경로)를 수집
-3. 외부 URL에 동시 HEAD 요청 전송
+3. 외부 URL에 동시 HEAD 요청 전송 (호스트가 HEAD를 405/403/501로 거부하면
+   GET으로 재시도, 리다이렉트는 최대 5회 추적)
 4. 내부 링크 대상이 디스크에 존재하는지 확인 (`.md`, `_index.md`, `index.md` 검사)
 5. 빌드가 생성하는 경로는 소스 파일 없이도 유효한 것으로 인정
 6. 깨졌거나 접근할 수 없는 링크 보고
+
+사설/내부 주소(localhost, RFC 1918 대역, `.local`/`.internal` 호스트)로
+해석되는 외부 링크에는 요청을 보내지 않습니다. 이런 링크는 사람용 출력과
+JSON의 `skipped_external` 항목 모두에 "건너뜀"으로 보고됩니다.
 
 ### 생성 경로
 
@@ -107,6 +126,17 @@ checked: 50 links, 3 dead
       },
       "status": 404,
       "error": null
+    }
+  ],
+  "skipped_external": [
+    {
+      "link": {
+        "file": "content/notes/intranet.md",
+        "url": "http://wiki.internal/page",
+        "kind": "external"
+      },
+      "status": -1,
+      "error": "Skipped: private/internal address"
     }
   ]
 }

--- a/docs/content/start/tools/check-links.ko.md
+++ b/docs/content/start/tools/check-links.ko.md
@@ -37,11 +37,13 @@ hwaro tool check-links --ignore-url twitter.com --allow-status 403,429
 | -j, --json | 결과를 JSON으로 출력 |
 | -h, --help | 도움말 표시 |
 
-`--ignore-url`은 소스에 적힌 URL을 부분 문자열로 매칭합니다 —
-`--ignore-url twitter.com`은 `twitter.com`이 포함된 모든 링크를 건너뛰고,
-`*`는 임의 문자열과 매칭됩니다(`--ignore-url 'https://example.com/*'`).
-여러 번 전달할 수 있으며, 매칭된 링크에는 요청 자체를 보내지 않고 스캔
-라인에 무시된 개수를 표시합니다.
+`--ignore-url`은 소스에 적힌 URL을 대소문자 구분 없는 부분 문자열로
+매칭합니다 — `--ignore-url twitter.com`은 `twitter.com`(또는 `Twitter.com`)이
+포함된 모든 링크를 건너뛰고, `*`는 임의 문자열과 매칭됩니다
+(`--ignore-url 'https://example.com/*'`). 여러 번 전달할 수 있으며, 매칭된
+링크에는 요청 자체를 보내지 않습니다. 무시된 개수는 스캔 라인과 JSON의
+`ignored_count`에 함께 표시되므로, "모두 정상"과 "패턴이 과하게 넓어 아무것도
+검사하지 않음"을 기계적으로 구분할 수 있습니다.
 
 `--allow-status`는 브라우저에는 정상 응답하면서 링크 검사기에는 `403`/`429`를
 돌려주는 호스트를 위한 것으로, 나열된 상태 코드는 CI를 실패시키지 않습니다.
@@ -138,6 +140,7 @@ checked: 50 links, 3 dead
       "status": -1,
       "error": "Skipped: private/internal address"
     }
-  ]
+  ],
+  "ignored_count": 0
 }
 ```

--- a/docs/content/start/tools/check-links.md
+++ b/docs/content/start/tools/check-links.md
@@ -18,6 +18,9 @@ hwaro tool check-links --timeout 30 --concurrency 4
 # Check only external or internal links
 hwaro tool check-links --external-only
 hwaro tool check-links --internal-only
+
+# Silence a known-flaky host, and accept bot-blocking status codes
+hwaro tool check-links --ignore-url twitter.com --allow-status 403,429
 ```
 
 ## Options
@@ -29,17 +32,35 @@ hwaro tool check-links --internal-only
 | --concurrency N | Max concurrent requests (default: 8) |
 | --external-only | Check external links only |
 | --internal-only | Check internal links only |
+| --ignore-url PATTERN | Skip links whose URL matches PATTERN (repeatable) |
+| --allow-status CODES | Treat these HTTP status codes as healthy (comma-separated) |
 | -j, --json | Output result as JSON |
 | -h, --help | Show help |
+
+`--ignore-url` matches the URL as written in the source, as a substring —
+`--ignore-url twitter.com` skips every link containing `twitter.com`, and `*`
+matches any run of characters (`--ignore-url 'https://example.com/*'`). The
+flag can be passed multiple times; matching links are never contacted at all,
+and the scan line reports how many were ignored.
+
+`--allow-status` is for hosts that answer link checkers with `403`/`429`
+while serving browsers fine: a listed status counts as healthy instead of
+failing CI.
 
 ## How It Works
 
 1. Scans all Markdown files in the `content/` directory
 2. Finds external URLs (http/https links) and internal links (relative/absolute paths)
-3. Sends concurrent HEAD requests to external URLs
+3. Sends concurrent HEAD requests to external URLs (falling back to GET when a
+   host rejects HEAD with 405/403/501, following up to 5 redirects)
 4. Verifies internal link targets exist on disk (checks `.md`, `_index.md`, `index.md`)
 5. Accepts routes the build generates rather than reads from disk
 6. Reports broken or unreachable links
+
+External links that resolve to private or internal addresses (localhost,
+RFC 1918 ranges, `.local`/`.internal` hosts) are never contacted — they are
+reported as skipped instead, both in the human output and under
+`skipped_external` in the JSON payload.
 
 ### Generated routes
 
@@ -108,6 +129,17 @@ command exits non-zero when dead links are found, so it can gate CI.
       },
       "status": 404,
       "error": null
+    }
+  ],
+  "skipped_external": [
+    {
+      "link": {
+        "file": "content/notes/intranet.md",
+        "url": "http://wiki.internal/page",
+        "kind": "external"
+      },
+      "status": -1,
+      "error": "Skipped: private/internal address"
     }
   ]
 }

--- a/docs/content/start/tools/check-links.md
+++ b/docs/content/start/tools/check-links.md
@@ -37,11 +37,14 @@ hwaro tool check-links --ignore-url twitter.com --allow-status 403,429
 | -j, --json | Output result as JSON |
 | -h, --help | Show help |
 
-`--ignore-url` matches the URL as written in the source, as a substring —
-`--ignore-url twitter.com` skips every link containing `twitter.com`, and `*`
-matches any run of characters (`--ignore-url 'https://example.com/*'`). The
-flag can be passed multiple times; matching links are never contacted at all,
-and the scan line reports how many were ignored.
+`--ignore-url` matches the URL as written in the source, as a
+case-insensitive substring — `--ignore-url twitter.com` skips every link
+containing `twitter.com` (or `Twitter.com`), and `*` matches any run of
+characters (`--ignore-url 'https://example.com/*'`). The flag can be passed
+multiple times; matching links are never contacted at all, the scan line
+reports how many were ignored, and the JSON payload carries the same number
+as `ignored_count` — so a machine consumer can tell "all healthy" from "an
+over-broad pattern checked nothing".
 
 `--allow-status` is for hosts that answer link checkers with `403`/`429`
 while serving browsers fine: a listed status counts as healthy instead of
@@ -141,6 +144,7 @@ command exits non-zero when dead links are found, so it can gate CI.
       "status": -1,
       "error": "Skipped: private/internal address"
     }
-  ]
+  ],
+  "ignored_count": 0
 }
 ```

--- a/docs/content/start/tools/convert.ko.md
+++ b/docs/content/start/tools/convert.ko.md
@@ -19,6 +19,9 @@ hwaro tool convert to-json
 # 특정 디렉터리만 변환
 hwaro tool convert to-yaml -c posts
 
+# 아무것도 바꾸지 않고 어떤 파일이 변환될지 미리보기
+hwaro tool convert to-yaml --dry-run
+
 # 결과를 JSON으로 출력
 hwaro tool convert to-yaml --json
 ```
@@ -27,9 +30,15 @@ hwaro tool convert to-yaml --json
 
 | 플래그 | 설명 |
 |------|-------------|
-| -c, --content DIR | 특정 콘텐츠 디렉터리로 변환 범위 제한 |
+| -c, --content-dir DIR | 특정 콘텐츠 디렉터리로 변환 범위 제한 |
+| --dry-run | 파일을 변경하지 않고 변환 대상만 미리보기 |
 | -j, --json | 결과를 JSON으로 출력 |
 | -h, --help | 도움말 표시 |
+
+변환은 파일을 제자리에서 다시 쓰며 프런트매터 주석을 보존할 수 없으므로,
+중요한 트리에는 `--dry-run`을 먼저 실행하세요. 파일을 쓰지 않을 뿐 파일별
+"dropping N comment line(s)" 경고를 포함한 전체 파이프라인이 동일하게
+동작합니다.
 
 ## JSON 출력
 
@@ -39,7 +48,8 @@ hwaro tool convert to-yaml --json
   "message": "Converted 5 files to YAML",
   "converted_count": 5,
   "skipped_count": 2,
-  "error_count": 0
+  "error_count": 0,
+  "dry_run": false
 }
 ```
 

--- a/docs/content/start/tools/convert.md
+++ b/docs/content/start/tools/convert.md
@@ -19,6 +19,9 @@ hwaro tool convert to-json
 # Convert only in a specific directory
 hwaro tool convert to-yaml -c posts
 
+# Preview which files would change without touching anything
+hwaro tool convert to-yaml --dry-run
+
 # Output result as JSON
 hwaro tool convert to-yaml --json
 ```
@@ -27,9 +30,15 @@ hwaro tool convert to-yaml --json
 
 | Flag | Description |
 |------|-------------|
-| -c, --content DIR | Limit conversion to a specific content directory |
+| -c, --content-dir DIR | Limit conversion to a specific content directory |
+| --dry-run | Preview what would be converted without changing any file |
 | -j, --json | Output result as JSON |
 | -h, --help | Show help |
+
+Conversion rewrites files in place and cannot preserve front-matter comments,
+so run `--dry-run` first on a tree you care about: it runs the full
+detection/conversion pipeline — including the per-file "dropping N comment
+line(s)" warnings — without writing anything back.
 
 ## JSON Output
 
@@ -39,7 +48,8 @@ hwaro tool convert to-yaml --json
   "message": "Converted 5 files to YAML",
   "converted_count": 5,
   "skipped_count": 2,
-  "error_count": 0
+  "error_count": 0,
+  "dry_run": false
 }
 ```
 

--- a/docs/content/start/tools/doctor.ko.md
+++ b/docs/content/start/tools/doctor.ko.md
@@ -164,6 +164,7 @@ ignore = [
 | `default-language-undefined` | config | default_language에 대응하는 `[languages.<code>]` 없음 |
 | `markdown-math-engine-invalid` | config | 지원하지 않는 markdown.math_engine |
 | `pwa-cache-strategy-invalid` | config | 지원하지 않는 pwa.cache_strategy |
+| `image-processing-widths-empty` | config | image_processing이 켜져 있으나 widths가 비어 있음 (무음 no-op) |
 | `deployment-target-undefined` | config | deployment.target에 대응하는 `[[deployment.targets]]` 없음 |
 | `related-taxonomy-undefined` | config | `[related]`가 정의되지 않은 택소노미를 참조 |
 | `menu-parent-undefined` | config | 메뉴 항목의 `parent`가 같은 메뉴의 identifier와 맞지 않음 |

--- a/docs/content/start/tools/doctor.md
+++ b/docs/content/start/tools/doctor.md
@@ -165,6 +165,7 @@ Rows marked ✗ are error level and **cannot** be ignored.
 | `default-language-undefined` | config | default_language has no `[languages.<code>]` block |
 | `markdown-math-engine-invalid` | config | Unsupported markdown.math_engine |
 | `pwa-cache-strategy-invalid` | config | Unsupported pwa.cache_strategy |
+| `image-processing-widths-empty` | config | image_processing enabled but widths is empty (silent no-op) |
 | `deployment-target-undefined` | config | deployment.target names no `[[deployment.targets]]` |
 | `related-taxonomy-undefined` | config | `[related]` references an undefined taxonomy |
 | `menu-parent-undefined` | config | Menu entry's `parent` matches no identifier in that menu |

--- a/docs/content/start/tools/export.ko.md
+++ b/docs/content/start/tools/export.ko.md
@@ -35,10 +35,34 @@ hwaro tool export hugo --verbose
 | 플래그 | 설명 |
 |------|-------------|
 | -o, --output DIR | 출력 디렉터리 (기본값: export) |
-| -c, --content DIR | 콘텐츠 디렉터리 (기본값: content) |
+| -c, --content-dir DIR | 콘텐츠 디렉터리 (기본값: content) |
 | -d, --drafts | 초안 콘텐츠 포함 |
+| --dry-run | 아무것도 쓰지 않고 모든 대상 경로 미리보기 |
 | -v, --verbose | 상세 출력 표시 |
+| -j, --json | 파일별 매니페스트를 JSON으로 출력 |
 | -h, --help | 도움말 표시 |
+
+같은 디렉터리로 다시 내보내면 이전 출력을 **대체**합니다 — 이것이 일반적인
+갱신 워크플로입니다. 기존 파일을 대체한 실행은 요약에 개수와 함께 경고가
+표시되고, JSON 매니페스트에서는 해당 행이 `overwritten`으로 표시됩니다(새
+대상은 `exported`). 쓰기 전에 전체 매니페스트를 보려면 `--dry-run`을
+사용하세요.
+
+## JSON 출력
+
+```json
+{
+  "success": true,
+  "dry_run": false,
+  "exported_count": 2,
+  "skipped_count": 0,
+  "error_count": 0,
+  "files": [
+    { "path": "export/_posts/2024-01-01-hello.md", "action": "exported" },
+    { "path": "export/about.md", "action": "overwritten" }
+  ]
+}
+```
 
 ## 필드 매핑
 

--- a/docs/content/start/tools/export.ko.md
+++ b/docs/content/start/tools/export.ko.md
@@ -64,6 +64,9 @@ hwaro tool export hugo --verbose
 }
 ```
 
+`files`에는 페이지 번들 에셋을 포함해 기록된 모든 대상 경로가 나열되며,
+카운트는 콘텐츠 문서만 셉니다.
+
 ## 필드 매핑
 
 ### Hugo

--- a/docs/content/start/tools/export.md
+++ b/docs/content/start/tools/export.md
@@ -35,10 +35,34 @@ hwaro tool export hugo --verbose
 | Flag | Description |
 |------|-------------|
 | -o, --output DIR | Output directory (default: export) |
-| -c, --content DIR | Content directory (default: content) |
+| -c, --content-dir DIR | Content directory (default: content) |
 | -d, --drafts | Include draft content |
+| --dry-run | Preview every destination without writing anything |
 | -v, --verbose | Show detailed output |
+| -j, --json | Output a per-file manifest as JSON |
 | -h, --help | Show help |
+
+Re-exporting into the same directory **replaces** the previous output — that
+is the normal refresh workflow. When a run replaces pre-existing files, the
+summary warns with the count, and the JSON manifest marks those rows
+`overwritten` (fresh destinations are `exported`). Use `--dry-run` to see the
+full manifest before writing.
+
+## JSON Output
+
+```json
+{
+  "success": true,
+  "dry_run": false,
+  "exported_count": 2,
+  "skipped_count": 0,
+  "error_count": 0,
+  "files": [
+    { "path": "export/_posts/2024-01-01-hello.md", "action": "exported" },
+    { "path": "export/about.md", "action": "overwritten" }
+  ]
+}
+```
 
 ## Field Mappings
 

--- a/docs/content/start/tools/export.md
+++ b/docs/content/start/tools/export.md
@@ -64,6 +64,9 @@ full manifest before writing.
 }
 ```
 
+`files` lists every destination written — page-bundle assets included —
+while the counts cover content documents only.
+
 ## Field Mappings
 
 ### Hugo

--- a/docs/content/start/tools/import.ko.md
+++ b/docs/content/start/tools/import.ko.md
@@ -48,8 +48,35 @@ hwaro tool import hugo path/to/site --verbose
 |------|-------------|
 | -o, --output DIR | 출력 콘텐츠 디렉터리 (기본값: `content`) |
 | -d, --drafts | 초안 콘텐츠 포함 |
+| --force | 기존 파일을 건너뛰지 않고 덮어쓰기 |
+| --dry-run | 아무것도 쓰지 않고 모든 대상 경로 미리보기 |
 | -v, --verbose | 상세 출력 표시 |
+| -j, --json | 파일별 매니페스트를 JSON으로 출력 |
 | -h, --help | 도움말 표시 |
+
+`--dry-run`은 충돌로 인한 이름 변경과 건너뛰기 판정을 포함해 모든 대상 경로를
+실제와 동일하게 해석하되 디스크는 건드리지 않으므로, 대규모 임포트가 정확히
+무엇을 할지 실행 전에 확인할 수 있습니다.
+
+## JSON 출력
+
+```json
+{
+  "success": true,
+  "dry_run": false,
+  "imported_count": 2,
+  "skipped_count": 1,
+  "error_count": 0,
+  "files": [
+    { "path": "content/posts/hello.md", "action": "imported" },
+    { "path": "content/posts/second.md", "action": "imported" },
+    { "path": "content/posts/existing.md", "action": "skipped" }
+  ]
+}
+```
+
+`action`은 `imported`, `skipped`(대상이 이미 존재하고 `--force` 미지정),
+`overwritten`(`--force`로 기존 파일 대체) 중 하나입니다.
 
 ## 동작
 

--- a/docs/content/start/tools/import.ko.md
+++ b/docs/content/start/tools/import.ko.md
@@ -77,6 +77,10 @@ hwaro tool import hugo path/to/site --verbose
 
 `action`은 `imported`, `skipped`(대상이 이미 존재하고 `--force` 미지정),
 `overwritten`(`--force`로 기존 파일 대체) 중 하나입니다.
+`files`에는 페이지 번들 에셋을 포함해 실행이 해석한 모든 대상 경로가
+나열되며, 카운트는 콘텐츠 문서만 셉니다. 대상 경로를 해석하기 전에 건너뛴
+소스(`--drafts` 없는 초안, 안전하지 않은 슬러그)는 카운트에만 반영되고 행은
+없습니다.
 
 ## 동작
 

--- a/docs/content/start/tools/import.md
+++ b/docs/content/start/tools/import.md
@@ -48,8 +48,35 @@ hwaro tool import hugo path/to/site --verbose
 |------|-------------|
 | -o, --output DIR | Output content directory (default: `content`) |
 | -d, --drafts | Include draft content |
+| --force | Overwrite existing files instead of skipping |
+| --dry-run | Preview every destination without writing anything |
 | -v, --verbose | Show detailed output |
+| -j, --json | Output a per-file manifest as JSON |
 | -h, --help | Show help |
+
+`--dry-run` resolves every destination — collision renames and skip decisions
+included — and reports the counts and manifest without touching disk, so you
+can inspect exactly what a large import will do before running it for real.
+
+## JSON Output
+
+```json
+{
+  "success": true,
+  "dry_run": false,
+  "imported_count": 2,
+  "skipped_count": 1,
+  "error_count": 0,
+  "files": [
+    { "path": "content/posts/hello.md", "action": "imported" },
+    { "path": "content/posts/second.md", "action": "imported" },
+    { "path": "content/posts/existing.md", "action": "skipped" }
+  ]
+}
+```
+
+`action` is `imported`, `skipped` (destination already exists and `--force`
+was not passed), or `overwritten` (`--force` replaced an existing file).
 
 ## Behavior
 

--- a/docs/content/start/tools/import.md
+++ b/docs/content/start/tools/import.md
@@ -77,6 +77,10 @@ can inspect exactly what a large import will do before running it for real.
 
 `action` is `imported`, `skipped` (destination already exists and `--force`
 was not passed), or `overwritten` (`--force` replaced an existing file).
+`files` lists every destination the run resolved — page-bundle assets
+included — while the counts cover content documents only; sources skipped
+before a destination was resolved (drafts without `--drafts`, unsafe slugs)
+appear in the counts but have no row.
 
 ## Behavior
 

--- a/docs/content/start/tools/list.ko.md
+++ b/docs/content/start/tools/list.ko.md
@@ -19,6 +19,13 @@ hwaro tool list published
 # 특정 디렉터리의 파일 나열
 hwaro tool list all -c posts
 
+# 가장 최근 발행 파일 5개
+hwaro tool list published --limit 5
+
+# 제목순 정렬(A→Z), 또는 임의 정렬의 역순
+hwaro tool list all --sort title
+hwaro tool list all --sort path --reverse
+
 # 결과를 JSON으로 출력
 hwaro tool list all --json
 ```
@@ -27,9 +34,17 @@ hwaro tool list all --json
 
 | 플래그 | 설명 |
 |------|-------------|
-| -c, --content DIR | 특정 콘텐츠 디렉터리로 목록 범위 제한 |
+| -c, --content-dir DIR | 특정 콘텐츠 디렉터리로 목록 범위 제한 |
+| --sort KEY | 정렬 키: `date`(최신순, 기본값), `title`, `path` |
+| -r, --reverse | 정렬 순서 뒤집기 |
+| -n, --limit N | 최대 N개 파일만 표시 (정렬 후 적용) |
 | -j, --json | 결과를 JSON으로 출력 |
 | -h, --help | 도움말 표시 |
+
+`--limit`은 정렬 후에 적용되므로 `--sort date --limit 5`는 "가장 최신 5개",
+`--sort date --reverse --limit 5`는 가장 오래된 5개를 의미합니다.
+
+필터 인자는 축약형 `draft`(`drafts`)와 `pub`(`published`)도 허용합니다.
 
 ## 필터
 

--- a/docs/content/start/tools/list.ko.md
+++ b/docs/content/start/tools/list.ko.md
@@ -43,6 +43,8 @@ hwaro tool list all --json
 
 `--limit`은 정렬 후에 적용되므로 `--sort date --limit 5`는 "가장 최신 5개",
 `--sort date --reverse --limit 5`는 가장 오래된 5개를 의미합니다.
+`--sort title`은 템플릿 엔진의 `sort_by="title"`과 같은 대소문자 구분
+정렬을 사용하므로 CLI 목록이 렌더링된 섹션 인덱스와 일치합니다.
 
 필터 인자는 축약형 `draft`(`drafts`)와 `pub`(`published`)도 허용합니다.
 

--- a/docs/content/start/tools/list.md
+++ b/docs/content/start/tools/list.md
@@ -19,6 +19,13 @@ hwaro tool list published
 # List files in a specific directory
 hwaro tool list all -c posts
 
+# The 5 newest published files
+hwaro tool list published --limit 5
+
+# Sort by title (A→Z), or reverse any ordering
+hwaro tool list all --sort title
+hwaro tool list all --sort path --reverse
+
 # Output result as JSON
 hwaro tool list all --json
 ```
@@ -27,9 +34,18 @@ hwaro tool list all --json
 
 | Flag | Description |
 |------|-------------|
-| -c, --content DIR | Limit listing to a specific content directory |
+| -c, --content-dir DIR | Limit listing to a specific content directory |
+| --sort KEY | Sort key: `date` (newest first, default), `title`, or `path` |
+| -r, --reverse | Reverse the sort order |
+| -n, --limit N | Show at most N files (applied after sorting) |
 | -j, --json | Output result as JSON |
 | -h, --help | Show help |
+
+`--limit` caps the result after sorting, so `--sort date --limit 5` means
+"the 5 newest files", and `--sort date --reverse --limit 5` the 5 oldest.
+
+The filter argument also accepts the shorthands `draft` (for `drafts`) and
+`pub` (for `published`).
 
 ## Filters
 

--- a/docs/content/start/tools/list.md
+++ b/docs/content/start/tools/list.md
@@ -43,6 +43,9 @@ hwaro tool list all --json
 
 `--limit` caps the result after sorting, so `--sort date --limit 5` means
 "the 5 newest files", and `--sort date --reverse --limit 5` the 5 oldest.
+`--sort title` uses the same case-sensitive ordering as the template
+engine's `sort_by="title"`, so the CLI listing matches a rendered section
+index.
 
 The filter argument also accepts the shorthands `draft` (for `drafts`) and
 `pub` (for `published`).

--- a/docs/content/start/tools/stats.ko.md
+++ b/docs/content/start/tools/stats.ko.md
@@ -19,6 +19,9 @@ hwaro tool stats
 # 사용자 지정 콘텐츠 디렉터리 사용
 hwaro tool stats -c posts
 
+# 기본 15개 대신 상위 30개 태그 차트
+hwaro tool stats --top 30
+
 # JSON으로 출력
 hwaro tool stats --json
 ```
@@ -27,7 +30,8 @@ hwaro tool stats --json
 
 | 플래그 | 설명 |
 |------|-------------|
-| -c, --content DIR | 콘텐츠 디렉터리 (기본값: content) |
+| -c, --content-dir DIR | 콘텐츠 디렉터리 (기본값: content) |
+| --top N | 차트에 상위 N개 태그 표시 (기본값: 15) |
 | -j, --json | 결과를 JSON으로 출력 |
 | -h, --help | 도움말 표시 |
 
@@ -53,8 +57,9 @@ counted: 42 files, 37 published, 4 drafts · 1 future
 ```
 
 색상 터미널에서는 같은 보고서가 `hwaro stats` 헤딩, 정렬된 영수증 형식 행,
-비례 막대 차트, `✦ counted` 결과 줄로 표시됩니다. 태그가 15개를 넘으면 상위
-15개만 차트로 그립니다(`tags: top 15`).
+비례 막대 차트, `✦ counted` 결과 줄로 표시됩니다. 태그가 차트 예산을 넘으면
+상위 N개만 차트로 그립니다(기본 `tags: top 15`, `--top N`으로 조정). JSON
+출력은 `--top`과 무관하게 항상 모든 태그를 담습니다.
 
 ## JSON 출력
 

--- a/docs/content/start/tools/stats.md
+++ b/docs/content/start/tools/stats.md
@@ -20,6 +20,9 @@ hwaro tool stats
 # Use a custom content directory
 hwaro tool stats -c posts
 
+# Chart the top 30 tags instead of the default 15
+hwaro tool stats --top 30
+
 # Output as JSON
 hwaro tool stats --json
 ```
@@ -28,7 +31,8 @@ hwaro tool stats --json
 
 | Flag | Description |
 |------|-------------|
-| -c, --content DIR | Content directory (default: content) |
+| -c, --content-dir DIR | Content directory (default: content) |
+| --top N | Show the top N tags in the chart (default: 15) |
 | -j, --json | Output result as JSON |
 | -h, --help | Show help |
 
@@ -55,7 +59,9 @@ counted: 42 files, 37 published, 4 drafts · 1 future
 
 In a color terminal the same report renders as an `hwaro stats` heading, aligned
 receipt rows, proportional bar charts, and a `✦ counted` outcome line. When
-there are more than 15 tags, only the top 15 are charted (`tags: top 15`).
+there are more tags than the chart budget, only the top N are charted
+(`tags: top 15` by default — raise or lower it with `--top N`). The JSON
+output always contains every tag regardless of `--top`.
 
 ## JSON Output
 

--- a/docs/content/start/tools/unused-assets.ko.md
+++ b/docs/content/start/tools/unused-assets.ko.md
@@ -30,8 +30,9 @@ hwaro tool unused-assets --delete --force --json
 
 | 플래그 | 설명 |
 |------|-------------|
-| -c, --content DIR | 콘텐츠 디렉터리 (기본값: content) |
+| -c, --content-dir DIR | 콘텐츠 디렉터리 (기본값: content) |
 | -s, --static-dir DIR | 정적 파일 디렉터리 (기본값: static) |
+| -t, --templates-dir DIR | 참조 스캔 대상 템플릿 디렉터리 (기본값: templates) |
 | --delete | 사용하지 않는 파일 삭제 (확인 프롬프트 표시) |
 | -f, --force | 삭제 시 확인 프롬프트 생략 (`--json`에서 삭제하려면 필수) |
 | -j, --json | 결과를 JSON으로 출력 |
@@ -45,10 +46,17 @@ hwaro tool unused-assets --delete --force --json
 
 **참조 소스:**
 - 모든 콘텐츠 파일 (`.md`, `.markdown`)
-- 모든 템플릿 파일 (`.html`, `.css`, `.js`)
+- 템플릿 파일 (`.html`, `.j2`, `.jinja`, `.jinja2`, `.ecr`, 그리고 `.css`, `.js`, `.xml`, `.json`, `.webmanifest`, `.svg`, `.txt`)
+- 다른 정적 파일을 참조할 수 있는 정적 소스 (`.css`, `.scss`, `.sass`, `.js`, `.json`, `.webmanifest`, `.xml`, `.svg`, `.txt`, `.html`, `.htm`)
+- 데이터·번역 파일 (`data/`, `i18n/` — `.yml`, `.yaml`, `.json`, `.toml`)
+- 파일을 지정하는 `config.toml` 값
+
+템플릿이 `templates/` 밖에 있다면 `--templates-dir`로 스캔 위치를 알려주세요.
+그렇지 않으면 해당 템플릿의 에셋 참조가 보이지 않아, 실제로 쓰이는 에셋이
+미사용으로 보고되고 `--delete`로 삭제될 수 있습니다.
 
 **지원 에셋 확장자:**
-이미지(png, jpg, jpeg, gif, svg, webp, avif, ico, bmp, tiff), 스타일시트(css), 스크립트(js), 폰트(woff, woff2, ttf, eot, otf), 미디어(mp4, webm, ogg, mp3, wav), 문서(pdf, zip).
+이미지(png, jpg, jpeg, gif, svg, webp, avif, ico, bmp, tiff, tif), 스타일시트(css), 스크립트(js), 폰트(woff, woff2, ttf, eot, otf), 미디어(mp4, webm, ogg, mp3, wav), 문서(pdf, zip).
 
 ## 출력 예시
 

--- a/docs/content/start/tools/unused-assets.ko.md
+++ b/docs/content/start/tools/unused-assets.ko.md
@@ -54,6 +54,9 @@ hwaro tool unused-assets --delete --force --json
 템플릿이 `templates/` 밖에 있다면 `--templates-dir`로 스캔 위치를 알려주세요.
 그렇지 않으면 해당 템플릿의 에셋 참조가 보이지 않아, 실제로 쓰이는 에셋이
 미사용으로 보고되고 `--delete`로 삭제될 수 있습니다.
+명시적으로 전달한 `--templates-dir`은 반드시 존재해야 하며(경로는 현재
+디렉터리 기준), 없는 경로면 템플릿 0개를 조용히 스캔하는 대신 실행을
+거부합니다.
 
 **지원 에셋 확장자:**
 이미지(png, jpg, jpeg, gif, svg, webp, avif, ico, bmp, tiff, tif), 스타일시트(css), 스크립트(js), 폰트(woff, woff2, ttf, eot, otf), 미디어(mp4, webm, ogg, mp3, wav), 문서(pdf, zip).

--- a/docs/content/start/tools/unused-assets.md
+++ b/docs/content/start/tools/unused-assets.md
@@ -30,8 +30,9 @@ hwaro tool unused-assets --delete --force --json
 
 | Flag | Description |
 |------|-------------|
-| -c, --content DIR | Content directory (default: content) |
+| -c, --content-dir DIR | Content directory (default: content) |
 | -s, --static-dir DIR | Static files directory (default: static) |
+| -t, --templates-dir DIR | Templates directory scanned for references (default: templates) |
 | --delete | Delete unused files (prompts for confirmation) |
 | -f, --force | Skip the confirmation prompt when deleting (required for deletion under `--json`) |
 | -j, --json | Output result as JSON |
@@ -45,10 +46,17 @@ hwaro tool unused-assets --delete --force --json
 
 **Reference sources:**
 - All content files (`.md`, `.markdown`)
-- All template files (`.html`, `.css`, `.js`)
+- Template files (`.html`, `.j2`, `.jinja`, `.jinja2`, `.ecr`, plus `.css`, `.js`, `.xml`, `.json`, `.webmanifest`, `.svg`, `.txt`)
+- Static sources that can reference other static files (`.css`, `.scss`, `.sass`, `.js`, `.json`, `.webmanifest`, `.xml`, `.svg`, `.txt`, `.html`, `.htm`)
+- Data and translation files (`data/` and `i18n/` — `.yml`, `.yaml`, `.json`, `.toml`)
+- `config.toml` values that name files
+
+If your templates live outside `templates/`, point the scan at them with
+`--templates-dir` — otherwise their asset references are invisible and the
+assets they use are reported (and can be deleted) as unused.
 
 **Supported asset extensions:**
-Images (png, jpg, jpeg, gif, svg, webp, avif, ico, bmp, tiff), stylesheets (css), scripts (js), fonts (woff, woff2, ttf, eot, otf), media (mp4, webm, ogg, mp3, wav), documents (pdf, zip).
+Images (png, jpg, jpeg, gif, svg, webp, avif, ico, bmp, tiff, tif), stylesheets (css), scripts (js), fonts (woff, woff2, ttf, eot, otf), media (mp4, webm, ogg, mp3, wav), documents (pdf, zip).
 
 ## Example Output
 

--- a/docs/content/start/tools/unused-assets.md
+++ b/docs/content/start/tools/unused-assets.md
@@ -53,7 +53,10 @@ hwaro tool unused-assets --delete --force --json
 
 If your templates live outside `templates/`, point the scan at them with
 `--templates-dir` — otherwise their asset references are invisible and the
-assets they use are reported (and can be deleted) as unused.
+assets they use are reported (and can be deleted) as unused. An explicitly
+passed `--templates-dir` must exist (the path is resolved relative to the
+current directory); the command refuses to run against a missing one rather
+than silently scanning zero templates.
 
 **Supported asset extensions:**
 Images (png, jpg, jpeg, gif, svg, webp, avif, ico, bmp, tiff, tif), stylesheets (css), scripts (js), fonts (woff, woff2, ttf, eot, otf), media (mp4, webm, ogg, mp3, wav), documents (pdf, zip).

--- a/docs/content/start/tools/validate.ko.md
+++ b/docs/content/start/tools/validate.ko.md
@@ -13,6 +13,10 @@ hwaro tool validate
 # 특정 콘텐츠 디렉터리 검증
 hwaro tool validate -c posts
 
+# 경고도 CI 실패로 처리하거나, 허용 경고 수 상한 지정
+hwaro tool validate --strict
+hwaro tool validate --max-warnings 5
+
 # JSON으로 출력
 hwaro tool validate --json
 ```
@@ -21,7 +25,9 @@ hwaro tool validate --json
 
 | 플래그 | 설명 |
 |------|-------------|
-| -c, --content DIR | 콘텐츠 디렉터리 (기본값: content) |
+| -c, --content-dir DIR | 콘텐츠 디렉터리 (기본값: content) |
+| --strict | 종료 코드 계산 시 경고를 오류로 취급 |
+| --max-warnings N | 경고 수가 N을 넘으면 0이 아닌 코드로 종료 (기본값: 무제한) |
 | -j, --json | 결과를 JSON으로 출력 |
 | -h, --help | 도움말 표시 |
 
@@ -55,6 +61,11 @@ checked: 0 errors, 2 warnings, 2 info
 색상 터미널에서는 발견 항목이 `hwaro validate` 헤딩 아래 `⚠`/`✗`/`ℹ` 기호로
 표시되고, 마지막 줄은 심각도별 색이 입혀진 `✦ checked` 결과입니다. 오류 수준
 문제가 발견되면 0이 아닌 종료 코드를 반환하므로 CI 게이트로 쓸 수 있습니다.
+
+종료 코드는 `hwaro doctor`와 같은 규칙을 따릅니다. 오류 수준 발견은 콘텐츠
+오류 코드(5)로, `--strict`/`--max-warnings`로 인한 경고 기반 실패는 일반
+코드(1)로 종료되어 파일 자체의 문제와 게이트 강화로 인한 실패를 구분할 수
+있습니다. 두 플래그는 `--json` 실행에도 동일하게 적용됩니다.
 
 ## 규칙 ID
 

--- a/docs/content/start/tools/validate.md
+++ b/docs/content/start/tools/validate.md
@@ -13,6 +13,10 @@ hwaro tool validate
 # Validate a specific content directory
 hwaro tool validate -c posts
 
+# Fail CI on any warning, or cap the allowed warning count
+hwaro tool validate --strict
+hwaro tool validate --max-warnings 5
+
 # Output as JSON
 hwaro tool validate --json
 ```
@@ -21,7 +25,9 @@ hwaro tool validate --json
 
 | Flag | Description |
 |------|-------------|
-| -c, --content DIR | Content directory (default: content) |
+| -c, --content-dir DIR | Content directory (default: content) |
+| --strict | Treat warnings as errors when computing the exit code |
+| --max-warnings N | Exit non-zero when warning count exceeds N (default: unlimited) |
 | -j, --json | Output result as JSON |
 | -h, --help | Show help |
 
@@ -55,6 +61,11 @@ checked: 0 errors, 2 warnings, 2 info
 In a color terminal the findings use `⚠`/`✗`/`ℹ` glyphs under an `hwaro validate`
 heading, and the closing line is a severity-colored `✦ checked` outcome. The
 command exits non-zero when error-level issues are found, so it can gate CI.
+
+Exit codes mirror `hwaro doctor`: error-level findings exit with the content
+error code (5), while warning-driven failures from `--strict` or
+`--max-warnings` exit with the generic code (1) — a consumer can still tell a
+broken file from a tightened gate. Both flags apply to `--json` runs too.
 
 ## Rule IDs
 

--- a/skills/hwaro/SKILL.md
+++ b/skills/hwaro/SKILL.md
@@ -187,8 +187,10 @@ hwaro tool import hugo /path/to/hugo-site     # also: jekyll, wordpress, notion,
 hwaro tool export jekyll                       # also: hugo
 ```
 
-`-c, --content DIR` scopes most tools to a subtree; `-j, --json` is widely
-available. Run `hwaro tool <name> --help` for specifics.
+`-c, --content-dir DIR` scopes most tools to a subtree; `-j, --json` is widely
+available (import/export emit a per-file manifest). `--dry-run` previews
+convert/import/export without writing. Run `hwaro tool <name> --help` for
+specifics.
 
 ### G. Platform config & deploy
 

--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -615,3 +615,285 @@ describe "hwaro tool check-links (generated routes)" do
     end
   end
 end
+
+# =============================================================================
+# Feature-flag coverage: the 2026-08 tool improvement batch.
+# =============================================================================
+
+describe "hwaro tool check-links (--ignore-url / --allow-status)" do
+  it "silences a broken link matched by --ignore-url" do
+    with_initialized_project do |project_dir|
+      File.write(File.join(project_dir, "content", "broken.md"),
+        "+++\ntitle = \"B\"\n+++\n\n[dead](/definitely-missing/)\n")
+
+      status, _, _ = run_hwaro(["tool", "check-links", "--internal-only"], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_GENERIC)
+
+      ignored, _, _ = run_hwaro(
+        ["tool", "check-links", "--internal-only", "--ignore-url", "definitely-missing"],
+        chdir: project_dir
+      )
+      ignored.success?.should be_true
+    end
+  end
+
+  it "supports * wildcards in --ignore-url patterns" do
+    with_initialized_project do |project_dir|
+      File.write(File.join(project_dir, "content", "broken.md"),
+        "+++\ntitle = \"B\"\n+++\n\n[dead](/definitely-missing/)\n")
+
+      status, _, _ = run_hwaro(
+        ["tool", "check-links", "--internal-only", "--ignore-url", "/definitely*missing/"],
+        chdir: project_dir
+      )
+      status.success?.should be_true
+    end
+  end
+
+  it "emits skipped_external in the --json payload" do
+    with_initialized_project do |project_dir|
+      _, output, _ = run_hwaro(["tool", "check-links", "--json", "--internal-only"], chdir: project_dir)
+      parsed = JSON.parse(output.strip)
+      parsed["skipped_external"].as_a?.should_not be_nil
+    end
+  end
+
+  it "rejects an invalid --allow-status value with the shared usage code" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(["tool", "check-links", "--allow-status", "abc"], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+    end
+  end
+
+  it "rejects an empty --ignore-url pattern with the shared usage code" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(["tool", "check-links", "--ignore-url", " "], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+    end
+  end
+end
+
+describe "hwaro tool validate (--strict / --max-warnings)" do
+  it "gates warnings behind --strict and --max-warnings" do
+    with_initialized_project do |project_dir|
+      # Guarantees at least one warning-level finding (missing description).
+      File.write(File.join(project_dir, "content", "warny.md"),
+        "+++\ntitle = \"W\"\n+++\n\nBody\n")
+
+      status, _, _ = run_hwaro(["tool", "validate"], chdir: project_dir)
+      status.success?.should be_true
+
+      strict, _, _ = run_hwaro(["tool", "validate", "--strict"], chdir: project_dir)
+      strict.exit_code.should eq(Hwaro::Errors::EXIT_GENERIC)
+
+      capped, _, _ = run_hwaro(["tool", "validate", "--max-warnings", "0"], chdir: project_dir)
+      capped.exit_code.should eq(Hwaro::Errors::EXIT_GENERIC)
+
+      loose, _, _ = run_hwaro(["tool", "validate", "--max-warnings", "999"], chdir: project_dir)
+      loose.success?.should be_true
+    end
+  end
+
+  it "applies --strict to the --json exit code too" do
+    with_initialized_project do |project_dir|
+      File.write(File.join(project_dir, "content", "warny.md"),
+        "+++\ntitle = \"W\"\n+++\n\nBody\n")
+
+      status, output, _ = run_hwaro(["tool", "validate", "--strict", "--json"], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_GENERIC)
+      JSON.parse(output.strip)["findings"].as_a?.should_not be_nil
+    end
+  end
+
+  it "rejects a negative --max-warnings with the shared usage code" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(["tool", "validate", "--max-warnings", "-1"], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+    end
+  end
+end
+
+describe "hwaro tool list (--sort / --reverse / --limit)" do
+  it "sorts by path, reverses, and limits the --json output" do
+    with_initialized_project do |project_dir|
+      status, output, _ = run_hwaro(["tool", "list", "all", "--json", "--sort", "path"], chdir: project_dir)
+      status.success?.should be_true
+      paths = JSON.parse(output.strip).as_a.map(&.["path"].as_s)
+      paths.should eq(paths.sort)
+      paths.size.should be > 1
+
+      _, reversed_out, _ = run_hwaro(
+        ["tool", "list", "all", "--json", "--sort", "path", "--reverse"], chdir: project_dir
+      )
+      JSON.parse(reversed_out.strip).as_a.map(&.["path"].as_s).should eq(paths.reverse)
+
+      _, limited_out, _ = run_hwaro(
+        ["tool", "list", "all", "--json", "--limit", "1"], chdir: project_dir
+      )
+      JSON.parse(limited_out.strip).as_a.size.should eq(1)
+    end
+  end
+
+  it "rejects an unknown --sort key with the shared usage code" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(["tool", "list", "all", "--sort", "size"], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+    end
+  end
+
+  it "rejects a non-positive --limit with the shared usage code" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(["tool", "list", "all", "--limit", "0"], chdir: project_dir)
+      status.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+    end
+  end
+end
+
+describe "hwaro tool stats (--top)" do
+  it "accepts --top and rejects a non-positive value" do
+    with_initialized_project do |project_dir|
+      status, _, _ = run_hwaro(["tool", "stats", "--top", "3"], chdir: project_dir)
+      status.success?.should be_true
+
+      bad, _, err = run_hwaro(["tool", "stats", "--top", "0"], chdir: project_dir)
+      bad.exit_code.should eq(Hwaro::Errors::EXIT_USAGE)
+      err.should contain("HWARO_E_USAGE")
+    end
+  end
+end
+
+describe "hwaro tool unused-assets (--templates-dir)" do
+  it "scans a custom templates directory for references" do
+    with_initialized_project do |project_dir|
+      File.write(File.join(project_dir, "static", "special.png"), "x")
+      custom = File.join(project_dir, "mytemplates")
+      FileUtils.mkdir_p(custom)
+      File.write(File.join(custom, "extra.html"), %(<img src="/special.png">))
+
+      _, default_out, _ = run_hwaro(["tool", "unused-assets", "--json"], chdir: project_dir)
+      JSON.parse(default_out.strip)["unused_files"].as_a.map(&.as_s)
+        .should contain("static/special.png")
+
+      _, custom_out, _ = run_hwaro(
+        ["tool", "unused-assets", "--json", "--templates-dir", "mytemplates"], chdir: project_dir
+      )
+      JSON.parse(custom_out.strip)["unused_files"].as_a.map(&.as_s)
+        .should_not contain("static/special.png")
+    end
+  end
+end
+
+describe "hwaro tool import (--json / --dry-run)" do
+  it "emits a per-file manifest under --json and writes nothing with --dry-run" do
+    with_initialized_project do |project_dir|
+      Dir.mktmpdir do |src|
+        posts = File.join(src, "_posts")
+        FileUtils.mkdir_p(posts)
+        File.write(File.join(posts, "2024-01-01-hi.md"), "---\ntitle: Hi\n---\n\nBody\n")
+        out_dir = File.join(project_dir, "imported")
+
+        status, output, _ = run_hwaro(
+          ["tool", "import", "jekyll", src, "-o", "imported", "--dry-run", "--json"],
+          chdir: project_dir
+        )
+        status.success?.should be_true
+        parsed = JSON.parse(output.strip)
+        parsed["dry_run"].as_bool.should be_true
+        parsed["imported_count"].as_i.should eq(1)
+        parsed["files"].as_a.first["action"].as_s.should eq("imported")
+        Dir.exists?(out_dir).should be_false
+      end
+    end
+  end
+
+  it "actually imports without --dry-run and reports the destination in the manifest" do
+    with_initialized_project do |project_dir|
+      Dir.mktmpdir do |src|
+        posts = File.join(src, "_posts")
+        FileUtils.mkdir_p(posts)
+        File.write(File.join(posts, "2024-01-01-hi.md"), "---\ntitle: Hi\n---\n\nBody\n")
+
+        status, output, _ = run_hwaro(
+          ["tool", "import", "jekyll", src, "-o", "imported", "--json"],
+          chdir: project_dir
+        )
+        status.success?.should be_true
+        parsed = JSON.parse(output.strip)
+        file = parsed["files"].as_a.first
+        file["action"].as_s.should eq("imported")
+        File.exists?(File.join(project_dir, file["path"].as_s)).should be_true
+      end
+    end
+  end
+end
+
+describe "hwaro tool export (--json / --dry-run / classified errors)" do
+  it "emits a per-file manifest under --json and writes nothing with --dry-run" do
+    with_initialized_project do |project_dir|
+      out_dir = File.join(project_dir, "exported")
+
+      status, output, _ = run_hwaro(
+        ["tool", "export", "jekyll", "-o", "exported", "--dry-run", "--json"],
+        chdir: project_dir
+      )
+      status.success?.should be_true
+      parsed = JSON.parse(output.strip)
+      parsed["dry_run"].as_bool.should be_true
+      parsed["exported_count"].as_i.should be > 0
+      parsed["files"].as_a.should_not be_empty
+      Dir.exists?(out_dir).should be_false
+    end
+  end
+
+  it "exits with HWARO_E_IO instead of a bare 1 when the export fails" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(
+        ["tool", "export", "jekyll", "-c", "no-such-dir", "-o", "exported"],
+        chdir: project_dir
+      )
+      status.exit_code.should eq(Hwaro::Errors::EXIT_IO)
+      err.should contain("HWARO_E_IO")
+    end
+  end
+end
+
+describe "hwaro tool convert (--dry-run)" do
+  it "previews the conversion without touching any file" do
+    with_initialized_project do |project_dir|
+      before = Dir.glob(File.join(project_dir, "content", "**", "*.md")).sort.map { |f| {f, File.read(f)} }
+      before.should_not be_empty
+
+      status, output, _ = run_hwaro(["tool", "convert", "to-yaml", "--dry-run"], chdir: project_dir)
+      status.success?.should be_true
+      output.should contain("would convert")
+
+      before.each do |(path, content)|
+        File.read(path).should eq(content)
+      end
+    end
+  end
+end
+
+describe "hwaro tool agents-md (site-specific preservation)" do
+  it "preserves the Site-Specific Instructions section on regeneration" do
+    with_initialized_project do |project_dir|
+      agents_md = File.join(project_dir, "AGENTS.md")
+      run_hwaro(["tool", "agents-md", "--write", "--force"], chdir: project_dir)
+
+      File.write(agents_md, File.read(agents_md) + "\n- NEVER touch data/secret.yml\n")
+
+      status, _, _ = run_hwaro(["tool", "agents-md", "--write", "--force"], chdir: project_dir)
+      status.success?.should be_true
+      File.read(agents_md).should contain("NEVER touch data/secret.yml")
+
+      # Preservation survives a mode switch too.
+      run_hwaro(["tool", "agents-md", "--remote", "--write", "--force"], chdir: project_dir)
+      File.read(agents_md).should contain("NEVER touch data/secret.yml")
+    end
+  end
+end

--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -897,3 +897,57 @@ describe "hwaro tool agents-md (site-specific preservation)" do
     end
   end
 end
+
+describe "hwaro tool review-fix regressions (2026-08 batch)" do
+  it "refuses a missing explicit --templates-dir instead of scanning nothing" do
+    with_initialized_project do |project_dir|
+      status, _, err = run_hwaro(
+        ["tool", "unused-assets", "--templates-dir", "no-such-templates"], chdir: project_dir
+      )
+      status.exit_code.should eq(Hwaro::Errors::EXIT_IO)
+      err.should contain("HWARO_E_IO")
+    end
+  end
+
+  it "matches --ignore-url patterns case-insensitively" do
+    with_initialized_project do |project_dir|
+      File.write(File.join(project_dir, "content", "broken.md"),
+        "+++\ntitle = \"B\"\n+++\n\n[dead](/definitely-missing/)\n")
+
+      status, _, _ = run_hwaro(
+        ["tool", "check-links", "--internal-only", "--ignore-url", "DEFINITELY-MISSING"],
+        chdir: project_dir
+      )
+      status.success?.should be_true
+    end
+  end
+
+  it "reports ignored_count in the --json payload" do
+    with_initialized_project do |project_dir|
+      File.write(File.join(project_dir, "content", "broken.md"),
+        "+++\ntitle = \"B\"\n+++\n\n[dead](/definitely-missing/)\n")
+
+      _, output, _ = run_hwaro(
+        ["tool", "check-links", "--internal-only", "--json", "--ignore-url", "definitely-missing"],
+        chdir: project_dir
+      )
+      parsed = JSON.parse(output.strip)
+      parsed["ignored_count"].as_i.should eq(1)
+      parsed["dead_internal"].as_a.should be_empty
+    end
+  end
+
+  it "warns and fully replaces an AGENTS.md without the Site-Specific heading" do
+    with_initialized_project do |project_dir|
+      agents_md = File.join(project_dir, "AGENTS.md")
+      File.write(agents_md, "# Hand-written file\n\n- my custom rule\n")
+
+      status, _, err = run_hwaro(["tool", "agents-md", "--write", "--force"], chdir: project_dir)
+      status.success?.should be_true
+      err.should contain("replacing the whole file")
+      content = File.read(agents_md)
+      content.should_not contain("my custom rule")
+      content.should contain("## Site-Specific Instructions")
+    end
+  end
+end

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -158,6 +158,27 @@ describe Hwaro::Services::Doctor do
         end
       end
 
+      # `[image_processing] enabled = true` with no widths is a silent
+      # no-op: the image hook returns early and no srcset is generated.
+      # Same "enabled but silently does nothing" class as math_engine.
+      it "warns when image_processing is enabled but widths is empty" do
+        config = base_config(%(\n[image_processing]\nenabled = true\n))
+        issues = run_doctor(config)
+        issues.any? { |i| i.id == "image-processing-widths-empty" && i.level == :warning }.should be_true
+      end
+
+      it "does not warn when image_processing is enabled with widths set" do
+        config = base_config(%(\n[image_processing]\nenabled = true\nwidths = [320, 640]\n))
+        issues = run_doctor(config)
+        issues.any?(&.id.==("image-processing-widths-empty")).should be_false
+      end
+
+      it "does not warn when image_processing is disabled" do
+        config = base_config(%(\n[image_processing]\nenabled = false\n))
+        issues = run_doctor(config)
+        issues.any?(&.id.==("image-processing-widths-empty")).should be_false
+      end
+
       # `Models::Config.load` silently coerces an unknown
       # `pwa.cache_strategy` back to "cache-first", so doctor reads the
       # raw TOML to surface what the user actually typed.

--- a/spec/unit/tool_feature_improvements_spec.cr
+++ b/spec/unit/tool_feature_improvements_spec.cr
@@ -1,0 +1,156 @@
+require "../spec_helper"
+
+# Service-level specs for the tool feature-improvement batch:
+# import/export dry-run + per-file manifests, convert --dry-run,
+# list sorting/limiting. CLI flag wiring is covered by the functional
+# suite in spec/functional/cli_tool_subcommands_spec.cr.
+describe "tool feature improvements" do
+  describe "importer dry run" do
+    it "counts and records would-be imports without writing anything" do
+      Dir.mktmpdir do |dir|
+        posts = File.join(dir, "site", "_posts")
+        FileUtils.mkdir_p(posts)
+        File.write(File.join(posts, "2024-01-01-hello.md"), "---\ntitle: Hello\n---\n\nBody\n")
+        output = File.join(dir, "content")
+
+        importer = Hwaro::Services::Importers::JekyllImporter.new
+        importer.dry_run = true
+        result = importer.run(Hwaro::Config::Options::ImportOptions.new(
+          source_type: "jekyll", path: File.join(dir, "site"), output_dir: output, dry_run: true))
+
+        result.success.should be_true
+        result.imported_count.should eq(1)
+        Dir.exists?(output).should be_false
+        importer.file_actions.size.should eq(1)
+        importer.file_actions.first.action.should eq("imported")
+        importer.file_actions.first.path.should end_with(".md")
+      end
+    end
+  end
+
+  describe "importer manifest" do
+    it "records imported on the first run and skipped on an idempotent re-run" do
+      Dir.mktmpdir do |dir|
+        posts = File.join(dir, "site", "_posts")
+        FileUtils.mkdir_p(posts)
+        File.write(File.join(posts, "2024-01-01-hello.md"), "---\ntitle: Hello\n---\n\nBody\n")
+        output = File.join(dir, "content")
+        options = Hwaro::Config::Options::ImportOptions.new(
+          source_type: "jekyll", path: File.join(dir, "site"), output_dir: output)
+
+        first = Hwaro::Services::Importers::JekyllImporter.new
+        first.run(options)
+        first.file_actions.map(&.action).should eq(["imported"])
+
+        second = Hwaro::Services::Importers::JekyllImporter.new
+        result = second.run(options)
+        result.skipped_count.should eq(1)
+        second.file_actions.map(&.action).should eq(["skipped"])
+      end
+    end
+
+    it "records overwritten when --force replaces an existing file" do
+      Dir.mktmpdir do |dir|
+        posts = File.join(dir, "site", "_posts")
+        FileUtils.mkdir_p(posts)
+        File.write(File.join(posts, "2024-01-01-hello.md"), "---\ntitle: Hello\n---\n\nBody\n")
+        output = File.join(dir, "content")
+        Hwaro::Services::Importers::JekyllImporter.new.run(Hwaro::Config::Options::ImportOptions.new(
+          source_type: "jekyll", path: File.join(dir, "site"), output_dir: output))
+
+        forced = Hwaro::Services::Importers::JekyllImporter.new
+        forced.run(Hwaro::Config::Options::ImportOptions.new(
+          source_type: "jekyll", path: File.join(dir, "site"), output_dir: output, force: true))
+        forced.file_actions.map(&.action).should eq(["overwritten"])
+      end
+    end
+  end
+
+  describe "exporter dry run and manifest" do
+    it "counts and records would-be exports without writing anything" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "content", "posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(File.join(posts_dir, "a.md"), "+++\ntitle = \"A\"\ndate = \"2024-01-01\"\n+++\n\nBody\n")
+        output = File.join(dir, "export")
+
+        exporter = Hwaro::Services::Exporters::JekyllExporter.new
+        exporter.dry_run = true
+        result = exporter.run(Hwaro::Config::Options::ExportOptions.new(
+          target_type: "jekyll", content_dir: File.join(dir, "content"), output_dir: output, dry_run: true))
+
+        result.success.should be_true
+        result.exported_count.should eq(1)
+        Dir.exists?(output).should be_false
+        exporter.file_actions.map(&.action).should eq(["exported"])
+      end
+    end
+
+    it "marks destinations that already existed as overwritten" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "content", "posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(File.join(posts_dir, "a.md"), "+++\ntitle = \"A\"\ndate = \"2024-01-01\"\n+++\n\nBody\n")
+        output = File.join(dir, "export")
+        options = Hwaro::Config::Options::ExportOptions.new(
+          target_type: "jekyll", content_dir: File.join(dir, "content"), output_dir: output)
+
+        Hwaro::Services::Exporters::JekyllExporter.new.run(options)
+
+        again = Hwaro::Services::Exporters::JekyllExporter.new
+        again.run(options)
+        again.file_actions.map(&.action).should eq(["overwritten"])
+      end
+    end
+  end
+
+  describe "convert dry run" do
+    it "reports the conversion without touching the file" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        path = File.join(content_dir, "a.md")
+        original = "---\ntitle: A\n---\n\nBody\n"
+        File.write(path, original)
+
+        converter = Hwaro::Services::FrontmatterConverter.new(content_dir, dry_run: true)
+        result = converter.convert_to_toml
+
+        result.success.should be_true
+        result.dry_run.should be_true
+        result.converted_count.should eq(1)
+        File.read(path).should eq(original)
+      end
+    end
+  end
+
+  describe "content lister sorting" do
+    it "sorts by title, path, honors reverse and limit" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "b.md"), "+++\ntitle = \"Beta\"\ndate = \"2024-02-01\"\n+++\n\nB\n")
+        File.write(File.join(content_dir, "a.md"), "+++\ntitle = \"alpha\"\ndate = \"2024-01-01\"\n+++\n\nA\n")
+        File.write(File.join(content_dir, "c.md"), "+++\ntitle = \"Gamma\"\n+++\n\nC\n")
+
+        lister = Hwaro::Services::ContentLister.new(content_dir)
+        all = Hwaro::Services::ContentFilter::All
+
+        by_title = lister.list_content(all, Hwaro::Services::ContentSort::Title)
+        by_title.map(&.title).should eq(["alpha", "Beta", "Gamma"])
+
+        by_path = lister.list_content(all, Hwaro::Services::ContentSort::Path)
+        by_path.map(&.path).should eq(by_path.map(&.path).sort!)
+
+        by_date = lister.list_content(all, Hwaro::Services::ContentSort::Date)
+        by_date.map(&.title).should eq(["Beta", "alpha", "Gamma"])
+
+        reversed = lister.list_content(all, Hwaro::Services::ContentSort::Date, reverse: true)
+        reversed.map(&.title).should eq(["Gamma", "alpha", "Beta"])
+
+        limited = lister.list_content(all, Hwaro::Services::ContentSort::Date, limit: 2)
+        limited.map(&.title).should eq(["Beta", "alpha"])
+      end
+    end
+  end
+end

--- a/spec/unit/tool_feature_improvements_spec.cr
+++ b/spec/unit/tool_feature_improvements_spec.cr
@@ -49,6 +49,50 @@ describe "tool feature improvements" do
       end
     end
 
+    it "lists page-bundle assets in the manifest alongside the document" do
+      Dir.mktmpdir do |dir|
+        bundle = File.join(dir, "site", "content", "posts", "bundle")
+        FileUtils.mkdir_p(bundle)
+        File.write(File.join(bundle, "index.md"), "+++\ntitle = \"Bundle\"\n+++\n\n![cover](cover.png)\n")
+        File.write(File.join(bundle, "cover.png"), "notapng")
+        output = File.join(dir, "content")
+
+        importer = Hwaro::Services::Importers::HugoImporter.new
+        importer.run(Hwaro::Config::Options::ImportOptions.new(
+          source_type: "hugo", path: File.join(dir, "site"), output_dir: output))
+
+        asset = importer.file_actions.find(&.path.ends_with?("cover.png"))
+        asset.should_not be_nil
+        asset.not_nil!.action.should eq("imported")
+        importer.file_actions.any?(&.path.ends_with?("index.md")).should be_true
+      end
+    end
+
+    it "refuses a pre-existing symlinked-outside section directory in dry run too" do
+      Dir.mktmpdir do |dir|
+        posts = File.join(dir, "site", "_posts")
+        FileUtils.mkdir_p(posts)
+        File.write(File.join(posts, "2024-01-01-hello.md"), "---\ntitle: Hello\n---\n\nBody\n")
+
+        outside = File.join(dir, "outside")
+        output = File.join(dir, "content")
+        FileUtils.mkdir_p(outside)
+        FileUtils.mkdir_p(output)
+        # The importer writes into <output>/posts — make that a symlink out
+        # of the tree, the exact case the real run refuses.
+        File.symlink(outside, File.join(output, "posts"))
+
+        importer = Hwaro::Services::Importers::JekyllImporter.new
+        importer.dry_run = true
+        result = importer.run(Hwaro::Config::Options::ImportOptions.new(
+          source_type: "jekyll", path: File.join(dir, "site"), output_dir: output, dry_run: true))
+
+        result.imported_count.should eq(0)
+        importer.file_actions.should be_empty
+        Dir.children(outside).should be_empty
+      end
+    end
+
     it "records overwritten when --force replaces an existing file" do
       Dir.mktmpdir do |dir|
         posts = File.join(dir, "site", "_posts")
@@ -136,8 +180,11 @@ describe "tool feature improvements" do
         lister = Hwaro::Services::ContentLister.new(content_dir)
         all = Hwaro::Services::ContentFilter::All
 
+        # Case-sensitive, matching the template engine's `sort_by="title"`
+        # ordering (SortUtils.compare_by_title): uppercase sorts before
+        # lowercase in ASCII.
         by_title = lister.list_content(all, Hwaro::Services::ContentSort::Title)
-        by_title.map(&.title).should eq(["alpha", "Beta", "Gamma"])
+        by_title.map(&.title).should eq(["Beta", "Gamma", "alpha"])
 
         by_path = lister.list_content(all, Hwaro::Services::ContentSort::Path)
         by_path.map(&.path).should eq(by_path.map(&.path).sort!)

--- a/src/cli/commands/tool/agents_md_command.cr
+++ b/src/cli/commands/tool/agents_md_command.cr
@@ -78,19 +78,45 @@ module Hwaro
               if existed && !force
                 # `confirm?` returns nil on EOF (piped/non-interactive stdin) —
                 # treat that the same as "no" and abort without writing.
-                unless Prompt.confirm?("AGENTS.md already exists. Overwrite?", default: false) == true
+                unless Prompt.confirm?("AGENTS.md already exists. Regenerate it? (your Site-Specific Instructions are kept)", default: false) == true
                   Logger.info "Aborted."
                   exit
                 end
               end
 
+              preserved = false
+              if existed
+                merged = merge_site_section(content, File.read(filename))
+                preserved = merged != content
+                content = merged
+              end
+
               File.write(filename, content)
               mode_name = remote ? "remote" : "local"
               outcome_verb = existed ? "updated" : "created"
-              Logger.outcome(outcome_verb, "AGENTS.md · #{mode_name} mode")
+              summary = "AGENTS.md · #{mode_name} mode"
+              summary += " · site-specific section preserved" if preserved
+              Logger.outcome(outcome_verb, summary)
             else
               puts content
             end
+          end
+
+          # The generated document ends with a "Site-Specific Instructions"
+          # section that explicitly invites the user to add their own rules.
+          # Regenerating used to overwrite the whole file — destroying exactly
+          # the content the template told them to write there. Carry the
+          # existing file's section (heading included) into the fresh
+          # template; a file without the marker falls back to a full rewrite,
+          # as does a template variant without one.
+          SITE_SECTION_MARKER = "## Site-Specific Instructions"
+
+          private def merge_site_section(fresh : String, existing : String) : String
+            existing_idx = existing.index(SITE_SECTION_MARKER)
+            return fresh unless existing_idx
+            fresh_idx = fresh.index(SITE_SECTION_MARKER)
+            return fresh unless fresh_idx
+            fresh[0...fresh_idx] + existing[existing_idx..]
           end
         end
       end

--- a/src/cli/commands/tool/agents_md_command.cr
+++ b/src/cli/commands/tool/agents_md_command.cr
@@ -34,7 +34,7 @@ module Hwaro
             FlagInfo.new(
               short: "-f",
               long: "--force",
-              description: "Overwrite existing file without confirmation"
+              description: "Regenerate an existing file without confirmation (the Site-Specific Instructions section is still preserved)"
             ),
             HELP_FLAG,
           ]
@@ -59,7 +59,7 @@ module Hwaro
               parser.on("--remote", "Generate lightweight version with links to online docs") { remote = true }
               parser.on("--local", "Generate full embedded reference (default)") { remote = false }
               parser.on("--write", "Write to AGENTS.md file instead of stdout") { write = true }
-              parser.on("-f", "--force", "Overwrite existing file without confirmation") { force = true }
+              parser.on("-f", "--force", "Regenerate an existing file without confirmation (the Site-Specific Instructions section is still preserved)") { force = true }
               CLI.register_flag(parser, HELP_FLAG) do |_|
                 Logger.info parser.to_s
                 exit
@@ -75,18 +75,33 @@ module Hwaro
             if write
               filename = "AGENTS.md"
               existed = File.exists?(filename)
+              existing = existed ? File.read(filename) : nil
+              # Only promise preservation when the merge can actually deliver
+              # it: an existing file without the marker heading gets a full
+              # overwrite, and the prompt must say so instead of reassuring.
+              has_marker = existing.try(&.includes?(SITE_SECTION_MARKER)) || false
               if existed && !force
+                question = if has_marker
+                             "AGENTS.md already exists. Regenerate it? (your Site-Specific Instructions are kept)"
+                           else
+                             "AGENTS.md already exists and has no '#{SITE_SECTION_MARKER}' heading — regenerating will replace it ENTIRELY. Continue?"
+                           end
                 # `confirm?` returns nil on EOF (piped/non-interactive stdin) —
                 # treat that the same as "no" and abort without writing.
-                unless Prompt.confirm?("AGENTS.md already exists. Regenerate it? (your Site-Specific Instructions are kept)", default: false) == true
+                unless Prompt.confirm?(question, default: false) == true
                   Logger.info "Aborted."
                   exit
                 end
               end
 
               preserved = false
-              if existed
-                merged = merge_site_section(content, File.read(filename))
+              if existing
+                if existed && !has_marker
+                  # `--force` skips the prompt above, so this loss warning is
+                  # the only signal the non-interactive path gets.
+                  Logger.warn "Existing AGENTS.md has no '#{SITE_SECTION_MARKER}' heading — replacing the whole file."
+                end
+                merged = merge_site_section(content, existing)
                 preserved = merged != content
                 content = merged
               end
@@ -107,9 +122,11 @@ module Hwaro
           # Regenerating used to overwrite the whole file — destroying exactly
           # the content the template told them to write there. Carry the
           # existing file's section (heading included) into the fresh
-          # template; a file without the marker falls back to a full rewrite,
-          # as does a template variant without one.
-          SITE_SECTION_MARKER = "## Site-Specific Instructions"
+          # template; a file without the marker falls back to a full rewrite
+          # (announced above), as does a template variant without one. The
+          # marker itself lives on the template service so the two can't
+          # drift apart.
+          SITE_SECTION_MARKER = Services::Defaults::AgentsMd::SITE_SECTION_MARKER
 
           private def merge_site_section(fresh : String, existing : String) : String
             existing_idx = existing.index(SITE_SECTION_MARKER)

--- a/src/cli/commands/tool/convert_command.cr
+++ b/src/cli/commands/tool/convert_command.cr
@@ -27,6 +27,7 @@ module Hwaro
           # Flags defined here are used both for OptionParser and completion generation
           FLAGS = [
             CONTENT_DIR_FLAG,
+            DRY_RUN_FLAG,
             JSON_FLAG,
             HELP_FLAG,
           ]
@@ -45,10 +46,12 @@ module Hwaro
             content_dir = "content"
             format : String? = nil
             json_output = false
+            dry_run = false
 
             OptionParser.parse(args) do |parser|
               parser.banner = "Usage: hwaro tool convert <to-yaml|to-toml|to-json> [options]"
               CLI.register_flag(parser, CONTENT_DIR_FLAG) { |v| content_dir = v }
+              CLI.register_flag(parser, DRY_RUN_FLAG) { |_| dry_run = true }
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
               parser.unknown_args do |unknown|
@@ -66,7 +69,7 @@ module Hwaro
               )
             end
 
-            converter = Services::FrontmatterConverter.new(content_dir)
+            converter = Services::FrontmatterConverter.new(content_dir, dry_run: dry_run)
 
             fmt = format.as(String).downcase
             if POSITIONAL_CHOICES.includes?(fmt)

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -31,6 +31,8 @@ module Hwaro
             FlagInfo.new(short: nil, long: "--concurrency", description: "Max concurrent requests (default: 8)", takes_value: true, value_hint: "N"),
             FlagInfo.new(short: nil, long: "--external-only", description: "Check external links only"),
             FlagInfo.new(short: nil, long: "--internal-only", description: "Check internal links only"),
+            FlagInfo.new(short: nil, long: "--ignore-url", description: "Skip links whose URL matches PATTERN (substring; * wildcards; repeatable)", takes_value: true, value_hint: "PATTERN"),
+            FlagInfo.new(short: nil, long: "--allow-status", description: "Treat these HTTP status codes as healthy (comma-separated, e.g. 403,429)", takes_value: true, value_hint: "CODES"),
             JSON_FLAG,
             HELP_FLAG,
           ]
@@ -78,6 +80,8 @@ module Hwaro
             concurrency = DEFAULT_CONCURRENCY
             external_only = false
             internal_only = false
+            ignore_patterns = [] of Regex
+            allowed_statuses = Set(Int32).new
 
             OptionParser.parse(args) do |parser|
               parser.banner = "Usage: hwaro tool check-links [options]"
@@ -106,6 +110,29 @@ module Hwaro
               end
               parser.on("--external-only", "Check external links only") { external_only = true }
               parser.on("--internal-only", "Check internal links only") { internal_only = true }
+              parser.on("--ignore-url PATTERN", "Skip links whose URL matches PATTERN (substring; * wildcards; repeatable)") do |v|
+                if v.strip.empty?
+                  raise Hwaro::HwaroError.new(
+                    code: Hwaro::Errors::HWARO_E_USAGE,
+                    message: "--ignore-url expects a non-empty pattern",
+                    hint: "Example: --ignore-url twitter.com or --ignore-url 'https://example.com/*'.",
+                  )
+                end
+                ignore_patterns << ignore_pattern_to_regex(v)
+              end
+              parser.on("--allow-status CODES", "Treat these HTTP status codes as healthy (comma-separated)") do |v|
+                v.split(',').each do |code|
+                  parsed = code.strip.to_i?
+                  unless parsed && (100..599).includes?(parsed)
+                    raise Hwaro::HwaroError.new(
+                      code: Hwaro::Errors::HWARO_E_USAGE,
+                      message: "Invalid --allow-status value: #{code.strip}",
+                      hint: "Pass comma-separated HTTP status codes between 100 and 599, e.g. --allow-status 403,429.",
+                    )
+                  end
+                  allowed_statuses << parsed
+                end
+              end
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
@@ -136,14 +163,27 @@ module Hwaro
             external_links = internal_only ? [] of Link : find_external_links(target_dir)
             internal_links = external_only ? [] of Link : find_internal_links(target_dir)
 
+            # `--ignore-url` drops matching links BEFORE any check runs, so an
+            # ignored external host is never contacted at all — the point is
+            # silencing a known-flaky or paywalled domain in CI, not merely
+            # hiding its failure afterwards.
+            ignored_count = 0
+            unless ignore_patterns.empty?
+              before = external_links.size + internal_links.size
+              external_links = external_links.reject { |l| ignore_patterns.any?(&.matches?(l.url)) }
+              internal_links = internal_links.reject { |l| ignore_patterns.any?(&.matches?(l.url)) }
+              ignored_count = before - external_links.size - internal_links.size
+            end
+
             if external_links.empty? && internal_links.empty?
               if json_output
                 puts({
-                  "dead_internal" => [] of Result,
-                  "dead_external" => [] of Result,
+                  "dead_internal"    => [] of Result,
+                  "dead_external"    => [] of Result,
+                  "skipped_external" => [] of Result,
                 }.to_json)
               else
-                Logger.outcome("checked", "no links found", :info)
+                Logger.outcome("checked", ignored_count > 0 ? "no links to check (#{ignored_count} ignored)" : "no links found", :info)
               end
               return
             end
@@ -151,7 +191,11 @@ module Hwaro
             # Check external links
             external_results = check_links_concurrently(external_links, timeout, concurrency)
             skipped_external = external_results.select { |r| r.error == "Skipped: private/internal address" }
-            dead_external = external_results.select { |r| !(200..299).includes?(r.status) && r.error != "Skipped: private/internal address" }
+            dead_external = external_results.select do |r|
+              !(200..299).includes?(r.status) &&
+                !allowed_statuses.includes?(r.status) &&
+                r.error != "Skipped: private/internal address"
+            end
 
             # Check internal links. Load taxonomy names from config.toml so
             # URLs like `/tags/` or `/categories/foo/` that Hwaro generates
@@ -174,9 +218,14 @@ module Hwaro
             dead_total = dead_external.size + dead_internal.size
 
             if json_output
+              # `skipped_external` names the links the SSRF guard refused to
+              # contact (private/localhost/.internal hosts). They used to be
+              # silently absent from the payload, so a JSON consumer could
+              # not tell "checked and healthy" from "never checked".
               puts({
-                "dead_internal" => dead_internal,
-                "dead_external" => dead_external,
+                "dead_internal"    => dead_internal,
+                "dead_external"    => dead_external,
+                "skipped_external" => skipped_external,
               }.to_json)
               # Exit non-zero so CI can gate on broken links (the JSON payload
               # has already been emitted to stdout for tooling to consume).
@@ -184,7 +233,9 @@ module Hwaro
               return
             end
 
-            Logger.section("scan", "#{external_links.size} external · #{internal_links.size} internal")
+            scan_detail = "#{external_links.size} external · #{internal_links.size} internal"
+            scan_detail += " · #{ignored_count} ignored" if ignored_count > 0
+            Logger.section("scan", scan_detail)
             links_noun = total == 1 ? "link" : "links"
 
             if dead_total == 0 && skipped_external.empty?
@@ -219,6 +270,13 @@ module Hwaro
             # usable as a CI gate; previously it always exited 0 regardless of
             # how many broken links were reported.
             exit(Hwaro::Errors::EXIT_GENERIC) if dead_total > 0
+          end
+
+          # Compile an `--ignore-url` pattern: matched as a SUBSTRING of the
+          # link URL as written, with `*` matching any run of characters.
+          # Everything else is literal — dots in domains don't need escaping.
+          private def ignore_pattern_to_regex(pattern : String) : Regex
+            Regex.new(pattern.split('*').map { |part| Regex.escape(part) }.join(".*"))
           end
 
           # Markdown links inside fenced code blocks or inline code spans are

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -177,10 +177,13 @@ module Hwaro
 
             if external_links.empty? && internal_links.empty?
               if json_output
+                # `ignored_count` distinguishes "all healthy" from "an
+                # over-broad --ignore-url pattern checked nothing".
                 puts({
                   "dead_internal"    => [] of Result,
                   "dead_external"    => [] of Result,
                   "skipped_external" => [] of Result,
+                  "ignored_count"    => ignored_count,
                 }.to_json)
               else
                 Logger.outcome("checked", ignored_count > 0 ? "no links to check (#{ignored_count} ignored)" : "no links found", :info)
@@ -226,6 +229,7 @@ module Hwaro
                 "dead_internal"    => dead_internal,
                 "dead_external"    => dead_external,
                 "skipped_external" => skipped_external,
+                "ignored_count"    => ignored_count,
               }.to_json)
               # Exit non-zero so CI can gate on broken links (the JSON payload
               # has already been emitted to stdout for tooling to consume).
@@ -275,8 +279,10 @@ module Hwaro
           # Compile an `--ignore-url` pattern: matched as a SUBSTRING of the
           # link URL as written, with `*` matching any run of characters.
           # Everything else is literal — dots in domains don't need escaping.
+          # Matching is case-insensitive: URL hosts are case-insensitive, so
+          # `--ignore-url twitter.com` must also silence `https://Twitter.com/…`.
           private def ignore_pattern_to_regex(pattern : String) : Regex
-            Regex.new(pattern.split('*').map { |part| Regex.escape(part) }.join(".*"))
+            Regex.new(pattern.split('*').map { |part| Regex.escape(part) }.join(".*"), Regex::Options::IGNORE_CASE)
           end
 
           # Markdown links inside fenced code blocks or inline code spans are

--- a/src/cli/commands/tool/doctor_command.cr
+++ b/src/cli/commands/tool/doctor_command.cr
@@ -87,6 +87,12 @@ module Hwaro
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
 
+            # Route through the shared JSON mode like every sibling command:
+            # it silences human log lines AND flips `Runner.json_mode?`, so a
+            # classified error raised mid-run renders as the standard JSON
+            # error payload instead of human text on a machine-read stream.
+            Runner.enable_json_mode! if json_output
+
             doctor = Services::Doctor.new(content_dir: content_dir, config_path: config_path)
 
             if dry_run_mode && !fix_mode && !approve_mode && !full_mode

--- a/src/cli/commands/tool/export_command.cr
+++ b/src/cli/commands/tool/export_command.cr
@@ -27,7 +27,9 @@ module Hwaro
             FlagInfo.new(short: "-o", long: "--output", description: "Output directory (default: export)", takes_value: true, value_hint: "DIR"),
             CONTENT_DIR_FLAG,
             DRAFTS_FLAG,
+            DRY_RUN_FLAG,
             VERBOSE_FLAG,
+            JSON_FLAG,
             HELP_FLAG,
           ]
 
@@ -42,7 +44,9 @@ module Hwaro
           end
 
           def run(args : Array(String))
-            options = parse_options(args)
+            options, json_output = parse_options(args)
+
+            Runner.enable_json_mode! if json_output
 
             supported = POSITIONAL_CHOICES.join(", ")
 
@@ -74,29 +78,57 @@ module Hwaro
             # failure is reported instead of a bogus "exported" header.
             Services::Exporters::Base.guard_output_dir!(options.output_dir, options.content_dir)
 
-            Logger::Receipt.new(NAME, options.target_type)
+            receipt = Logger::Receipt.new(NAME, options.target_type)
               .row("source", options.content_dir)
               .row("output", options.output_dir)
-              .emit
+            receipt.row("mode", "dry run — nothing will be written") if options.dry_run
+            receipt.emit
 
+            exporter.dry_run = options.dry_run
             result = exporter.run(options)
 
-            if result.success
-              summary = "#{result.exported_count} files · #{result.skipped_count} skipped"
-              summary += " · #{result.error_count} errors" if result.error_count > 0
-              Logger.info "" if Logger.color_enabled?
-              Logger.outcome("exported", summary, glyph: result.error_count > 0 ? :err : :result)
-            else
-              Logger.error "Export failed: #{result.message}"
-              exit(1)
+            unless result.success
+              # A classified error instead of the old bare `exit(1)`: every
+              # sibling tool command reports failures through HwaroError, so
+              # `--json` consumers get the standard error payload and the
+              # exit code lands in the documented IO class.
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_IO,
+                message: result.message,
+                hint: "Pass -c DIR if your content lives outside 'content'; per-file errors are listed above.",
+              )
+            end
+
+            if json_output
+              puts({
+                "success"        => result.success,
+                "dry_run"        => options.dry_run,
+                "exported_count" => result.exported_count,
+                "skipped_count"  => result.skipped_count,
+                "error_count"    => result.error_count,
+                "files"          => exporter.file_actions,
+              }.to_json)
+              return
+            end
+
+            summary = "#{result.exported_count} files · #{result.skipped_count} skipped"
+            summary += " · #{result.error_count} errors" if result.error_count > 0
+            Logger.info "" if Logger.color_enabled?
+            Logger.outcome(options.dry_run ? "would export" : "exported", summary, glyph: result.error_count > 0 ? :err : :result)
+
+            overwritten = exporter.file_actions.count { |a| a.action == "overwritten" }
+            if overwritten > 0
+              Logger.warn "#{overwritten} existing file(s) #{options.dry_run ? "would be" : "were"} overwritten in #{options.output_dir} (re-exports replace previous output)."
             end
           end
 
-          private def parse_options(args : Array(String)) : Config::Options::ExportOptions
+          private def parse_options(args : Array(String)) : {Config::Options::ExportOptions, Bool}
             output_dir = "export"
             content_dir = "content"
             drafts = false
             verbose = false
+            dry_run = false
+            json_output = false
             positional = [] of String
 
             supported_targets = POSITIONAL_CHOICES.join("|")
@@ -106,7 +138,9 @@ module Hwaro
               parser.on("-o DIR", "--output DIR", "Output directory (default: export)") { |dir| output_dir = dir }
               CLI.register_flag(parser, CONTENT_DIR_FLAG) { |v| content_dir = v }
               CLI.register_flag(parser, DRAFTS_FLAG) { |_| drafts = true }
+              CLI.register_flag(parser, DRY_RUN_FLAG) { |_| dry_run = true }
               CLI.register_flag(parser, VERBOSE_FLAG) { |_| verbose = true }
+              CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) do |_|
                 Logger.info parser.to_s
                 Logger.info ""
@@ -120,13 +154,15 @@ module Hwaro
 
             target_type = positional.shift? || ""
 
-            Config::Options::ExportOptions.new(
+            options = Config::Options::ExportOptions.new(
               target_type: target_type,
               output_dir: output_dir,
               content_dir: content_dir,
               drafts: drafts,
               verbose: verbose,
+              dry_run: dry_run,
             )
+            {options, json_output}
           end
         end
       end

--- a/src/cli/commands/tool/import_command.cr
+++ b/src/cli/commands/tool/import_command.cr
@@ -30,7 +30,9 @@ module Hwaro
             FlagInfo.new(short: "-o", long: "--output", description: "Output content directory (default: content)", takes_value: true, value_hint: "DIR"),
             DRAFTS_FLAG,
             FORCE_FLAG,
+            DRY_RUN_FLAG,
             VERBOSE_FLAG,
+            JSON_FLAG,
             HELP_FLAG,
           ]
 
@@ -45,7 +47,9 @@ module Hwaro
           end
 
           def run(args : Array(String))
-            options = parse_options(args)
+            options, json_output = parse_options(args)
+
+            Runner.enable_json_mode! if json_output
 
             supported = POSITIONAL_CHOICES.join(", ")
 
@@ -98,11 +102,13 @@ module Hwaro
                          )
                        end
 
-            Logger::Receipt.new(NAME, options.source_type)
+            receipt = Logger::Receipt.new(NAME, options.source_type)
               .row("source", options.path)
               .row("output", options.output_dir)
-              .emit
+            receipt.row("mode", "dry run — nothing will be written") if options.dry_run
+            receipt.emit
 
+            importer.dry_run = options.dry_run
             result = importer.run(options)
 
             unless result.success
@@ -122,10 +128,22 @@ module Hwaro
               )
             end
 
+            if json_output
+              puts({
+                "success"        => result.success,
+                "dry_run"        => options.dry_run,
+                "imported_count" => result.imported_count,
+                "skipped_count"  => result.skipped_count,
+                "error_count"    => result.error_count,
+                "files"          => importer.file_actions,
+              }.to_json)
+              return
+            end
+
             summary = "#{result.imported_count} files · #{result.skipped_count} skipped"
             summary += " · #{result.error_count} errors" if result.error_count > 0
             Logger.info "" if Logger.color_enabled?
-            Logger.outcome("imported", summary, glyph: result.error_count > 0 ? :err : :result)
+            Logger.outcome(options.dry_run ? "would import" : "imported", summary, glyph: result.error_count > 0 ? :err : :result)
 
             if result.skipped_count > 0 && !options.force
               Logger.warn "#{result.skipped_count} file(s) skipped because they may already exist (use --force to overwrite) or be drafts (use --drafts to import)."
@@ -158,11 +176,13 @@ module Hwaro
             end
           end
 
-          private def parse_options(args : Array(String)) : Config::Options::ImportOptions
+          private def parse_options(args : Array(String)) : {Config::Options::ImportOptions, Bool}
             output_dir = "content"
             drafts = false
             verbose = false
             force = false
+            dry_run = false
+            json_output = false
             positional = [] of String
 
             OptionParser.parse(args) do |parser|
@@ -170,7 +190,9 @@ module Hwaro
               parser.on("-o DIR", "--output DIR", "Output content directory (default: content)") { |dir| output_dir = dir }
               CLI.register_flag(parser, DRAFTS_FLAG) { |_| drafts = true }
               CLI.register_flag(parser, FORCE_FLAG) { |_| force = true }
+              CLI.register_flag(parser, DRY_RUN_FLAG) { |_| dry_run = true }
               CLI.register_flag(parser, VERBOSE_FLAG) { |_| verbose = true }
+              CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) do |_|
                 Logger.info parser.to_s
                 Logger.info ""
@@ -185,14 +207,16 @@ module Hwaro
             source_type = positional.shift? || ""
             path = positional.shift? || ""
 
-            Config::Options::ImportOptions.new(
+            options = Config::Options::ImportOptions.new(
               source_type: source_type,
               path: path,
               output_dir: output_dir,
               drafts: drafts,
               verbose: verbose,
               force: force,
+              dry_run: dry_run,
             )
+            {options, json_output}
           end
         end
       end

--- a/src/cli/commands/tool/list_command.cr
+++ b/src/cli/commands/tool/list_command.cr
@@ -24,9 +24,16 @@ module Hwaro
           POSITIONAL_ARGS    = ["filter"]
           POSITIONAL_CHOICES = ["all", "drafts", "published"]
 
+          SORT_FLAG    = FlagInfo.new(short: nil, long: "--sort", description: "Sort key: date (newest first, default), title, or path", takes_value: true, value_hint: "KEY")
+          REVERSE_FLAG = FlagInfo.new(short: "-r", long: "--reverse", description: "Reverse the sort order")
+          LIMIT_FLAG   = FlagInfo.new(short: "-n", long: "--limit", description: "Show at most N files (applied after sorting)", takes_value: true, value_hint: "N")
+
           # Flags defined here are used both for OptionParser and completion generation
           FLAGS = [
             CONTENT_DIR_FLAG,
+            SORT_FLAG,
+            REVERSE_FLAG,
+            LIMIT_FLAG,
             JSON_FLAG,
             HELP_FLAG,
           ]
@@ -45,10 +52,32 @@ module Hwaro
             content_dir = "content"
             filter : String? = nil
             json_output = false
+            sort = Services::ContentSort::Date
+            reverse = false
+            limit : Int32? = nil
 
             OptionParser.parse(args) do |parser|
               parser.banner = "Usage: hwaro tool list <all|drafts|published> [options]"
               CLI.register_flag(parser, CONTENT_DIR_FLAG) { |v| content_dir = v }
+              CLI.register_flag(parser, SORT_FLAG) do |v|
+                sort = Services::ContentSort.parse?(v) || raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "Invalid --sort value: #{v}",
+                  hint: "Supported keys: date, title, path.",
+                )
+              end
+              CLI.register_flag(parser, REVERSE_FLAG) { |_| reverse = true }
+              CLI.register_flag(parser, LIMIT_FLAG) do |v|
+                parsed = v.to_i?
+                unless parsed && parsed > 0
+                  raise Hwaro::HwaroError.new(
+                    code: Hwaro::Errors::HWARO_E_USAGE,
+                    message: "Invalid --limit value: #{v}",
+                    hint: "Pass a positive integer, e.g. --limit 10.",
+                  )
+                end
+                limit = parsed
+              end
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
               parser.unknown_args do |unknown|
@@ -98,10 +127,10 @@ module Hwaro
                              end
 
             if json_output
-              contents = lister.list_content(content_filter)
+              contents = lister.list_content(content_filter, sort, reverse, limit)
               puts contents.to_json
             else
-              lister.display(content_filter)
+              lister.display(content_filter, sort, reverse, limit)
             end
           end
         end

--- a/src/cli/commands/tool/stats_command.cr
+++ b/src/cli/commands/tool/stats_command.cr
@@ -23,8 +23,14 @@ module Hwaro
           POSITIONAL_ARGS    = [] of String
           POSITIONAL_CHOICES = [] of String
 
+          # Historical default for the tag chart; `--top` overrides it.
+          DEFAULT_TOP_TAGS = 15
+
+          TOP_FLAG = FlagInfo.new(short: nil, long: "--top", description: "Show the top N tags in the chart (default: #{DEFAULT_TOP_TAGS})", takes_value: true, value_hint: "N")
+
           FLAGS = [
             CONTENT_DIR_FLAG,
+            TOP_FLAG,
             JSON_FLAG,
             HELP_FLAG,
           ]
@@ -42,10 +48,22 @@ module Hwaro
           def run(args : Array(String))
             content_dir = "content"
             json_output = false
+            top = DEFAULT_TOP_TAGS
 
             OptionParser.parse(args) do |parser|
               parser.banner = "Usage: hwaro tool stats [options]"
               CLI.register_flag(parser, CONTENT_DIR_FLAG) { |v| content_dir = v }
+              CLI.register_flag(parser, TOP_FLAG) do |v|
+                parsed = v.to_i?
+                unless parsed && parsed > 0
+                  raise Hwaro::HwaroError.new(
+                    code: Hwaro::Errors::HWARO_E_USAGE,
+                    message: "Invalid --top value: #{v}",
+                    hint: "Pass a positive integer, e.g. --top 25.",
+                  )
+                end
+                top = parsed
+              end
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
@@ -108,17 +126,17 @@ module Hwaro
             # Top tags — bars scale against the most-used tag.
             unless result.tags.empty?
               Logger.info ""
-              Logger.section("tags", result.tags.size > 15 ? "top 15" : nil)
+              Logger.section("tags", result.tags.size > top ? "top #{top}" : nil)
               # Tag names come from semi-trusted front matter — strip control
               # bytes so a crafted tag can't inject ANSI into the report.
-              top_tags = result.tags.first(15).map { |tag, count| {Utils::TextUtils.strip_control(tag), count} }
+              top_tags = result.tags.first(top).map { |tag, count| {Utils::TextUtils.strip_control(tag), count} }
               max_count = top_tags.max_of { |_, count| count }
               label_width = top_tags.max_of { |tag, _| tag.size }.clamp(0, 20)
               top_tags.each do |tag, count|
                 Logger.info "    #{truncate_label(tag, label_width).ljust(label_width)}  #{count.to_s.rjust(4)}  #{Logger.bar(count, max_count)}"
               end
-              if result.tags.size > 15
-                Logger.info "    … and #{result.tags.size - 15} more"
+              if result.tags.size > top
+                Logger.info "    … and #{result.tags.size - top} more"
               end
             end
 

--- a/src/cli/commands/tool/unused_assets_command.cr
+++ b/src/cli/commands/tool/unused_assets_command.cr
@@ -10,6 +10,7 @@ require "option_parser"
 require "../../metadata"
 require "../../prompt"
 require "../../../services/unused_assets"
+require "../../../utils/errors"
 require "../../../utils/logger"
 
 module Hwaro
@@ -46,6 +47,7 @@ module Hwaro
             content_dir = "content"
             static_dir = "static"
             templates_dir = "templates"
+            templates_dir_given = false
             delete_mode = false
             force = false
             json_output = false
@@ -58,11 +60,27 @@ module Hwaro
               # directory silently scanned the wrong (empty) tree: every
               # template-referenced asset came back "unused", and `--delete`
               # then removed files the build still needs.
-              parser.on("-t DIR", "--templates-dir DIR", "Templates directory scanned for references (default: templates)") { |v| templates_dir = v }
+              parser.on("-t DIR", "--templates-dir DIR", "Templates directory scanned for references (default: templates)") do |v|
+                templates_dir = v
+                templates_dir_given = true
+              end
               parser.on("--delete", "Delete unused files (with confirmation)") { delete_mode = true }
               parser.on("-f", "--force", "Skip confirmation prompt when deleting") { force = true }
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
+            end
+
+            # An explicit --templates-dir that doesn't exist must fail, not
+            # silently scan zero templates: every template-referenced asset
+            # would come back "unused", and `--delete --force` would then
+            # remove files the build still needs. The default "templates" is
+            # exempt — projects without a templates directory are legitimate.
+            if templates_dir_given && !Dir.exists?(templates_dir)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_IO,
+                message: "Templates directory '#{templates_dir}' does not exist",
+                hint: "The path is resolved relative to the current directory. Pass an existing directory to --templates-dir.",
+              )
             end
 
             # In JSON mode stdout must stay a single parseable document, so

--- a/src/cli/commands/tool/unused_assets_command.cr
+++ b/src/cli/commands/tool/unused_assets_command.cr
@@ -25,6 +25,7 @@ module Hwaro
           FLAGS = [
             CONTENT_DIR_FLAG,
             FlagInfo.new(short: "-s", long: "--static-dir", description: "Static files directory (default: static)", takes_value: true, value_hint: "DIR"),
+            FlagInfo.new(short: "-t", long: "--templates-dir", description: "Templates directory scanned for references (default: templates)", takes_value: true, value_hint: "DIR"),
             FlagInfo.new(short: nil, long: "--delete", description: "Delete unused files (with confirmation)"),
             FlagInfo.new(short: "-f", long: "--force", description: "Skip confirmation prompt when deleting"),
             JSON_FLAG,
@@ -44,6 +45,7 @@ module Hwaro
           def run(args : Array(String))
             content_dir = "content"
             static_dir = "static"
+            templates_dir = "templates"
             delete_mode = false
             force = false
             json_output = false
@@ -52,6 +54,11 @@ module Hwaro
               parser.banner = "Usage: hwaro tool unused-assets [options]"
               CLI.register_flag(parser, CONTENT_DIR_FLAG) { |v| content_dir = v }
               parser.on("-s DIR", "--static-dir DIR", "Static files directory (default: static)") { |v| static_dir = v }
+              # Without this flag a project with a non-default templates
+              # directory silently scanned the wrong (empty) tree: every
+              # template-referenced asset came back "unused", and `--delete`
+              # then removed files the build still needs.
+              parser.on("-t DIR", "--templates-dir DIR", "Templates directory scanned for references (default: templates)") { |v| templates_dir = v }
               parser.on("--delete", "Delete unused files (with confirmation)") { delete_mode = true }
               parser.on("-f", "--force", "Skip confirmation prompt when deleting") { force = true }
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
@@ -68,6 +75,7 @@ module Hwaro
             service = Services::UnusedAssets.new(
               content_dir: content_dir,
               static_dir: static_dir,
+              templates_dir: templates_dir,
             )
             result = service.run
 

--- a/src/cli/commands/tool/validate_command.cr
+++ b/src/cli/commands/tool/validate_command.cr
@@ -23,8 +23,13 @@ module Hwaro
           POSITIONAL_ARGS    = [] of String
           POSITIONAL_CHOICES = [] of String
 
+          STRICT_FLAG       = FlagInfo.new(short: nil, long: "--strict", description: "Treat warnings as errors when computing the exit code")
+          MAX_WARNINGS_FLAG = FlagInfo.new(short: nil, long: "--max-warnings", description: "Exit non-zero when warning count exceeds N (default: unlimited)", takes_value: true, value_hint: "N")
+
           FLAGS = [
             CONTENT_DIR_FLAG,
+            STRICT_FLAG,
+            MAX_WARNINGS_FLAG,
             JSON_FLAG,
             HELP_FLAG,
           ]
@@ -42,10 +47,24 @@ module Hwaro
           def run(args : Array(String))
             content_dir = "content"
             json_output = false
+            strict_mode = false
+            max_warnings = -1 # < 0 means "unlimited"
 
             OptionParser.parse(args) do |parser|
               parser.banner = "Usage: hwaro tool validate [options]"
               CLI.register_flag(parser, CONTENT_DIR_FLAG) { |v| content_dir = v }
+              CLI.register_flag(parser, STRICT_FLAG) { |_| strict_mode = true }
+              CLI.register_flag(parser, MAX_WARNINGS_FLAG) do |v|
+                parsed = v.to_i?
+                unless parsed && parsed >= 0
+                  raise Hwaro::HwaroError.new(
+                    code: Hwaro::Errors::HWARO_E_USAGE,
+                    message: "Invalid --max-warnings value: #{v}",
+                    hint: "Pass a non-negative integer, e.g. --max-warnings 0.",
+                  )
+                end
+                max_warnings = parsed
+              end
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
             end
@@ -83,8 +102,7 @@ module Hwaro
               puts({"findings" => findings}.to_json)
               # Exit non-zero on hard errors so CI can gate on broken content
               # (mirrors `tool doctor`'s exit-code behavior).
-              errors = issues.count { |i| i.level == :error }
-              exit(errors > 0 ? Hwaro::Errors::EXIT_CONTENT : Hwaro::Errors::EXIT_SUCCESS)
+              exit(exit_code_for(issues, strict: strict_mode, max_warnings: max_warnings))
             end
 
             Logger.heading("validate", content_dir)
@@ -121,7 +139,22 @@ module Hwaro
             Logger.outcome("checked", summary, worst)
 
             # Gate CI on hard errors (matches `tool doctor`).
-            exit(Hwaro::Errors::EXIT_CONTENT) if errors > 0
+            code = exit_code_for(issues, strict: strict_mode, max_warnings: max_warnings)
+            exit(code) if code != Hwaro::Errors::EXIT_SUCCESS
+          end
+
+          # Mirrors `tool doctor`'s exit policy: hard errors keep their
+          # category exit code (`EXIT_CONTENT` — everything validate reports
+          # is content), while warning-driven failures (`--strict`,
+          # `--max-warnings`) exit `EXIT_GENERIC` so a consumer can still
+          # tell a broken file from a tightened gate.
+          private def exit_code_for(issues : Array(Services::Issue), strict : Bool, max_warnings : Int32) : Int32
+            errors = issues.count { |i| i.level == :error }
+            warnings = issues.count { |i| i.level == :warning }
+            return Hwaro::Errors::EXIT_CONTENT if errors > 0
+            return Hwaro::Errors::EXIT_GENERIC if strict && warnings > 0
+            return Hwaro::Errors::EXIT_GENERIC if max_warnings >= 0 && warnings > max_warnings
+            Hwaro::Errors::EXIT_SUCCESS
           end
 
           # Issue messages quote author-controlled text (tags, link targets,

--- a/src/cli/metadata.cr
+++ b/src/cli/metadata.cr
@@ -59,6 +59,7 @@ module Hwaro
     OPEN_BROWSER_FLAG          = FlagInfo.new(short: nil, long: "--open", description: "Open browser after starting server")
     NO_OPEN_BROWSER_FLAG       = FlagInfo.new(short: nil, long: "--no-open", description: "Do not open browser after starting server (default behavior)")
     INPUT_DIR_FLAG             = FlagInfo.new(short: "-i", long: "--input", description: "Input directory (default: current directory)", takes_value: true, value_hint: "DIR")
+    DRY_RUN_FLAG               = FlagInfo.new(short: nil, long: "--dry-run", description: "Preview what would be written without changing any file")
     CONTENT_DIR_FLAG           = FlagInfo.new(short: "-c", long: "--content-dir", description: "Content directory (default: content)", takes_value: true, value_hint: "DIR")
 
     # Register a FlagInfo on an OptionParser, eliminating manual duplication

--- a/src/config/options/export_options.cr
+++ b/src/config/options/export_options.cr
@@ -7,6 +7,7 @@ module Hwaro
         property content_dir : String
         property drafts : Bool
         property verbose : Bool
+        property dry_run : Bool
 
         def initialize(
           @target_type : String = "",
@@ -14,6 +15,7 @@ module Hwaro
           @content_dir : String = "content",
           @drafts : Bool = false,
           @verbose : Bool = false,
+          @dry_run : Bool = false,
         )
         end
       end

--- a/src/config/options/import_options.cr
+++ b/src/config/options/import_options.cr
@@ -8,6 +8,7 @@ module Hwaro
         property drafts : Bool
         property verbose : Bool
         property force : Bool
+        property dry_run : Bool
 
         def initialize(
           @source_type : String = "",
@@ -16,6 +17,7 @@ module Hwaro
           @drafts : Bool = false,
           @verbose : Bool = false,
           @force : Bool = false,
+          @dry_run : Bool = false,
         )
         end
       end

--- a/src/services/content_lister.cr
+++ b/src/services/content_lister.cr
@@ -79,6 +79,11 @@ module Hwaro
     # Sort key for listing content. `Date` is the historical default
     # (newest first, path as tie-breaker); `Title` and `Path` sort
     # ascending. `--reverse` flips whichever order the key produced.
+    #
+    # `Title` matches the template engine's `sort_by="title"` ordering
+    # (`Utils::SortUtils.compare_by_title`): a plain case-sensitive
+    # comparison with path as tie-breaker — the CLI listing and a rendered
+    # section index must not order the same titles differently.
     enum ContentSort
       Date
       Title
@@ -248,9 +253,9 @@ module Hwaro
             {-(info.date.try(&.to_unix) || 0_i64), info.path}
           end
         in ContentSort::Title
-          # Case-insensitive so "apple" and "Apple" don't split apart; path
-          # keeps equal titles deterministic.
-          contents.sort_by! { |info| {info.title.downcase, info.path} }
+          # Case-sensitive, matching SortUtils.compare_by_title — see the
+          # enum comment. Path keeps equal titles deterministic.
+          contents.sort_by! { |info| {info.title, info.path} }
         in ContentSort::Path
           contents.sort_by!(&.path)
         end

--- a/src/services/content_lister.cr
+++ b/src/services/content_lister.cr
@@ -76,6 +76,15 @@ module Hwaro
       Published
     end
 
+    # Sort key for listing content. `Date` is the historical default
+    # (newest first, path as tie-breaker); `Title` and `Path` sort
+    # ascending. `--reverse` flips whichever order the key produced.
+    enum ContentSort
+      Date
+      Title
+      Path
+    end
+
     # Publication state a file will have in a DEFAULT `hwaro build`.
     #
     # `draft` alone never described that: the build also drops future-dated
@@ -197,8 +206,15 @@ module Hwaro
         list_content(ContentFilter::Published)
       end
 
-      # List content files based on filter
-      def list_content(filter : ContentFilter) : Array(ContentInfo)
+      # List content files based on filter. `sort` picks the ordering key,
+      # `reverse` flips it, and `limit` caps the result AFTER sorting — so
+      # `--sort date --limit 5` means "the 5 newest", not 5 arbitrary files.
+      def list_content(
+        filter : ContentFilter,
+        sort : ContentSort = ContentSort::Date,
+        reverse : Bool = false,
+        limit : Int32? = nil,
+      ) : Array(ContentInfo)
         unless Dir.exists?(@content_dir)
           Logger.error "Content directory '#{@content_dir}' not found"
           return [] of ContentInfo
@@ -225,17 +241,33 @@ module Hwaro
           end
         end
 
-        # Sort by date (newest first), then by path
-        contents.sort_by! do |info|
-          {-(info.date.try(&.to_unix) || 0_i64), info.path}
+        case sort
+        in ContentSort::Date
+          # Sort by date (newest first), then by path
+          contents.sort_by! do |info|
+            {-(info.date.try(&.to_unix) || 0_i64), info.path}
+          end
+        in ContentSort::Title
+          # Case-insensitive so "apple" and "Apple" don't split apart; path
+          # keeps equal titles deterministic.
+          contents.sort_by! { |info| {info.title.downcase, info.path} }
+        in ContentSort::Path
+          contents.sort_by!(&.path)
         end
+        contents.reverse! if reverse
+        contents = contents.first(limit) if limit
 
         contents
       end
 
       # Display content list in a formatted table
-      def display(filter : ContentFilter)
-        contents = list_content(filter)
+      def display(
+        filter : ContentFilter,
+        sort : ContentSort = ContentSort::Date,
+        reverse : Bool = false,
+        limit : Int32? = nil,
+      )
+        contents = list_content(filter, sort, reverse, limit)
 
         filter_name = case filter
                       when ContentFilter::Drafts    then "drafts"

--- a/src/services/defaults/agents_md.cr
+++ b/src/services/defaults/agents_md.cr
@@ -2,6 +2,13 @@ module Hwaro
   module Services
     module Defaults
       class AgentsMd
+        # Heading of the user-owned tail section in both generated variants.
+        # `AgentsMdCommand#merge_site_section` carries everything from this
+        # marker onward across a regenerating `--write`, so the command and
+        # the templates must agree on the exact text — the templates below
+        # interpolate this constant rather than spelling it out.
+        SITE_SECTION_MARKER = "## Site-Specific Instructions"
+
         def self.remote_content : String
           <<-CONTENT
             # AGENTS.md - AI Agent Instructions for Hwaro Site
@@ -70,7 +77,7 @@ module Hwaro
             hwaro tool agents-md --local --write
             ```
 
-            ## Site-Specific Instructions
+            #{SITE_SECTION_MARKER}
 
             <!-- Add your site-specific rules and conventions below -->
             CONTENT
@@ -336,7 +343,7 @@ module Hwaro
             6. **Use `{{ base_url }}` prefix** for URLs in templates.
             7. **Escape user content** with `{{ value | e }}` (or `| escape`) in templates.
 
-            ## Site-Specific Instructions
+            #{SITE_SECTION_MARKER}
 
             <!-- Add your site-specific rules and conventions below -->
             CONTENT

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -107,6 +107,8 @@ module Hwaro
             ["default-language-undefined"]),
           CheckSpec.new("markdown / pwa (valid enums)",
             ["markdown-math-engine-invalid", "pwa-cache-strategy-invalid"]),
+          CheckSpec.new("image processing (widths set)",
+            ["image-processing-widths-empty"]),
           CheckSpec.new("deployment / related (refs resolve)",
             ["deployment-target-undefined", "related-taxonomy-undefined"]),
           CheckSpec.new("menus (parent references)",
@@ -720,6 +722,16 @@ module Hwaro
         if config.markdown.math && !VALID_MATH_ENGINES.includes?(config.markdown.math_engine)
           issues << Issue.new(id: "markdown-math-engine-invalid", level: :warning, category: "config", file: @config_path,
             message: "markdown.math_engine \"#{config.markdown.math_engine}\" is not supported (expected: #{VALID_MATH_ENGINES.join(", ")})")
+        end
+
+        # An enabled [image_processing] with no widths is a silent no-op:
+        # the image hook returns early on an empty widths array and the
+        # renderer generates no srcset, so the user turns the feature on
+        # and nothing visibly happens. Same "enabled but silently does
+        # nothing" class as the math_engine and pwa checks around it.
+        if config.image_processing.enabled && config.image_processing.widths.empty?
+          issues << Issue.new(id: "image-processing-widths-empty", level: :warning, category: "config", file: @config_path,
+            message: "image_processing is enabled but widths is empty — no resized variants will be generated (set e.g. widths = [320, 640, 1024])")
         end
 
         # PWA cache_strategy is enforced at runtime via VALID_STRATEGIES.

--- a/src/services/exporters/base.cr
+++ b/src/services/exporters/base.cr
@@ -1,6 +1,7 @@
 require "file_utils"
 require "yaml"
 require "toml"
+require "../file_action"
 require "../../config/options/export_options"
 require "../../utils/errors"
 require "../../utils/file_safe"
@@ -132,6 +133,17 @@ module Hwaro
 
         abstract def run(options : Config::Options::ExportOptions) : ExportResult
 
+        # When set, the run resolves and reports every destination (counts,
+        # manifest) but writes nothing to disk.
+        property dry_run : Bool = false
+
+        # Per-file manifest of this run, in write order. Unlike import, an
+        # export OVERWRITES an existing destination by design (re-exporting
+        # into the same directory is the normal refresh workflow) — the
+        # manifest marks those rows `overwritten` so the caller can see
+        # exactly which pre-existing files a run replaced.
+        getter file_actions = [] of FileAction
+
         # Scan content directory for markdown files
         protected def scan_content_files(content_dir : String) : Array(String)
           files = [] of String
@@ -164,7 +176,10 @@ module Hwaro
           # `within_output_dir?` is lexical. If the destination directory —
           # or any ancestor — is a symlink out of the tree, `Dir.exists?`
           # follows it and `File.copy` would write straight through it.
-          return 0 unless Hwaro::Utils::PathUtils.resolves_within?(dest_dir, output_dir)
+          # A dry run never created `dest_dir`, so the resolved check can't
+          # run there — the lexical check above still applies, and the real
+          # run re-checks with symlinks resolved.
+          return 0 unless @dry_run || Hwaro::Utils::PathUtils.resolves_within?(dest_dir, output_dir)
 
           copied = 0
           Dir.children(source_dir).sort!.each do |entry|
@@ -175,9 +190,11 @@ module Hwaro
             dest = File.join(dest_dir, entry)
             next unless Hwaro::Utils::OutputGuard.within_output_dir?(dest, output_dir)
 
-            Hwaro::Utils::FileSafe.mkdir_p(dest_dir) unless Dir.exists?(dest_dir)
-            File.copy(src, dest)
-            Logger.debug "Exported bundle asset: #{dest}" if verbose
+            unless @dry_run
+              Hwaro::Utils::FileSafe.mkdir_p(dest_dir) unless Dir.exists?(dest_dir)
+              File.copy(src, dest)
+            end
+            Logger.debug "#{@dry_run ? "Would export" : "Exported"} bundle asset: #{dest}" if verbose
             copied += 1
           rescue ex
             Logger.warn "Could not export bundle asset #{src}: #{ex.message}"
@@ -304,9 +321,13 @@ module Hwaro
           safe_path = Hwaro::Utils::OutputGuard.safe_output_path(path, output_dir)
           return false unless safe_path
 
-          Hwaro::Utils::FileSafe.mkdir_p(File.dirname(safe_path))
-          File.write(safe_path, content)
-          Logger.debug "Exported: #{path}" if verbose
+          action = File.exists?(safe_path) ? "overwritten" : "exported"
+          unless @dry_run
+            Hwaro::Utils::FileSafe.mkdir_p(File.dirname(safe_path))
+            File.write(safe_path, content)
+          end
+          @file_actions << FileAction.new(safe_path, action)
+          Logger.debug "#{@dry_run ? "Would export" : "Exported"}: #{path}" if verbose
           true
         end
 

--- a/src/services/exporters/base.cr
+++ b/src/services/exporters/base.cr
@@ -176,10 +176,14 @@ module Hwaro
           # `within_output_dir?` is lexical. If the destination directory —
           # or any ancestor — is a symlink out of the tree, `Dir.exists?`
           # follows it and `File.copy` would write straight through it.
-          # A dry run never created `dest_dir`, so the resolved check can't
-          # run there — the lexical check above still applies, and the real
-          # run re-checks with symlinks resolved.
-          return 0 unless @dry_run || Hwaro::Utils::PathUtils.resolves_within?(dest_dir, output_dir)
+          # A dry run never created `dest_dir`, so it can only apply the
+          # resolved check to a directory that already exists — the same
+          # pre-existing-symlink case the real run refuses.
+          if @dry_run
+            return 0 if Dir.exists?(dest_dir) && !Hwaro::Utils::PathUtils.resolves_within?(dest_dir, output_dir)
+          else
+            return 0 unless Hwaro::Utils::PathUtils.resolves_within?(dest_dir, output_dir)
+          end
 
           copied = 0
           Dir.children(source_dir).sort!.each do |entry|
@@ -190,10 +194,12 @@ module Hwaro
             dest = File.join(dest_dir, entry)
             next unless Hwaro::Utils::OutputGuard.within_output_dir?(dest, output_dir)
 
+            action = File.exists?(dest) ? "overwritten" : "exported"
             unless @dry_run
               Hwaro::Utils::FileSafe.mkdir_p(dest_dir) unless Dir.exists?(dest_dir)
               File.copy(src, dest)
             end
+            @file_actions << FileAction.new(dest, action)
             Logger.debug "#{@dry_run ? "Would export" : "Exported"} bundle asset: #{dest}" if verbose
             copied += 1
           rescue ex

--- a/src/services/file_action.cr
+++ b/src/services/file_action.cr
@@ -1,0 +1,16 @@
+# Per-file manifest row shared by the import and export services.
+
+require "json"
+
+module Hwaro
+  module Services
+    # One row of a per-file manifest: the destination a source resolved to
+    # and what happened there (`imported` / `exported` / `overwritten` /
+    # `skipped`). Import and export surface these through `--json`, so
+    # scripts get a source-of-truth file list instead of re-deriving it
+    # from log lines.
+    record FileAction, path : String, action : String do
+      include JSON::Serializable
+    end
+  end
+end

--- a/src/services/frontmatter_converter.cr
+++ b/src/services/frontmatter_converter.cr
@@ -31,6 +31,9 @@ module Hwaro
       property converted_count : Int32
       property skipped_count : Int32
       property error_count : Int32
+      # True when the run only previewed: `converted_count` then means
+      # "would be converted" and no file was touched.
+      property dry_run : Bool
 
       def initialize(
         @success : Bool = true,
@@ -38,6 +41,7 @@ module Hwaro
         @converted_count : Int32 = 0,
         @skipped_count : Int32 = 0,
         @error_count : Int32 = 0,
+        @dry_run : Bool = false,
       )
       end
     end
@@ -77,7 +81,10 @@ module Hwaro
       # Content directory path
       @content_dir : String
 
-      def initialize(@content_dir : String = "content")
+      # A dry run performs the full detection/conversion pipeline — including
+      # the dropped-comment warnings, which are the main reason to preview an
+      # in-place bulk rewrite — but never writes a file back.
+      def initialize(@content_dir : String = "content", @dry_run : Bool = false)
       end
 
       # Convert all content files to YAML format
@@ -175,8 +182,12 @@ module Hwaro
         converted_content = convert_content(content, current_format, target_format)
 
         if converted_content
-          write_in_place(file_path, converted_content)
-          Logger.item(file_path, glyph: :ok)
+          if @dry_run
+            Logger.item("would convert: #{file_path}", glyph: :ok)
+          else
+            write_in_place(file_path, converted_content)
+            Logger.item(file_path, glyph: :ok)
+          end
           ConversionStatus::Converted
         else
           Logger.error "  Failed to convert: #{file_path}"
@@ -219,16 +230,17 @@ module Hwaro
         summary += " (#{skip_breakdown(skips, target_format)})" if skipped > 0
         summary += " · #{errors} errors" if errors > 0
         Logger.info "" if Logger.color_enabled?
-        Logger.outcome("converted", summary, glyph: errors > 0 ? :err : :result)
+        Logger.outcome(@dry_run ? "would convert" : "converted", summary, glyph: errors > 0 ? :err : :result)
 
         ConversionResult.new(
           success: errors == 0,
           # On failure `message` is what the CLI surfaces as the error, so it
           # has to describe the failure — not the (partial) success.
-          message: errors > 0 ? "#{errors} file(s) could not be converted to #{format_name}" : "Converted #{converted} files to #{format_name}",
+          message: errors > 0 ? "#{errors} file(s) could not be converted to #{format_name}" : "#{@dry_run ? "Would convert" : "Converted"} #{converted} files to #{format_name}",
           converted_count: converted,
           skipped_count: skipped,
-          error_count: errors
+          error_count: errors,
+          dry_run: @dry_run
         )
       end
 

--- a/src/services/importers/base.cr
+++ b/src/services/importers/base.cr
@@ -1,5 +1,7 @@
 require "file_utils"
+require "json"
 require "set"
+require "../file_action"
 require "../../config/options/import_options"
 require "../../utils/date_utils"
 require "../../utils/file_safe"
@@ -35,6 +37,13 @@ module Hwaro
 
       abstract class Base
         abstract def run(options : Config::Options::ImportOptions) : ImportResult
+
+        # When set, the run resolves and reports every destination (counts,
+        # manifest, collision renames) but writes nothing to disk.
+        property dry_run : Bool = false
+
+        # Per-file manifest of this run, in write order.
+        getter file_actions = [] of FileAction
 
         # Regex matching YAML frontmatter: opening `---` on the first line and a
         # closing `---` on its own line (multiline mode so ^ matches line starts).
@@ -216,6 +225,7 @@ module Hwaro
           @claimed_paths.clear
           @claim_suffixes.clear
           @collision_count = 0
+          @file_actions.clear
         end
 
         # Emit the single end-of-run collision summary, if any. Importers call
@@ -325,25 +335,33 @@ module Hwaro
           path = claim_path(resolved)
           dir = File.dirname(path)
 
-          Hwaro::Utils::FileSafe.mkdir_p(dir) unless Dir.exists?(dir)
+          unless @dry_run
+            Hwaro::Utils::FileSafe.mkdir_p(dir) unless Dir.exists?(dir)
 
-          # `within_output_dir?` above is lexical. If the section directory
-          # (or any ancestor) is a symlink pointing out of the tree, that
-          # check still passes and `File.write` follows the link straight out
-          # of `output_dir`. Re-check with symlinks resolved now that the
-          # directory exists.
-          unless Utils::PathUtils.resolves_within?(dir, output_dir)
-            Logger.warn "Skipped (destination directory resolves outside the output directory): #{dir}"
-            return {false, nil}
+            # `within_output_dir?` above is lexical. If the section directory
+            # (or any ancestor) is a symlink pointing out of the tree, that
+            # check still passes and `File.write` follows the link straight out
+            # of `output_dir`. Re-check with symlinks resolved now that the
+            # directory exists. A dry run creates no directories, so it can't
+            # perform this resolved check — the real run still does.
+            unless Utils::PathUtils.resolves_within?(dir, output_dir)
+              Logger.warn "Skipped (destination directory resolves outside the output directory): #{dir}"
+              return {false, nil}
+            end
           end
 
           if File.exists?(path) && !force
             Logger.warn "Skipped (already exists): #{path}" if verbose
+            @file_actions << FileAction.new(path, "skipped")
             return {false, path}
           end
 
-          content = "#{frontmatter}\n\n#{body}\n"
-          File.write(path, content)
+          action = File.exists?(path) ? "overwritten" : "imported"
+
+          unless @dry_run
+            content = "#{frontmatter}\n\n#{body}\n"
+            File.write(path, content)
+          end
 
           # Only now is the rename real. Counting/announcing it at claim time
           # asserted a write that never happened when the disambiguated
@@ -353,7 +371,11 @@ module Hwaro
             Logger.debug "Renamed: #{File.basename(resolved)} → #{File.basename(path)} (claimed by an earlier source in this run)" if verbose
           end
 
-          Logger.debug(force ? "Overwrote: #{path}" : "Imported: #{path}") if verbose
+          @file_actions << FileAction.new(path, action)
+          if verbose
+            label = @dry_run ? "Would import" : (action == "overwritten" ? "Overwrote" : "Imported")
+            Logger.debug "#{label}: #{path}"
+          end
           {true, path}
         end
 
@@ -376,7 +398,10 @@ module Hwaro
           # `within_output_dir?` is lexical. If the destination directory —
           # or any ancestor — is a symlink out of the tree, `Dir.exists?`
           # follows it and `File.copy` would write straight through it.
-          return 0 unless Utils::PathUtils.resolves_within?(dest_dir, output_dir)
+          # A dry run never created `dest_dir`, so the resolved check can't
+          # run there — the lexical check above still applies, and the real
+          # run re-checks with symlinks resolved.
+          return 0 unless @dry_run || Utils::PathUtils.resolves_within?(dest_dir, output_dir)
 
           copied = 0
           Dir.children(source_dir).sort!.each do |entry|
@@ -394,9 +419,11 @@ module Hwaro
             next unless Utils::OutputGuard.within_output_dir?(dest, output_dir)
             next if File.exists?(dest) && !force
 
-            Hwaro::Utils::FileSafe.mkdir_p(dest_dir) unless Dir.exists?(dest_dir)
-            File.copy(src, dest)
-            Logger.debug "Copied bundle asset: #{dest}" if verbose
+            unless @dry_run
+              Hwaro::Utils::FileSafe.mkdir_p(dest_dir) unless Dir.exists?(dest_dir)
+              File.copy(src, dest)
+            end
+            Logger.debug "#{@dry_run ? "Would copy" : "Copied"} bundle asset: #{dest}" if verbose
             copied += 1
           rescue ex
             Logger.warn "Could not copy bundle asset #{src}: #{ex.message}"

--- a/src/services/importers/base.cr
+++ b/src/services/importers/base.cr
@@ -335,19 +335,19 @@ module Hwaro
           path = claim_path(resolved)
           dir = File.dirname(path)
 
-          unless @dry_run
-            Hwaro::Utils::FileSafe.mkdir_p(dir) unless Dir.exists?(dir)
+          Hwaro::Utils::FileSafe.mkdir_p(dir) unless @dry_run || Dir.exists?(dir)
 
-            # `within_output_dir?` above is lexical. If the section directory
-            # (or any ancestor) is a symlink pointing out of the tree, that
-            # check still passes and `File.write` follows the link straight out
-            # of `output_dir`. Re-check with symlinks resolved now that the
-            # directory exists. A dry run creates no directories, so it can't
-            # perform this resolved check — the real run still does.
-            unless Utils::PathUtils.resolves_within?(dir, output_dir)
-              Logger.warn "Skipped (destination directory resolves outside the output directory): #{dir}"
-              return {false, nil}
-            end
+          # `within_output_dir?` above is lexical. If the section directory
+          # (or any ancestor) is a symlink pointing out of the tree, that
+          # check still passes and `File.write` follows the link straight out
+          # of `output_dir`. Re-check with symlinks resolved now that the
+          # directory exists. A dry run creates no directories, so it can only
+          # perform this resolved check against directories that already exist
+          # — which is exactly the pre-existing-symlink case the real run
+          # would refuse, keeping the dry-run manifest honest.
+          if Dir.exists?(dir) && !Utils::PathUtils.resolves_within?(dir, output_dir)
+            Logger.warn "Skipped (destination directory resolves outside the output directory): #{dir}"
+            return {false, nil}
           end
 
           if File.exists?(path) && !force
@@ -398,10 +398,14 @@ module Hwaro
           # `within_output_dir?` is lexical. If the destination directory —
           # or any ancestor — is a symlink out of the tree, `Dir.exists?`
           # follows it and `File.copy` would write straight through it.
-          # A dry run never created `dest_dir`, so the resolved check can't
-          # run there — the lexical check above still applies, and the real
-          # run re-checks with symlinks resolved.
-          return 0 unless @dry_run || Utils::PathUtils.resolves_within?(dest_dir, output_dir)
+          # A dry run never created `dest_dir`, so it can only apply the
+          # resolved check to a directory that already exists — the same
+          # pre-existing-symlink case the real run refuses.
+          if @dry_run
+            return 0 if Dir.exists?(dest_dir) && !Utils::PathUtils.resolves_within?(dest_dir, output_dir)
+          else
+            return 0 unless Utils::PathUtils.resolves_within?(dest_dir, output_dir)
+          end
 
           copied = 0
           Dir.children(source_dir).sort!.each do |entry|
@@ -417,12 +421,17 @@ module Hwaro
             # still broken. The exporter twin does the same.
             dest = File.join(dest_dir, entry)
             next unless Utils::OutputGuard.within_output_dir?(dest, output_dir)
-            next if File.exists?(dest) && !force
+            if File.exists?(dest) && !force
+              @file_actions << FileAction.new(dest, "skipped")
+              next
+            end
 
+            action = File.exists?(dest) ? "overwritten" : "imported"
             unless @dry_run
               Hwaro::Utils::FileSafe.mkdir_p(dest_dir) unless Dir.exists?(dest_dir)
               File.copy(src, dest)
             end
+            @file_actions << FileAction.new(dest, action)
             Logger.debug "#{@dry_run ? "Would copy" : "Copied"} bundle asset: #{dest}" if verbose
             copied += 1
           rescue ex


### PR DESCRIPTION
## Summary

A feature-improvement pass over the `hwaro tool` subcommand family, closing the biggest capability/consistency gaps between sibling commands, plus one doctor check from the issue queue.

### Consistency & safety

- **export**: classified `HWARO_E_IO` failure instead of a bare `exit(1)`; `--json` per-file manifest; `--dry-run`; a warning (with count) when a re-export replaces pre-existing files.
- **import**: `--json` per-file manifest (`imported` / `overwritten` / `skipped`, bundle assets included) and `--dry-run` that resolves every destination — collision renames and skip decisions included — without writing.
- **convert**: `--dry-run` runs the full pipeline (dropped-comment warnings included) without rewriting any file.
- **unused-assets**: `-t/--templates-dir` so a non-default templates tree is scanned for references; an explicitly passed dir must exist (refuses instead of silently scanning zero templates and feeding false positives to `--delete`).
- **doctor**: `--json` now routes through `Runner.enable_json_mode!` like every sibling, so mid-run classified errors render as JSON payloads.

### New capabilities

- **list**: `--sort date|title|path`, `-r/--reverse`, `-n/--limit` (applied after sorting). Title ordering matches the template engine's `sort_by="title"` (`SortUtils.compare_by_title`) so CLI and rendered listings agree.
- **stats**: `--top N` replaces the hardcoded top-15 tag chart cap.
- **check-links**: `--ignore-url PATTERN` (case-insensitive substring with `*` wildcards, repeatable; matching links are never contacted) and `--allow-status CODES`; the JSON payload gains `skipped_external` (SSRF-guard skips were previously invisible to JSON consumers) and `ignored_count` (so an over-broad ignore pattern is distinguishable from a clean check).
- **validate**: `--strict` / `--max-warnings` mirroring doctor's exit policy (content errors exit 5, warning-driven gates exit 1).
- **agents-md `--write`**: the Site-Specific Instructions section of an existing AGENTS.md is preserved across regeneration, as the docs already promised; the marker constant lives on the template service, and a marker-less file is announced as a full replacement (prompt, or warning under `--force`) instead of silently losing content.
- **doctor**: new `image-processing-widths-empty` warning for an enabled `[image_processing]` with no `widths` (silent no-op).

### Docs

Fixes the long-standing `-c, --content` flag misspelling across six tool pages (en+ko; the flag is `--content-dir`), documents all new flags, adds the `--force` row the import options table omitted, and documents check-links' GET fallback, redirect follow, private-address skip, and unused-assets' real scan sources. All pages updated in English and Korean.

### Behavior changes to note

- `tool export` failures now exit 6 (`EXIT_IO`) with the standard `Error [HWARO_E_IO]` line instead of exit 1 with `Export failed:` — intentional alignment with every sibling tool command.
- `tool convert --json` payloads gain an additive `dry_run` key.
- `check-links --json` payloads gain additive `skipped_external` and `ignored_count` keys.

## Testing

- New unit specs (`spec/unit/tool_feature_improvements_spec.cr`, 9 examples) for dry-run/manifest/sorting semantics, including the pre-existing-symlink dry-run refusal and bundle-asset manifest rows.
- Paired warns/does-not-warn doctor specs for the widths check.
- 21 new functional CLI specs covering every new flag, error path, and the review-fix regressions.
- Adversarially reviewed (fresh multi-angle review); 8 of 10 confirmed findings fixed in the follow-up commit, the other 2 are the intentional behavior changes listed above. Two low-tier cleanups noted but deferred: validate/doctor `exit_code_for` duplication, and `skipped_external` classification by error-string sentinel.
- Full suite: 8016 examples, 0 failures. `crystal tool format --check` and ameba clean.

Closes #632