### PR TITLE
fix(tool): stability audit across the tool subcommand family — 60+ crash/correctness fixes

### DIFF
--- a/spec/unit/agents_md_merge_stability_spec.cr
+++ b/spec/unit/agents_md_merge_stability_spec.cr
@@ -141,6 +141,97 @@ describe "agents-md site-section merge" do
     end
   end
 
+  # Review follow-up: requiring the marker to be the ENTIRE line meant a
+  # user-annotated heading was no longer found and --force discarded the
+  # section the annotation asked to keep.
+  it "preserves a user section under an annotated marker heading" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("AGENTS.md", <<-MD)
+          # AGENTS.md - AI Agent Instructions for Hwaro Site
+
+          Stale body.
+
+          #{marker} (do not delete)
+
+          - Always deploy on Friday
+          MD
+
+        with_captured_log do
+          Hwaro::CLI::Commands::Tool::AgentsMdCommand.new.run(["--write", "--force"])
+        end
+
+        File.read("AGENTS.md").should contain("Always deploy on Friday")
+      end
+    end
+  end
+
+  # Review follow-up: a closing fence carries no info string (CommonMark), so
+  # a ```text line inside an open block must NOT flip the parity and expose a
+  # quoted marker as the merge point.
+  it "does not treat an info-string fence line as a closer" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("AGENTS.md", <<-MD)
+          # AGENTS.md - AI Agent Instructions for Hwaro Site
+
+          ```markdown
+          ```text
+          #{marker}
+          ```
+
+          Stale generated body.
+
+          #{marker}
+
+          - Always deploy on Friday
+          MD
+
+        with_captured_log do
+          Hwaro::CLI::Commands::Tool::AgentsMdCommand.new.run(["--write", "--force"])
+        end
+
+        merged = File.read("AGENTS.md")
+        merged.should contain("Always deploy on Friday")
+        merged.should_not contain("Stale generated body")
+      end
+    end
+  end
+
+  # Review follow-up: the unclosed-fence fallback must scan only FROM the
+  # open fence — a marker quoted in an earlier properly CLOSED fence must
+  # never become the merge point.
+  it "ignores a closed-fence quote even when a later fence is unclosed" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("AGENTS.md", <<-MD)
+          # AGENTS.md - AI Agent Instructions for Hwaro Site
+
+          ```markdown
+          #{marker}
+          ```
+
+          Stale generated body.
+
+          ```bash
+          hwaro build
+
+          #{marker}
+
+          - Always deploy on Friday
+          MD
+
+        with_captured_log do
+          Hwaro::CLI::Commands::Tool::AgentsMdCommand.new.run(["--write", "--force"])
+        end
+
+        merged = File.read("AGENTS.md")
+        merged.should contain("Always deploy on Friday")
+        merged.should_not contain("Stale generated body")
+      end
+    end
+  end
+
   # Review follow-up: an unclosed fence above the marker swallowed the rest of
   # the file, so the real heading was invisible and --force destroyed the
   # user's section. The scanner now falls back to a fence-blind pass when the

--- a/spec/unit/agents_md_merge_stability_spec.cr
+++ b/spec/unit/agents_md_merge_stability_spec.cr
@@ -1,0 +1,170 @@
+require "../spec_helper"
+
+# Regression specs for `hwaro tool agents-md --write` merging.
+#
+# The `## Site-Specific Instructions` marker used to be located by FIRST
+# SUBSTRING occurrence, so a mention of the heading inside a code fence or
+# mid-prose shifted the merge point — duplicating stale generated content or
+# silently discarding user sections above the real heading. The marker is now
+# matched as a full line, skipping fenced code blocks.
+describe "agents-md site-section merge" do
+  marker = Hwaro::Services::Defaults::AgentsMd::SITE_SECTION_MARKER
+
+  it "ignores a marker mentioned inside a code fence" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("AGENTS.md", <<-MD)
+          # AGENTS.md - AI Agent Instructions for Hwaro Site
+
+          Some stale generated body.
+
+          ```markdown
+          #{marker}
+          ```
+
+          More stale generated body.
+
+          #{marker}
+
+          - Always deploy on Friday
+          MD
+
+        with_captured_log do
+          cmd = Hwaro::CLI::Commands::Tool::AgentsMdCommand.new
+          cmd.run(["--write", "--force"])
+        end
+
+        merged = File.read("AGENTS.md")
+        # The user's section survives...
+        merged.should contain("Always deploy on Friday")
+        # ...but the merge point is the REAL heading, not the fenced mention:
+        # nothing between the fence and the real heading leaks through, and
+        # the heading appears exactly once.
+        merged.should_not contain("More stale generated body")
+        merged.scan(/^#{Regex.escape(marker)}$/m).size.should eq(1)
+      end
+    end
+  end
+
+  it "ignores a marker mentioned mid-prose" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("AGENTS.md", <<-MD)
+          # AGENTS.md - AI Agent Instructions for Hwaro Site
+
+          See the #{marker} heading below for user rules.
+
+          #{marker}
+
+          - My custom rule
+          MD
+
+        with_captured_log do
+          cmd = Hwaro::CLI::Commands::Tool::AgentsMdCommand.new
+          cmd.run(["--write", "--force"])
+        end
+
+        merged = File.read("AGENTS.md")
+        merged.should contain("- My custom rule")
+        # The prose sentence belongs to the replaced generated body; a
+        # substring match used to cut the file mid-sentence there.
+        merged.should_not contain("heading below for user rules")
+      end
+    end
+  end
+
+  it "still preserves a normal user section across regeneration" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        with_captured_log do
+          Hwaro::CLI::Commands::Tool::AgentsMdCommand.new.run(["--write"])
+        end
+        File.write("AGENTS.md", File.read("AGENTS.md") + "\n- Custom: use pnpm\n")
+
+        output = with_captured_log do
+          Hwaro::CLI::Commands::Tool::AgentsMdCommand.new.run(["--write", "--force"])
+        end
+
+        output.should contain("site-specific section preserved")
+        File.read("AGENTS.md").should contain("- Custom: use pnpm")
+      end
+    end
+  end
+
+  it "treats a file whose only marker is fenced as having no marker (full rewrite)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("AGENTS.md", <<-MD)
+          # Some other document
+
+          ```markdown
+          #{marker}
+          ```
+
+          - not a real site section
+          MD
+
+        output = with_captured_log do
+          Hwaro::CLI::Commands::Tool::AgentsMdCommand.new.run(["--write", "--force"])
+        end
+
+        # The warning names the missing heading, and the file is regenerated
+        # wholesale instead of being stitched at the fenced mention.
+        output.should contain("no '#{marker}' heading")
+        File.read("AGENTS.md").should eq(Hwaro::Services::Defaults::AgentsMd.content)
+      end
+    end
+  end
+
+  # Review follow-up: a marker indented 1-3 spaces still renders as the same
+  # heading and used to be preserved by the substring search; the line-anchored
+  # regex must keep matching it.
+  it "preserves a user section under a slightly indented marker" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("AGENTS.md", <<-MD)
+          # AGENTS.md - AI Agent Instructions for Hwaro Site
+
+          Stale body.
+
+           #{marker}
+
+          - Always deploy on Friday
+          MD
+
+        with_captured_log do
+          Hwaro::CLI::Commands::Tool::AgentsMdCommand.new.run(["--write", "--force"])
+        end
+
+        File.read("AGENTS.md").should contain("Always deploy on Friday")
+      end
+    end
+  end
+
+  # Review follow-up: an unclosed fence above the marker swallowed the rest of
+  # the file, so the real heading was invisible and --force destroyed the
+  # user's section. The scanner now falls back to a fence-blind pass when the
+  # file ends inside an open fence.
+  it "preserves a user section below an unclosed fence" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("AGENTS.md", <<-MD)
+          # AGENTS.md - AI Agent Instructions for Hwaro Site
+
+          ```bash
+          hwaro build
+
+          #{marker}
+
+          - Always deploy on Friday
+          MD
+
+        with_captured_log do
+          Hwaro::CLI::Commands::Tool::AgentsMdCommand.new.run(["--write", "--force"])
+        end
+
+        File.read("AGENTS.md").should contain("Always deploy on Friday")
+      end
+    end
+  end
+end

--- a/spec/unit/content_lister_spec.cr
+++ b/spec/unit/content_lister_spec.cr
@@ -574,3 +574,37 @@ describe Hwaro::Services::ContentInfo do
     end
   end
 end
+
+describe "ContentLister date sort with undated entries" do
+  # Regression: undated files keyed as epoch 0 — "older than everything
+  # post-1970" — so `--sort date --reverse` ranked them ABOVE every dated
+  # post and polluted `--reverse --limit N` results. Undated means "date
+  # unknown": those entries sort AFTER dated ones in both directions, with
+  # the path tie-breaker keeping the order deterministic.
+  it "sorts undated entries after dated ones in both directions" do
+    Dir.mktmpdir do |dir|
+      content_dir = File.join(dir, "content")
+      FileUtils.mkdir_p(content_dir)
+
+      File.write(File.join(content_dir, "new.md"), "---\ntitle: New\ndate: 2024-06-15\n---\nN")
+      File.write(File.join(content_dir, "old.md"), "---\ntitle: Old\ndate: 2023-01-01\n---\nO")
+      File.write(File.join(content_dir, "z-undated.md"), "---\ntitle: Undated Z\n---\nU")
+      File.write(File.join(content_dir, "a-undated.md"), "---\ntitle: Undated A\n---\nU")
+
+      lister = Hwaro::Services::ContentLister.new(content_dir)
+      all = Hwaro::Services::ContentFilter::All
+      date = Hwaro::Services::ContentSort::Date
+
+      forward = lister.list_content(all, date)
+      forward.map(&.title).should eq(["New", "Old", "Undated A", "Undated Z"])
+
+      reversed = lister.list_content(all, date, reverse: true)
+      reversed.map(&.title).should eq(["Old", "New", "Undated A", "Undated Z"])
+
+      # --reverse --limit returns the oldest DATED entries, not the undated
+      # ones.
+      limited = lister.list_content(all, date, reverse: true, limit: 2)
+      limited.map(&.title).should eq(["Old", "New"])
+    end
+  end
+end

--- a/spec/unit/content_stats_regression_spec.cr
+++ b/spec/unit/content_stats_regression_spec.cr
@@ -76,6 +76,25 @@ describe "content analysis regressions" do
       end
     end
 
+    # Review follow-up: extract_body's frontmatter regex raises ArgumentError
+    # (PCRE2) on a body with invalid UTF-8, escaping the loop's IO::Error
+    # rescue and killing the whole report over one bad file.
+    it "skips a file whose body holds invalid UTF-8 instead of aborting" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "good.md"), "+++\ntitle = \"G\"\n+++\nfour words right here\n")
+        File.open(File.join(content_dir, "bad.md"), "w") do |f|
+          f << "+++\ntitle = \"B\"\n+++\nbody "
+          f.write_byte(0xFF_u8)
+          f << " tail\n"
+        end
+
+        result = Hwaro::Services::ContentStats.new(content_dir).run
+        result.words_total.should eq(4)
+      end
+    end
+
     it "does not count Markdown punctuation as words" do
       Hwaro::Utils::TextUtils.count_words("## Heading").should eq(1)
       Hwaro::Utils::TextUtils.count_words("| a | b |").should eq(2)

--- a/spec/unit/content_stats_regression_spec.cr
+++ b/spec/unit/content_stats_regression_spec.cr
@@ -82,14 +82,32 @@ describe "content analysis regressions" do
       Hwaro::Utils::TextUtils.count_words("<p>one two</p>").should eq(2)
     end
 
-    it "keeps excluding fenced code blocks from the stats report" do
+    it "agrees with Models::Page#calculate_word_count for a fenced body too" do
+      # Expectation changed: stats used to strip fenced code blocks while the
+      # build's `page.word_count` counted them, so the two "can never drift"
+      # numbers drifted on every page with a code block. The build is the
+      # source of truth, so stats now counts fences the same way.
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         FileUtils.mkdir_p(content_dir)
-        File.write(File.join(content_dir, "code.md"),
-          "---\ntitle: Code\n---\n\nReal words here\n\n```crystal\nputs \"not counted\"\n```\n")
+        fenced = "Real words here\n\n```crystal\nputs \"not counted\"\n```\n"
+        File.write(File.join(content_dir, "code.md"), "---\ntitle: Code\n---\n\n#{fenced}")
 
-        Hwaro::Services::ContentStats.new(content_dir).run.words_total.should eq(3)
+        page = Hwaro::Models::Page.new(File.join(content_dir, "code.md"))
+        page.raw_content = "\n#{fenced}"
+
+        Hwaro::Services::ContentStats.new(content_dir).run.words_total
+          .should eq(page.calculate_word_count)
+      end
+    end
+
+    it "sums word counts in Int64 so a giant corpus cannot overflow Int32" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "a.md"), "---\ntitle: A\n---\none two\n")
+
+        Hwaro::Services::ContentStats.new(content_dir).run.words_total.should be_a(Int64)
       end
     end
   end

--- a/spec/unit/content_stats_spec.cr
+++ b/spec/unit/content_stats_spec.cr
@@ -211,18 +211,23 @@ describe Hwaro::Services::ContentStats do
       end
     end
 
-    it "excludes code blocks from word count" do
+    it "counts fenced code blocks exactly like the build's page.word_count" do
+      # Expectation changed: stats used to strip fenced code blocks, but the
+      # build's `page.word_count` (the source of truth) does not — the two
+      # numbers drifted on any page with a code block.
       Dir.mktmpdir do |dir|
         content_dir = File.join(dir, "content")
         FileUtils.mkdir_p(content_dir)
 
-        File.write(File.join(content_dir, "code.md"), "---\ntitle: Code\n---\n\nReal words here\n\n```crystal\nputs \"not counted\"\nvar = 123\n```\n")
+        body = "\nReal words here\n\n```crystal\nputs \"not counted\"\nvar = 123\n```\n"
+        File.write(File.join(content_dir, "code.md"), "---\ntitle: Code\n---\n#{body}")
 
         stats = Hwaro::Services::ContentStats.new(content_dir)
         result = stats.run
 
-        # Only "Real words here" should count
-        result.words_total.should eq(3)
+        result.words_total.should eq(Hwaro::Utils::TextUtils.count_words(body))
+        # The fenced words are counted, not stripped.
+        result.words_total.should be > 3
       end
     end
 

--- a/spec/unit/convert_regression_spec.cr
+++ b/spec/unit/convert_regression_spec.cr
@@ -59,4 +59,97 @@ describe "convert regressions" do
       end
     end
   end
+
+  # Stability audit 2026-08-23. `write_in_place` renamed the temp file over
+  # the given path, so converting a symlinked content file destroyed the
+  # symlink and left the real target unconverted.
+  describe "symlinked content files" do
+    it "converts the symlink's target and keeps the symlink" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        target = File.join(dir, "real.md")
+        File.write(target, "+++\ntitle = \"Linked\"\n+++\n\nBody.\n")
+        link = File.join(content_dir, "linked.md")
+        File.symlink(target, link)
+
+        result = Hwaro::Services::FrontmatterConverter.new(content_dir).convert_to_yaml
+        result.converted_count.should eq(1)
+
+        File.symlink?(link).should be_true
+        File.read(target).should start_with("---\ntitle: Linked\n---\n")
+      end
+    end
+  end
+
+  # Stability audit 2026-08-23. An empty source mapping serialized through
+  # `to_yaml` as `--- {}`, which ended up embedded inside the new fences.
+  describe "empty frontmatter blocks" do
+    it "converts empty JSON frontmatter to an empty YAML block" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        path = File.join(dir, "post.md")
+        File.write(path, "{}\n\nBody.\n")
+
+        converter.convert_file(path, Hwaro::Services::FrontmatterFormat::YAML).should be_true
+
+        content = File.read(path)
+        content.should start_with("---\n---\n")
+        content.should_not contain("--- {}")
+      end
+    end
+
+    it "converts empty TOML frontmatter to an empty YAML block" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        path = File.join(dir, "post.md")
+        File.write(path, "+++\n+++\n\nBody.\n")
+
+        converter.convert_file(path, Hwaro::Services::FrontmatterFormat::YAML).should be_true
+
+        content = File.read(path)
+        content.should eq("---\n---\n\nBody.\n")
+      end
+    end
+
+    # `YAML.parse("")` is nil, so `---\n---\n` was misclassified as "not
+    # front matter" and skipped instead of converting to `+++\n+++`.
+    it "converts an empty YAML frontmatter block to TOML" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        path = File.join(dir, "post.md")
+        File.write(path, "---\n---\n\nBody.\n")
+
+        converter.convert_file(path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+
+        File.read(path).should eq("+++\n+++\n\nBody.\n")
+      end
+    end
+  end
+
+  # Stability audit 2026-08-23. `detect_format` required the opener to be
+  # exactly `---\n`, while the build parser accepts trailing whitespace —
+  # `--- \n` files were skipped as "no frontmatter".
+  describe "delimiter trailing whitespace" do
+    it "detects frontmatter whose opening delimiter has trailing whitespace" do
+      converter = Hwaro::Services::FrontmatterConverter.new(".")
+      converter.detect_format("--- \ntitle: x\n---\n").should eq(Hwaro::Services::FrontmatterFormat::YAML)
+      converter.detect_format("+++\t\ntitle = \"x\"\n+++\n").should eq(Hwaro::Services::FrontmatterFormat::TOML)
+      converter.detect_format("--- \r\ntitle: x\n---\n").should eq(Hwaro::Services::FrontmatterFormat::YAML)
+    end
+
+    it "converts a file whose opening delimiter has a trailing space" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        path = File.join(dir, "post.md")
+        File.write(path, "--- \ntitle: X\n---\n\nBody.\n")
+
+        converter.convert_file(path, Hwaro::Services::FrontmatterFormat::TOML).should be_true
+
+        content = File.read(path)
+        content.should start_with("+++\n")
+        content.should contain(%(title = "X"))
+      end
+    end
+  end
 end

--- a/spec/unit/deadlink_command_spec.cr
+++ b/spec/unit/deadlink_command_spec.cr
@@ -373,30 +373,16 @@ describe Hwaro::CLI::Commands::Tool::DeadlinkCommand do
     end
   end
 
-  describe "#private_172?" do
-    it "returns true for 172.16.x.x" do
+  # 172.x classification now goes through Socket::IPAddress#private? inside
+  # private_ip_address? (the string-prefix helper it replaced missed
+  # IPv4-mapped IPv6 forms entirely).
+  describe "172.16.0.0/12 classification" do
+    it "classifies the range boundaries like the old helper" do
       cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
-      cmd.private_172_for_test?("172.16.0.1").should be_true
-    end
-
-    it "returns true for 172.31.x.x" do
-      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
-      cmd.private_172_for_test?("172.31.255.255").should be_true
-    end
-
-    it "returns false for 172.15.x.x (below range)" do
-      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
-      cmd.private_172_for_test?("172.15.0.1").should be_false
-    end
-
-    it "returns false for 172.32.x.x (above range)" do
-      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
-      cmd.private_172_for_test?("172.32.0.1").should be_false
-    end
-
-    it "returns false for non-172 addresses" do
-      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
-      cmd.private_172_for_test?("192.168.1.1").should be_false
+      cmd.private_ip_for_test?(Socket::IPAddress.new("172.16.0.1", 0)).should be_true
+      cmd.private_ip_for_test?(Socket::IPAddress.new("172.31.255.255", 0)).should be_true
+      cmd.private_ip_for_test?(Socket::IPAddress.new("172.15.0.1", 0)).should be_false
+      cmd.private_ip_for_test?(Socket::IPAddress.new("172.32.0.1", 0)).should be_false
     end
   end
 
@@ -612,28 +598,13 @@ class Hwaro::CLI::Commands::Tool::DeadlinkCommand
     @@disable_private_host_check = val
   end
 
+  # Delegate to the real implementation (memoization + structured
+  # Socket::IPAddress classification) instead of duplicating it, so the spec
+  # binary exercises exactly what ships; the flag only bypasses the guard for
+  # examples that talk to a local test server.
   private def private_host?(host : String) : Bool
     return false if @@disable_private_host_check
-    return true if host == "localhost" || host.ends_with?(".local") || host.ends_with?(".internal")
-
-    begin
-      addrs = Socket::Addrinfo.resolve(host, 80, type: Socket::Type::STREAM)
-      addrs.any? do |addr|
-        ip = addr.ip_address.address
-        ip.starts_with?("127.") ||
-          ip.starts_with?("10.") ||
-          ip.starts_with?("192.168.") ||
-          ip.starts_with?("169.254.") ||
-          ip == "0.0.0.0" ||
-          ip == "::1" ||
-          ip == "::" ||
-          ip.starts_with?("fc") || ip.starts_with?("fd") ||
-          ip.starts_with?("fe80") ||
-          private_172?(ip)
-      end
-    rescue Socket::Error
-      false
-    end
+    previous_def
   end
 
   def find_links_for_test(dir : String) : Array(Link)
@@ -656,8 +627,8 @@ class Hwaro::CLI::Commands::Tool::DeadlinkCommand
     private_host?(host)
   end
 
-  def private_172_for_test?(ip : String) : Bool
-    private_172?(ip)
+  def private_ip_for_test?(ip : Socket::IPAddress) : Bool
+    private_ip_address?(ip)
   end
 
   def sanitize_for_terminal_for_test(s : String) : String
@@ -810,6 +781,203 @@ describe "check-links ember output" do
 
       output.should contain("Skipped: private/internal address")
       output.should_not contain("✗")
+    end
+  end
+end
+
+describe "check-links redirect and dedup behavior" do
+  # Finding 8: 303 was missing from the followed-redirect set, so a live link
+  # behind a See Other was reported dead with status 303.
+  it "follows a 303 redirect with GET" do
+    Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = true
+    begin
+      target_methods = [] of String
+      server = HTTP::Server.new do |context|
+        case context.request.path
+        when "/see-other"
+          context.response.status_code = 303
+          context.response.headers["Location"] = "/result"
+        when "/result"
+          target_methods << context.request.method
+          context.response.status_code = 200
+        else
+          context.response.status_code = 404
+        end
+      end
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+        file: "test.md", url: "http://127.0.0.1:#{address.port}/see-other", kind: :external
+      )
+      results = cmd.check_links_concurrently_for_test([link], 5, 1)
+
+      results.size.should eq(1)
+      results[0].status.should eq(200)
+      # RFC 9110: 303 is followed with GET regardless of the original method.
+      target_methods.should eq(["GET"])
+    ensure
+      server.try(&.close)
+      Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = false
+    end
+  end
+
+  # Finding 9: redirect loops / Location-less redirects recorded the redirect
+  # code as the result status, so `--allow-status 301` classified broken
+  # redirects as healthy. They must carry the -1 sentinel like other failures.
+  it "reports a redirect loop with the -1 sentinel, not the redirect code" do
+    Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = true
+    begin
+      server = HTTP::Server.new do |context|
+        context.response.status_code = 301
+        context.response.headers["Location"] = "/loop"
+      end
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+        file: "test.md", url: "http://127.0.0.1:#{address.port}/loop", kind: :external
+      )
+      results = cmd.check_links_concurrently_for_test([link], 5, 1)
+
+      results.size.should eq(1)
+      results[0].status.should eq(-1)
+      results[0].error.not_nil!.should contain("Too many redirects")
+    ensure
+      server.try(&.close)
+      Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = false
+    end
+  end
+
+  it "reports a Location-less redirect with the -1 sentinel" do
+    Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = true
+    begin
+      server = HTTP::Server.new do |context|
+        context.response.status_code = 302
+      end
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+        file: "test.md", url: "http://127.0.0.1:#{address.port}/nowhere", kind: :external
+      )
+      results = cmd.check_links_concurrently_for_test([link], 5, 1)
+
+      results.size.should eq(1)
+      results[0].status.should eq(-1)
+      results[0].error.not_nil!.should contain("Redirect without Location")
+    ensure
+      server.try(&.close)
+      Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = false
+    end
+  end
+
+  # Finding 10: identical external URLs were contacted once per occurrence,
+  # so 50 pages linking the same site produced 50 simultaneous requests and
+  # 429 false positives. Each unique URL must be contacted once, with the
+  # result fanned back out to every occurrence.
+  it "contacts an identical external URL only once but reports every occurrence" do
+    Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = true
+    begin
+      hits = Atomic(Int32).new(0)
+      server = HTTP::Server.new do |context|
+        hits.add(1) if context.request.path == "/dup"
+        context.response.status_code = 200
+      end
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      url = "http://127.0.0.1:#{address.port}/dup"
+      links = ["a.md", "b.md", "c.md"].map do |file|
+        Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(file: file, url: url, kind: :external)
+      end
+
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      results = cmd.check_links_concurrently_for_test(links, 5, 4)
+
+      # One reported result per occurrence, each with its own file...
+      results.size.should eq(3)
+      results.map(&.link.file).sort!.should eq(["a.md", "b.md", "c.md"])
+      results.all? { |r| r.status == 200 }.should be_true
+      # ...but the server was contacted exactly once.
+      hits.get.should eq(1)
+    ensure
+      server.try(&.close)
+      Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = false
+    end
+  end
+
+  # Finding 13: each redirect hop could take up to the full --timeout, so a
+  # slow chain multiplied the budget. Elapsed time is now tracked across hops
+  # and following stops once 3× the configured timeout is exceeded (the
+  # headroom keeps slow-but-healthy few-hop chains passing).
+  it "stops following redirects when the total time budget is exhausted" do
+    Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = true
+    begin
+      server = HTTP::Server.new do |context|
+        case context.request.path
+        when "/r1", "/r2", "/r3", "/r4"
+          sleep 0.9.seconds
+          nxt = {"/r1" => "/r2", "/r2" => "/r3", "/r3" => "/r4", "/r4" => "/final"}[context.request.path]
+          context.response.status_code = 302
+          context.response.headers["Location"] = nxt
+        else
+          context.response.status_code = 200
+        end
+      end
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+        file: "test.md", url: "http://127.0.0.1:#{address.port}/r1", kind: :external
+      )
+      # Each hop stays under the 1s per-request timeout, but the chain as a
+      # whole (~3.6s of server sleeps) exceeds the 3s (1s × 3) total budget.
+      results = cmd.check_links_concurrently_for_test([link], 1, 1)
+
+      results.size.should eq(1)
+      results[0].status.should eq(-1)
+      results[0].error.not_nil!.downcase.should contain("timed out")
+    ensure
+      server.try(&.close)
+      Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = false
+    end
+  end
+
+  # The 3× headroom exists so a slow-but-healthy short chain (every hop within
+  # the per-request timeout) is NOT converted into a false dead link.
+  it "still passes a slow-but-healthy two-hop redirect chain" do
+    Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = true
+    begin
+      server = HTTP::Server.new do |context|
+        case context.request.path
+        when "/s1", "/s2"
+          sleep 0.6.seconds
+          nxt = {"/s1" => "/s2", "/s2" => "/final"}[context.request.path]
+          context.response.status_code = 302
+          context.response.headers["Location"] = nxt
+        else
+          context.response.status_code = 200
+        end
+      end
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      link = Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+        file: "test.md", url: "http://127.0.0.1:#{address.port}/s1", kind: :external
+      )
+      results = cmd.check_links_concurrently_for_test([link], 1, 1)
+
+      results.size.should eq(1)
+      results[0].status.should eq(200)
+    ensure
+      server.try(&.close)
+      Hwaro::CLI::Commands::Tool::DeadlinkCommand.disable_private_host_check = false
     end
   end
 end

--- a/spec/unit/deadlink_stability_spec.cr
+++ b/spec/unit/deadlink_stability_spec.cr
@@ -1,0 +1,194 @@
+require "../spec_helper"
+
+# Helpers exposing private methods under names that do not collide with the
+# other deadlink spec files (they all compile into one binary).
+class Hwaro::CLI::Commands::Tool::DeadlinkCommand
+  def stability_external_links_for_test(dir : String) : Array(Link)
+    find_external_links(dir)
+  end
+
+  def stability_private_host_for_test?(host : String) : Bool
+    private_host?(host)
+  end
+
+  def stability_ascii_host_for_test(host : String) : String
+    ascii_host(host)
+  end
+
+  def stability_private_ip_for_test?(ip : Socket::IPAddress) : Bool
+    private_ip_address?(ip)
+  end
+
+  def stability_private_host_cache_for_test : Hash(String, Bool)
+    @private_host_cache
+  end
+end
+
+private def external_urls(body : String) : Array(String)
+  urls = [] of String
+  Dir.mktmpdir do |dir|
+    File.write(File.join(dir, "a.md"), "---\ntitle: A\n---\n#{body}\n")
+    urls = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new.stability_external_links_for_test(dir).map(&.url)
+  end
+  urls
+end
+
+describe "check-links stability regressions" do
+  # Finding 5: external URLs written in raw HTML were never checked — the
+  # external scan only saw markdown-style links, and the HTML pass dropped
+  # scheme-carrying URLs via skip_internal?.
+  describe "external URLs in raw HTML" do
+    it "finds http(s) hrefs in raw anchors" do
+      external_urls(%(<a href="https://example.com/html-x">x</a>))
+        .should eq(["https://example.com/html-x"])
+    end
+
+    it "finds external img src and srcset candidates" do
+      external_urls(%(<img srcset="https://cdn.example.com/a.webp 1x, /local.webp 2x" src="https://cdn.example.com/p.png">))
+        .should eq(["https://cdn.example.com/a.webp", "https://cdn.example.com/p.png"])
+    end
+
+    it "does not resurrect HTML externals from fenced code" do
+      external_urls("```html\n<a href=\"https://example.com/fenced\">x</a>\n```")
+        .should be_empty
+    end
+
+    it "skips unrendered template syntax, matching the internal HTML pass" do
+      external_urls(%(<a href="https://example.com/{{ page.slug }}">x</a><a href="https://example.com/{% if a %}b{% endif %}">y</a>))
+        .should be_empty
+    end
+  end
+
+  # Finding 6: the external regex required `)` right after the URL, so a
+  # CommonMark title or angle-bracket destination hid the link entirely.
+  describe "titled and angle-bracket external destinations" do
+    it "checks a titled external link" do
+      external_urls(%([x](https://example.com/titled "T")))
+        .should eq(["https://example.com/titled"])
+    end
+
+    it "checks an angle-bracket external link" do
+      external_urls("[x](<https://example.com/angled>)")
+        .should eq(["https://example.com/angled"])
+    end
+
+    it "checks a titled external image" do
+      external_urls(%(![a](https://example.com/img.png 'title')))
+        .should eq(["https://example.com/img.png"])
+    end
+
+    it "keeps query strings and fragments on external destinations" do
+      external_urls("[x](https://example.com/s?q=a&b=c#frag)")
+        .should eq(["https://example.com/s?q=a&b=c#frag"])
+    end
+
+    it "still ignores relative and scheme-only destinations" do
+      external_urls("[r](/relative/) [m](mailto:a@b.c) [t](tel:123)")
+        .should be_empty
+    end
+  end
+
+  # Finding 11: the SSRF guard used string prefixes, missing IPv4-mapped IPv6
+  # loopback and fe81–febf link-local addresses.
+  describe "SSRF guard address classification" do
+    it "blocks an IPv4-mapped IPv6 loopback literal" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      cmd.stability_private_host_for_test?("::ffff:127.0.0.1").should be_true
+    end
+
+    it "blocks fe81 link-local (fe80::/10 is wider than the 'fe80' prefix string)" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      cmd.stability_private_host_for_test?("fe81::1").should be_true
+    end
+  end
+
+  # Finding 11 continued: pure address classification (no DNS involved).
+  describe "private_ip_address? classification" do
+    it "classifies mapped, link-local, ULA and unspecified addresses as private" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      {"::ffff:127.0.0.1", "::ffff:192.168.1.5", "::ffff:10.0.0.1",
+       "fe81::1", "febf::1", "fd00::1", "127.0.0.1", "10.1.1.1",
+       "192.168.0.9", "172.20.1.1", "169.254.1.1", "::", "0.0.0.0", "::1"}.each do |addr|
+        cmd.stability_private_ip_for_test?(Socket::IPAddress.new(addr, 0)).should be_true
+      end
+    end
+
+    it "leaves public addresses alone" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      {"8.8.8.8", "93.184.216.34", "2607:f8b0::1", "172.15.0.1", "172.32.0.1"}.each do |addr|
+        cmd.stability_private_ip_for_test?(Socket::IPAddress.new(addr, 0)).should be_false
+      end
+    end
+  end
+
+  # Finding 4: private_host? resolved DNS synchronously on every occurrence
+  # and redirect hop. Results are now memoized per host for the run.
+  describe "private_host? memoization" do
+    it "caches the verdict per host" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      cmd.stability_private_host_for_test?("localhost").should be_true
+      cmd.stability_private_host_for_test?("localhost").should be_true
+      cmd.stability_private_host_for_test?("127.0.0.1").should be_true
+
+      cache = cmd.stability_private_host_cache_for_test
+      cache.size.should eq(2)
+      cache["localhost"].should be_true
+      cache["127.0.0.1"].should be_true
+    end
+  end
+
+  # Finding 7: non-ASCII (IDN) hosts failed DNS as-is and were reported
+  # dead. Labels are punycoded for resolution/connection; the original URL
+  # is kept for reporting.
+  describe "IDN host conversion" do
+    it "punycodes a non-ASCII host" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      cmd.stability_ascii_host_for_test("例え.jp").should eq("xn--r8jz45g.jp")
+    end
+
+    it "leaves an ASCII host untouched" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      cmd.stability_ascii_host_for_test("example.com").should eq("example.com")
+    end
+
+    it "punycodes only the non-ASCII labels of a mixed host" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      cmd.stability_ascii_host_for_test("docs.例え.jp").should eq("docs.xn--r8jz45g.jp")
+    end
+  end
+
+  # Finding 12: `--allow-status "403,"` rejected the empty trailing segment
+  # with a confusing "Invalid --allow-status value:" (empty) message.
+  describe "--allow-status parsing" do
+    it "skips empty segments from a trailing comma" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "index.md"), "---\ntitle: I\n---\nNo links here")
+
+        output = with_captured_log do
+          cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+          cmd.run(["-c", dir, "--internal-only", "--allow-status", "403,"])
+        end
+
+        output.should contain("checked")
+      end
+    end
+
+    it "still rejects a non-numeric segment" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      ex = expect_raises(Hwaro::HwaroError) do
+        cmd.run(["--allow-status", "403,abc"])
+      end
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.not_nil!.should contain("Invalid --allow-status")
+    end
+
+    it "rejects an all-empty value instead of silently allowing nothing" do
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      ex = expect_raises(Hwaro::HwaroError) do
+        cmd.run(["--allow-status", ","])
+      end
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.not_nil!.should contain("Invalid --allow-status")
+    end
+  end
+end

--- a/spec/unit/doctor_stability_spec.cr
+++ b/spec/unit/doctor_stability_spec.cr
@@ -1,0 +1,185 @@
+require "../spec_helper"
+require "../../src/services/doctor"
+
+# Regression specs for doctor stability fixes:
+#  - symlink-cycle resilience in the content and template scans
+#  - TOML multi-line-string awareness in the line-oriented scanners
+#    (`--fix` value fixers + `mentioned_sections`)
+#  - unclassified parse errors surfacing as issues instead of being
+#    silently dropped by ParallelHelper.map's success-only filter
+#  - `--max-warnings` usage-error parity with `hwaro tool validate`
+
+private def new_doctor(dir : String) : Hwaro::Services::Doctor
+  Hwaro::Services::Doctor.new(
+    content_dir: File.join(dir, "content"),
+    config_path: File.join(dir, "config.toml"),
+    templates_dir: File.join(dir, "templates"),
+  )
+end
+
+private def write_site(dir : String, config : String = %(title = "S"\nbase_url = "https://example.com"\n))
+  File.write(File.join(dir, "config.toml"), config)
+  FileUtils.mkdir_p(File.join(dir, "content"))
+end
+
+describe Hwaro::Services::Doctor do
+  describe "symlink-cycle resilience" do
+    # `File.file?` FOLLOWS symlinks, so a self-referential link matching
+    # the content glob raised File::Error (ELOOP) out of the whole run —
+    # zero diagnostics, and no JSON payload under --json.
+    it "survives a symlink cycle matching the content glob" do
+      Dir.mktmpdir do |dir|
+        write_site(dir)
+        File.write(File.join(dir, "content", "ok.md"), "+++\ntitle = \"A\"\n+++\nbody\n")
+        File.symlink("loop.md", File.join(dir, "content", "loop.md"))
+
+        issues = new_doctor(dir).run
+        # The healthy sibling file must still have been scanned cleanly.
+        issues.any? { |i| i.id == "content-frontmatter-invalid" }.should be_false
+        issues.any? { |i| i.id == "content-read-error" }.should be_false
+      end
+    end
+
+    # `File.directory?` in template_files followed symlinks the same way,
+    # so one bad link under templates/ killed every check.
+    it "survives a symlink cycle under templates/" do
+      Dir.mktmpdir do |dir|
+        write_site(dir)
+        tpl = File.join(dir, "templates")
+        FileUtils.mkdir_p(tpl)
+        File.write(File.join(tpl, "page.html"), "<html>{{ page.title }}</html>")
+        File.write(File.join(tpl, "section.html"), "<html>{{ section.title }}</html>")
+        File.symlink("loop.html", File.join(tpl, "loop.html"))
+
+        issues = new_doctor(dir).run
+        issues.any? { |i| i.id == "template-required-missing" }.should be_false
+        issues.any? { |i| i.id == "template-read-error" }.should be_false
+      end
+    end
+  end
+
+  describe "TOML multi-line string awareness" do
+    it "does not edit a base_url-looking line inside a multi-line string but fixes the real one" do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, "config.toml")
+        config = <<-TOML
+          title = "S"
+          notes = """
+          base_url = "https://inside.example.com/"
+          """
+          base_url = "https://example.com/"
+
+          TOML
+        File.write(config_path, config)
+
+        doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path)
+        summary = doctor.fix_config
+        summary.value_fixes.any? { |f| f.field == "base_url" && f.after == "https://example.com" }.should be_true
+
+        text = File.read(config_path)
+        # The string CONTENT is user data and must survive byte-exactly.
+        text.should contain(%(base_url = "https://inside.example.com/"))
+        text.should contain(%(base_url = "https://example.com"))
+        text.should_not contain(%(base_url = "https://example.com/"))
+      end
+    end
+
+    it "does not clamp a priority-looking line inside a multi-line string after [sitemap]" do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, "config.toml")
+        original = <<-TOML
+          title = "S"
+          base_url = "https://example.com"
+
+          [sitemap]
+          changefreq = "weekly"
+          note = '''
+          priority = 9.5
+          '''
+
+          TOML
+        File.write(config_path, original)
+
+        doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path)
+        summary = doctor.fix_config
+        summary.value_fixes.should be_empty
+        File.read(config_path).should eq(original)
+      end
+    end
+
+    it "still reports a section missing when its header only appears inside a multi-line string" do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, "config.toml")
+        config = <<-TOML
+          title = "S"
+          base_url = "https://example.com"
+          notes = """
+          [menus]
+          """
+
+          TOML
+        File.write(config_path, config)
+
+        doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path)
+        doctor.missing_config_sections.should contain("menus")
+      end
+    end
+
+    it "treats a multi-line string that opens and closes on one line as closed" do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, "config.toml")
+        config = <<-TOML
+          title = "S"
+          note = """[menus] not a header"""
+          base_url = "https://example.com/"
+
+          TOML
+        File.write(config_path, config)
+
+        doctor = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path)
+        summary = doctor.fix_config
+        summary.value_fixes.any? { |f| f.field == "base_url" && f.after == "https://example.com" }.should be_true
+        File.read(config_path).should contain(%(note = """[menus] not a header"""))
+      end
+    end
+  end
+
+  describe "unclassified content parse errors" do
+    # A file whose parse raises a non-HwaroError (invalid UTF-8 makes the
+    # frontmatter regex raise ArgumentError) was silently dropped by
+    # ParallelHelper.map's success-only filter — doctor said "no issues"
+    # while `hwaro build` fails on the same file.
+    it "reports a content file whose parse raises a non-classified error" do
+      Dir.mktmpdir do |dir|
+        write_site(dir)
+        path = File.join(dir, "content", "bad.md")
+        File.open(path, "w") do |f|
+          f << "+++\ntitle = \""
+          f.write(Bytes[0xff, 0xfe, 0xfa])
+          f << "\"\n+++\nbody\n"
+        end
+
+        issues = new_doctor(dir).run
+        issues.any? { |i| i.id == "content-frontmatter-invalid" && i.file == path && i.level == :error }.should be_true
+      end
+    end
+  end
+end
+
+describe Hwaro::CLI::Commands::Tool::DoctorCommand do
+  # `tool validate` raises HWARO_E_USAGE (exit 2, JSON-aware) for a bad
+  # --max-warnings; doctor used Logger.error + exit(1) with no JSON.
+  it "raises a classified usage error for a non-numeric --max-warnings" do
+    err = expect_raises(Hwaro::HwaroError) do
+      Hwaro::CLI::Commands::Tool::DoctorCommand.new.run(["--max-warnings", "abc"])
+    end
+    err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+  end
+
+  it "raises a classified usage error for a negative --max-warnings" do
+    err = expect_raises(Hwaro::HwaroError) do
+      Hwaro::CLI::Commands::Tool::DoctorCommand.new.run(["--max-warnings=-3"])
+    end
+    err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+  end
+end

--- a/spec/unit/export_command_spec.cr
+++ b/spec/unit/export_command_spec.cr
@@ -101,4 +101,28 @@ describe Hwaro::CLI::Commands::Tool::ExportCommand do
       end
     end
   end
+
+  # Stability audit 2026-08-23. A run with per-file errors used to exit 0 as
+  # long as one file exported; it must fail with the classified IO error the
+  # sibling `tool convert` already uses.
+  describe "#run partial failure" do
+    it "raises a classified IO error when some files fail to export" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "good.md"), "+++\ntitle = \"G\"\n+++\n\nBody.\n")
+        File.write(File.join(content_dir, "bad.md"), "+++\ntitle = = broken\n+++\n\nBody.\n")
+
+        cmd = Hwaro::CLI::Commands::Tool::ExportCommand.new
+        ex = expect_raises(Hwaro::HwaroError) do
+          with_captured_log { cmd.run(["hugo", "-c", content_dir, "-o", output_dir]) }
+        end
+
+        ex.code.should eq(Hwaro::Errors::HWARO_E_IO)
+        # The good file still exported before the failure was reported.
+        File.exists?(File.join(output_dir, "content", "good.md")).should be_true
+      end
+    end
+  end
 end

--- a/spec/unit/exporter_regression_spec.cr
+++ b/spec/unit/exporter_regression_spec.cr
@@ -1,5 +1,15 @@
 require "../spec_helper"
 
+# Exposes the bundle-asset copy failure path deterministically: a bundle
+# directory that becomes unlistable mid-run (permissions, NFS hiccup) makes
+# `Dir.children` raise inside `copy_bundle_assets` after the post itself was
+# already written.
+private class BundleListFailHugoExporter < Hwaro::Services::Exporters::HugoExporter
+  protected def copy_bundle_assets(source_dir : String, dest_dir : String, output_dir : String, verbose : Bool = false) : Int32
+    raise File::Error.new("Permission denied", file: source_dir)
+  end
+end
+
 # Regression specs for defects found by dogfooding `hwaro tool export`.
 # Numbering matches the audit report.
 describe "exporter regressions" do
@@ -191,6 +201,266 @@ describe "exporter regressions" do
         # would silently turn the author's literal text into an "A".
         File.read(File.join(output_dir, "lit.md"))
           .should contain(%(title: "Literal \\\\u{41} backslash"))
+      end
+    end
+  end
+
+  # Stability audit 2026-08-23. Non-string values of the explicitly handled
+  # Jekyll keys were silently dropped: `as_s?` returned nil so nothing was
+  # emitted, and the passthrough skipped every handled key by name.
+  describe "non-string handled keys (Jekyll)" do
+    it "stringifies scalar non-string values and passes a hash-valued tags through" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "content", "posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "nn.md"),
+          "+++\ntitle = 123\ndescription = 4.5\nimage = true\ndate = \"2024-01-01\"\n\n[tags]\nname = \"x\"\n+++\n\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "export")
+        Hwaro::Services::Exporters::JekyllExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "jekyll",
+            content_dir: File.join(dir, "content"),
+            output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "_posts", "2024-01-01-nn.md"))
+        content.should contain(%(title: "123"))
+        content.should contain(%(description: "4.5"))
+        content.should contain(%(image: "true"))
+        # A hash cannot be a tag list; it must survive via the passthrough
+        # instead of being swallowed.
+        content.should contain("tags:")
+        content.should contain("name: x")
+      end
+    end
+
+    it "passes a non-bool draft value through instead of swallowing it" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "content", "posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "d.md"),
+          "+++\ntitle = \"D\"\ndate = \"2024-01-01\"\ndraft = \"yes\"\n+++\n\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "export")
+        Hwaro::Services::Exporters::JekyllExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "jekyll",
+            content_dir: File.join(dir, "content"),
+            output_dir: output_dir,
+          ))
+
+        # A string draft is not translatable to `published: false` (only
+        # `draft = true` is a Jekyll draft) — but it must not vanish either.
+        content = File.read(File.join(output_dir, "_posts", "2024-01-01-d.md"))
+        content.should match(/draft: "?yes"?/)
+        content.should_not contain("published: false")
+      end
+    end
+  end
+
+  # Stability audit 2026-08-23. `date` was interpolated raw into the YAML,
+  # so a date string containing a newline injected frontmatter keys.
+  describe "date YAML injection (Jekyll)" do
+    it "does not let a newline in date inject frontmatter keys" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "content", "posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "evil.md"),
+          "+++\ntitle = \"E\"\ndate = \"2024-01-01\\nmalicious: true\"\n+++\n\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "export")
+        Hwaro::Services::Exporters::JekyllExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "jekyll",
+            content_dir: File.join(dir, "content"),
+            output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "_posts", "2024-01-01-evil.md"))
+        content.lines.none?(&.starts_with?("malicious:")).should be_true
+        content.should contain(%(date: "2024-01-01\\nmalicious: true"))
+      end
+    end
+
+    it "keeps emitting a well-formed date raw" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "content", "posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "ok.md"),
+          "+++\ntitle = \"OK\"\ndate = \"2024-01-01\"\n+++\n\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "export")
+        Hwaro::Services::Exporters::JekyllExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "jekyll",
+            content_dir: File.join(dir, "content"),
+            output_dir: output_dir,
+          ))
+
+        File.read(File.join(output_dir, "_posts", "2024-01-01-ok.md"))
+          .should contain("date: 2024-01-01\n")
+      end
+    end
+  end
+
+  # Stability audit 2026-08-23. The Hugo key renames (`updated`→`lastmod`,
+  # `image`→`images`) clobbered a coexisting authored target key depending on
+  # source order. The authored target must win, like `flatten_taxonomies`.
+  describe "Hugo rename vs authored target key" do
+    it "keeps an authored lastmod over a renamed updated" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(
+          File.join(content_dir, "p.md"),
+          "+++\ntitle = \"P\"\nlastmod = \"2024-07-01\"\nupdated = \"2024-06-01\"\n+++\n\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "export")
+        Hwaro::Services::Exporters::HugoExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "hugo",
+            content_dir: content_dir,
+            output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "content", "p.md"))
+        content.should contain(%(lastmod = "2024-07-01"))
+        content.should_not contain("2024-06-01")
+      end
+    end
+
+    it "keeps an authored images over a renamed image" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(
+          File.join(content_dir, "q.md"),
+          "+++\ntitle = \"Q\"\nimages = [\"a.jpg\", \"b.jpg\"]\nimage = \"c.jpg\"\n+++\n\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "export")
+        Hwaro::Services::Exporters::HugoExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "hugo",
+            content_dir: content_dir,
+            output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "content", "q.md"))
+        content.should contain(%(images = ["a.jpg", "b.jpg"]))
+        content.should_not contain("c.jpg")
+      end
+    end
+  end
+
+  # Stability audit 2026-08-23. A run with per-file errors still reported
+  # success (and exited 0) as long as one file exported.
+  describe "partial-failure result" do
+    it "reports failure when any file errors even if others exported (Hugo)" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "good.md"), "+++\ntitle = \"G\"\n+++\n\nBody.\n")
+        File.write(File.join(content_dir, "bad.md"), "+++\ntitle = = broken\n+++\n\nBody.\n")
+
+        result = Hwaro::Services::Exporters::HugoExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "hugo",
+            content_dir: content_dir,
+            output_dir: File.join(dir, "export"),
+          ))
+
+        result.exported_count.should eq(1)
+        result.error_count.should eq(1)
+        result.success.should be_false
+      end
+    end
+
+    it "reports failure when any file errors even if others exported (Jekyll)" do
+      Dir.mktmpdir do |dir|
+        content_dir = File.join(dir, "content")
+        FileUtils.mkdir_p(content_dir)
+        File.write(File.join(content_dir, "good.md"), "+++\ntitle = \"G\"\n+++\n\nBody.\n")
+        File.write(File.join(content_dir, "bad.md"), "+++\ntitle = = broken\n+++\n\nBody.\n")
+
+        result = Hwaro::Services::Exporters::JekyllExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "jekyll",
+            content_dir: content_dir,
+            output_dir: File.join(dir, "export"),
+          ))
+
+        result.exported_count.should eq(1)
+        result.error_count.should eq(1)
+        result.success.should be_false
+      end
+    end
+  end
+
+  # Stability audit 2026-08-23. `write_file` checked containment only
+  # lexically, so a pre-existing symlinked directory inside the destination
+  # routed the post write outside the output directory.
+  describe "write_file symlinked destination directory" do
+    it "refuses to write a post through a symlinked directory inside the destination" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "content", "posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "p.md"),
+          "+++\ntitle = \"P\"\ndate = \"2024-01-01\"\n+++\n\nBody.\n"
+        )
+
+        outside = File.join(dir, "outside")
+        FileUtils.mkdir_p(outside)
+        output_dir = File.join(dir, "export")
+        FileUtils.mkdir_p(output_dir)
+        File.symlink(outside, File.join(output_dir, "_posts"))
+
+        result = Hwaro::Services::Exporters::JekyllExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "jekyll",
+            content_dir: File.join(dir, "content"),
+            output_dir: output_dir,
+          ))
+
+        Dir.glob(File.join(outside, "*.md")).should be_empty
+        result.exported_count.should eq(0)
+      end
+    end
+  end
+
+  # Stability audit 2026-08-23. If listing the bundle directory raised after
+  # the post was written, the exception escaped `export_file`, so the run's
+  # counts and manifest disagreed with what was on disk.
+  describe "Hugo bundle-asset copy failure" do
+    it "still counts the post as exported when bundle assets cannot be listed" do
+      Dir.mktmpdir do |dir|
+        bundle_dir = File.join(dir, "content", "posts", "bundle")
+        FileUtils.mkdir_p(bundle_dir)
+        File.write(File.join(bundle_dir, "index.md"), "+++\ntitle = \"B\"\n+++\n\nBody.\n")
+
+        output_dir = File.join(dir, "export")
+        result = BundleListFailHugoExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "hugo",
+            content_dir: File.join(dir, "content"),
+            output_dir: output_dir,
+          ))
+
+        result.exported_count.should eq(1)
+        result.error_count.should eq(0)
+        result.success.should be_true
+        File.exists?(File.join(output_dir, "content", "posts", "bundle", "index.md")).should be_true
       end
     end
   end

--- a/spec/unit/exporter_regression_spec.cr
+++ b/spec/unit/exporter_regression_spec.cr
@@ -261,6 +261,42 @@ describe "exporter regressions" do
         content.should_not contain("published: false")
       end
     end
+
+    # Review follow-up: the template→layout and draft→published translations
+    # never claimed their TARGET keys, so an authored `published`/`layout`
+    # re-emerged from the passthrough as a duplicate YAML key — and under
+    # Jekyll's last-wins loader an authored `published: true` republished
+    # the draft.
+    it "does not emit duplicate keys for authored published/layout" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "content", "posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "dup.md"),
+          "+++\ntitle = \"Dup\"\ndate = \"2024-01-01\"\ndraft = true\npublished = true\ntemplate = \"post\"\nlayout = \"custom\"\n+++\n\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "export")
+        Hwaro::Services::Exporters::JekyllExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "jekyll",
+            content_dir: File.join(dir, "content"),
+            output_dir: output_dir,
+            drafts: true,
+          ))
+
+        content = File.read(File.join(output_dir, "_drafts", "dup.md"))
+        # The draft flag is hwaro's source of truth: exactly one published
+        # line, and it says false.
+        content.scan(/^published:/m).size.should eq(1)
+        content.should contain("published: false")
+        # Authored layout wins; the unrenamed template passes through, so
+        # nothing is lost and no key is doubled.
+        content.scan(/^layout:/m).size.should eq(1)
+        content.should contain("layout: custom")
+        content.should contain(%(template: post))
+      end
+    end
   end
 
   # Stability audit 2026-08-23. `date` was interpolated raw into the YAML,
@@ -314,7 +350,9 @@ describe "exporter regressions" do
 
   # Stability audit 2026-08-23. The Hugo key renames (`updated`→`lastmod`,
   # `image`→`images`) clobbered a coexisting authored target key depending on
-  # source order. The authored target must win, like `flatten_taxonomies`.
+  # source order. The authored target must win, like `flatten_taxonomies` —
+  # and (review follow-up) the blocked source key passes through under its
+  # own name instead of being dropped: Hugo accepts arbitrary page params.
   describe "Hugo rename vs authored target key" do
     it "keeps an authored lastmod over a renamed updated" do
       Dir.mktmpdir do |dir|
@@ -335,7 +373,7 @@ describe "exporter regressions" do
 
         content = File.read(File.join(output_dir, "content", "p.md"))
         content.should contain(%(lastmod = "2024-07-01"))
-        content.should_not contain("2024-06-01")
+        content.should contain(%(updated = "2024-06-01"))
       end
     end
 
@@ -358,7 +396,7 @@ describe "exporter regressions" do
 
         content = File.read(File.join(output_dir, "content", "q.md"))
         content.should contain(%(images = ["a.jpg", "b.jpg"]))
-        content.should_not contain("c.jpg")
+        content.should contain(%(image = "c.jpg"))
       end
     end
   end
@@ -435,6 +473,36 @@ describe "exporter regressions" do
 
         Dir.glob(File.join(outside, "*.md")).should be_empty
         result.exported_count.should eq(0)
+      end
+    end
+
+    # Review follow-up: copy_bundle_assets resolve-checked the destination
+    # DIRECTORY but not the destination FILE, so a pre-existing symlink leaf
+    # inside the tree let File.copy write through it to an outside path.
+    it "refuses to copy a bundle asset over a symlink leaf pointing outside" do
+      Dir.mktmpdir do |dir|
+        bundle_dir = File.join(dir, "content", "posts", "bundle")
+        FileUtils.mkdir_p(bundle_dir)
+        File.write(File.join(bundle_dir, "index.md"), "+++\ntitle = \"B\"\ndate = \"2024-01-01\"\n+++\n\nBody.\n")
+        File.write(File.join(bundle_dir, "cover.png"), "png-bytes")
+
+        outside_target = File.join(dir, "victim.txt")
+        File.write(outside_target, "original")
+
+        output_dir = File.join(dir, "export")
+        # Hugo keeps the bundle layout: content/posts/bundle/cover.png.
+        dest_bundle = File.join(output_dir, "content", "posts", "bundle")
+        FileUtils.mkdir_p(dest_bundle)
+        File.symlink(outside_target, File.join(dest_bundle, "cover.png"))
+
+        Hwaro::Services::Exporters::HugoExporter.new.run(
+          Hwaro::Config::Options::ExportOptions.new(
+            target_type: "hugo",
+            content_dir: File.join(dir, "content"),
+            output_dir: output_dir,
+          ))
+
+        File.read(outside_target).should eq("original")
       end
     end
   end

--- a/spec/unit/frontmatter_converter_spec.cr
+++ b/spec/unit/frontmatter_converter_spec.cr
@@ -763,8 +763,17 @@ describe Hwaro::Services::ConversionResult do
     # zone. Forcing it through `to_rfc3339` (UTC) rolls the day back in any
     # positive-offset zone; these cases must keep the calendar day regardless of
     # the zone the value was parsed in.
-    it "keeps the calendar day for a positive-offset midnight (no UTC rollback)" do
+    it "keeps the calendar day for a fixed positive-offset midnight (no UTC rollback)" do
+      # A FIXED-offset midnight is a genuine timestamp, not a local date, so
+      # collapsing it to a bare `2026-05-20` silently shifted the instant.
+      # The calendar day is still preserved — via the offset, not by
+      # discarding it.
       time = Time.local(2026, 5, 20, 0, 0, 0, location: Time::Location.fixed(9 * 3600))
+      Hwaro::Services::FrontmatterConverter.serialize_time(time).should eq("2026-05-20T00:00:00+09:00")
+    end
+
+    it "keeps the calendar day for a local-zone midnight (a parsed local date)" do
+      time = Time.local(2026, 5, 20)
       Hwaro::Services::FrontmatterConverter.serialize_time(time).should eq("2026-05-20")
     end
 
@@ -773,9 +782,9 @@ describe Hwaro::Services::ConversionResult do
       Hwaro::Services::FrontmatterConverter.serialize_time(time).should eq("2026-05-20")
     end
 
-    it "keeps the calendar day for a negative-offset midnight" do
+    it "keeps the calendar day for a fixed negative-offset midnight" do
       time = Time.local(2026, 5, 20, 0, 0, 0, location: Time::Location.fixed(-5 * 3600))
-      Hwaro::Services::FrontmatterConverter.serialize_time(time).should eq("2026-05-20")
+      Hwaro::Services::FrontmatterConverter.serialize_time(time).should eq("2026-05-20T00:00:00-05:00")
     end
 
     it "preserves genuine timestamps as RFC 3339" do

--- a/spec/unit/frontmatter_writer_spec.cr
+++ b/spec/unit/frontmatter_writer_spec.cr
@@ -16,9 +16,12 @@ end
 describe Hwaro::Utils::FrontmatterWriter do
   describe ".serialize_time" do
     # The whole reason this helper exists: `to_rfc3339` converts to UTC, so a
-    # local date in any positive-offset zone rolls back a calendar day.
+    # local date in any positive-offset zone rolls back a calendar day. A
+    # parsed local date is midnight in the ambient LOCAL zone; a fixed-offset
+    # midnight is a genuine timestamp and keeps its offset (see the
+    # stability spec).
     it "emits a bare date when the value carries no time-of-day" do
-      time = Time.local(2026, 5, 20, 0, 0, 0, location: Time::Location.fixed(9 * 3600))
+      time = Time.local(2026, 5, 20)
       Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20")
     end
 

--- a/spec/unit/frontmatter_writer_stability_spec.cr
+++ b/spec/unit/frontmatter_writer_stability_spec.cr
@@ -1,0 +1,58 @@
+require "../spec_helper"
+
+# Stability audit 2026-08-23 for `FrontmatterWriter.serialize_time` — the
+# single source of truth for frontmatter date emission (`tool convert`,
+# `tool export`, importers).
+#
+# (a) A midnight with a NON-local fixed offset collapsed to a bare
+#     `YYYY-MM-DD`, silently shifting the instant when reparsed. Only a
+#     local-zone midnight (what a parsed TOML/YAML *local date* produces) or
+#     a UTC midnight may take the bare-date shortcut — for those the bare
+#     date round-trips.
+# (b) Fractional seconds were dropped by both the UTC and offset formats.
+describe Hwaro::Utils::FrontmatterWriter do
+  describe ".serialize_time stability" do
+    it "keeps the offset for a fixed-offset midnight instead of collapsing to a bare date" do
+      time = Time.local(2026, 5, 20, 0, 0, 0, location: Time::Location.fixed(9 * 3600))
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20T00:00:00+09:00")
+    end
+
+    it "keeps the offset for a fixed negative-offset midnight" do
+      time = Time.local(2026, 5, 20, 0, 0, 0, location: Time::Location.fixed(-5 * 3600))
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20T00:00:00-05:00")
+    end
+
+    # A local date (`date = 2026-05-20`) parses to midnight in the ambient
+    # local zone; the bare date is exact for it and must survive whatever
+    # zone the machine runs in.
+    it "still collapses a local-zone midnight to a bare date" do
+      time = Time.local(2026, 5, 20)
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20")
+    end
+
+    it "still collapses a UTC midnight to a bare date" do
+      time = Time.utc(2026, 5, 20)
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20")
+    end
+
+    it "keeps millisecond fractions in the UTC format" do
+      time = Time.utc(2026, 5, 20, 1, 2, 3, nanosecond: 500_000_000)
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20T01:02:03.500Z")
+    end
+
+    it "keeps sub-millisecond fractions in the UTC format" do
+      time = Time.utc(2026, 5, 20, 1, 2, 3, nanosecond: 1)
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20T01:02:03.000000001Z")
+    end
+
+    it "keeps fractional seconds in the offset format" do
+      time = Time.local(2026, 5, 20, 8, 0, 0, nanosecond: 123_456_000, location: Time::Location.fixed(9 * 3600))
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20T08:00:00.123456+09:00")
+    end
+
+    it "does not shift a fixed-offset sub-second midnight onto the bare-date path" do
+      time = Time.local(2026, 5, 20, 0, 0, 0, nanosecond: 250_000_000, location: Time::Location.fixed(9 * 3600))
+      Hwaro::Utils::FrontmatterWriter.serialize_time(time).should eq("2026-05-20T00:00:00.250+09:00")
+    end
+  end
+end

--- a/spec/unit/importer_stability_spec.cr
+++ b/spec/unit/importer_stability_spec.cr
@@ -1,0 +1,569 @@
+require "../spec_helper"
+
+# Stability regression specs for the importer subsystem. Each describe block
+# matches one verified finding from the 2026-08 importer stability audit:
+# crash-on-bad-input paths (invalid UTF-8, unreadable directories, overflowing
+# numbers, truncated DOCTYPE windows) and silent data-loss paths (null-key
+# fallback chains, first-occurrence extension stripping, empty taxonomy terms,
+# O(n^2) HTML conversion blowups).
+
+private def build_wxr(item_fields : String) : String
+  <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0"
+         xmlns:content="http://purl.org/rss/1.0/modules/content/"
+         xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:wp="http://wordpress.org/export/1.2/">
+      <channel>
+        <item>
+    #{item_fields}
+        </item>
+      </channel>
+    </rss>
+    XML
+end
+
+describe "importer stability" do
+  # (1) `parse_lenient` rescued only Time::Format::Error around
+  # Time.parse_rfc3339, but a well-formed RFC 3339 string with an impossible
+  # date ("2024-02-30") raises ArgumentError, which escaped to the caller.
+  describe "DateUtils.parse_lenient" do
+    it "returns nil for an RFC 3339 string with an out-of-range date" do
+      Hwaro::Utils::DateUtils.parse_lenient("2024-02-30T00:00:00Z").should be_nil
+    end
+
+    it "still parses a valid RFC 3339 date" do
+      parsed = Hwaro::Utils::DateUtils.parse_lenient("2024-02-28T10:20:30Z")
+      parsed.should_not be_nil
+      parsed.try(&.year).should eq(2024)
+    end
+  end
+
+  # (2) A single invalid UTF-8 byte in a markdown source made every regex
+  # pass raise ArgumentError, dropping the whole file with a cryptic error.
+  # `read_text` is the single choke point, so it scrubs.
+  describe "invalid UTF-8 in markdown sources" do
+    it "imports a Jekyll post containing an invalid UTF-8 byte" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "_posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.open(File.join(posts_dir, "2024-01-02-scrub.md"), "w") do |f|
+          f << "---\ntitle: Scrub Me\n---\n\nBody "
+          f.write_byte(0xFF_u8)
+          f << " tail.\n"
+        end
+
+        output_dir = File.join(dir, "out")
+        result = Hwaro::Services::Importers::JekyllImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "jekyll", path: dir, output_dir: output_dir,
+          ))
+
+        result.error_count.should eq(0)
+        result.imported_count.should eq(1)
+        content = File.read(File.join(output_dir, "posts", "scrub.md"))
+        content.should contain(%(title = "Scrub Me"))
+        content.should contain("tail.")
+      end
+    end
+  end
+
+  # (3) An invalid UTF-8 byte anywhere in a WXR file made the DOCTYPE guard's
+  # regex raise ArgumentError, aborting the whole import before parsing.
+  describe "invalid UTF-8 in a WXR export" do
+    it "imports a WXR whose content carries an invalid byte" do
+      Dir.mktmpdir do |dir|
+        wxr = File.join(dir, "export.xml")
+        wxr_text = build_wxr(<<-ITEM)
+          <title>Hello</title>
+          <wp:post_type>post</wp:post_type>
+          <wp:status>publish</wp:status>
+          <wp:post_name>hello</wp:post_name>
+          <wp:post_date>2024-01-02 03:04:05</wp:post_date>
+          <content:encoded><![CDATA[<p>Hi ITEM_BYTE there</p>]]></content:encoded>
+          ITEM
+        # Splice an invalid byte where the placeholder sits.
+        before, _, after = wxr_text.partition("ITEM_BYTE")
+        File.open(wxr, "w") do |f|
+          f << before
+          f.write_byte(0xFF_u8)
+          f << after
+        end
+
+        output_dir = File.join(dir, "out")
+        result = Hwaro::Services::Importers::WordPressImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "wordpress", path: wxr, output_dir: output_dir,
+          ))
+
+        result.error_count.should eq(0)
+        result.imported_count.should eq(1)
+        File.exists?(File.join(output_dir, "posts", "hello.md")).should be_true
+      end
+    end
+  end
+
+  # (4) `File.exists?` is true for a directory, so passing a directory as the
+  # WXR path crashed with "Is a directory" instead of the friendly error.
+  describe "WXR path pointing at a directory" do
+    it "refuses with a friendly message instead of raising" do
+      Dir.mktmpdir do |dir|
+        result = Hwaro::Services::Importers::WordPressImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "wordpress", path: dir, output_dir: File.join(dir, "out"),
+          ))
+
+        result.success.should be_false
+        result.message.should contain(dir)
+      end
+    end
+  end
+
+  # (5) `safe_filename_component` split with a regex, which raises on the
+  # invalid UTF-8 that URI.decode can produce (`a%ffb`), erroring the item.
+  describe "percent-encoded invalid UTF-8 in a WordPress slug" do
+    it "imports the item with a scrubbed filename" do
+      Dir.mktmpdir do |dir|
+        wxr = File.join(dir, "export.xml")
+        File.write(wxr, build_wxr(<<-ITEM))
+          <title>Bad Slug</title>
+          <wp:post_type>post</wp:post_type>
+          <wp:status>publish</wp:status>
+          <wp:post_name>a%ffb</wp:post_name>
+          <content:encoded><![CDATA[<p>Body</p>]]></content:encoded>
+          ITEM
+
+        output_dir = File.join(dir, "out")
+        result = Hwaro::Services::Importers::WordPressImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "wordpress", path: wxr, output_dir: output_dir,
+          ))
+
+        result.error_count.should eq(0)
+        result.imported_count.should eq(1)
+        written = Dir.glob(File.join(output_dir, "posts", "*.md"))
+        written.size.should eq(1)
+        File.basename(written.first).should eq("a�b.md")
+      end
+    end
+  end
+
+  # (6) A Notion internal link whose target URI-decodes to invalid UTF-8 made
+  # the 32-hex regex raise, dropping the whole note.
+  describe "invalid UTF-8 in a decoded Notion link target" do
+    it "imports the note instead of erroring" do
+      Dir.mktmpdir do |dir|
+        vault = File.join(dir, "export")
+        FileUtils.mkdir_p(vault)
+        File.write(
+          File.join(vault, "Note abcdef1234567890.md"),
+          "# Note\n\nSee [Sub](Sub%ff%20abcdef0123456789abcdef0123456789ab.md) page.\n"
+        )
+
+        output_dir = File.join(dir, "out")
+        result = Hwaro::Services::Importers::NotionImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "notion", path: vault, output_dir: output_dir,
+          ))
+
+        result.error_count.should eq(0)
+        result.imported_count.should eq(1)
+      end
+    end
+  end
+
+  # (7) An unreadable subdirectory raised File::AccessDeniedError out of
+  # `Dir.children` in the middle of the walk, aborting the entire import.
+  describe "unreadable subdirectory in the source tree" do
+    it "skips it and imports the readable files" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "_posts")
+        locked_dir = File.join(posts_dir, "locked")
+        FileUtils.mkdir_p(locked_dir)
+        File.write(File.join(posts_dir, "2024-01-02-open.md"), "---\ntitle: Open\n---\nBody.\n")
+        File.write(File.join(locked_dir, "2024-01-03-hidden.md"), "---\ntitle: Hidden\n---\nBody.\n")
+        File.chmod(locked_dir, 0o000)
+
+        # Running as root would make the directory readable anyway.
+        readable_anyway = begin
+          Dir.children(locked_dir)
+          true
+        rescue File::Error
+          false
+        end
+
+        begin
+          unless readable_anyway
+            output_dir = File.join(dir, "out")
+            result = Hwaro::Services::Importers::JekyllImporter.new.run(
+              Hwaro::Config::Options::ImportOptions.new(
+                source_type: "jekyll", path: dir, output_dir: output_dir,
+              ))
+
+            result.imported_count.should eq(1)
+            File.exists?(File.join(output_dir, "posts", "open.md")).should be_true
+          end
+        ensure
+          File.chmod(locked_dir, 0o755)
+        end
+      end
+    end
+  end
+
+  # (8) An 11ty data-file path that turns out to be a directory raised a bare
+  # IO::Error ("Is a directory") past the `File::Error` rescue, aborting the
+  # whole import before a single file was read.
+  describe "Eleventy data file that is a directory" do
+    it "skips it and imports the content" do
+      Dir.mktmpdir do |dir|
+        blog_dir = File.join(dir, "blog")
+        FileUtils.mkdir_p(File.join(blog_dir, "blog.11tydata.json"))
+        File.write(File.join(blog_dir, "post.md"), "---\ntitle: Post\n---\nBody.\n")
+
+        output_dir = File.join(dir, "out")
+        result = Hwaro::Services::Importers::EleventyImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "eleventy", path: dir, output_dir: output_dir,
+          ))
+
+        result.imported_count.should eq(1)
+        File.exists?(File.join(output_dir, "blog", "post.md")).should be_true
+      end
+    end
+  end
+
+  # (9) A Hugo `weight` that parses as a huge/non-finite Float64 overflowed
+  # `to_i64`, erroring the whole file. The weight is ignored instead.
+  describe "Hugo weight out of Int64 range" do
+    it "imports the page and drops the unusable weight" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "content", "posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(File.join(posts_dir, "big.md"), "---\ntitle: Big\nweight: 1.0e300\n---\nBody.\n")
+        File.write(File.join(posts_dir, "small.md"), "---\ntitle: Small\nweight: 2.0\n---\nBody.\n")
+
+        output_dir = File.join(dir, "out")
+        result = Hwaro::Services::Importers::HugoImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "hugo", path: dir, output_dir: output_dir,
+          ))
+
+        result.error_count.should eq(0)
+        result.imported_count.should eq(2)
+        File.read(File.join(output_dir, "posts", "big.md")).should_not contain("weight")
+        File.read(File.join(output_dir, "posts", "small.md")).should contain("weight = 2")
+      end
+    end
+  end
+
+  # (10) A trailing slash on the source path broke the File.dirname-based
+  # prefix strip ("site" vs "site/"), misclassifying the site-root index.md.
+  describe "Eleventy source path with a trailing slash" do
+    it "still recognizes the site-root index" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "index.md"), "---\ntitle: Home\n---\nWelcome.\n")
+        File.write(File.join(dir, "about.md"), "---\ntitle: About\n---\nAbout.\n")
+
+        output_dir = File.join(dir, "out")
+        result = Hwaro::Services::Importers::EleventyImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "eleventy", path: "#{dir}/", output_dir: output_dir,
+          ))
+
+        result.imported_count.should eq(2)
+        File.exists?(File.join(output_dir, "index.md")).should be_true
+      end
+    end
+  end
+
+  # (11) `yaml["a"]? || yaml["b"]?` treats a present-but-null key as truthy
+  # (YAML::Any is a struct), silently discarding every fallback after it.
+  describe "null-key fallback chains" do
+    it "Astro: falls back to `date` when `pubDate` is null" do
+      Dir.mktmpdir do |dir|
+        blog_dir = File.join(dir, "src", "content", "blog")
+        FileUtils.mkdir_p(blog_dir)
+        File.write(
+          File.join(blog_dir, "post.md"),
+          "---\ntitle: Post\npubDate:\ndate: 2024-03-04\nheroImage:\ncover: /img/c.png\n---\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "out")
+        Hwaro::Services::Importers::AstroImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "astro", path: dir, output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "blog", "post.md"))
+        content.should contain("date = ")
+        content.should contain("2024-03-04")
+        content.should contain(%(image = "/img/c.png"))
+      end
+    end
+
+    it "Jekyll: falls back to `description` when `excerpt` is null" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "_posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "2024-01-02-post.md"),
+          "---\ntitle: Post\nexcerpt:\ndescription: Real summary\n---\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "out")
+        Hwaro::Services::Importers::JekyllImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "jekyll", path: dir, output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "posts", "post.md"))
+        content.should contain(%(description = "Real summary"))
+      end
+    end
+
+    it "Hexo: falls back to `thumbnail` when `cover` is null" do
+      Dir.mktmpdir do |dir|
+        posts_dir = File.join(dir, "source", "_posts")
+        FileUtils.mkdir_p(posts_dir)
+        File.write(
+          File.join(posts_dir, "post.md"),
+          "---\ntitle: Post\ndescription:\nexcerpt: From excerpt\ncover:\nthumbnail: /img/t.png\n---\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "out")
+        Hwaro::Services::Importers::HexoImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "hexo", path: dir, output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "posts", "post.md"))
+        content.should contain(%(image = "/img/t.png"))
+        content.should contain(%(description = "From excerpt"))
+      end
+    end
+
+    it "Eleventy: falls back to `excerpt` when `description` is null" do
+      Dir.mktmpdir do |dir|
+        blog_dir = File.join(dir, "blog")
+        FileUtils.mkdir_p(blog_dir)
+        File.write(
+          File.join(blog_dir, "post.md"),
+          "---\ntitle: Post\ndescription:\nexcerpt: Fallback text\nimage:\nfeaturedImage: /img/f.png\n---\nBody.\n"
+        )
+
+        output_dir = File.join(dir, "out")
+        Hwaro::Services::Importers::EleventyImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "eleventy", path: dir, output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "blog", "post.md"))
+        content.should contain(%(description = "Fallback text"))
+        content.should contain(%(image = "/img/f.png"))
+      end
+    end
+  end
+
+  # (12) `sub(File.extname(...))` strips the FIRST occurrence of the
+  # extension substring, so `sub/deep.md.old.md` registered the wrong
+  # link-map key and a path wiki-link to it fell back to a dead slug.
+  describe "Obsidian extension stripping" do
+    it "resolves a path wiki-link to a note whose stem contains .md" do
+      Dir.mktmpdir do |dir|
+        vault = File.join(dir, "vault")
+        FileUtils.mkdir_p(File.join(vault, "sub"))
+        File.write(File.join(vault, "sub", "deep.md.old.md"), "---\ntitle: Deep Old\n---\nOld note.\n")
+        File.write(File.join(vault, "linker.md"), "---\ntitle: Linker\n---\nSee [[sub/deep.md.old]].\n")
+
+        output_dir = File.join(dir, "out")
+        Hwaro::Services::Importers::ObsidianImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "obsidian", path: vault, output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "posts", "linker.md"))
+        content.should contain("(/sub/deep-old/)")
+      end
+    end
+  end
+
+  # (13) The array branch of `collect_string_list` didn't filter empty
+  # strings (the string branch does), emitting an empty taxonomy term.
+  describe "empty strings in tag arrays" do
+    it "drops empty items from an Astro tags array" do
+      Dir.mktmpdir do |dir|
+        blog_dir = File.join(dir, "src", "content", "blog")
+        FileUtils.mkdir_p(blog_dir)
+        File.write(File.join(blog_dir, "post.md"), "---\ntitle: Post\ntags: [\"\", \"a\"]\n---\nBody.\n")
+
+        output_dir = File.join(dir, "out")
+        Hwaro::Services::Importers::AstroImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "astro", path: dir, output_dir: output_dir,
+          ))
+
+        content = File.read(File.join(output_dir, "blog", "post.md"))
+        content.should contain(%(tags = ["a"]))
+      end
+    end
+  end
+
+  # (14) Every lazy-body regex pass except the anchor pass was unbounded, so
+  # adversarial markup (many unclosed tags) degraded to O(n^2). The bounded
+  # rewrite must not change output for normal documents — this expected
+  # string was captured from the converter BEFORE the bounding change.
+  describe "HtmlToMarkdown bounded passes" do
+    it "converts a normal nested document byte-identically to the unbounded version" do
+      html = <<-HTML
+        <h1>Main Title</h1>
+        <p>Intro paragraph with <strong>bold</strong>, <em>italic</em>, <code>inline_code()</code> and <del>gone</del>.</p>
+        <h2>Section &amp; Sub</h2>
+        <p>A link: <a href="https://example.com/a?b=1&amp;c=2">Example</a> and an image <img src="/img/pic.png" alt="A pic"/> inline.</p>
+        <blockquote><p>Quoted line one.</p><p>Quoted line two.</p></blockquote>
+        <ul>
+          <li>alpha</li>
+          <li>beta<ul><li>beta-one</li><li>beta-two</li></ul></li>
+          <li>gamma</li>
+        </ul>
+        <ol>
+          <li>first</li>
+          <li>second<ol><li>second-one</li></ol></li>
+        </ol>
+        <pre><code>def hello
+          puts "hi &lt;world&gt;"
+        end</code></pre>
+        <table>
+          <thead><tr><th>Name</th><th>Value</th></tr></thead>
+          <tbody><tr><td>one</td><td>1 | one</td></tr><tr><td>two</td><td>2</td></tr></tbody>
+        </table>
+        <hr/>
+        <p>Tail paragraph.<br/>Second line &#8212; done&#8230;</p>
+        HTML
+
+      expected = "# Main Title\n\nIntro paragraph with **bold**, *italic*, `inline_code()` and ~~gone~~.\n\n" \
+                 "## Section & Sub\n\nA link: [Example](https://example.com/a?b=1&c=2) and an image " \
+                 "![A pic](/img/pic.png) inline.\n\n> Quoted line one.Quoted line two.\n\n" \
+                 "- alpha\n- beta\n  - beta-one\n  - beta-two\n- gamma\n\n" \
+                 "1. first\n2. second\n   1. second-one\n\n" \
+                 "```\ndef hello\n  puts \"hi <world>\"\nend\n```\n\n" \
+                 "| Name | Value |\n| --- | --- |\n| one | 1 \\| one |\n| two | 2 |\n\n" \
+                 "---\n\nTail paragraph.  \nSecond line -- done..."
+
+      Hwaro::Services::Importers::HtmlToMarkdown.convert(html).should eq(expected)
+    end
+
+    it "keeps converting a long (multi-KB) code block to a fence" do
+      code = (["line = compute(#{"x" * 40})"] * 300).join("\n")
+      html = "<p>Intro</p><pre><code>#{code}</code></pre>"
+      converted = Hwaro::Services::Importers::HtmlToMarkdown.convert(html)
+      converted.should contain("```\nline = compute(")
+      converted.should contain("Intro")
+    end
+
+    it "completes on unclosed <pre><code> spam (the quadratic two-literal-tail pass)" do
+      html = "<pre><code>x" * 30_000 + "</code>"
+      converted = Hwaro::Services::Importers::HtmlToMarkdown.convert(html)
+      converted.should contain("x")
+      converted.should_not contain("<pre>")
+    end
+
+    it "completes on a document of tens of thousands of unclosed <p> tags" do
+      html = "<p>data" * 30_000
+      converted = Hwaro::Services::Importers::HtmlToMarkdown.convert(html)
+      converted.should contain("datadata")
+      converted.should_not contain("<p>")
+    end
+
+    it "completes on pathologically deep nested lists" do
+      depth = 500
+      html = "<ul><li>x" * depth + "</li></ul>" * depth
+      converted = Hwaro::Services::Importers::HtmlToMarkdown.convert(html)
+      converted.should contain("- x")
+      converted.should_not contain("<ul>")
+    end
+  end
+
+  # (15) The anti-ENTITY DOCTYPE guard scanned only the first 64 KB after
+  # <!DOCTYPE; an internal subset longer than the window smuggled its
+  # <!ENTITY> declarations past the scan.
+  describe "WXR DOCTYPE longer than the scan window" do
+    it "refuses a WXR whose DOCTYPE runs past the guard window" do
+      Dir.mktmpdir do |dir|
+        wxr = File.join(dir, "export.xml")
+        filler = "<!-- #{"a" * 70_000} -->"
+        doc = <<-XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE rss [
+          #{filler}
+          <!ENTITY smuggled "boom">
+          ]>
+          <rss version="2.0"
+               xmlns:content="http://purl.org/rss/1.0/modules/content/"
+               xmlns:wp="http://wordpress.org/export/1.2/">
+            <channel>
+              <item>
+                <title>Hi</title>
+                <wp:post_type>post</wp:post_type>
+                <wp:status>publish</wp:status>
+                <wp:post_name>hi</wp:post_name>
+                <content:encoded><![CDATA[<p>Body</p>]]></content:encoded>
+              </item>
+            </channel>
+          </rss>
+          XML
+        File.write(wxr, doc)
+
+        result = Hwaro::Services::Importers::WordPressImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "wordpress", path: wxr, output_dir: File.join(dir, "out"),
+          ))
+
+        result.success.should be_false
+        result.message.should contain("declares XML entities")
+      end
+    end
+
+    # Review follow-up: the guard seeded its scan from the first `<!DOCTYPE`
+    # match anywhere in the file, so a post body that merely mentions one
+    # (a DTD tutorial with unbalanced brackets in prose) never "closed" the
+    # scan and got the whole import refused.
+    it "imports a WXR whose post body merely mentions <!DOCTYPE" do
+      Dir.mktmpdir do |dir|
+        wxr = File.join(dir, "export.xml")
+        body = %(Example: <!DOCTYPE note [ ... then array[0 and list[1 keep "these unclosed)
+        item = <<-ITEM
+          <title>DTD Tutorial</title>
+          <wp:post_type>post</wp:post_type>
+          <wp:status>publish</wp:status>
+          <wp:post_name>dtd-tutorial</wp:post_name>
+          <content:encoded><![CDATA[<p>#{body}</p>]]></content:encoded>
+          ITEM
+        File.write(wxr, build_wxr(item))
+
+        result = Hwaro::Services::Importers::WordPressImporter.new.run(
+          Hwaro::Config::Options::ImportOptions.new(
+            source_type: "wordpress", path: wxr, output_dir: File.join(dir, "out"),
+          ))
+
+        result.success.should be_true
+        result.imported_count.should eq(1)
+      end
+    end
+  end
+
+  # Review follow-up: a <pre><code> body longer than the bounded pass's
+  # ceiling fell through to the plain <pre> pass with its <code> wrapper
+  # still attached, leaving literal tags inside the emitted fence.
+  describe "oversized pre+code blocks" do
+    it "strips the code wrapper from a body past the bounded-pass ceiling" do
+      body = "line\n" * 15_000 # ~75k chars, past MAX_CODE_BODY_CHARS
+      converted = Hwaro::Services::Importers::HtmlToMarkdown.convert(
+        "<p>Intro</p><pre><code class=\"language-x\">#{body}</code></pre>"
+      )
+      converted.should_not contain("<code")
+      converted.should_not contain("</code>")
+      converted.should contain("```\nline\n")
+    end
+  end
+end

--- a/spec/unit/platform_config_regression_spec.cr
+++ b/spec/unit/platform_config_regression_spec.cr
@@ -96,4 +96,38 @@ describe "PlatformConfig alias-scan stability" do
       end
     end
   end
+
+  # Review follow-up: the alias walk itself had no rescue, so one unreadable
+  # subdirectory under content/ aborted the whole platform-config run (the
+  # same class walk_files_into was fixed for on the importer side).
+  it "skips an unreadable content subdirectory instead of aborting" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        FileUtils.mkdir_p("content/posts")
+        FileUtils.mkdir_p("content/locked")
+        File.write("content/posts/p.md", "---\ntitle: P\naliases:\n  - /kept/\n---\nBody\n")
+        File.write("content/locked/hidden.md", "---\ntitle: H\n---\nBody\n")
+        File.chmod("content/locked", 0o000)
+
+        readable_anyway = begin
+          Dir.children("content/locked")
+          true
+        rescue File::Error
+          false
+        end
+
+        begin
+          unless readable_anyway
+            config = Hwaro::Models::Config.new
+            generator = Hwaro::Services::PlatformConfig.new(config)
+            result = ""
+            with_captured_log { result = generator.generate("netlify") }
+            result.should contain("from = \"/kept/\"")
+          end
+        ensure
+          File.chmod("content/locked", 0o755)
+        end
+      end
+    end
+  end
 end

--- a/spec/unit/platform_config_regression_spec.cr
+++ b/spec/unit/platform_config_regression_spec.cr
@@ -1,0 +1,99 @@
+require "../spec_helper"
+require "../../src/services/platform_config"
+
+describe "PlatformConfig alias-scan stability" do
+  # Finding 1: scan_content_for_aliases recursed through symlinked
+  # directories, so a symlink cycle (`ln -s . content/loop`) recursed until
+  # ELOOP aborted the whole command. Symlinked directories are skipped.
+  it "survives a symlinked directory cycle in content/" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        FileUtils.mkdir_p("content/posts")
+        File.write("content/posts/p.md", "---\ntitle: P\naliases:\n  - /old/\n---\nBody\n")
+        File.symlink(File.join(dir, "content"), File.join(dir, "content", "loop"))
+
+        config = Hwaro::Models::Config.new
+        generator = Hwaro::Services::PlatformConfig.new(config)
+        result = generator.generate("netlify")
+
+        result.should contain("from = \"/old/\"")
+        result.should contain("to = \"/posts/p/\"")
+      end
+    end
+  end
+
+  # Finding 2: one unparseable content file (invalid UTF-8 → ArgumentError
+  # from PCRE2; malformed frontmatter → HwaroError) aborted all platform
+  # config generation. It must degrade per file and keep going.
+  it "continues past an unparseable content file and keeps the healthy aliases" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        FileUtils.mkdir_p("content/posts")
+        # Invalid UTF-8 bytes make PCRE2 raise ArgumentError mid-parse.
+        File.write("content/posts/bad-utf8.md", Bytes[0x2B, 0x2B, 0x2B, 0x0A, 0xFF, 0x0A])
+        # Malformed TOML frontmatter raises a HwaroError from the parser.
+        File.write("content/posts/bad-toml.md", "+++\ntitle = = broken\n+++\nBody\n")
+        File.write("content/posts/good.md", "---\ntitle: Good\naliases:\n  - /kept/\n---\nBody\n")
+
+        config = Hwaro::Models::Config.new
+        generator = Hwaro::Services::PlatformConfig.new(config)
+
+        result = ""
+        with_captured_log { result = generator.generate("netlify") }
+        result.should contain("from = \"/kept/\"")
+      end
+    end
+  end
+
+  # Finding 3: toml_escape only handled \ and ", so an alias containing a
+  # newline produced an unparseable netlify.toml. Control characters are now
+  # escaped (chosen over skipping, matching the existing escape-not-drop
+  # behavior for quotes/backslashes; cloudflare's _redirects keeps skipping
+  # because that format has no escape syntax).
+  it "escapes control characters in netlify redirect aliases so the TOML stays parseable" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        FileUtils.mkdir_p("content/posts")
+        # YAML double-quoted scalars inject a real newline and tab into the
+        # alias values.
+        File.write("content/posts/p.md",
+          "---\ntitle: P\naliases:\n  - \"/line\\nbreak/\"\n  - \"/tab\\there/\"\n---\nBody\n")
+
+        config = Hwaro::Models::Config.new
+        generator = Hwaro::Services::PlatformConfig.new(config)
+        result = generator.generate("netlify")
+
+        # The raw control bytes must not appear inside the basic strings.
+        result.should contain("from = \"/line\\nbreak/\"")
+        result.should contain("from = \"/tab\\there/\"")
+
+        # The emitted netlify.toml parses, and the values round-trip.
+        parsed = TOML.parse(result)
+        froms = parsed["redirects"].as_a.map(&.["from"].as_s)
+        froms.should contain("/line\nbreak/")
+        froms.should contain("/tab\there/")
+      end
+    end
+  end
+
+  # Review follow-up: TOML's \u escape takes exactly four hex digits, so a
+  # control/format character above U+FFFF (Char#control? is true for Cf tag
+  # characters) emitted a five-digit \u that TOML parsers reject.
+  it "escapes supplementary-plane control characters with the 8-digit \\U form" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        FileUtils.mkdir_p("content/posts")
+        File.write("content/posts/p.md",
+          "---\ntitle: P\naliases:\n  - \"/tag\\U000E0001here/\"\n---\nBody\n")
+
+        config = Hwaro::Models::Config.new
+        generator = Hwaro::Services::PlatformConfig.new(config)
+        result = generator.generate("netlify")
+
+        result.should contain("\\U000E0001")
+        result.should_not contain("\\ue0001")
+        result.should_not contain("\\uE0001")
+      end
+    end
+  end
+end

--- a/spec/unit/stats_command_spec.cr
+++ b/spec/unit/stats_command_spec.cr
@@ -57,5 +57,52 @@ describe Hwaro::CLI::Commands::Tool::StatsCommand do
         output.should contain("counted: 2 files, 2 published, 0 drafts")
       end
     end
+
+    # Regression: the tag chart padded and truncated by CODEPOINTS, so CJK or
+    # emoji labels (2 columns per glyph) misaligned every row after them.
+    it "pads tag labels by display width so CJK tags stay aligned" do
+      Dir.mktmpdir do |dir|
+        File.write(
+          File.join(dir, "one.md"),
+          "---\ntitle: One\ntags:\n  - 한글태그\n  - aa\n---\nwords here\n"
+        )
+        File.write(
+          File.join(dir, "two.md"),
+          "---\ntitle: Two\ntags:\n  - 한글태그\n---\nmore words\n"
+        )
+
+        output = with_captured_log do
+          cmd = Hwaro::CLI::Commands::Tool::StatsCommand.new
+          cmd.run(["-c", dir])
+        end
+
+        # The label column is 8 display columns wide (한글태그 = 4 chars × 2
+        # columns), so "aa" gets 6 columns of padding before the 2-space gap
+        # and the 4-wide right-aligned count. Codepoint padding gave it 2.
+        output.should contain("한글태그  " + "   2")
+        output.should contain("aa" + " " * 6 + "  " + "   1")
+      end
+    end
+
+    it "truncates overlong tag labels by display width" do
+      Dir.mktmpdir do |dir|
+        long_tag = "가" * 12 # 24 columns wide, but only 12 codepoints
+        File.write(
+          File.join(dir, "one.md"),
+          "---\ntitle: One\ntags:\n  - #{long_tag}\n---\nwords\n"
+        )
+
+        output = with_captured_log do
+          cmd = Hwaro::CLI::Commands::Tool::StatsCommand.new
+          cmd.run(["-c", dir])
+        end
+
+        # 24 columns exceed the 20-column cap: 9 chars (18 columns) fit the
+        # 19-column budget, then the ellipsis. Codepoint truncation saw only
+        # 12 "characters" and never truncated at all.
+        output.should_not contain(long_tag)
+        output.should contain("#{"가" * 9}…")
+      end
+    end
   end
 end

--- a/spec/unit/tool_feature_improvements_spec.cr
+++ b/spec/unit/tool_feature_improvements_spec.cr
@@ -192,8 +192,12 @@ describe "tool feature improvements" do
         by_date = lister.list_content(all, Hwaro::Services::ContentSort::Date)
         by_date.map(&.title).should eq(["Beta", "alpha", "Gamma"])
 
+        # Expectation changed: undated entries ("Gamma") stay pinned AFTER
+        # dated ones even in reverse — undated means "date unknown", not
+        # "older than 1970" — so reverse now yields oldest-dated first with
+        # undated last instead of undated first.
         reversed = lister.list_content(all, Hwaro::Services::ContentSort::Date, reverse: true)
-        reversed.map(&.title).should eq(["Gamma", "alpha", "Beta"])
+        reversed.map(&.title).should eq(["alpha", "Beta", "Gamma"])
 
         limited = lister.list_content(all, Hwaro::Services::ContentSort::Date, limit: 2)
         limited.map(&.title).should eq(["Beta", "alpha"])

--- a/spec/unit/unused_assets_command_spec.cr
+++ b/spec/unit/unused_assets_command_spec.cr
@@ -71,5 +71,41 @@ describe Hwaro::CLI::Commands::Tool::UnusedAssetsCommand do
         output.should contain("found: 1 unused asset")
       end
     end
+
+    # Regression: an explicitly passed `--templates-dir templates` was
+    # indistinguishable from the default inside the service and got silently
+    # re-rooted to <project_root>/templates — even though the command had
+    # just existence-checked ./templates. Every template-referenced asset
+    # then came back "unused", and `--delete --force` removed in-use files.
+    it "scans an explicitly passed --templates-dir even when it matches the default name" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          # ./templates exists (the command existence-checks it) and holds
+          # the only reference to keep.png...
+          FileUtils.mkdir_p("templates")
+          File.write(File.join("templates", "base.html"), %(<img src="/keep.png">))
+
+          # ...while the project root resolves to proj/, which has no
+          # templates directory of its own.
+          proj = File.join(dir, "proj")
+          FileUtils.mkdir_p(File.join(proj, "content"))
+          FileUtils.mkdir_p(File.join(proj, "static"))
+          File.write(File.join(proj, "config.toml"), "title = \"P\"\n")
+          File.write(File.join(proj, "static", "keep.png"), "png")
+          File.write(File.join(proj, "content", "post.md"), "---\ntitle: P\n---\nBody\n")
+
+          output = with_captured_log do
+            cmd = Hwaro::CLI::Commands::Tool::UnusedAssetsCommand.new
+            cmd.run([
+              "-c", File.join(proj, "content"),
+              "-s", File.join(proj, "static"),
+              "--templates-dir", "templates",
+            ])
+          end
+
+          output.should contain("found: no unused assets")
+        end
+      end
+    end
   end
 end

--- a/spec/unit/unused_assets_scan_sources_spec.cr
+++ b/spec/unit/unused_assets_scan_sources_spec.cr
@@ -127,6 +127,31 @@ describe Hwaro::Services::UnusedAssets do
         end
       end
 
+      it "skips a config.toml containing invalid UTF-8 instead of aborting" do
+        # config.toml was the one scan source concatenated WITHOUT the UTF-8
+        # gate every other source goes through, so one bad byte in it still
+        # aborted the command with a PCRE2 ArgumentError.
+        Dir.mktmpdir do |dir|
+          Dir.cd(dir) do
+            scaffold_project(dir)
+            File.write("config.toml", Bytes[0x74, 0xFF, 0x0A])
+            File.write(File.join("static", "orphan.png"), "png")
+
+            result = nil
+            output = with_captured_log do
+              result = Hwaro::Services::UnusedAssets.new(
+                content_dir: File.join(dir, "content"),
+                static_dir: File.join(dir, "static"),
+                templates_dir: File.join(dir, "templates"),
+              ).run
+            end
+
+            output.should contain("config.toml")
+            result.not_nil!.unused_files.map { |f| File.basename(f) }.should eq(["orphan.png"])
+          end
+        end
+      end
+
       it "keeps working when a content file is invalid UTF-8" do
         Dir.mktmpdir do |dir|
           scaffold_project(dir)

--- a/spec/unit/unused_assets_spec.cr
+++ b/spec/unit/unused_assets_spec.cr
@@ -557,5 +557,122 @@ describe Hwaro::Services::UnusedAssets do
         end
       end
     end
+
+    # Regression: project-root resolution mixed two trees. With a config.toml
+    # in the CWD, @project_root was pinned to "." even when --content-dir
+    # pointed at a DIFFERENT project — so the default static/ (never
+    # re-rooted at all) plus data/, i18n/ and config.toml were read from the
+    # CWD project while content came from the other one, and
+    # `--delete --force` removed in-use files.
+    it "scans the static/, data/ and config.toml of the project the content dir belongs to" do
+      Dir.mktmpdir do |other|
+        Dir.mktmpdir do |cwd|
+          Dir.cd(cwd) do
+            # The CWD is itself a hwaro project with its own static tree...
+            FileUtils.mkdir_p("static")
+            File.write("config.toml", "title = \"CWD project\"\n")
+            File.write(File.join("static", "decoy.png"), "png")
+
+            # ...but --content-dir points into another project that carries
+            # its own config.toml, static/ and data/.
+            FileUtils.mkdir_p(File.join(other, "content"))
+            FileUtils.mkdir_p(File.join(other, "static"))
+            FileUtils.mkdir_p(File.join(other, "data"))
+            File.write(File.join(other, "config.toml"), <<-TOML)
+              title = "Other"
+              [og]
+              default_image = "static/og.png"
+              TOML
+            File.write(File.join(other, "content", "post.md"), "---\ntitle: P\n---\nBody\n")
+            File.write(File.join(other, "static", "og.png"), "png")
+            File.write(File.join(other, "static", "sponsor.png"), "png")
+            File.write(File.join(other, "data", "site.yml"), "logo: /sponsor.png\n")
+            File.write(File.join(other, "static", "orphan.png"), "png")
+
+            result = Hwaro::Services::UnusedAssets.new(
+              content_dir: File.join(other, "content"),
+            ).run
+
+            # THAT project's static tree is the one scanned (3 assets, not
+            # the CWD's decoy.png), its config.toml and data/ count as
+            # reference sources, and only its genuine orphan is reported.
+            result.total_assets.should eq(3)
+            result.unused_files.should eq([File.join(other, "static", "orphan.png")])
+          end
+        end
+      end
+    end
+
+    it "keeps resolving everything relative to an in-project CWD (defaults unchanged)" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          FileUtils.mkdir_p("content")
+          FileUtils.mkdir_p("static")
+          FileUtils.mkdir_p("templates")
+          File.write("config.toml", "title = \"T\"\n")
+          File.write(File.join("content", "post.md"), "---\ntitle: P\n---\n![x](/used.png)\n")
+          File.write(File.join("static", "used.png"), "png")
+          File.write(File.join("static", "orphan.png"), "png")
+
+          result = Hwaro::Services::UnusedAssets.new.run
+
+          # Paths keep their historical relative form ("static/…").
+          result.total_assets.should eq(2)
+          result.unused_files.should eq([File.join("static", "orphan.png")])
+        end
+      end
+    end
+
+    # Regression: the safety-net `Regex.new` built from an asset basename
+    # raised ArgumentError for a non-UTF-8 filename (possible on Linux
+    # filesystems), aborting the whole command.
+    describe "non-UTF-8 asset basenames" do
+      it "boundary_referenced? refuses an invalid basename instead of raising" do
+        bad = String.new(Bytes[0xFF]) + ".png"
+        Hwaro::Services::UnusedAssets.boundary_referenced?("some corpus", bad).should be_false
+      end
+
+      it "boundary_referenced? keeps the space/paren safety net intact" do
+        Hwaro::Services::UnusedAssets.boundary_referenced?("![t](/team photo.png)", "team photo.png").should be_true
+        Hwaro::Services::UnusedAssets.boundary_referenced?("![b](/page-header.png)", "header.png").should be_false
+      end
+
+      it "skips (with a warning) an asset whose file name is not valid UTF-8" do
+        Dir.mktmpdir do |dir|
+          content_dir = File.join(dir, "content")
+          static_dir = File.join(dir, "static")
+          FileUtils.mkdir_p(content_dir)
+          FileUtils.mkdir_p(static_dir)
+          File.write(File.join(content_dir, "post.md"), "---\ntitle: P\n---\nBody\n")
+          File.write(File.join(static_dir, "orphan.png"), "png")
+
+          bad_name = String.new(Bytes[0xC3]) + ".png" # truncated UTF-8 sequence
+          created = begin
+            File.write(File.join(static_dir, bad_name), "png")
+            true
+          rescue File::Error
+            # APFS refuses to create non-UTF-8 names at all; the in-loop
+            # guard is unreachable on this filesystem and is covered by the
+            # boundary_referenced? specs above.
+            false
+          end
+
+          result = nil
+          output = with_captured_log do
+            result = Hwaro::Services::UnusedAssets.new(
+              content_dir: content_dir,
+              static_dir: static_dir,
+              templates_dir: File.join(dir, "templates"),
+            ).run
+          end
+
+          r = result.not_nil!
+          # The bad name is never flagged (and so never handed to --delete);
+          # the genuine orphan still is.
+          r.unused_files.should eq([File.join(static_dir, "orphan.png")])
+          output.should contain("not valid UTF-8") if created
+        end
+      end
+    end
   end
 end

--- a/spec/unit/validate_command_spec.cr
+++ b/spec/unit/validate_command_spec.cr
@@ -38,6 +38,13 @@ describe Hwaro::CLI::Commands::Tool::ValidateCommand do
       end
     end
 
+    it "raises a classified usage error for a non-numeric --max-warnings" do
+      err = expect_raises(Hwaro::HwaroError) do
+        Hwaro::CLI::Commands::Tool::ValidateCommand.new.run(["--max-warnings", "abc"])
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+    end
+
     it "groups issues by file and prints a summary when problems exist" do
       Dir.mktmpdir do |dir|
         # Missing title triggers a validation issue.
@@ -57,6 +64,68 @@ describe Hwaro::CLI::Commands::Tool::ValidateCommand do
         output.should contain("bad.md")
         output.should match(/checked: \d+ errors?, \d+ warnings?, \d+ info/)
       end
+    end
+  end
+end
+
+# Service-level regressions for ContentValidator error classification and
+# the tag plumbing (previously smuggled through the frontmatter hash under
+# a fake "_tags" key).
+describe Hwaro::Services::ContentValidator do
+  it "distinguishes an unprocessable (invalid encoding) file from a read failure" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "bad.md")
+      File.open(path, "w") do |f|
+        f << "---\ntitle: ok\n---\n\nbody "
+        f.write(Bytes[0xff, 0xfe, 0xfa])
+      end
+
+      issues = Hwaro::Services::ContentValidator.new(content_dir: dir).run
+      issue = issues.find { |i| i.id == "content-read-error" }
+      issue.should_not be_nil
+      # A perfectly readable file must not be blamed on I/O: that message
+      # pointed authors at permissions/disk when the problem is encoding.
+      issue.not_nil!.message.should_not contain("Failed to read file")
+    end
+  end
+
+  it "does not misreport a real front matter key named _tags as tags" do
+    Dir.mktmpdir do |dir|
+      File.write(
+        File.join(dir, "post.md"),
+        "+++\ntitle = \"T\"\ndescription = \"D\"\n_tags = \"FooBar\"\n+++\n\nBody text.\n"
+      )
+
+      issues = Hwaro::Services::ContentValidator.new(content_dir: dir).run
+      issues.any? { |i| i.id == "content-tag-mixed-case" }.should be_false
+    end
+  end
+
+  it "keeps a tag containing a comma intact for the mixed-case check" do
+    Dir.mktmpdir do |dir|
+      File.write(
+        File.join(dir, "post.md"),
+        "+++\ntitle = \"T\"\ndescription = \"D\"\ntags = [\"Foo,Bar\"]\n+++\n\nBody text.\n"
+      )
+
+      issues = Hwaro::Services::ContentValidator.new(content_dir: dir).run
+      mixed = issues.select { |i| i.id == "content-tag-mixed-case" }
+      mixed.size.should eq(1)
+      mixed.first.message.should contain(%("Foo,Bar"))
+    end
+  end
+
+  it "still warns on ordinary mixed-case tags" do
+    Dir.mktmpdir do |dir|
+      File.write(
+        File.join(dir, "post.md"),
+        "+++\ntitle = \"T\"\ndescription = \"D\"\ntags = [\"FooBar\", \"fine\"]\n+++\n\nBody text.\n"
+      )
+
+      issues = Hwaro::Services::ContentValidator.new(content_dir: dir).run
+      mixed = issues.select { |i| i.id == "content-tag-mixed-case" }
+      mixed.size.should eq(1)
+      mixed.first.message.should contain(%("FooBar"))
     end
   end
 end

--- a/src/cli/commands/tool/agents_md_command.cr
+++ b/src/cli/commands/tool/agents_md_command.cr
@@ -131,14 +131,18 @@ module Hwaro
           # drift apart.
           SITE_SECTION_MARKER = Services::Defaults::AgentsMd::SITE_SECTION_MARKER
 
-          # The heading only counts when it is a whole line on its own
-          # (trailing blanks aside). A first-substring `index` let a mention
-          # inside a code fence or mid-prose shift the merge point —
-          # duplicating stale generated content or silently discarding user
-          # sections above the real heading.
-          # Up to three leading spaces still renders as the same ATX heading.
-          MARKER_LINE_RE = /\A {0,3}#{Regex.escape(Services::Defaults::AgentsMd::SITE_SECTION_MARKER)}[ \t]*\z/
+          # The heading only counts when the line STARTS with the marker
+          # (≤3 leading spaces still renders as the same ATX heading) — a
+          # first-substring `index` let a mid-prose mention shift the merge
+          # point. Trailing text after a separating blank is allowed so a
+          # user-annotated heading ("## Site-Specific Instructions (do not
+          # delete)") keeps being found; losing it meant `--write --force`
+          # discarded the user's whole section.
+          MARKER_LINE_RE = /\A {0,3}#{Regex.escape(Services::Defaults::AgentsMd::SITE_SECTION_MARKER)}(?:[ \t].*)?\z/
           FENCE_RE       = /\A {0,3}(`{3,}|~{3,})/
+          # A CLOSING fence carries no info string (CommonMark) — accepting
+          # one (```text) would flip the in/out-of-fence parity.
+          FENCE_CLOSE_RE = /\A {0,3}(`{3,}|~{3,})[ \t]*\z/
 
           private def merge_site_section(fresh : String, existing : String) : String
             existing_idx = site_section_index(existing)
@@ -149,38 +153,45 @@ module Hwaro
           end
 
           # Char index of the real Site-Specific Instructions heading: the
-          # FIRST line equal to the marker that is not inside a fenced code
-          # block — deterministic, and identical to the old behavior for
-          # normal files, where the heading occurs exactly once. When an
-          # UNCLOSED fence swallowed the rest of the file, rescan ignoring
-          # fences: preserving the user's section on malformed markdown beats
-          # a full rewrite that silently discards it. (A marker inside a
-          # properly closed fence stays a non-match — that's the quoted
-          # example the fence tracking exists for.)
+          # FIRST marker line that is not inside a fenced code block —
+          # deterministic, and identical to the old behavior for normal
+          # files, where the heading occurs exactly once. When an UNCLOSED
+          # fence swallowed the rest of the file, rescan fence-blind FROM
+          # that fence's opening: preserving the user's section on malformed
+          # markdown beats a full rewrite that silently discards it, while a
+          # marker quoted inside an earlier properly CLOSED fence stays a
+          # non-match either way.
           private def site_section_index(text : String) : Int32?
-            index, unterminated = scan_for_marker(text, fence_aware: true)
+            index, open_fence_at = scan_for_marker(text)
             return index if index
-            return unless unterminated
-            scan_for_marker(text, fence_aware: false)[0]
+            return unless open_fence_at
+            tail_index, _ = scan_for_marker(text[open_fence_at..], fences: false)
+            tail_index.try { |i| open_fence_at + i }
           end
 
-          private def scan_for_marker(text : String, fence_aware : Bool) : {Int32?, Bool}
+          # Returns {marker index, offset of a fence left open at EOF}.
+          private def scan_for_marker(text : String, fences : Bool = true) : {Int32?, Int32?}
             offset = 0
             fence_delim : String? = nil
+            fence_start : Int32? = nil
             text.each_line(chomp: false) do |raw_line|
               line = raw_line.chomp
               if delim = fence_delim
-                if closing = line.match(FENCE_RE).try(&.[1])
-                  fence_delim = nil if closing[0] == delim[0] && closing.size >= delim.size
+                if closing = line.match(FENCE_CLOSE_RE).try(&.[1])
+                  if closing[0] == delim[0] && closing.size >= delim.size
+                    fence_delim = nil
+                    fence_start = nil
+                  end
                 end
-              elsif fence_aware && (opening = line.match(FENCE_RE).try(&.[1]))
+              elsif fences && (opening = line.match(FENCE_RE).try(&.[1]))
                 fence_delim = opening
+                fence_start = offset
               elsif line.matches?(MARKER_LINE_RE)
-                return {offset, false}
+                return {offset, nil}
               end
               offset += raw_line.size
             end
-            {nil, !fence_delim.nil?}
+            {nil, fence_delim ? fence_start : nil}
           end
         end
       end

--- a/src/cli/commands/tool/agents_md_command.cr
+++ b/src/cli/commands/tool/agents_md_command.cr
@@ -79,7 +79,10 @@ module Hwaro
               # Only promise preservation when the merge can actually deliver
               # it: an existing file without the marker heading gets a full
               # overwrite, and the prompt must say so instead of reassuring.
-              has_marker = existing.try(&.includes?(SITE_SECTION_MARKER)) || false
+              # Uses the same line-anchored, fence-aware detection as the
+              # merge itself so the prompt never promises what the merge
+              # won't do.
+              has_marker = existing ? !site_section_index(existing).nil? : false
               if existed && !force
                 question = if has_marker
                              "AGENTS.md already exists. Regenerate it? (your Site-Specific Instructions are kept)"
@@ -128,12 +131,56 @@ module Hwaro
           # drift apart.
           SITE_SECTION_MARKER = Services::Defaults::AgentsMd::SITE_SECTION_MARKER
 
+          # The heading only counts when it is a whole line on its own
+          # (trailing blanks aside). A first-substring `index` let a mention
+          # inside a code fence or mid-prose shift the merge point —
+          # duplicating stale generated content or silently discarding user
+          # sections above the real heading.
+          # Up to three leading spaces still renders as the same ATX heading.
+          MARKER_LINE_RE = /\A {0,3}#{Regex.escape(Services::Defaults::AgentsMd::SITE_SECTION_MARKER)}[ \t]*\z/
+          FENCE_RE       = /\A {0,3}(`{3,}|~{3,})/
+
           private def merge_site_section(fresh : String, existing : String) : String
-            existing_idx = existing.index(SITE_SECTION_MARKER)
+            existing_idx = site_section_index(existing)
             return fresh unless existing_idx
-            fresh_idx = fresh.index(SITE_SECTION_MARKER)
+            fresh_idx = site_section_index(fresh)
             return fresh unless fresh_idx
             fresh[0...fresh_idx] + existing[existing_idx..]
+          end
+
+          # Char index of the real Site-Specific Instructions heading: the
+          # FIRST line equal to the marker that is not inside a fenced code
+          # block — deterministic, and identical to the old behavior for
+          # normal files, where the heading occurs exactly once. When an
+          # UNCLOSED fence swallowed the rest of the file, rescan ignoring
+          # fences: preserving the user's section on malformed markdown beats
+          # a full rewrite that silently discards it. (A marker inside a
+          # properly closed fence stays a non-match — that's the quoted
+          # example the fence tracking exists for.)
+          private def site_section_index(text : String) : Int32?
+            index, unterminated = scan_for_marker(text, fence_aware: true)
+            return index if index
+            return unless unterminated
+            scan_for_marker(text, fence_aware: false)[0]
+          end
+
+          private def scan_for_marker(text : String, fence_aware : Bool) : {Int32?, Bool}
+            offset = 0
+            fence_delim : String? = nil
+            text.each_line(chomp: false) do |raw_line|
+              line = raw_line.chomp
+              if delim = fence_delim
+                if closing = line.match(FENCE_RE).try(&.[1])
+                  fence_delim = nil if closing[0] == delim[0] && closing.size >= delim.size
+                end
+              elsif fence_aware && (opening = line.match(FENCE_RE).try(&.[1]))
+                fence_delim = opening
+              elsif line.matches?(MARKER_LINE_RE)
+                return {offset, false}
+              end
+              offset += raw_line.size
+            end
+            {nil, !fence_delim.nil?}
           end
         end
       end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -1075,7 +1075,9 @@ module Hwaro
               # so without this a slow chain multiplied the configured
               # --timeout by up to 12×. 3× leaves room for a slow-but-healthy
               # chain of a few hops while still bounding the worst case.
-              deadline = Time.instant + (timeout_seconds * 3).seconds
+              # Int64 math: an absurd-but-accepted --timeout must not
+              # overflow Int32 here and flip every link to "dead".
+              deadline = Time.instant + (timeout_seconds.to_i64 * 3).seconds
 
               loop do
                 host = current_uri.host

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -2,6 +2,7 @@ require "json"
 require "http/client"
 require "socket"
 require "uri"
+require "uri/punycode"
 require "file"
 require "option_parser"
 require "../../metadata"
@@ -121,7 +122,21 @@ module Hwaro
                 ignore_patterns << ignore_pattern_to_regex(v)
               end
               parser.on("--allow-status CODES", "Treat these HTTP status codes as healthy (comma-separated)") do |v|
-                v.split(',').each do |code|
+                segments = v.split(',')
+                # All-empty input (`--allow-status ","`) would otherwise be a
+                # silent no-op; reject it like any other unusable value.
+                if segments.all?(&.strip.empty?)
+                  raise Hwaro::HwaroError.new(
+                    code: Hwaro::Errors::HWARO_E_USAGE,
+                    message: "Invalid --allow-status value: #{v}",
+                    hint: "Pass comma-separated HTTP status codes between 100 and 599, e.g. --allow-status 403,429.",
+                  )
+                end
+                segments.each do |code|
+                  # A trailing/doubled comma (`--allow-status "403,"`) yields
+                  # empty segments; skip them instead of rejecting with a
+                  # confusing empty-value message.
+                  next if code.strip.empty?
                   parsed = code.strip.to_i?
                   unless parsed && (100..599).includes?(parsed)
                     raise Hwaro::HwaroError.new(
@@ -408,21 +423,50 @@ module Hwaro
             s.gsub { |c| c.control? ? "" : c }
           end
 
+          # Markdown link/image destinations share LINK_DEST +
+          # clean_external_target with the internal scan, so titled
+          # (`[x](https://url "t")`) and angle-bracket (`[x](<https://url>)`)
+          # external destinations are checked too — the old regex required
+          # `)` right after the URL and silently skipped both forms.
+          # Raw HTML (`<a href="https://…">`, `<img src="https://…">`) is also
+          # scanned here: the internal HTML pass drops scheme-carrying URLs
+          # via skip_internal?, so without this pass they were never checked.
           private def find_external_links(dir : String) : Array(Link)
             links = [] of Link
-            link_regex = /(?:!\[[^\]]*?\]|\[[^\]]*?\])\((https?:\/\/(?:\([^\s()]*\)|[^\s()])+)\)/
+            link_regex = /!?\[[^\]]*?\]\(#{LINK_DEST.source}\)/
 
             Dir.glob("#{dir}/**/*.md").each do |file|
               content = readable_markdown(file) || next
               content.scan(link_regex) do |match|
-                links << Link.new(file: file, url: match[1], kind: :external)
-              end
-              scan_reference_definitions(content) do |url|
-                next unless url.starts_with?("http://") || url.starts_with?("https://")
+                url = clean_external_target(match[1])
+                next unless external_url?(url)
                 links << Link.new(file: file, url: url, kind: :external)
+              end
+              scan_reference_definitions(content) do |raw|
+                url = clean_external_target(raw)
+                next unless external_url?(url)
+                links << Link.new(file: file, url: url, kind: :external)
+              end
+              content.scan(HTML_TAG_RE) do |tag|
+                tag[2].scan(HTML_ATTR_RE) do |attr|
+                  raw = attr[2]? || attr[3]? || attr[4]?
+                  next unless raw
+                  html_link_targets(attr[1], raw).each do |candidate|
+                    url = clean_external_target(candidate)
+                    next unless external_url?(url)
+                    # Unrendered template syntax — same guard as the internal
+                    # HTML pass; contacting the literal braces is never right.
+                    next if url.includes?("{{") || url.includes?("{%")
+                    links << Link.new(file: file, url: url, kind: :external)
+                  end
+                end
               end
             end
             links
+          end
+
+          private def external_url?(url : String) : Bool
+            url.starts_with?("http://") || url.starts_with?("https://")
           end
 
           # Read and code-strip one Markdown file, returning nil when the file
@@ -470,14 +514,19 @@ module Hwaro
           # `</my`, and even a space-free `</about/>` was reported dead while
           # the build resolved it correctly.
           private def clean_link_target(raw : String) : String
+            clean_external_target(raw).split("#").first.split("?").first.strip
+          end
+
+          # The external half of clean_link_target: strip the optional title
+          # and unwrap an angle-bracket destination, but KEEP query string and
+          # fragment — they are significant when contacting an external URL.
+          private def clean_external_target(raw : String) : String
             stripped = raw.strip
-            dest =
-              if stripped.starts_with?('<') && (close = stripped.index('>'))
-                stripped[1...close]
-              else
-                stripped.split(/\s/, 2).first
-              end
-            dest.split("#").first.split("?").first.strip
+            if stripped.starts_with?('<') && (close = stripped.index('>'))
+              stripped[1...close]
+            else
+              stripped.split(/\s/, 2).first
+            end
           end
 
           private def find_internal_links(dir : String) : Array(Link)
@@ -960,129 +1009,221 @@ module Hwaro
             nil
           end
 
+          # Identical external URLs are checked ONCE and the outcome fanned
+          # back out to every occurrence — 50 pages linking the same site used
+          # to fire 50 simultaneous requests and collect 429 false positives.
+          # The worker/channel accounting stays exact: one outcome per unique
+          # URL from the pool, then one reported Result per occurrence (each
+          # with its own file), in the caller's link order.
           private def check_links_concurrently(links : Array(Link), timeout_seconds : Int32, max_concurrency : Int32) : Array(Result)
-            results_channel = Channel(Result).new(links.size)
-            work_channel = Channel(Link?).new(max_concurrency)
+            unique_urls = [] of String
+            seen = Set(String).new
+            links.each do |link|
+              unique_urls << link.url if seen.add?(link.url)
+            end
+
+            outcomes = check_urls_concurrently(unique_urls, timeout_seconds, max_concurrency)
+
+            links.map do |link|
+              status, error_message = outcomes[link.url]
+              Result.new(link: link, status: status, error: error_message)
+            end
+          end
+
+          private def check_urls_concurrently(urls : Array(String), timeout_seconds : Int32, max_concurrency : Int32) : Hash(String, {Int32, String?})
+            results_channel = Channel({String, Int32, String?}).new(urls.size)
+            work_channel = Channel(String?).new(max_concurrency)
 
             # Spawn bounded worker pool
             max_concurrency.times do
               spawn do
-                while link = work_channel.receive?
-                  error_message : String? = nil
-                  status = begin
-                    current_uri = URI.parse(link.url)
-                    method = "HEAD"
-                    redirects_left = 5
-                    response_status = -1
-
-                    loop do
-                      host = current_uri.host
-                      if host && private_host?(host)
-                        error_message = "Skipped: private/internal address"
-                        response_status = -1
-                        break
-                      end
-
-                      client = HTTP::Client.new(current_uri)
-                      client.connect_timeout = timeout_seconds.seconds
-                      client.read_timeout = timeout_seconds.seconds
-
-                      begin
-                        headers = HTTP::Headers{"User-Agent" => "hwaro-link-checker/1.0"}
-                        response = if method == "HEAD"
-                                     client.head(current_uri.request_target, headers: headers)
-                                   else
-                                     client.get(current_uri.request_target, headers: headers)
-                                   end
-
-                        status_code = response.status_code
-
-                        if {301, 302, 307, 308}.includes?(status_code)
-                          if redirects_left > 0
-                            location = response.headers["Location"]?
-                            if location
-                              current_uri = current_uri.resolve(location)
-                              redirects_left -= 1
-                              next
-                            else
-                              error_message = "Redirect without Location header"
-                              response_status = status_code
-                              break
-                            end
-                          else
-                            error_message = "Too many redirects"
-                            response_status = status_code
-                            break
-                          end
-                        elsif method == "HEAD" && {405, 403, 501}.includes?(status_code)
-                          method = "GET"
-                          next
-                        else
-                          response_status = status_code
-                          break
-                        end
-                      ensure
-                        client.close
-                      end
-                    end
-
-                    response_status
-                  rescue ex : Socket::ConnectError
-                    error_message = "Connection failed: #{ex.message}"
-                    -1
-                  rescue IO::TimeoutError
-                    error_message = "Request timed out (#{timeout_seconds}s)"
-                    -1
-                  rescue ex : Socket::Addrinfo::Error
-                    error_message = "DNS resolution failed: #{ex.message}"
-                    -1
-                  rescue ex
-                    error_message = ex.message
-                    -1
-                  end
-                  results_channel.send(Result.new(link: link, status: status, error: error_message))
+                while url = work_channel.receive?
+                  status, error_message = check_external_url(url, timeout_seconds)
+                  results_channel.send({url, status, error_message})
                 end
               end
             end
 
-            # Feed links to workers
-            links.each { |link| work_channel.send(link) }
+            # Feed URLs to workers
+            urls.each { |url| work_channel.send(url) }
             max_concurrency.times { work_channel.send(nil) }
 
             # Collect all results
-            Array.new(links.size) { results_channel.receive }
+            outcomes = {} of String => {Int32, String?}
+            urls.size.times do
+              url, status, error_message = results_channel.receive
+              outcomes[url] = {status, error_message}
+            end
+            outcomes
           end
+
+          # Check one external URL, following redirects. Returns
+          # {status, error}. Redirect FAILURES (loop, missing Location,
+          # exhausted time budget) report the -1 sentinel, never the redirect
+          # code itself, so `--allow-status 301` only matches links whose
+          # TERMINAL response is 301 — a broken redirect used to be classified
+          # healthy by it.
+          private def check_external_url(url : String, timeout_seconds : Int32) : {Int32, String?}
+            error_message : String? = nil
+            status = begin
+              current_uri = URI.parse(url)
+              method = "HEAD"
+              redirects_left = 5
+              response_status = -1
+              # Total time budget for the whole redirect chain: each hop can
+              # take up to the per-request timeout (HEAD may retry as GET),
+              # so without this a slow chain multiplied the configured
+              # --timeout by up to 12×. 3× leaves room for a slow-but-healthy
+              # chain of a few hops while still bounding the worst case.
+              deadline = Time.instant + (timeout_seconds * 3).seconds
+
+              loop do
+                host = current_uri.host
+                # Non-ASCII (IDN) hosts are punycoded for DNS/connection;
+                # the original URL is kept for reporting.
+                connect_host = host ? ascii_host(host) : nil
+                if connect_host && private_host?(connect_host)
+                  error_message = "Skipped: private/internal address"
+                  response_status = -1
+                  break
+                end
+
+                request_uri = current_uri
+                if host && connect_host && connect_host != host
+                  request_uri = current_uri.dup
+                  request_uri.host = connect_host
+                end
+
+                client = HTTP::Client.new(request_uri)
+                client.connect_timeout = timeout_seconds.seconds
+                client.read_timeout = timeout_seconds.seconds
+
+                begin
+                  headers = HTTP::Headers{"User-Agent" => "hwaro-link-checker/1.0"}
+                  response = if method == "HEAD"
+                               client.head(request_uri.request_target, headers: headers)
+                             else
+                               client.get(request_uri.request_target, headers: headers)
+                             end
+
+                  status_code = response.status_code
+
+                  if {301, 302, 303, 307, 308}.includes?(status_code)
+                    if redirects_left > 0
+                      location = response.headers["Location"]?
+                      if location
+                        if Time.instant > deadline
+                          error_message = "Request timed out (#{timeout_seconds}s): redirect chain exceeded the time budget"
+                          response_status = -1
+                          break
+                        end
+                        current_uri = current_uri.resolve(location)
+                        # RFC 9110: 303 See Other is followed with GET.
+                        method = "GET" if status_code == 303
+                        redirects_left -= 1
+                        next
+                      else
+                        error_message = "Redirect without Location header (#{status_code})"
+                        response_status = -1
+                        break
+                      end
+                    else
+                      error_message = "Too many redirects (last status #{status_code})"
+                      response_status = -1
+                      break
+                    end
+                  elsif method == "HEAD" && {405, 403, 501}.includes?(status_code)
+                    method = "GET"
+                    next
+                  else
+                    response_status = status_code
+                    break
+                  end
+                ensure
+                  client.close
+                end
+              end
+
+              response_status
+            rescue ex : Socket::ConnectError
+              error_message = "Connection failed: #{ex.message}"
+              -1
+            rescue IO::TimeoutError
+              error_message = "Request timed out (#{timeout_seconds}s)"
+              -1
+            rescue ex : Socket::Addrinfo::Error
+              error_message = "DNS resolution failed: #{ex.message}"
+              -1
+            rescue ex
+              error_message = ex.message
+              -1
+            end
+            {status, error_message}
+          end
+
+          # RFC 3490 conversion for a host with non-ASCII labels
+          # (`例え.jp` → `xn--r8jz45g.jp`) so DNS resolution and the
+          # connection use the registrable form — such links used to fail
+          # DNS and be reported dead.
+          private def ascii_host(host : String) : String
+            return host if host.ascii_only?
+            URI::Punycode.to_ascii(host)
+          rescue ArgumentError
+            host
+          end
+
+          # Memoized per run: the same host used to be resolved synchronously
+          # on every occurrence and every redirect hop, stalling all workers
+          # on slow DNS. The cache is bounded by the finite host set of one
+          # invocation. Resolution happens OUTSIDE the mutex so a slow lookup
+          # for one host never serializes the others; a rare duplicate
+          # resolution for the same host is benign.
+          @private_host_cache = {} of String => Bool
+          @private_host_cache_mutex = Mutex.new
 
           # Check if a hostname resolves to a private/internal IP address (SSRF protection).
           private def private_host?(host : String) : Bool
+            @private_host_cache_mutex.synchronize do
+              if @private_host_cache.has_key?(host)
+                return @private_host_cache[host]
+              end
+            end
+            result = resolve_private_host?(host)
+            @private_host_cache_mutex.synchronize { @private_host_cache[host] = result }
+            result
+          end
+
+          private def resolve_private_host?(host : String) : Bool
             return true if host == "localhost" || host.ends_with?(".local") || host.ends_with?(".internal")
 
             begin
               addrs = Socket::Addrinfo.resolve(host, 80, type: Socket::Type::STREAM)
-              addrs.any? do |addr|
-                ip = addr.ip_address.address
-                ip.starts_with?("127.") ||
-                  ip.starts_with?("10.") ||
-                  ip.starts_with?("192.168.") ||
-                  ip.starts_with?("169.254.") ||
-                  ip == "0.0.0.0" ||
-                  ip == "::1" ||
-                  ip == "::" ||
-                  ip.starts_with?("fc") || ip.starts_with?("fd") || # IPv6 ULA
-                  ip.starts_with?("fe80") ||                        # IPv6 link-local
-                  private_172?(ip)
-              end
+              addrs.any? { |addr| private_ip_address?(addr.ip_address) }
             rescue Socket::Error
               false
             end
           end
 
-          private def private_172?(ip : String) : Bool
-            return false unless ip.starts_with?("172.")
-            parts = ip.split(".")
-            return false if parts.size < 2
-            second = parts[1].to_i? || return false
-            second >= 16 && second <= 31
+          # Structured classification via Socket::IPAddress predicates — the
+          # old string-prefix checks missed IPv4-mapped IPv6 loopback
+          # (`::ffff:127.0.0.1`) and the fe81–febf link-local range. An
+          # IPv4-mapped address is unmapped first because the stdlib
+          # predicates only classify the mapped form as loopback, not as
+          # private/link-local.
+          private def private_ip_address?(ip : Socket::IPAddress) : Bool
+            if mapped = ipv4_mapped_address(ip)
+              return private_ip_address?(mapped)
+            end
+            ip.loopback? || ip.private? || ip.link_local? || ip.unspecified?
+          end
+
+          private def ipv4_mapped_address(ip : Socket::IPAddress) : Socket::IPAddress?
+            return unless ip.family.inet6?
+            address = ip.address
+            return unless address.starts_with?("::ffff:") && address.includes?('.')
+            Socket::IPAddress.new(address.lchop("::ffff:"), 0)
+          rescue Socket::Error | ArgumentError
+            nil
           end
         end
       end

--- a/src/cli/commands/tool/doctor_command.cr
+++ b/src/cli/commands/tool/doctor_command.cr
@@ -77,8 +77,15 @@ module Hwaro
               CLI.register_flag(parser, MAX_WARNINGS_FLAG) do |v|
                 parsed = v.to_i?
                 unless parsed && parsed >= 0
-                  Logger.error "--max-warnings expects a non-negative integer (got: #{v.inspect})"
-                  exit(Hwaro::Errors::EXIT_GENERIC)
+                  # Raise the classified usage error exactly as `tool
+                  # validate` does: the runner maps it to EXIT_USAGE (2)
+                  # and renders the standard JSON error payload under
+                  # --json, where Logger.error + exit(1) emitted neither.
+                  raise Hwaro::HwaroError.new(
+                    code: Hwaro::Errors::HWARO_E_USAGE,
+                    message: "Invalid --max-warnings value: #{v}",
+                    hint: "Pass a non-negative integer, e.g. --max-warnings 0.",
+                  )
                 end
                 max_warnings = parsed
               end

--- a/src/cli/commands/tool/export_command.cr
+++ b/src/cli/commands/tool/export_command.cr
@@ -87,19 +87,12 @@ module Hwaro
             exporter.dry_run = options.dry_run
             result = exporter.run(options)
 
-            unless result.success
-              # A classified error instead of the old bare `exit(1)`: every
-              # sibling tool command reports failures through HwaroError, so
-              # `--json` consumers get the standard error payload and the
-              # exit code lands in the documented IO class.
-              raise Hwaro::HwaroError.new(
-                code: Hwaro::Errors::HWARO_E_IO,
-                message: result.message,
-                hint: "Pass -c DIR if your content lives outside 'content'; per-file errors are listed above.",
-              )
-            end
-
             if json_output
+              # The manifest is printed for failed runs too (success=false,
+              # error_count set), then the process exits with the same
+              # classified IO status the human path raises — mirroring
+              # `tool convert`, so a machine consumer branching on exit
+              # status gets the identical answer in both modes.
               puts({
                 "success"        => result.success,
                 "dry_run"        => options.dry_run,
@@ -108,7 +101,21 @@ module Hwaro
                 "error_count"    => result.error_count,
                 "files"          => exporter.file_actions,
               }.to_json)
+              exit(Hwaro::Errors::EXIT_IO) unless result.success
               return
+            end
+
+            unless result.success
+              # A classified error instead of the old bare `exit(1)`: every
+              # sibling tool command reports failures through HwaroError, so
+              # the exit code lands in the documented IO class. A run with
+              # ANY per-file error fails here — `success` no longer reports
+              # a partial export as clean.
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_IO,
+                message: result.message,
+                hint: "Pass -c DIR if your content lives outside 'content'; per-file errors are listed above.",
+              )
             end
 
             summary = "#{result.exported_count} files · #{result.skipped_count} skipped"

--- a/src/cli/commands/tool/stats_command.cr
+++ b/src/cli/commands/tool/stats_command.cr
@@ -131,9 +131,13 @@ module Hwaro
               # bytes so a crafted tag can't inject ANSI into the report.
               top_tags = result.tags.first(top).map { |tag, count| {Utils::TextUtils.strip_control(tag), count} }
               max_count = top_tags.max_of { |_, count| count }
-              label_width = top_tags.max_of { |tag, _| tag.size }.clamp(0, 20)
+              # Measure and pad in terminal COLUMNS, not codepoints: a CJK or
+              # emoji tag renders wider than its codepoint count, so
+              # `size`/`ljust` misaligned every row after it.
+              label_width = top_tags.max_of { |tag, _| Utils::TextUtils.display_width(tag) }.clamp(0, 20)
               top_tags.each do |tag, count|
-                Logger.info "    #{truncate_label(tag, label_width).ljust(label_width)}  #{count.to_s.rjust(4)}  #{Logger.bar(count, max_count)}"
+                label = Utils::TextUtils.pad_display(truncate_label(tag, label_width), label_width)
+                Logger.info "    #{label}  #{count.to_s.rjust(4)}  #{Logger.bar(count, max_count)}"
               end
               if result.tags.size > top
                 Logger.info "    … and #{result.tags.size - top} more"
@@ -170,11 +174,25 @@ module Hwaro
             parts.empty? ? nil : parts.join(" · ")
           end
 
-          # Cap a bar-chart label to the column width, marking the cut with an
-          # ellipsis so rows stay aligned even for very long tag names.
+          # Cap a bar-chart label to `width` terminal COLUMNS, marking the cut
+          # with an ellipsis so rows stay aligned even for very long tag
+          # names. Walks characters by display width, the same way
+          # ContentLister#truncate does — codepoint slicing let a long CJK
+          # tag claim double the column and skipped truncating it at all.
           private def truncate_label(label : String, width : Int32) : String
-            return label if label.size <= width
-            "#{label[0, width - 1]}…"
+            return label if Utils::TextUtils.display_width(label) <= width
+
+            budget = width - 1
+            kept = String.build do |io|
+              used = 0
+              label.each_char do |c|
+                w = Utils::TextUtils.display_width(c.to_s)
+                break if used + w > budget
+                io << c
+                used += w
+              end
+            end
+            "#{kept}…"
           end
         end
       end

--- a/src/cli/commands/tool/unused_assets_command.cr
+++ b/src/cli/commands/tool/unused_assets_command.cr
@@ -46,6 +46,7 @@ module Hwaro
           def run(args : Array(String))
             content_dir = "content"
             static_dir = "static"
+            static_dir_given = false
             templates_dir = "templates"
             templates_dir_given = false
             delete_mode = false
@@ -55,7 +56,10 @@ module Hwaro
             OptionParser.parse(args) do |parser|
               parser.banner = "Usage: hwaro tool unused-assets [options]"
               CLI.register_flag(parser, CONTENT_DIR_FLAG) { |v| content_dir = v }
-              parser.on("-s DIR", "--static-dir DIR", "Static files directory (default: static)") { |v| static_dir = v }
+              parser.on("-s DIR", "--static-dir DIR", "Static files directory (default: static)") do |v|
+                static_dir = v
+                static_dir_given = true
+              end
               # Without this flag a project with a non-default templates
               # directory silently scanned the wrong (empty) tree: every
               # template-referenced asset came back "unused", and `--delete`
@@ -90,10 +94,16 @@ module Hwaro
             # below survives.
             Runner.enable_json_mode! if json_output
 
+            # The `*_explicit` flags distinguish an explicitly passed
+            # `--templates-dir templates` / `--static-dir static` (validated
+            # against the CWD above) from the bare defaults: only the true
+            # defaults may be re-rooted to the resolved project root.
             service = Services::UnusedAssets.new(
               content_dir: content_dir,
               static_dir: static_dir,
               templates_dir: templates_dir,
+              templates_dir_explicit: templates_dir_given,
+              static_dir_explicit: static_dir_given,
             )
             result = service.run
 

--- a/src/services/content_lister.cr
+++ b/src/services/content_lister.cr
@@ -248,9 +248,20 @@ module Hwaro
 
         case sort
         in ContentSort::Date
-          # Sort by date (newest first), then by path
+          # Sort by date (newest first), then by path. Undated entries used
+          # to key as epoch 0 — "older than everything post-1970" — so
+          # `--reverse` (oldest first) ranked them ABOVE every dated post and
+          # polluted `--reverse --limit` results. Undated means "date
+          # unknown": the leading field pins those AFTER every dated entry in
+          # both directions, which requires folding `reverse` into the key
+          # here (the blanket `reverse!` below would flip the pin too); the
+          # path tie-breaker keeps equal keys deterministic.
           contents.sort_by! do |info|
-            {-(info.date.try(&.to_unix) || 0_i64), info.path}
+            if date = info.date
+              {0, reverse ? date.to_unix : -date.to_unix, info.path}
+            else
+              {1, 0_i64, info.path}
+            end
           end
         in ContentSort::Title
           # Case-sensitive, matching SortUtils.compare_by_title — see the
@@ -259,7 +270,8 @@ module Hwaro
         in ContentSort::Path
           contents.sort_by!(&.path)
         end
-        contents.reverse! if reverse
+        # Date sort already applied `reverse` inside its key (see above).
+        contents.reverse! if reverse && sort != ContentSort::Date
         contents = contents.first(limit) if limit
 
         contents

--- a/src/services/content_stats.cr
+++ b/src/services/content_stats.cr
@@ -98,7 +98,14 @@ module Hwaro
             next
           end
 
-          body = extract_body(content)
+          # PCRE2 raises ArgumentError on invalid UTF-8 — the same escape
+          # extract_tags guards against; one bad file must not kill the
+          # whole report.
+          body = begin
+            extract_body(content)
+          rescue ArgumentError
+            next
+          end
           wc = count_words(body)
           word_counts << wc
 

--- a/src/services/content_stats.cr
+++ b/src/services/content_stats.cr
@@ -23,7 +23,9 @@ module Hwaro
       # to be counted as published, so the report disagreed with the site.
       property future : Int32
       property expired : Int32
-      property words_total : Int32
+      # Int64: summing per-file Int32 counts overflowed Int32 on giant
+      # corpora (an Int32 total caps out around 2 billion words).
+      property words_total : Int64
       property words_avg : Int32
       property words_min : Int32
       property words_max : Int32
@@ -36,7 +38,7 @@ module Hwaro
         @published : Int32 = 0,
         @future : Int32 = 0,
         @expired : Int32 = 0,
-        @words_total : Int32 = 0,
+        @words_total : Int64 = 0_i64,
         @words_avg : Int32 = 0,
         @words_min : Int32 = 0,
         @words_max : Int32 = 0,
@@ -112,12 +114,15 @@ module Hwaro
           end
         end
 
-        words_total = word_counts.sum
+        # Sum in Int64: a giant corpus overflows Int32 (Crystal raises
+        # OverflowError, killing the report).
+        words_total = word_counts.sum(0_i64)
         # Divide by the number of files actually read (word_counts), not the
         # published count — a file unreadable between listing and read is skipped
         # from word_counts but would otherwise dilute the average. Matches the
-        # population used by words_min/words_max below.
-        words_avg = word_counts.empty? ? 0 : words_total // word_counts.size
+        # population used by words_min/words_max below. The average of Int32
+        # per-file counts always fits Int32, so `.to_i` cannot overflow.
+        words_avg = word_counts.empty? ? 0 : (words_total // word_counts.size).to_i
         words_min = word_counts.min? || 0
         words_max = word_counts.max? || 0
 
@@ -147,12 +152,13 @@ module Hwaro
       end
 
       private def count_words(body : String) : Int32
-        # Strip code blocks, then count with the same tokenizer the build uses
-        # for `page.word_count` / `page.reading_time`. Splitting on whitespace
-        # alone counted `##`, `|` and `|-----|` as words, so the report
-        # disagreed with the numbers the site itself renders.
-        stripped = body.gsub(/(?ms)^(`{3,}|~{3,})[^\n]*\n.*?^\1\s*$/, "")
-        Utils::TextUtils.count_words(stripped)
+        # Exactly the code path the build uses for `page.word_count` /
+        # `page.reading_time`: `Models::Page#calculate_word_count` calls
+        # `TextUtils.count_words` on the frontmatter-stripped body, fenced
+        # code blocks included. Stats used to strip fences first, so the
+        # report drifted from the numbers the site itself renders — and the
+        # build is the source of truth.
+        Utils::TextUtils.count_words(body)
       end
 
       # Front matter that does not parse costs this file its tags, never the

--- a/src/services/content_validator.cr
+++ b/src/services/content_validator.cr
@@ -22,6 +22,16 @@ module Hwaro
 
       alias FrontmatterValue = String | Bool | Int64 | Float64?
 
+      # Parsed front matter plus the tag list carried OUT-OF-BAND. Tags
+      # used to be smuggled through the field hash under a fake "_tags"
+      # key joined with commas, so a real front matter key named `_tags`
+      # triggered bogus mixed-case tag warnings for non-tag data, and
+      # genuine tags containing commas were split apart before the
+      # convention check ever saw them.
+      private record ParsedFrontmatter,
+        fields : Hash(String, FrontmatterValue),
+        tags : Array(String) = [] of String
+
       @content_dir : String
 
       def initialize(@content_dir : String = "content")
@@ -66,13 +76,14 @@ module Hwaro
         # BOM'd file isn't reported as missing every front matter field.
         content = Utils::TextUtils.strip_bom(File.read(file_path))
 
-        frontmatter = parse_frontmatter(file_path, content, issues) || {} of String => FrontmatterValue
+        parsed = parse_frontmatter(file_path, content, issues)
+        frontmatter = parsed.try(&.fields) || {} of String => FrontmatterValue
+        tags = parsed.try(&.tags) || [] of String
 
         title = frontmatter["title"]?
         description = frontmatter["description"]?
         date = frontmatter["date"]?
         draft = frontmatter["draft"]?
-        tags = frontmatter["_tags"]?
 
         # title check
         if title.nil? || title == "Untitled"
@@ -98,21 +109,26 @@ module Hwaro
         end
 
         # tag convention check (mixed-case warning)
-        if tags.is_a?(String) && !tags.as(String).empty?
-          check_tag_conventions(file_path, tags.as(String), issues)
-        end
+        check_tag_conventions(file_path, tags, issues) unless tags.empty?
 
         # image alt text check
         check_image_alt(file_path, content, issues)
 
         # internal link check
         check_internal_links(file_path, content, issues)
-      rescue ex
+      rescue ex : IO::Error | File::Error
         issues << Issue.new(id: "content-read-error", level: :error, category: "content", file: file_path,
           message: "Failed to read file: #{ex.message}")
+      rescue ex
+        # A readable file can still blow up the scanners — invalid UTF-8
+        # makes the front-matter regex raise ArgumentError. Calling that a
+        # read failure pointed authors at permissions/disk when the
+        # problem is the file's encoding or structure.
+        issues << Issue.new(id: "content-read-error", level: :error, category: "content", file: file_path,
+          message: "Cannot process file (invalid encoding or malformed content): #{ex.message}")
       end
 
-      private def parse_frontmatter(file_path : String, content : String, issues : Array(Issue)) : Hash(String, FrontmatterValue)?
+      private def parse_frontmatter(file_path : String, content : String, issues : Array(Issue)) : ParsedFrontmatter?
         if match = content.match(TOML_FRONTMATTER_RE)
           begin
             toml_data = TOML.parse(match[1])
@@ -133,8 +149,7 @@ module Hwaro
             # sites were never tag-checked at all.
             tag_strs = toml_tag_list(toml_data["tags"]?)
             tag_strs = toml_tag_list(toml_data["taxonomies"]?.try(&.as_h?).try(&.["tags"]?)) if tag_strs.empty?
-            result["_tags"] = tag_strs.join(",") unless tag_strs.empty?
-            return result
+            return ParsedFrontmatter.new(result, tag_strs)
           rescue ex
             issues << Issue.new(id: "content-frontmatter-toml-error", level: :error, category: "content", file: file_path,
               message: "TOML frontmatter parse error: #{ex.message}")
@@ -173,14 +188,13 @@ module Hwaro
               if tag_strs.empty?
                 tag_strs = yaml_tag_list(h[YAML::Any.new("taxonomies")]?.try(&.as_h?).try(&.[YAML::Any.new("tags")]?))
               end
-              result["_tags"] = tag_strs.join(",") unless tag_strs.empty?
-              return result
+              return ParsedFrontmatter.new(result, tag_strs)
             end
             # Empty or non-mapping YAML frontmatter (e.g. `---\n---`) is valid
             # YAML but carries no title/description. Return an empty hash (not
             # nil) so the missing-field checks still fire — matching empty TOML,
             # which already reaches them via its `{}` result.
-            return {} of String => FrontmatterValue
+            return ParsedFrontmatter.new({} of String => FrontmatterValue)
           rescue ex
             issues << Issue.new(id: "content-frontmatter-yaml-error", level: :error, category: "content", file: file_path,
               message: "YAML frontmatter parse error: #{ex.message}")
@@ -214,8 +228,7 @@ module Hwaro
               end
               tag_strs = json_tag_list(h["tags"]?)
               tag_strs = json_tag_list(h["taxonomies"]?.try(&.as_h?).try(&.["tags"]?)) if tag_strs.empty?
-              result["_tags"] = tag_strs.join(",") unless tag_strs.empty?
-              return result
+              return ParsedFrontmatter.new(result, tag_strs)
             end
             return
           rescue ex
@@ -281,8 +294,7 @@ module Hwaro
         end
       end
 
-      private def check_tag_conventions(file_path : String, tags_csv : String, issues : Array(Issue))
-        tags = tags_csv.split(",")
+      private def check_tag_conventions(file_path : String, tags : Array(String), issues : Array(Issue))
         mixed = tags.select { |tag| tag != tag.downcase && tag != tag.upcase }
         mixed.each do |tag|
           issues << Issue.new(id: "content-tag-mixed-case", level: :info, category: "content", file: file_path,

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -14,6 +14,7 @@ require "../content/processors/markdown"
 require "../content/processors/internal_link_resolver"
 require "../core/build/parallel"
 require "./config_snippets"
+require "./content_lister"
 
 module Hwaro
   module Services
@@ -302,12 +303,97 @@ module Hwaro
       # config forever.
       private def mentioned_sections(text : String) : Set(String)
         found = Set(String).new
-        text.each_line do |line|
+        lines = text.split('\n')
+        in_string = multiline_string_line_states(lines)
+        lines.each_with_index do |line, idx|
+          # A `[menus]`-looking line inside a TOML multi-line string is
+          # string CONTENT, not a header; counting it suppressed the real
+          # missing-section detection.
+          next if in_string[idx]
           next unless m = line.match(/^\s*(?:#\s*)?\[\[?\s*([^\[\]]+?)\s*\]\]?/)
           parts = m[1].downcase.split('.').map(&.strip)
           parts.each_index { |i| found << parts[0..i].join('.') }
         end
         found
+      end
+
+      # TOML multi-line strings (`"""…"""` / `'''…'''`) can span lines
+      # whose text looks exactly like a key assignment or a table header.
+      # Every line-oriented scanner in this service must skip those lines:
+      # matching them edits user DATA (violating the "--fix preserves
+      # content byte-exactly outside the fixed region" invariant), flips
+      # the header-tracking state, and fools `mentioned_sections`. Returns,
+      # for each line of `lines`, whether that line STARTS inside a
+      # multi-line string.
+      private def multiline_string_line_states(lines : Array(String)) : Array(Bool)
+        states = Array(Bool).new(lines.size)
+        delim = nil.as(Char?)
+        lines.each do |line|
+          states << !delim.nil?
+          delim = advance_multiline_string_state(line, delim)
+        end
+        states
+      end
+
+      # Advance the multi-line-string tracker across one line. `delim` is
+      # the quote character of the currently open multi-line string (nil
+      # when outside one). Handles delimiters that open and close on the
+      # same line, backslash escapes in basic strings, and single-line
+      # strings/comments whose quote characters could otherwise fake an
+      # opener.
+      private def advance_multiline_string_state(line : String, delim : Char?) : Char?
+        chars = line.chars
+        i = 0
+        while i < chars.size
+          c = chars[i]
+
+          if d = delim
+            if c == '\\' && d == '"'
+              i += 2 # escaped char in a basic multi-line string
+            elsif c == d && chars[i + 1]? == d && chars[i + 2]? == d
+              # Consume the whole quote run: TOML allows one or two extra
+              # quote chars of CONTENT adjacent to the delimiter (`""""`
+              # is `"` + close), and the closing delimiter is the last
+              # three of the run.
+              i += 3
+              while chars[i]? == d
+                i += 1
+              end
+              delim = nil
+            else
+              i += 1
+            end
+            next
+          end
+
+          case c
+          when '#'
+            break # comment — nothing after it can open a string
+          when '"', '\''
+            if chars[i + 1]? == c && chars[i + 2]? == c
+              delim = c
+              i += 3
+            else
+              # Single-line string: skip to its closing quote so a quote
+              # char inside it can't fake a multi-line opener.
+              i += 1
+              while i < chars.size
+                ch = chars[i]
+                if ch == '\\' && c == '"'
+                  i += 2
+                elsif ch == c
+                  i += 1
+                  break
+                else
+                  i += 1
+                end
+              end
+            end
+          else
+            i += 1
+          end
+        end
+        delim
       end
 
       # Sections that are advanced/niche or low-value for most users.
@@ -530,7 +616,13 @@ module Hwaro
       # so the caller can skip emitting a spurious ValueFix.
       private def trim_base_url_trailing_slash(text : String) : NamedTuple(text: String, fix: ValueFix)?
         lines = text.split('\n', remove_empty: false)
+        in_string = multiline_string_line_states(lines)
         lines.each_with_index do |line, idx|
+          # A base_url-looking line inside a TOML multi-line string is
+          # string CONTENT — editing it corrupts user data, and a
+          # `[section]`-looking line in one must not end the top-level
+          # scan early either.
+          next if in_string[idx]
           break if line =~ /^\s*\[/ # entered a section table; base_url is top-level only
           # `[^"']*` refuses values containing either quote char, so a
           # string this regex can't round-trip safely is skipped rather
@@ -563,10 +655,15 @@ module Hwaro
       # down the file — silent corruption of user data.
       private def clamp_sitemap_priority(text : String) : NamedTuple(text: String, fix: ValueFix)?
         lines = text.split('\n', remove_empty: false)
+        in_string = multiline_string_line_states(lines)
         in_sitemap = false
         top_level = true
         number = /[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/
         lines.each_with_index do |line, idx|
+          # Lines inside a TOML multi-line string are string CONTENT: a
+          # priority-looking line there must never be clamped, and a
+          # header-looking line there must not flip in_sitemap/top_level.
+          next if in_string[idx]
           if header = line.match(/^\s*\[\[?\s*([^\[\]]+?)\s*\]\]?\s*(?:#.*)?$/)
             in_sitemap = (header[1] == "sitemap")
             top_level = false
@@ -859,7 +956,21 @@ module Hwaro
       # templates as missing — and never syntax-checked any of them.
       private def template_files : Array(String)
         Dir.glob(File.join(@templates_dir, "**", "*")).select do |path|
-          !File.directory?(path) && path.matches?(Core::Build::Builder::TEMPLATE_EXTENSION_REGEX)
+          next false unless path.matches?(Core::Build::Builder::TEMPLATE_EXTENSION_REGEX)
+          # lstat first: `File.directory?` FOLLOWS symlinks, so a link
+          # cycle anywhere under templates/ raised ELOOP out of the whole
+          # doctor run. Mirror walk_section_dirs' guard — judge the entry
+          # itself, and skip a symlink whose target can't be resolved.
+          info = File.info?(path, follow_symlinks: false)
+          next false unless info
+          next info.file? unless info.symlink?
+          target = begin
+            File.info?(path, follow_symlinks: true)
+          rescue ex : File::Error
+            Logger.debug "Doctor: skipping unresolvable template symlink #{path}: #{ex.message}"
+            nil
+          end
+          target ? target.file? : false
         end
       end
 
@@ -1120,8 +1231,13 @@ module Hwaro
         files = [] of String
         Dir.glob(File.join(@content_dir, "**", "*.{md,markdown}")) do |path|
           # Skip things that aren't regular files (symlink to nowhere,
-          # directory matching the glob, etc.).
-          files << path if File.file?(path)
+          # directory matching the glob, etc.). `File.file?` FOLLOWS
+          # symlinks, so a link cycle (`ln -s loop.md content/loop.md`)
+          # raised File::Error (ELOOP) out of the whole doctor run —
+          # zero diagnostics, and no JSON payload under --json.
+          # `ContentWalk.readable_file?` stats lstat-first, exactly like
+          # the sibling `tool validate` walk.
+          files << path if ContentWalk.readable_file?(path)
         end
         return if files.empty?
 
@@ -1158,6 +1274,16 @@ module Hwaro
           first_line = (ex.message || "Invalid front matter").lines.first?.to_s.strip
           return [Issue.new(id: "content-frontmatter-invalid", level: :error, category: "content", file: path,
             message: first_line.empty? ? "Invalid front matter" : first_line)]
+        rescue ex
+          # A parse failure that isn't a classified HwaroError (invalid
+          # UTF-8 raising ArgumentError out of the front-matter regex,
+          # etc.) used to escape into ParallelHelper.map, whose
+          # success-only filter silently dropped the file — doctor said
+          # "no issues found" while `hwaro build` fails on the same file.
+          first_line = (ex.message || "").lines.first?.to_s.strip
+          detail = first_line.empty? ? ex.class.name : first_line
+          return [Issue.new(id: "content-frontmatter-invalid", level: :error, category: "content", file: path,
+            message: "Cannot parse content file (invalid encoding or front matter): #{detail}")]
         end
 
         issues = [] of Issue

--- a/src/services/exporters/base.cr
+++ b/src/services/exporters/base.cr
@@ -327,6 +327,19 @@ module Hwaro
           safe_path = Hwaro::Utils::OutputGuard.safe_output_path(path, output_dir)
           return false unless safe_path
 
+          # `safe_output_path` is lexical; `mkdir_p` + `File.write` follow a
+          # pre-existing symlinked directory (or file) inside the destination,
+          # routing the write outside `output_dir`. Re-check the RESOLVED
+          # destination — deepest-existing-ancestor resolution, so a
+          # not-yet-created path still resolves — the same containment rule
+          # `copy_bundle_assets` applies.
+          resolved = Hwaro::Utils::PathUtils.resolved_real_path(safe_path)
+          resolved_root = Hwaro::Utils::PathUtils.resolved_real_path(output_dir)
+          unless resolved == resolved_root || resolved.starts_with?(resolved_root + File::SEPARATOR)
+            Logger.warn "Skipping output outside output directory (symlinked destination): #{path}"
+            return false
+          end
+
           action = File.exists?(safe_path) ? "overwritten" : "exported"
           unless @dry_run
             Hwaro::Utils::FileSafe.mkdir_p(File.dirname(safe_path))

--- a/src/services/exporters/base.cr
+++ b/src/services/exporters/base.cr
@@ -193,6 +193,16 @@ module Hwaro
 
             dest = File.join(dest_dir, entry)
             next unless Hwaro::Utils::OutputGuard.within_output_dir?(dest, output_dir)
+            # The directory was resolve-checked above, but the destination
+            # FILE itself can be a pre-existing symlink leaf: File.copy
+            # follows it and would write through it to a path outside the
+            # tree. Same resolved re-check write_file applies.
+            resolved_dest = Hwaro::Utils::PathUtils.resolved_real_path(dest)
+            resolved_root = Hwaro::Utils::PathUtils.resolved_real_path(output_dir)
+            unless resolved_dest.starts_with?(resolved_root + File::SEPARATOR)
+              Logger.warn "Skipping bundle asset outside output directory (symlinked destination): #{dest}"
+              next
+            end
 
             action = File.exists?(dest) ? "overwritten" : "exported"
             unless @dry_run

--- a/src/services/exporters/hugo_exporter.cr
+++ b/src/services/exporters/hugo_exporter.cr
@@ -34,9 +34,11 @@ module Hwaro
             Logger.warn "Error exporting #{file_path}: #{ex.message}"
           end
 
+          # Any per-file error fails the run: `exported > 0` used to mask
+          # errors, so a partial export reported success and exited 0.
           ExportResult.new(
-            success: exported > 0 || errors == 0,
-            message: "Exported #{exported} items, skipped #{skipped}, errors #{errors}",
+            success: errors == 0,
+            message: errors > 0 ? "#{errors} file(s) could not be exported (#{exported} exported, #{skipped} skipped)" : "Exported #{exported} items, skipped #{skipped}, errors #{errors}",
             exported_count: exported,
             skipped_count: skipped,
             error_count: errors
@@ -73,15 +75,25 @@ module Hwaro
           # through cost the post every taxonomy it belonged to.
           # Source-iteration order is preserved so Hugo frontmatter reads
           # similarly to the original.
+          # A rename only applies when its TARGET key is not authored in the
+          # source — an authored target wins regardless of key order, the
+          # same existing-key-wins rule `flatten_taxonomies` uses (the source
+          # key is dropped, mirroring how the losing taxonomy entry is).
+          # Renaming unconditionally clobbered a coexisting authored key
+          # whenever the source key happened to iterate second.
           hugo_fields = {} of String => YAML::Any
-          flatten_taxonomies(fields).each do |key, value|
+          flattened = flatten_taxonomies(fields)
+          flattened.each do |key, value|
             next if value.raw.nil?
             case key
             when "updated"
+              next if authored?(flattened, "lastmod")
               hugo_fields["lastmod"] = value
             when "expires"
+              next if authored?(flattened, "expiryDate")
               hugo_fields["expiryDate"] = value
             when "image"
+              next if authored?(flattened, "images")
               if image = value.as_s?
                 hugo_fields["images"] = YAML::Any.new([YAML::Any.new(image)])
               else
@@ -108,10 +120,23 @@ module Hwaro
           # co-located resources out of this same directory, so carry them
           # across instead of exporting a post whose images all 404.
           if File.basename(relative).in?("index.md", "index.markdown") && relative.includes?('/')
-            copy_bundle_assets(File.dirname(file_path), File.dirname(out_path), output_dir, verbose)
+            begin
+              copy_bundle_assets(File.dirname(file_path), File.dirname(out_path), output_dir, verbose)
+            rescue ex : File::Error
+              # The bundle directory vanished or became unlistable after the
+              # post was written — the post itself exported, so warn instead
+              # of letting the counts/manifest disagree with disk.
+              Logger.warn "Could not export bundle assets for #{file_path}: #{ex.message}"
+            end
           end
 
           :exported
+        end
+
+        # An authored, non-null value for `key` exists in the source fields.
+        private def authored?(fields : Hash(String, YAML::Any), key : String) : Bool
+          value = fields[key]?
+          !value.nil? && !value.raw.nil?
         end
 
         private def generate_toml_frontmatter(fields : Hash(String, YAML::Any)) : String

--- a/src/services/exporters/hugo_exporter.cr
+++ b/src/services/exporters/hugo_exporter.cr
@@ -77,24 +77,33 @@ module Hwaro
           # similarly to the original.
           # A rename only applies when its TARGET key is not authored in the
           # source — an authored target wins regardless of key order, the
-          # same existing-key-wins rule `flatten_taxonomies` uses (the source
-          # key is dropped, mirroring how the losing taxonomy entry is).
-          # Renaming unconditionally clobbered a coexisting authored key
-          # whenever the source key happened to iterate second.
+          # same existing-key-wins rule `flatten_taxonomies` uses. When the
+          # rename is blocked, the source key is passed through under its own
+          # name instead of being dropped: Hugo accepts arbitrary page
+          # params, and silent data loss is this exporter's cardinal sin
+          # (gh#527). Renaming unconditionally clobbered a coexisting
+          # authored key whenever the source key happened to iterate second.
           hugo_fields = {} of String => YAML::Any
           flattened = flatten_taxonomies(fields)
           flattened.each do |key, value|
             next if value.raw.nil?
             case key
             when "updated"
-              next if authored?(flattened, "lastmod")
-              hugo_fields["lastmod"] = value
+              if authored?(flattened, "lastmod")
+                hugo_fields[key] = value
+              else
+                hugo_fields["lastmod"] = value
+              end
             when "expires"
-              next if authored?(flattened, "expiryDate")
-              hugo_fields["expiryDate"] = value
+              if authored?(flattened, "expiryDate")
+                hugo_fields[key] = value
+              else
+                hugo_fields["expiryDate"] = value
+              end
             when "image"
-              next if authored?(flattened, "images")
-              if image = value.as_s?
+              if authored?(flattened, "images")
+                hugo_fields[key] = value
+              elsif image = value.as_s?
                 hugo_fields["images"] = YAML::Any.new([YAML::Any.new(image)])
               else
                 hugo_fields["images"] = value

--- a/src/services/exporters/jekyll_exporter.cr
+++ b/src/services/exporters/jekyll_exporter.cr
@@ -135,15 +135,23 @@ module Hwaro
           # Hwaro's `template` is Jekyll's `layout`, the exact inverse of the
           # Jekyll importer's `layout` → `template` mapping. Passing the key
           # through verbatim meant Jekyll ignored it (rendering the page with
-          # no layout at all) and a re-import dropped it entirely.
-          if layout = scalar_string(fields["template"]?)
+          # no layout at all) and a re-import dropped it entirely. An
+          # authored `layout` wins (existing-key-wins, like the Hugo
+          # renames): emitting both would produce a duplicate YAML key.
+          if (layout = scalar_string(fields["template"]?)) && fields["layout"]?.try(&.raw).nil?
             yaml_lines << "layout: #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(layout)}"
             handled << "template"
+            handled << "layout"
           end
 
-          # Jekyll uses `published: false` instead of `draft: true`
+          # Jekyll uses `published: false` instead of `draft: true`. The
+          # draft flag is hwaro's source of truth, so it also claims
+          # `published`: letting an authored `published: true` pass through
+          # would duplicate the key and (under Jekyll's last-wins loader)
+          # publish the draft.
           if is_draft
             yaml_lines << "published: false"
+            handled << "published"
           end
 
           # Accept both list (`tags: [a, b]`) and scalar (`tags: crystal`)

--- a/src/services/exporters/jekyll_exporter.cr
+++ b/src/services/exporters/jekyll_exporter.cr
@@ -60,20 +60,32 @@ module Hwaro
           # are content the user handed the exporter and did not get back.
           skipped += @unexported_assets
 
+          # Any per-file error fails the run: `exported > 0` used to mask
+          # errors, so a partial export reported success and exited 0.
           ExportResult.new(
-            success: exported > 0 || errors == 0,
-            message: "Exported #{exported} items, skipped #{skipped}, errors #{errors}",
+            success: errors == 0,
+            message: errors > 0 ? "#{errors} file(s) could not be exported (#{exported} exported, #{skipped} skipped)" : "Exported #{exported} items, skipped #{skipped}, errors #{errors}",
             exported_count: exported,
             skipped_count: skipped,
             error_count: errors
           )
         end
 
-        # Keys emitted explicitly below; everything else passes through as a
-        # Jekyll page variable (Jekyll accepts arbitrary front-matter keys, so
-        # dropping `slug`, `weight`, `layout`, `extra.*`, … was silent data
-        # loss — the same bug class gh#527 fixed for the Hugo exporter).
+        # Keys the explicit emitters below may claim; everything else passes
+        # through as a Jekyll page variable (Jekyll accepts arbitrary
+        # front-matter keys, so dropping `slug`, `weight`, `layout`,
+        # `extra.*`, … was silent data loss — the same bug class gh#527 fixed
+        # for the Hugo exporter). A key is only excluded from the passthrough
+        # when its emitter actually produced a line: a value the emitter
+        # cannot represent (hash-valued `tags`, array `title`, …) used to be
+        # swallowed — skipped by the emitter AND skipped by name here.
         HANDLED_KEYS = Set{"title", "date", "description", "draft", "tags", "categories", "authors", "image", "template"}
+
+        # Matches the date/timestamp shapes Jekyll's YAML loader reads
+        # natively; anything else is emitted via `yaml_scalar` — raw
+        # interpolation of an arbitrary string into `date:` let a newline or
+        # `: ` inject or break the frontmatter.
+        DATE_SHAPE_RE = /\A\d{4}-\d{2}-\d{2}([Tt ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?( ?([Zz]|[+-]\d{2}:?\d{2}))?)?\z/
 
         private def export_file(
           file_path : String,
@@ -94,27 +106,39 @@ module Hwaro
             return :skipped
           end
 
-          # Build Jekyll YAML frontmatter
+          # Build Jekyll YAML frontmatter. Keys are marked handled only when
+          # an emitter actually produced a line, so a value the emitters
+          # cannot represent falls through to `passthrough_yaml` instead of
+          # being silently dropped.
           yaml_lines = [] of String
+          handled = Set(String).new
+          # A boolean draft is fully translated (true → `published: false`,
+          # false → omitted, Jekyll's default); any other type falls through
+          # to passthrough_yaml like every other unrepresentable value.
+          handled << "draft" if fields["draft"]?.try(&.raw).is_a?(Bool)
 
-          if title = fields["title"]?.try(&.as_s?)
+          if title = scalar_string(fields["title"]?)
             yaml_lines << "title: #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(title)}"
+            handled << "title"
           end
 
-          if date = fields["date"]?.try(&.as_s?)
-            yaml_lines << "date: #{date}"
+          if date = scalar_string(fields["date"]?)
+            yaml_lines << "date: #{yaml_date_value(date)}"
+            handled << "date"
           end
 
-          if desc = fields["description"]?.try(&.as_s?)
+          if desc = scalar_string(fields["description"]?)
             yaml_lines << "description: #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(desc)}"
+            handled << "description"
           end
 
           # Hwaro's `template` is Jekyll's `layout`, the exact inverse of the
           # Jekyll importer's `layout` → `template` mapping. Passing the key
           # through verbatim meant Jekyll ignored it (rendering the page with
           # no layout at all) and a re-import dropped it entirely.
-          if layout = fields["template"]?.try(&.as_s?)
+          if layout = scalar_string(fields["template"]?)
             yaml_lines << "layout: #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(layout)}"
+            handled << "template"
           end
 
           # Jekyll uses `published: false` instead of `draft: true`
@@ -130,12 +154,14 @@ module Hwaro
           if tags = string_list_field(fields["tags"]?)
             yaml_lines << "tags:"
             tags.each { |t| yaml_lines << "  - #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(t)}" }
+            handled << "tags"
           end
 
           # categories from taxonomies if present
           if cats = string_list_field(fields["categories"]?)
             yaml_lines << "categories:"
             cats.each { |c| yaml_lines << "  - #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(c)}" }
+            handled << "categories"
           end
 
           # Jekyll natively understands an `authors` front-matter list, so
@@ -143,13 +169,15 @@ module Hwaro
           if authors = string_list_field(fields["authors"]?)
             yaml_lines << "authors:"
             authors.each { |a| yaml_lines << "  - #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(a)}" }
+            handled << "authors"
           end
 
-          if image = fields["image"]?.try(&.as_s?)
+          if image = scalar_string(fields["image"]?)
             yaml_lines << "image: #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(image)}"
+            handled << "image"
           end
 
-          if passthrough = passthrough_yaml(fields)
+          if passthrough = passthrough_yaml(fields, handled)
             yaml_lines << passthrough
           end
 
@@ -205,13 +233,38 @@ module Hwaro
           0
         end
 
-        # Serialize the non-allowlisted fields through the YAML emitter (which
-        # handles nesting, typing, and quoting), returning frontmatter lines
-        # without the `---` fences, or nil when there is nothing to carry.
-        private def passthrough_yaml(fields : Hash(String, YAML::Any)) : String?
+        # String form of a scalar front-matter value: strings pass through
+        # and Bool/Int/Float stringify (a non-string `title: 2024` used to be
+        # silently dropped). Structured or null values return nil so the
+        # caller leaves the key to `passthrough_yaml`. Time never reaches
+        # here — `parse_content` already normalizes it to a date string.
+        private def scalar_string(value : YAML::Any?) : String?
+          return unless value
+          if str = value.as_s?
+            return str
+          end
+          case raw = value.raw
+          when Bool, Int64, Float64
+            raw.to_s
+          end
+        end
+
+        # A well-formed date/timestamp is written raw so Jekyll's YAML loader
+        # reads it as a date; anything else goes through `yaml_scalar`.
+        private def yaml_date_value(date : String) : String
+          date.matches?(DATE_SHAPE_RE) ? date : Hwaro::Utils::FrontmatterWriter.yaml_scalar(date)
+        end
+
+        # Serialize the fields no emitter claimed through the YAML emitter
+        # (which handles nesting, typing, and quoting), returning frontmatter
+        # lines without the `---` fences, or nil when there is nothing to
+        # carry. `handled` holds the keys actually emitted above — filtering
+        # by the static HANDLED_KEYS list swallowed handled-key values the
+        # emitters had skipped as unrepresentable.
+        private def passthrough_yaml(fields : Hash(String, YAML::Any), handled : Set(String)) : String?
           leftovers = {} of YAML::Any => YAML::Any
           fields.each do |key, value|
-            next if HANDLED_KEYS.includes?(key)
+            next if handled.includes?(key)
             next if value.raw.nil?
             leftovers[YAML::Any.new(key)] = value
           end

--- a/src/services/frontmatter_converter.cr
+++ b/src/services/frontmatter_converter.cr
@@ -102,11 +102,18 @@ module Hwaro
         convert_files(FrontmatterFormat::JSON)
       end
 
+      # Opening delimiter matchers. The build parser accepts trailing
+      # horizontal whitespace after the delimiter (`\A---\s*\n` in
+      # FrontmatterScanner), so detection must too — a `--- \n` file used to
+      # be skipped as "no frontmatter" while `hwaro build` parsed it fine.
+      TOML_OPENER_RE = /\A\+\+\+[ \t]*\r?\n/
+      YAML_OPENER_RE = /\A---[ \t]*\r?\n/
+
       # Detect the frontmatter format of a file
       def detect_format(content : String) : FrontmatterFormat
-        if content.starts_with?("#{TOML_DELIMITER}\n") || content.starts_with?("#{TOML_DELIMITER}\r\n")
+        if content.matches?(TOML_OPENER_RE)
           FrontmatterFormat::TOML
-        elsif content.starts_with?("#{YAML_DELIMITER}\n") || content.starts_with?("#{YAML_DELIMITER}\r\n")
+        elsif content.matches?(YAML_OPENER_RE)
           FrontmatterFormat::YAML
         elsif content.starts_with?('{') && json_frontmatter_object?(content)
           FrontmatterFormat::JSON
@@ -185,7 +192,9 @@ module Hwaro
           if @dry_run
             Logger.item("would convert: #{file_path}", glyph: :ok)
           else
-            write_in_place(file_path, converted_content)
+            # An unwritable target (e.g. the path stopped resolving mid-run)
+            # must surface as an error, not a false "converted".
+            return ConversionStatus::Error unless write_in_place(file_path, converted_content)
             Logger.item(file_path, glyph: :ok)
           end
           ConversionStatus::Converted
@@ -303,7 +312,11 @@ module Hwaro
         when FrontmatterFormat::YAML
           return false unless match = content.match(YAML_FRONTMATTER_RE)
           begin
-            YAML.parse(match[1]).as_h? ? true : false
+            parsed = YAML.parse(match[1])
+            # An empty block (`---\n---\n`) parses to nil; that is empty
+            # front matter, not body text — it must convert, not be skipped
+            # as "not front matter".
+            parsed.raw.nil? || parsed.as_h? ? true : false
           rescue YAML::ParseException
             true
           end
@@ -321,16 +334,27 @@ module Hwaro
       # rename(2) only needs directory permission, so check the file itself
       # first — a read-only file must fail instead of being silently replaced
       # — and carry its permissions onto the replacement.
-      private def write_in_place(file_path : String, content : String) : Nil
-        unless File::Info.writable?(file_path)
-          raise File::Error.new("File not writable", file: file_path)
+      # The rename must land on the RESOLVED path: renaming over a symlink
+      # replaces the symlink itself with a regular file, leaving the real
+      # target unconverted and a diverging copy in its place.
+      private def write_in_place(file_path : String, content : String) : Bool
+        target = begin
+          File.realpath(file_path)
+        rescue File::Error
+          Logger.warn "#{file_path}: could not resolve real path — left unchanged."
+          return false
         end
 
-        permissions = File.info(file_path).permissions
-        tmp_path = "#{file_path}.hwaro-convert.tmp"
+        unless File::Info.writable?(target)
+          raise File::Error.new("File not writable", file: target)
+        end
+
+        permissions = File.info(target).permissions
+        tmp_path = "#{target}.hwaro-convert.tmp"
         File.write(tmp_path, content)
         File.chmod(tmp_path, permissions)
-        File.rename(tmp_path, file_path)
+        File.rename(tmp_path, target)
+        true
       rescue ex
         File.delete(tmp_path) if tmp_path && File.exists?(tmp_path)
         raise ex
@@ -592,6 +616,9 @@ module Hwaro
             hash[key_str] = v
           end
         end
+        # An empty mapping serializes as `--- {}`, which would end up
+        # embedded verbatim inside the new fences; emit an empty block.
+        return "" if hash.empty?
         hash.to_yaml.lchop("---\n")
       end
 
@@ -601,6 +628,8 @@ module Hwaro
 
       private def convert_toml_to_yaml_string(toml : TOML::Table) : String
         yaml_hash = toml_to_hash(toml)
+        # See convert_json_to_yaml_string: `{}` must not leak into the fences.
+        return "" if yaml_hash.empty?
         yaml_hash.to_yaml.lchop("---\n")
       end
 

--- a/src/services/importers/astro_importer.cr
+++ b/src/services/importers/astro_importer.cr
@@ -101,13 +101,14 @@ module Hwaro
               fields["title"] = yaml_string(title)
             end
 
-            # Date (pubDate is Astro's convention)
-            if date_val = yaml["pubDate"]? || yaml["date"]? || yaml["publishDate"]?
+            # Date (pubDate is Astro's convention). `first_present`, not
+            # `||`: a present-but-null key would discard the fallbacks.
+            if date_val = first_present(yaml, "pubDate", "date", "publishDate")
               assign_date_field(fields, "date", date_val)
             end
 
             # Updated date
-            if updated = yaml["updatedDate"]? || yaml["updated"]? || yaml["lastmod"]?
+            if updated = first_present(yaml, "updatedDate", "updated", "lastmod")
               assign_date_field(fields, "updated", updated)
             end
 
@@ -144,7 +145,7 @@ module Hwaro
             fields["tags"] = tags unless tags.empty?
 
             # Image (heroImage is Astro's blog template convention)
-            if image = yaml["heroImage"]? || yaml["image"]? || yaml["cover"]?
+            if image = first_present(yaml, "heroImage", "image", "cover")
               case image.raw
               when String
                 fields["image"] = image.as_s

--- a/src/services/importers/base.cr
+++ b/src/services/importers/base.cr
@@ -18,6 +18,13 @@ module Hwaro
       # `generate_frontmatter` renders it as TOML.
       alias FieldValue = (String | Bool | Int64 | Array(String))?
 
+      # Every importer computes `success: imported > 0 || errors == 0` —
+      # DELIBERATELY more lenient than the exporters' `errors == 0` rule.
+      # Imports digest messy third-party dumps where some items are simply
+      # unimportable; a best-effort partial migration is the expected
+      # outcome, and per-item failures are counted and reported alongside
+      # it. Exports and conversions operate on the user's own valid content,
+      # where any error means the run must fail.
       struct ImportResult
         property success : Bool
         property message : String

--- a/src/services/importers/base.cr
+++ b/src/services/importers/base.cr
@@ -56,8 +56,13 @@ module Hwaro
         # leaking raw YAML into the page body. A leading U+FEFF does the same
         # to the `\A---` / `\A+++` anchors — every other reader hwaro hands
         # file text to already goes through `TextUtils.strip_bom`.
+        #
+        # `scrub` because sources are third-party exports: a single invalid
+        # UTF-8 byte made every downstream regex pass raise ArgumentError,
+        # dropping the whole file with a cryptic error. This is the single
+        # choke point, so scrubbing here protects every importer.
         protected def read_text(path : String) : String
-          Utils::TextUtils.strip_bom(File.read(path)).gsub("\r\n", "\n")
+          Utils::TextUtils.strip_bom(File.read(path).scrub).gsub("\r\n", "\n")
         end
 
         # Split YAML frontmatter from a document body. Returns {frontmatter, body}
@@ -88,7 +93,17 @@ module Hwaro
         end
 
         private def walk_files_into(dir : String, files : Array(String), extensions : Array(String), skip_dir : Proc(String, Bool)?)
-          Dir.children(dir).sort!.each do |entry|
+          # An unreadable subdirectory (permissions, or one removed mid-walk)
+          # raised straight out of the recursion and aborted the entire
+          # import. Skip it and keep importing everything that is readable.
+          entries = begin
+            Dir.children(dir).sort!
+          rescue ex : File::Error
+            Logger.warn "Skipped unreadable directory: #{dir} (#{ex.message})"
+            return
+          end
+
+          entries.each do |entry|
             full_path = File.join(dir, entry)
             if File.directory?(full_path)
               # A symlinked directory can close a cycle (`ln -s .. sub`), and
@@ -447,8 +462,12 @@ module Hwaro
         # carry a trailing ".md"). Unicode is preserved. We intentionally do NOT
         # URL-decode: the filesystem treats `%2f` as a literal, so decoding
         # would only manufacture separators that aren't really there.
+        # `scrub` first: URI-decoded slugs (`a%ffb`) can carry invalid UTF-8,
+        # and the split regex raises ArgumentError on an invalid byte
+        # sequence — scrubbing here protects every caller.
         protected def safe_filename_component(value : String) : String
-          value.delete(Char::ZERO)
+          value.scrub
+            .delete(Char::ZERO)
             .split(/[\/\\]/)
             .reject { |seg| seg.empty? || seg == "." || seg == ".." }
             .last? || ""
@@ -491,10 +510,36 @@ module Hwaro
         protected def collect_string_list(value : YAML::Any, into list : Array(String)) : Nil
           case value.raw
           when Array
-            value.as_a.each { |v| list << yaml_string(v) }
+            # Filter blank items like the string branch below does — an
+            # empty array element otherwise became an empty taxonomy term.
+            value.as_a.each do |v|
+              s = yaml_string(v)
+              list << s unless s.blank?
+            end
           when String
             value.as_s.split(/[\s,]+/).each { |v| list << v.strip unless v.strip.empty? }
           end
+        end
+
+        # First value among `keys` that is present AND non-null. The naive
+        # `yaml["a"]? || yaml["b"]?` chain can't express this: YAML::Any is a
+        # struct, so a present-but-null key (`pubDate:` with no value) is
+        # truthy and silently discards every fallback after it.
+        protected def first_present(yaml : YAML::Any, *keys : String) : YAML::Any?
+          keys.each do |key|
+            value = yaml[key]?
+            return value if value && !value.raw.nil?
+          end
+          nil
+        end
+
+        # :ditto:
+        protected def first_present(yaml : Hash(YAML::Any, YAML::Any), *keys : String) : YAML::Any?
+          keys.each do |key|
+            value = yaml[key]?
+            return value if value && !value.raw.nil?
+          end
+          nil
         end
       end
     end

--- a/src/services/importers/eleventy_importer.cr
+++ b/src/services/importers/eleventy_importer.cr
@@ -16,7 +16,11 @@ module Hwaro
         @used_paths = Set(String).new
 
         def run(options : Config::Options::ImportOptions) : ImportResult
-          path = options.path
+          # Strip trailing separators once: "site/" otherwise broke the
+          # File.dirname-based prefix strip in `import_file` (dirname never
+          # carries the slash), misclassifying the site-root index.md.
+          path = options.path.rstrip('/')
+          path = "/" if path.empty? && !options.path.empty?
           output_dir = options.output_dir
           imported = 0
           skipped = 0
@@ -117,8 +121,11 @@ module Hwaro
                 end
                 data[relative_dir] = parsed
               end
-            rescue JSON::ParseException | File::Error
-              # Skip invalid or unreadable data files
+            rescue JSON::ParseException | IO::Error
+              # Skip invalid or unreadable data files. IO::Error, not just
+              # File::Error: a data-file path that turns out to be a
+              # directory raises a bare IO::Error ("Is a directory") from
+              # File.read, which used to abort the whole import.
             end
           end
 
@@ -252,12 +259,12 @@ module Hwaro
               end
 
               # Description
-              if desc = yaml_hash["description"]? || yaml_hash["excerpt"]? || yaml_hash["summary"]?
+              if desc = first_present(yaml_hash, "description", "excerpt", "summary")
                 fields["description"] = yaml_string(desc)
               end
 
               # Image
-              if image = yaml_hash["image"]? || yaml_hash["featuredImage"]? || yaml_hash["cover"]?
+              if image = first_present(yaml_hash, "image", "featuredImage", "cover")
                 fields["image"] = yaml_string(image)
               end
 

--- a/src/services/importers/hexo_importer.cr
+++ b/src/services/importers/hexo_importer.cr
@@ -166,17 +166,14 @@ module Hwaro
             categories = categories.uniq
             fields["categories"] = categories unless categories.empty?
 
-            # Description
-            if desc = yaml["description"]?
+            # Description. `first_present`, not `if/elsif` on `[]?`: a
+            # present-but-null `description:` would discard the excerpt.
+            if desc = first_present(yaml, "description", "excerpt")
               fields["description"] = yaml_string(desc)
-            elsif excerpt = yaml["excerpt"]?
-              fields["description"] = yaml_string(excerpt)
             end
 
             # Image / thumbnail
-            if image = yaml["cover"]?
-              fields["image"] = yaml_string(image)
-            elsif image = yaml["thumbnail"]?
+            if image = first_present(yaml, "cover", "thumbnail")
               fields["image"] = yaml_string(image)
             end
 

--- a/src/services/importers/html_to_markdown.cr
+++ b/src/services/importers/html_to_markdown.cr
@@ -18,7 +18,50 @@ module Hwaro
         # Longest anchor TEXT the link conversion will match. Bounding the lazy
         # body is what actually makes an unclosed-anchor document linear — see
         # the anchor pass below. Far above any real inline link.
+        #
+        # The bound is needed exactly where a pass's tail carries MORE THAN
+        # ONE closing literal (the anchor pass: `["'][^>]*>` then `</a>`;
+        # the pre+code pass: `</code>` then `</pre>`). A failed attempt then
+        # rescans between the literals from every opening tag — measured
+        # O(n^2), minutes of CPU inside the 4 MB cap. Passes whose tail is a
+        # SINGLE closing literal (`(.*?)</p>` and friends) are deliberately
+        # left open: PCRE2 satisfies those in linear time (the required-
+        # literal scan is memoized across bump-along attempts), and bounding
+        # them defeats that optimization — measured ~200x SLOWER on
+        # unclosed-tag spam with a `{0,n}?` body than with `(.*?)`.
         MAX_INLINE_BODY_CHARS = 4096
+
+        # Longest <pre><code> body the fenced-code pass will match — the
+        # bounded-lazy-body treatment for the one other multi-literal-tail
+        # pass (see MAX_INLINE_BODY_CHARS above), sized up because real code
+        # samples run far longer than inline spans. 65535 is PCRE2's {n,m}
+        # quantifier ceiling. An over-long body keeps its text: the plain
+        # `<pre>` pass right after has a single-literal tail and no bound.
+        MAX_CODE_BODY_CHARS = 65_535
+
+        # Innermost-list matcher (see the list pass below). The body is
+        # consumed in CHUNKS — possessive runs of non-`<` plus single `<`
+        # guarded against opening a nested list — rather than the previous
+        # per-character `(?:(?!<[uo]l[^>]*>).)*?`: PCRE2's JIT pushes a
+        # backtrack frame per lazy iteration onto a fixed-size JIT stack,
+        # and per-character iteration crashed the whole conversion with
+        # "JIT stack limit reached" on list bodies only a few thousand
+        # characters long. Chunking makes the frame count scale with the
+        # number of tags instead of characters; the language matched is
+        # identical (only `<` could ever start a nested-list open, and a
+        # match can only ever end before the `<` of the closing tag, which
+        # is always a chunk boundary). A `{0,n}` bound is no alternative —
+        # PCRE2 unrolls bounded GROUP repeats and the pattern blows the
+        # compile-size limit. A tag-spam body can still overflow the JIT
+        # stack, which raises Regex::Error — `convert` catches that and
+        # falls back to the linear tag strip.
+        INNERMOST_LIST_RE = /<(ul|ol)[^>]*>((?:[^<]++|<(?![uo]l[^>]*>))*?)<\/\1>/mi
+
+        # Maximum innermost-list conversion passes (one per nesting level).
+        # Real content nests a handful of levels; a crafted thousand-deep
+        # nest costs a full-document gsub per level, so cap it — deeper
+        # levels fall through to `strip_tags`, which keeps their text.
+        MAX_LIST_PASSES = 64
 
         # Cheap short-circuit for the anchor pass: a document with no closing
         # anchor tag has no link to convert. Exposed so the skip is assertable
@@ -40,15 +83,37 @@ module Hwaro
 
           if html.bytesize > MAX_REGEX_HTML_BYTES
             Logger.warn "HTML content is very large (#{html.bytesize} bytes); converting as plain text to avoid excessive processing time."
-            return html.gsub(/<[^>]*>/, " ").gsub(/[ \t]+/, " ").strip
+            return strip_to_text(html)
           end
 
+          convert_via_regexes(html)
+        rescue Regex::Error
+          # Belt and suspenders: pathological markup can still error inside
+          # PCRE2 (e.g. "JIT stack limit reached") despite the bounded
+          # passes. Fall back to the same linear tag strip as the size cap
+          # rather than dropping the whole item.
+          Logger.warn "HTML content is too complex to convert; converting as plain text."
+          strip_to_text(html)
+        end
+
+        # The plain-text fallback shared by the size cap and the
+        # Regex::Error rescue in `convert`: linear tag strip, no Markdown.
+        private def self.strip_to_text(html : String) : String
+          html.gsub(/<[^>]*>/, " ").gsub(/[ \t]+/, " ").strip
+        end
+
+        private def self.convert_via_regexes(html : String) : String
           result = html
 
           # Normalize line endings
           result = result.gsub("\r\n", "\n")
 
-          # Convert block elements first (order matters)
+          # Convert block elements first (order matters).
+          #
+          # Lazy-body policy: a pass whose tail is a single closing literal
+          # keeps an open `(.*?)` body — linear under PCRE2, and bounding it
+          # is a measured ~200x regression. A pass with a multi-literal tail
+          # is bounded. See the MAX_INLINE_BODY_CHARS comment.
 
           # Headings
           (1..6).each do |level|
@@ -62,13 +127,17 @@ module Hwaro
           # decode) would otherwise run INSIDE the code sample, converting or
           # stripping the HTML it demonstrates and double-decoding entities.
           code_stash = [] of String
-          result = result.gsub(/<pre[^>]*>\s*<code[^>]*>(.*?)<\/code>\s*<\/pre>/mi) do
+          result = result.gsub(/<pre[^>]*>\s*<code[^>]*>(.{0,#{MAX_CODE_BODY_CHARS}}?)<\/code>\s*<\/pre>/mi) do
             code = decode_html_entities($1)
             code_stash << "```\n#{code.strip}\n```\n\n"
             code_placeholder(code_stash.size - 1)
           end
           result = result.gsub(/<pre[^>]*>(.*?)<\/pre>/mi) do
-            code = decode_html_entities($1)
+            # A <pre><code> body longer than MAX_CODE_BODY_CHARS falls through
+            # to this pass with its <code> wrapper still attached — strip it
+            # here (both tags have single-literal tails, so this stays linear).
+            body = $1.sub(/\A\s*<code[^>]*>/mi, "").sub(/<\/code>\s*\z/mi, "")
+            code = decode_html_entities(body)
             code_stash << "```\n#{code.strip}\n```\n\n"
             code_placeholder(code_stash.size - 1)
           end
@@ -91,8 +160,9 @@ module Hwaro
           # so without those two things `<li>b<ul><li>b1</li></ul></li>`
           # collapsed to the single line `- b- b1` (and `2. second1. s1` for
           # ordered lists), which renders as literal text.
-          innermost_list = /<(ul|ol)[^>]*>((?:(?!<[uo]l[^>]*>).)*?)<\/\1>/mi
-          while result.matches?(innermost_list)
+          innermost_list = INNERMOST_LIST_RE
+          passes = 0
+          while (passes += 1) <= MAX_LIST_PASSES && result.matches?(innermost_list)
             result = result.gsub(innermost_list) do
               kind = $1.downcase
               items = $2.scan(/<li[^>]*>(.*?)<\/li>/mi)

--- a/src/services/importers/hugo_importer.cr
+++ b/src/services/importers/hugo_importer.cr
@@ -149,9 +149,15 @@ module Hwaro
             # and every imported page loses its ordering.
             if weight_val = data["weight"]?
               case weight_raw = weight_val.raw
-              when Int64   then fields["weight"] = weight_raw
-              when Float64 then fields["weight"] = weight_raw.to_i64
-              when String  then fields["weight"] = weight_raw.to_i64?
+              when Int64 then fields["weight"] = weight_raw
+              when Float64
+                # Guard the conversion: 1e300 / Infinity / NaN would raise
+                # OverflowError out of `to_i64` and error the whole file.
+                # An absurd weight is ignored instead.
+                if weight_raw.finite? && weight_raw.in?(-9.0e18..9.0e18)
+                  fields["weight"] = weight_raw.to_i64
+                end
+              when String then fields["weight"] = weight_raw.to_i64?
               end
             end
 

--- a/src/services/importers/jekyll_importer.cr
+++ b/src/services/importers/jekyll_importer.cr
@@ -168,11 +168,10 @@ module Hwaro
               end
             end
 
-            # Description
-            if excerpt = yaml["excerpt"]?
-              fields["description"] = yaml_string(excerpt)
-            elsif description = yaml["description"]?
-              fields["description"] = yaml_string(description)
+            # Description. `first_present`, not `if/elsif` on `[]?`: a
+            # present-but-null `excerpt:` would discard the description.
+            if desc = first_present(yaml, "excerpt", "description")
+              fields["description"] = yaml_string(desc)
             end
 
             # Image

--- a/src/services/importers/notion_importer.cr
+++ b/src/services/importers/notion_importer.cr
@@ -184,7 +184,9 @@ module Hwaro
             text = $1
             target = $2
             if target.ends_with?(".md") && !target.starts_with?("http://") && !target.starts_with?("https://")
-              target_decoded = URI.decode(target)
+              # `scrub`: URI.decode can materialize invalid UTF-8 (`%ff`),
+              # and the regex below raises on it — dropping the whole note.
+              target_decoded = URI.decode(target).scrub
               if /[0-9a-fA-F]{32}/.match(target_decoded)
                 filename = File.basename(target_decoded, ".md")
                 clean_name = filename.sub(/\s+[0-9a-f]{16,}$/i, "").strip

--- a/src/services/importers/obsidian_importer.cr
+++ b/src/services/importers/obsidian_importer.cr
@@ -132,7 +132,10 @@ module Hwaro
             end
 
             relative_path = file_path.sub(base_path, "").lstrip('/')
-            relative_path_no_ext = relative_path.sub(File.extname(relative_path), "")
+            # `rchop`, not `sub`: sub strips the FIRST occurrence of the
+            # extension substring, registering the wrong link-map key for a
+            # stem that itself contains ".md" (`a.md.old.md` → `a.old.md`).
+            relative_path_no_ext = relative_path.rchop(File.extname(relative_path))
 
             slug = slugify(title)
             url = "/#{section}/#{slug}/"

--- a/src/services/importers/wordpress_importer.cr
+++ b/src/services/importers/wordpress_importer.cr
@@ -16,14 +16,20 @@ module Hwaro
 
           reset_written_paths
 
-          unless File.exists?(wxr_path)
+          # `File.file?`, not `File.exists?`: a directory passes the latter
+          # and then crashes File.read with a bare "Is a directory".
+          unless File.file?(wxr_path)
+            message = Dir.exists?(wxr_path) ? "WXR path is a directory, not a file: #{wxr_path}" : "WXR file not found: #{wxr_path}"
             return ImportResult.new(
               success: false,
-              message: "WXR file not found: #{wxr_path}"
+              message: message
             )
           end
 
-          xml_content = File.read(wxr_path)
+          # `scrub` because the export is third-party bytes: a single invalid
+          # UTF-8 byte made the DOCTYPE guard's regex below raise
+          # ArgumentError, aborting the whole import.
+          xml_content = File.read(wxr_path).scrub
 
           # Guard against XML entity-expansion / recursive-entity DoS. A
           # malicious WXR can declare nested internal entities (e.g.
@@ -106,9 +112,19 @@ module Hwaro
           start = xml.index(/<!DOCTYPE/i)
           return false unless start
 
+          # A real DOCTYPE can only live in the prolog, before the root
+          # element. A `<!DOCTYPE` mention inside a post body (a DTD tutorial,
+          # escaped markup) must not seed the scan: its surrounding prose can
+          # hold unbalanced brackets/quotes that would never "close" and get
+          # the whole file refused.
+          if root = xml.index(/<[A-Za-z]/)
+            return false if start > root
+          end
+
           window = xml[start, 1 << 16]
           in_quote : Char? = nil
           depth = 0
+          closed = false
           doctype = String.build do |io|
             window.each_char do |c|
               io << c
@@ -121,10 +137,17 @@ module Hwaro
               elsif c == ']'
                 depth -= 1 if depth > 0
               elsif c == '>' && depth == 0
+                closed = true
                 break
               end
             end
           end
+          # The DOCTYPE never terminated inside the scan window, so an
+          # internal subset longer than the window could smuggle its
+          # `<!ENTITY` declarations past the scan. No legitimate WXR carries
+          # a DOCTYPE anywhere near this size — treat it as if it declared
+          # entities and refuse.
+          return true unless closed
           doctype.matches?(/<!ENTITY/i)
         end
 

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -312,7 +312,15 @@ module Hwaro
       PAGE_EXTENSIONS = {".md", ".markdown"}
 
       private def scan_content_for_aliases(dir : String, redirects : Array(Tuple(String, String)))
-        Dir.each_child(dir) do |entry|
+        # An unreadable subdirectory (Dir.each_child raises on entry) skips
+        # that subtree with a warning instead of aborting the whole run.
+        children = begin
+          Dir.children(dir)
+        rescue ex : File::Error
+          Logger.warn "Skipping unreadable directory during alias scan: #{dir} (#{ex.message})"
+          return
+        end
+        children.each do |entry|
           path = File.join(dir, entry)
           # `follow_symlinks: false` keeps a symlinked directory (including a
           # cycle like `ln -s . content/loop`) from being recursed into —

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -56,10 +56,37 @@ module Hwaro
       end
 
       # Escape a value for a TOML basic string. Front-matter aliases are
-      # arbitrary user input; an unescaped quote/backslash would produce an
-      # unparseable netlify.toml.
+      # arbitrary user input; an unescaped quote/backslash — or a raw control
+      # character such as a newline — would produce an unparseable
+      # netlify.toml. Control characters are ESCAPED rather than the alias
+      # skipped (the cloudflare generator skips because `_redirects` has no
+      # escape syntax; TOML does, so the user's redirect is preserved).
       private def toml_escape(s : String) : String
-        s.gsub('\\', "\\\\").gsub('"', "\\\"")
+        String.build do |io|
+          s.each_char do |char|
+            case char
+            when '\\' then io << "\\\\"
+            when '"'  then io << "\\\""
+            when '\n' then io << "\\n"
+            when '\t' then io << "\\t"
+            when '\r' then io << "\\r"
+            when '\b' then io << "\\b"
+            when '\f' then io << "\\f"
+            else
+              if char.control?
+                # TOML `\u` takes exactly four hex digits; codepoints above
+                # U+FFFF (e.g. Cf tag characters) need the 8-digit `\U` form.
+                if char.ord > 0xFFFF
+                  io << "\\U" << char.ord.to_s(16).upcase.rjust(8, '0')
+                else
+                  io << "\\u" << char.ord.to_s(16).upcase.rjust(4, '0')
+                end
+              else
+                io << char
+              end
+            end
+          end
+        end
       end
 
       private def generate_netlify : String
@@ -287,7 +314,14 @@ module Hwaro
       private def scan_content_for_aliases(dir : String, redirects : Array(Tuple(String, String)))
         Dir.each_child(dir) do |entry|
           path = File.join(dir, entry)
-          if File.directory?(path)
+          # `follow_symlinks: false` keeps a symlinked directory (including a
+          # cycle like `ln -s . content/loop`) from being recursed into —
+          # following one used to recurse until ELOOP aborted the whole
+          # command. Symlinked FILES still work: they fall through to the
+          # extension branch and File.read follows the link as usual.
+          info = File.info?(path, follow_symlinks: false)
+          next unless info
+          if info.directory?
             scan_content_for_aliases(path, redirects)
           elsif PAGE_EXTENSIONS.includes?(Path[entry].extension.downcase)
             extract_aliases_from_file(path, redirects)
@@ -353,6 +387,12 @@ module Hwaro
           to = with_base_path(target_url)
           redirects << {from, to}
         end
+      rescue ex : ArgumentError | Hwaro::HwaroError | IO::Error
+        # One bad content file (invalid UTF-8 → ArgumentError from PCRE2,
+        # malformed frontmatter → HwaroError, unreadable file → IO::Error)
+        # must not abort ALL platform config generation — degrade per file,
+        # matching how check-links skips unreadable Markdown.
+        Logger.warn "Skipping #{path} while collecting aliases: #{ex.message}"
       end
 
       # Calculate the URL for a page through the same shared resolver as the

--- a/src/services/unused_assets.cr
+++ b/src/services/unused_assets.cr
@@ -76,16 +76,52 @@ module Hwaro
         @content_dir : String = "content",
         @static_dir : String = "static",
         @templates_dir : String = "templates",
+        templates_dir_explicit : Bool = false,
+        static_dir_explicit : Bool = false,
       )
-        if File.exists?("config.toml")
-          @project_root = "."
-        else
-          @project_root = find_project_root(@content_dir)
-        end
+        @project_root = resolve_project_root
 
-        if @templates_dir == "templates"
-          @templates_dir = File.join(@project_root, "templates")
+        # Only the true defaults get re-rooted. An explicitly passed
+        # `--templates-dir templates` (or `--static-dir static`) was
+        # existence-checked by the command against the CWD; silently
+        # re-rooting it would scan a different directory than the one the
+        # user named — the `*_explicit` flags keep that path as given.
+        if !templates_dir_explicit && @templates_dir == "templates"
+          @templates_dir = rooted("templates")
         end
+        if !static_dir_explicit && @static_dir == "static"
+          @static_dir = rooted("static")
+        end
+      end
+
+      # One coherent project root for every derived input (static/,
+      # templates/, data/, i18n/, config.toml). The root used to be pinned to
+      # "." as soon as the CWD held a config.toml — even when --content-dir
+      # pointed into a DIFFERENT project — so the scan mixed two trees:
+      # assets came from one project, references from another, and
+      # `--delete --force` removed files the other project still uses.
+      private def resolve_project_root : String
+        candidate = find_project_root(@content_dir)
+        # A config.toml next to the content tree is authoritative.
+        return candidate if File.exists?(File.join(candidate, "config.toml"))
+        # Fall back to the CWD only when the content tree actually lives
+        # inside it; a foreign tree without its own config.toml still roots
+        # at itself rather than borrowing the CWD's project files.
+        return "." if File.exists?("config.toml") && inside_cwd?(@content_dir)
+        candidate
+      end
+
+      private def inside_cwd?(path : String) : Bool
+        expanded = File.expand_path(path)
+        cwd = Dir.current
+        expanded == cwd || expanded.starts_with?(cwd + File::SEPARATOR)
+      end
+
+      # Join `name` under the project root, keeping the historical relative
+      # form ("static", not "./static") for the in-project case so reported
+      # paths stay byte-identical.
+      private def rooted(name : String) : String
+        @project_root == "." ? name : File.join(@project_root, name)
       end
 
       private def find_project_root(content_dir : String) : String
@@ -111,6 +147,15 @@ module Hwaro
         unused = [] of String
         assets.each do |asset_path|
           basename = File.basename(asset_path)
+          # A non-UTF-8 basename (possible on Linux filesystems; APFS refuses
+          # them) cannot be matched against the UTF-8 scan corpus — building
+          # a PCRE2 Regex from it raises ArgumentError, which used to abort
+          # the whole command. Warn and leave the file alone rather than flag
+          # it unused and let `--delete` remove something we could not check.
+          unless basename.valid_encoding?
+            Logger.warn "Skipping #{asset_path.inspect}: file name is not valid UTF-8"
+            next
+          end
           next if referenced.includes?(basename)
           # Safety net against the `delete_unused` data-loss path: the
           # reference regex only captures filenames built from [\w\-.], so a
@@ -123,8 +168,7 @@ module Hwaro
           # a raw substring) still rescues the space/paren names while keeping a
           # genuinely-unused `header.png` flagged when only `page-header.png` is
           # referenced (their shared suffix is preceded by `-`, inside the token).
-          next if scanned_text.matches?(/(?<![\w\-.])#{Regex.escape(basename)}(?![\w\-.])/)
-          next if scanned_text.matches?(/(?<![\w\-.])#{Regex.escape(URI.encode_path(basename))}(?![\w\-.])/)
+          next if UnusedAssets.boundary_referenced?(scanned_text, basename)
           unused << asset_path
         end
 
@@ -134,6 +178,18 @@ module Hwaro
           referenced_count: assets.size - unused.size,
           unused_count: unused.size,
         )
+      end
+
+      # Boundary-anchored literal check backing the safety net above. A class
+      # method so it stays testable on filesystems (APFS) that refuse to
+      # create non-UTF-8 filenames at all. A basename that is not valid UTF-8
+      # cannot become a PCRE2 pattern — `Regex.new` raises `ArgumentError` —
+      # so it is reported as not-referenced here without raising; `run` skips
+      # (and warns about) such assets before this check is reached.
+      def self.boundary_referenced?(scanned_text : String, basename : String) : Bool
+        return false unless basename.valid_encoding?
+        return true if scanned_text.matches?(/(?<![\w\-.])#{Regex.escape(basename)}(?![\w\-.])/)
+        scanned_text.matches?(/(?<![\w\-.])#{Regex.escape(URI.encode_path(basename))}(?![\w\-.])/)
       end
 
       def delete_unused(files : Array(String))
@@ -222,11 +278,13 @@ module Hwaro
             sb << text << '\n'
           end
 
+          # config.toml goes through the same UTF-8 gate as every other scan
+          # source: concatenated raw, one invalid byte in it aborted the whole
+          # command with a PCRE2 ArgumentError.
           config_path = File.join(@project_root, "config.toml")
           if File.exists?(config_path)
-            begin
-              sb << File.read(config_path) << '\n'
-            rescue IO::Error
+            if text = readable_scan_source(config_path)
+              sb << text << '\n'
             end
           end
         end

--- a/src/utils/date_utils.cr
+++ b/src/utils/date_utils.cr
@@ -43,8 +43,10 @@ module Hwaro
 
         begin
           return Time.parse_rfc3339(str)
-        rescue Time::Format::Error
-          # Not RFC 3339; fall through to the lenient formats.
+        rescue Time::Format::Error | ArgumentError
+          # Time::Format::Error → not RFC 3339 at all. ArgumentError → the
+          # shape is RFC 3339 but the value is impossible ("2024-02-30").
+          # Either way, fall through to the lenient formats.
         end
 
         formats.each do |fmt|

--- a/src/utils/frontmatter_writer.cr
+++ b/src/utils/frontmatter_writer.cr
@@ -24,13 +24,45 @@ module Hwaro
       # a bare `YYYY-MM-DD`; genuine timestamps keep their own offset
       # (`to_rfc3339` would silently convert `08:00+09:00` to the previous
       # day's `23:00Z`).
+      #
+      # The bare-date shortcut applies only to a UTC or LOCAL-ZONE midnight —
+      # the shapes a parsed bare date actually takes (TOML parses one as
+      # local midnight, YAML as UTC midnight) — so authored bare dates
+      # round-trip unchanged through their own format. Note the UTC branch is
+      # deliberately lossy for an *authored* `...T00:00:00Z` timestamp when
+      # the file is later reparsed as TOML (local zone); that trade-off keeps
+      # YAML bare dates stable and predates this rule. A midnight with any
+      # other fixed offset is a genuine timestamp: collapsing it to
+      # `YYYY-MM-DD` silently shifted the instant, so it keeps its offset.
+      # Fractional seconds are preserved in both timestamp forms.
       def self.serialize_time(time : Time) : String
-        if time.hour == 0 && time.minute == 0 && time.second == 0 && time.nanosecond == 0
+        midnight = time.hour == 0 && time.minute == 0 && time.second == 0 && time.nanosecond == 0
+        if midnight && (time.offset == 0 || time.location == Time::Location.local)
           time.to_s("%Y-%m-%d")
         elsif time.offset == 0
-          time.to_rfc3339
+          time.to_rfc3339(fraction_digits: rfc3339_fraction_digits(time.nanosecond))
         else
-          time.to_s("%Y-%m-%dT%H:%M:%S%:z")
+          "#{time.to_s("%Y-%m-%dT%H:%M:%S")}#{second_fraction(time.nanosecond)}#{time.to_s("%:z")}"
+        end
+      end
+
+      # Fraction width for `to_rfc3339`, which only accepts 0/3/6/9 digits.
+      private def self.rfc3339_fraction_digits(nanosecond : Int32) : Int32
+        return 0 if nanosecond == 0
+        return 3 if nanosecond % 1_000_000 == 0
+        return 6 if nanosecond % 1_000 == 0
+        9
+      end
+
+      # `.NNN` suffix for the offset format, at the same widths RFC 3339 uses.
+      private def self.second_fraction(nanosecond : Int32) : String
+        return "" if nanosecond == 0
+        if nanosecond % 1_000_000 == 0
+          ".#{(nanosecond // 1_000_000).to_s.rjust(3, '0')}"
+        elsif nanosecond % 1_000 == 0
+          ".#{(nanosecond // 1_000).to_s.rjust(6, '0')}"
+        else
+          ".#{nanosecond.to_s.rjust(9, '0')}"
         end
       end
 


### PR DESCRIPTION
## Summary

A five-cluster stability audit of the `tool` subcommand family (importers, exporters/converter, check-links/platform, doctor/validate, list/stats/unused-assets/agents-md), followed by an adversarial review pass and a `/code-review high` pass whose findings are all addressed. Every fix ships with a regression spec that failed before the fix.

**Full suite: 8131 examples, 0 failures · ameba clean · `crystal tool format --check` clean.**

## Crash fixes (tool dies → tool degrades per file)

- **Invalid UTF-8** no longer aborts runs: importer `read_text`/WXR scrub at the choke points; `unused-assets` reads `config.toml` through the validated scan source; `stats` skips a bad body; `validate` reports encoding failures distinctly; platform alias scan rescues per file (PCRE2 `ArgumentError` class)
- **Symlink cycles** no longer ELOOP-abort `doctor` (content glob + template walk) or `tool platform` (alias walk); unreadable subdirectories are skipped with a warning in importers and the platform walk
- `date: 2024-02-30`-class RFC3339 values no longer raise out of `DateUtils.parse_lenient` (dropped posts / mispublished listings); Hugo `weight = 1e300/inf/nan` no longer OverflowErrors the file; Eleventy directory-shaped data files no longer abort the run
- HtmlToMarkdown: the genuinely quadratic `pre+code` pass is bounded (measured 141s → 9s at 2.4MB), the innermost-list rewrite fixes a real PCRE2 JIT-stack crash, with a linear tag-strip fallback for residual regex errors — normal-document output is byte-identical (spec-pinned)

## Correctness / data-safety

- `convert` writes through symlinks instead of destroying them; realpath failures count as errors, not silent "converted"
- `serialize_time` keeps fixed-offset midnights and fractional seconds (no more instant-shifting collapses); empty frontmatter round-trips cleanly in all six directions
- Jekyll export: non-string `title`/`date`/… are stringified instead of dropped; raw `date` interpolation (YAML injection) closed; `template→layout`/`draft→published` can't emit duplicate keys, and an authored `published: true` can't republish a draft
- Hugo export: renames are existing-key-wins and the blocked source key passes through (no silent loss); bundle-asset copy failures no longer desync counts
- Export fails the run (`HWARO_E_IO`) when any file errors, matching `convert`; importer partial-success leniency is documented as deliberate
- Exporters resolve-check destination dirs **and** files — a pre-existing symlink leaf inside the export tree can no longer route writes outside it (probed against the previous binary: it really clobbered the target)
- `unused-assets` resolves one coherent project root (content-dir's own project wins; explicit `--templates-dir` never re-rooted) — mixed-tree scans could feed `--delete` in-use files
- doctor `--fix` line scanners track TOML multi-line strings: bytes inside `"""…"""` can never be edited again; unparseable content files surface as issues instead of vanishing from the report
- AGENTS.md merge: marker matched as a heading line outside closed fences, annotated headings (`## Site-Specific Instructions (do not delete)`) still found, unclosed-fence fallback scans only from the open fence, `​```text` is not a fence closer — `--write --force` can no longer discard the user's section in these shapes

## check-links

- Raw-HTML external URLs are now actually checked (with the internal pass's template-syntax guard); titled/angle-bracket destinations too
- Identical URLs contacted once, results fanned out per occurrence (kills 429-driven flaky false positives)
- IDN hosts punycoded; 303 followed with GET; redirect failures report a `-1` sentinel so `--allow-status 301` can't bless a redirect loop; SSRF guard rebuilt on `Socket::IPAddress` predicates (IPv4-mapped IPv6 included); per-host DNS verdicts memoized; redirect chains capped at 3×`--timeout` (Int64 math)

## Verification

- Per-fix regression specs proven to fail pre-fix (fixer agents captured the failures before applying each change)
- Two independent adversarial reviewers over the diff; all 5 CONFIRMED counter-findings fixed in the same batch
- `/code-review high`: 10 findings → 9 fixed, 1 documented as deliberate (importer leniency), re-verified green
- `hwaro tool check-links` on `docs/` matches the pre-change baseline binary exactly (696 links, same 8 pre-existing dead)