### PR TITLE
fix(ux): dogfooding round — slugify word-welding, sass doctor checks, strict import/export args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+### Changed
+- **`slugify` treats word-joining punctuation as a separator instead of deleting it.** A slash, backslash, or Unicode dash (‐ – — ― −) between two words used to vanish and weld the words together — a `security/xss` tag published at `/tags/securityxss/`, a "CI/CD" heading anchored as `#cicd`, `2010–2020` became `201020` — while every slug convention (and hwaro's own filename slugifier in `hwaro new`) separates them. They now emit a hyphen: `/tags/security-xss/`, `#ci-cd`, `2010-2020`. Other punctuation (`.`, `&`, apostrophes, …) keeps the historical drop behavior, so only slugs containing these characters move; affected taxonomy URLs and heading anchors change on the next build
+
 ### Added
+- `hwaro doctor` diagnoses the two silent ways SCSS ships broken: a Zola-style root `sass/` directory (never scanned — hwaro compiles SCSS from `static/`) warns, and `.scss` entry files under `static/` while `[sass]` is disabled (they publish raw, so the compiled `.css` URLs 404) gets an advisory info. Issue ids `sass-dir-not-scanned` / `sass-disabled-with-sources` for `[doctor] ignore`
+- `hwaro tool import` / `hwaro tool export` reject a stray positional argument instead of silently dropping it — `hwaro tool import jekyll ./site ./dest` (the cp-style source/dest shape) used to import into `./content` while the named destination stayed empty; both now fail with `HWARO_E_USAGE` and point at `-o/--output`
 - Sass: static `calc()` folding (dart-sass simplification) — `calc(10px + 5px * 2)` → `20px`, `calc(9 / 21 * 100%)` → `42.8571428571%`, nested `calc`/`min`/`max`/`clamp` included; anything not fully foldable (`calc(100% - 20px)`, `var()`, interpolated `#{…}`) keeps its verbatim text
 - Sass: built-in functions accept their documented keyword names (`list.append($l, x, $separator: comma)`, `string.slice($string: …, $start-at: 2)`, `map.get($map: …, $key: …)`, `math.div($number1: …, $number2: …)`) — previously only the color functions did
 - Sass: dart-sass output formatting — a blank line only after each top-level rule's output group (not between every rule), selector lists keep the author's line structure (`.a, .b` stays on one line; a source line break before a selector is preserved through nesting resolution), and `@keyframes` blocks no longer carry internal blank lines

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -1671,3 +1671,86 @@ describe "Hwaro::Services::Doctor#fix_config temp files" do
     end
   end
 end
+
+describe "sass diagnostics" do
+  it "warns when SCSS files sit in a Zola-style root sass/ directory" do
+    Dir.mktmpdir do |dir|
+      config_path = File.join(dir, "config.toml")
+      File.write(config_path, %(title = "My Site"\nbase_url = "https://example.com"\n))
+      FileUtils.mkdir_p(File.join(dir, "sass"))
+      File.write(File.join(dir, "sass", "style.scss"), ".a { color: red; }")
+
+      issues = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path).run
+      issue = issues.find { |i| i.id == "sass-dir-not-scanned" }
+      issue.should_not be_nil
+      issue.not_nil!.level.should eq(:warning)
+    end
+  end
+
+  it "does not warn for an empty or SCSS-less sass/ directory" do
+    Dir.mktmpdir do |dir|
+      config_path = File.join(dir, "config.toml")
+      File.write(config_path, %(title = "My Site"\nbase_url = "https://example.com"\n))
+      FileUtils.mkdir_p(File.join(dir, "sass"))
+      File.write(File.join(dir, "sass", "notes.txt"), "not scss")
+
+      issues = Hwaro::Services::Doctor.new(content_dir: File.join(dir, "content"), config_path: config_path).run
+      issues.any? { |i| i.id == "sass-dir-not-scanned" }.should be_false
+    end
+  end
+
+  it "advises when static/ holds SCSS entries but [sass] is disabled" do
+    Dir.mktmpdir do |dir|
+      config_path = File.join(dir, "config.toml")
+      File.write(config_path, %(title = "My Site"\nbase_url = "https://example.com"\n))
+      static_dir = File.join(dir, "static", "css")
+      FileUtils.mkdir_p(static_dir)
+      File.write(File.join(static_dir, "style.scss"), ".a { color: red; }")
+      File.write(File.join(static_dir, "_partial.scss"), "$c: red;")
+
+      issues = Hwaro::Services::Doctor.new(
+        content_dir: File.join(dir, "content"),
+        config_path: config_path,
+        static_dir: File.join(dir, "static"),
+      ).run
+      issue = issues.find { |i| i.id == "sass-disabled-with-sources" }
+      issue.should_not be_nil
+      issue.not_nil!.level.should eq(:info)
+      issue.not_nil!.message.should contain("1 SCSS entry file(s)")
+    end
+  end
+
+  it "stays quiet when [sass] is enabled for static/ SCSS entries" do
+    Dir.mktmpdir do |dir|
+      config_path = File.join(dir, "config.toml")
+      File.write(config_path, %(title = "My Site"\nbase_url = "https://example.com"\n\n[sass]\nenabled = true\n))
+      static_dir = File.join(dir, "static", "css")
+      FileUtils.mkdir_p(static_dir)
+      File.write(File.join(static_dir, "style.scss"), ".a { color: red; }")
+
+      issues = Hwaro::Services::Doctor.new(
+        content_dir: File.join(dir, "content"),
+        config_path: config_path,
+        static_dir: File.join(dir, "static"),
+      ).run
+      issues.any? { |i| i.id == "sass-disabled-with-sources" }.should be_false
+    end
+  end
+
+  it "stays quiet when only partials sit under static/ with [sass] disabled" do
+    Dir.mktmpdir do |dir|
+      config_path = File.join(dir, "config.toml")
+      File.write(config_path, %(title = "My Site"\nbase_url = "https://example.com"\n))
+      static_dir = File.join(dir, "static", "css")
+      FileUtils.mkdir_p(static_dir)
+      File.write(File.join(static_dir, "_partial.scss"), "$c: red;")
+
+      issues = Hwaro::Services::Doctor.new(
+        content_dir: File.join(dir, "content"),
+        config_path: config_path,
+        static_dir: File.join(dir, "static"),
+      ).run
+      issues.any? { |i| i.id == "sass-disabled-with-sources" }.should be_false
+    end
+  end
+end

--- a/spec/unit/export_command_spec.cr
+++ b/spec/unit/export_command_spec.cr
@@ -44,6 +44,14 @@ describe Hwaro::CLI::Commands::Tool::ExportCommand do
       ex.message.to_s.should contain("unknown target type")
     end
 
+    it "rejects a second positional instead of silently exporting to the default directory" do
+      cmd = Hwaro::CLI::Commands::Tool::ExportCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["hugo", "/tmp/dest"]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): '/tmp/dest'")
+      ex.hint.to_s.should contain("--output")
+    end
+
     # Regression: `-o .` (and `-o ""`) used to resolve every destination back
     # onto the source file the exporter had just read, so the command rewrote
     # the project's own content/ in place — YAML front matter re-emitted as

--- a/spec/unit/import_command_spec.cr
+++ b/spec/unit/import_command_spec.cr
@@ -55,6 +55,17 @@ describe Hwaro::CLI::Commands::Tool::ImportCommand do
       ex.message.to_s.should contain("missing <path>")
     end
 
+    it "rejects a third positional instead of silently importing into ./content" do
+      # `hwaro tool import jekyll ./site ./dest` follows the cp-style
+      # source/dest convention; the extra positional used to be dropped and
+      # the import landed in the default output directory unannounced.
+      cmd = Hwaro::CLI::Commands::Tool::ImportCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["jekyll", "/tmp/x", "/tmp/dest"]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): '/tmp/dest'")
+      ex.hint.to_s.should contain("--output")
+    end
+
     it "includes a source-specific hint when nothing importable is found" do
       Dir.mktmpdir do |dir|
         # An empty directory: jekyll importer finds no _posts/, reports 0 items.

--- a/spec/unit/text_utils_spec.cr
+++ b/spec/unit/text_utils_spec.cr
@@ -102,6 +102,41 @@ describe Hwaro::Utils::TextUtils do
       # ㄱ is in Hangul Jamo range 0x1100-0x11FF
       Hwaro::Utils::TextUtils.slugify("ᄀᄁ test").should eq("ᄀᄁ-test")
     end
+
+    # Word-joining punctuation must separate, not vanish — dropping it
+    # welded the words together ("CI/CD" → "cicd", "security/xss" →
+    # "securityxss"), unlike every slug convention and Hwaro's own
+    # Creator.slugify for filenames.
+    it "treats a slash between words as a separator" do
+      Hwaro::Utils::TextUtils.slugify("CI/CD").should eq("ci-cd")
+      Hwaro::Utils::TextUtils.slugify("security/xss").should eq("security-xss")
+      Hwaro::Utils::TextUtils.slugify("a/b testing").should eq("a-b-testing")
+    end
+
+    it "treats a backslash as a separator" do
+      Hwaro::Utils::TextUtils.slugify("dir\\file").should eq("dir-file")
+    end
+
+    it "treats Unicode dashes as separators" do
+      Hwaro::Utils::TextUtils.slugify("보안—우회").should eq("보안-우회")               # em dash
+      Hwaro::Utils::TextUtils.slugify("2010–2020").should eq("2010-2020")       # en dash
+      Hwaro::Utils::TextUtils.slugify("non‑breaking").should eq("non-breaking") # U+2011
+      Hwaro::Utils::TextUtils.slugify("−5 degrees").should eq("5-degrees")      # minus sign, leading hyphen suppressed
+    end
+
+    it "collapses slash runs mixed with spaces" do
+      Hwaro::Utils::TextUtils.slugify("a / b // c").should eq("a-b-c")
+    end
+
+    it "still drops other interior punctuation" do
+      Hwaro::Utils::TextUtils.slugify("don't panic").should eq("dont-panic")
+      Hwaro::Utils::TextUtils.slugify("v1.2.3").should eq("v123")
+    end
+
+    it "returns empty for separator-only input" do
+      Hwaro::Utils::TextUtils.slugify("///").should eq("")
+      Hwaro::Utils::TextUtils.slugify("—").should eq("")
+    end
   end
 
   describe ".safe_slugify" do

--- a/src/cli/commands/tool/export_command.cr
+++ b/src/cli/commands/tool/export_command.cr
@@ -161,6 +161,17 @@ module Hwaro
 
             target_type = positional.shift? || ""
 
+            # Mirror `tool import`: a second positional is almost always an
+            # attempted destination directory, and silently dropping it wrote
+            # the export somewhere else. The output directory is `-o`.
+            unless positional.empty?
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "unexpected extra argument(s): '#{positional.join("', '")}'",
+                hint: "hwaro tool export takes <#{supported_targets}>. To choose the output directory, pass -o/--output DIR.",
+              )
+            end
+
             options = Config::Options::ExportOptions.new(
               target_type: target_type,
               output_dir: output_dir,

--- a/src/cli/commands/tool/import_command.cr
+++ b/src/cli/commands/tool/import_command.cr
@@ -207,6 +207,19 @@ module Hwaro
             source_type = positional.shift? || ""
             path = positional.shift? || ""
 
+            # A third positional is almost always an attempted destination
+            # (`hwaro tool import jekyll ./site ./dest` — the source/dest
+            # convention of cp and of `hwaro init <path>`). Silently dropping
+            # it imported into ./content while the user watched a directory
+            # they named stay empty; the output directory is `-o`.
+            unless positional.empty?
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_USAGE,
+                message: "unexpected extra argument(s): '#{positional.join("', '")}'",
+                hint: "hwaro tool import takes <source-type> <path>. To choose the output content directory, pass -o/--output DIR.",
+              )
+            end
+
             options = Config::Options::ImportOptions.new(
               source_type: source_type,
               path: path,

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -116,6 +116,8 @@ module Hwaro
             ["menu-parent-undefined"]),
           CheckSpec.new("referenced files & dirs",
             ["config-path-missing", "config-dir-missing"]),
+          CheckSpec.new("sass (sources & enablement)",
+            ["sass-dir-not-scanned", "sass-disabled-with-sources"]),
         ],
         blocked_by: CONFIG_BLOCKING_IDS,
       ),
@@ -220,7 +222,10 @@ module Hwaro
         check_templates(issues)
         check_directory_structure(issues, config)
         check_content_frontmatter(issues, config)
-        check_referenced_paths(issues, config) if config
+        if config
+          check_referenced_paths(issues, config)
+          check_sass(issues, config)
+        end
         @observed_blocking_ids = issues.map(&.id).to_set & ALL_BLOCKING_IDS
 
         ignore = config.try(&.doctor.ignore) || [] of String
@@ -1393,6 +1398,49 @@ module Hwaro
                 message: "#{label_prefix} files[#{f_idx}]: #{file} — file not found under #{source_dir.empty? ? "(repo root)" : source_dir}/",
               )
             end
+          end
+        end
+      end
+
+      # [sass] pitfalls that build and serve stay silent about: SCSS sources
+      # in a directory the compiler never scans, or sources in the right
+      # place with compilation left off. Both ship a site whose stylesheet
+      # URLs silently 404 — worth a diagnostic here since no build phase
+      # ever touches the files.
+      private def check_sass(issues : Array(Issue), config : Models::Config)
+        glob = File::MatchOptions.glob_default | File::MatchOptions::DotFiles
+
+        # Zola keeps SCSS under a root `sass/` directory, so that's where
+        # migrating users put it. Hwaro compiles from `static/`
+        # (features/sass) and never scans `sass/`. Anchored next to
+        # config.toml rather than the CWD so a doctor run pointed at
+        # another project (-i / spec temp dirs) inspects that project.
+        sass_dir = File.join(File.dirname(@config_path), "sass")
+        if Dir.exists?(sass_dir) && Dir.glob(File.join(sass_dir, "**", "*.scss"), match: glob).any? { |p| File.file?(p) }
+          issues << Issue.new(
+            id: "sass-dir-not-scanned",
+            level: :warning,
+            category: "config",
+            file: "sass/",
+            message: "SCSS files found under sass/, which Hwaro never scans — SCSS sources belong under #{@static_dir}/ (e.g. #{@static_dir}/css/style.scss). Move them there (see features/sass).",
+          )
+        end
+
+        # Entry files under static/ while [sass] is disabled: the raw
+        # `.scss` publishes verbatim and any `<link>` to the compiled
+        # `.css` 404s. Shipping raw sources can be deliberate (the bundles
+        # escape hatch), so this stays advisory.
+        unless config.sass.enabled
+          entries = Dir.glob(File.join(@static_dir, "**", "*.scss"), match: glob)
+            .select { |p| File.file?(p) && !File.basename(p).starts_with?("_") }
+          unless entries.empty?
+            issues << Issue.new(
+              id: "sass-disabled-with-sources",
+              level: :info,
+              category: "config",
+              file: entries.first,
+              message: "#{entries.size} SCSS entry file(s) under #{@static_dir}/ but [sass] is not enabled — they publish as raw .scss. Add a [sass] section with enabled = true to compile them to .css (see features/sass).",
+            )
           end
         end
       end

--- a/src/utils/text_utils.cr
+++ b/src/utils/text_utils.cr
@@ -305,6 +305,8 @@ module Hwaro
       #   slugify("한글 제목")      # => "한글-제목"
       #   slugify("CJK 테스트!")   # => "cjk-테스트"
       #   slugify("日本語　テスト") # => "日本語-テスト"  (U+3000)
+      #   slugify("CI/CD")         # => "ci-cd"
+      #   slugify("보안—우회")      # => "보안-우회"  (em dash)
       #
       def slugify(text : String) : String
         # Single-pass: directly emit hyphens for separators, collapsing runs.
@@ -320,7 +322,7 @@ module Hwaro
             if char.ascii_letter? || char.ascii_number?
               io << char.downcase
               last_was_sep = false
-            elsif char.whitespace? || char == '-' || char == '_'
+            elsif char.whitespace? || char == '-' || char == '_' || slug_separator?(char)
               unless last_was_sep
                 io << '-'
                 last_was_sep = true
@@ -332,6 +334,19 @@ module Hwaro
             # All other characters (punctuation, symbols) are dropped
           end
         end.rstrip('-')
+      end
+
+      # Punctuation that joins two words WITHOUT surrounding spaces and so
+      # must become a hyphen rather than vanish. Dropping these welded the
+      # words together: "CI/CD" → "cicd", "security/xss" → "securityxss",
+      # "보안—우회" → "보안우회" — while every slug convention (and Hwaro's own
+      # `Creator.slugify` for filenames) separates them ("ci-cd").
+      # Deliberately narrow: slash, backslash, and the Unicode dash block
+      # (hyphen U+2010 … horizontal bar U+2015) plus minus sign U+2212.
+      # Other punctuation ('.', '&', apostrophes, …) keeps the historical
+      # drop behavior so existing heading anchors and term URLs don't move.
+      private def slug_separator?(char : Char) : Bool
+        char == '/' || char == '\\' || char.in?('‐'..'―') || char == '−'
       end
 
       # Longest slug `safe_slugify` returns, in bytes.


### PR DESCRIPTION
## Summary

Built a fresh binary and exercised `init`/`build`/`serve`/`new`/`doctor`/the `tool` family/importers/sass/multilingual/OG images end to end on scaffolded sites. Three issues found and fixed:

### 1. `slugify` welded words joined by a slash or dash
A slash, backslash, or Unicode dash (‐ – — ― −) between two words was dropped outright, welding the words together:
- `security/xss` tag → `/tags/securityxss/`
- "CI/CD" heading → `#cicd`
- `2010–2020` → `201020`

These now emit a hyphen (`/tags/security-xss/`, `#ci-cd`, `2010-2020`), matching `Creator.slugify` (the filename slugifier `hwaro new` already uses) and common slug conventions. Other punctuation (`.`, `&`, apostrophes, …) keeps the historical drop behavior so existing anchors and term URLs don't move. **Behavior change:** slugs containing these characters move on the next build — noted under `### Changed` in the CHANGELOG.

### 2. `hwaro doctor` diagnoses the two silent ways SCSS ships broken
- A Zola-style root `sass/` directory is never scanned (hwaro compiles SCSS from `static/`) → warning `sass-dir-not-scanned`
- `.scss` entry files under `static/` while `[sass]` is disabled publish raw, so the compiled `.css` URLs 404 → advisory `sass-disabled-with-sources`

Both ids work with `[doctor] ignore`.

### 3. `tool import` / `tool export` silently dropped a stray positional
`hwaro tool import jekyll ./site ./dest` (the cp-style source/dest shape) imported into `./content` while the named destination stayed empty. Both commands now raise `HWARO_E_USAGE` pointing at `-o/--output`, matching the rejection `init`/`new` already do.

## Test plan
- [x] `crystal spec` — 8,162 examples, 0 failures
- [x] `just fix` (format + ameba) — 506 inspected, 0 failures
- [x] Re-ran the dogfooding scenarios against the rebuilt binary: `security/xss` publishes at `/tags/security-xss/` consistently across post links, tag dir, and sitemap; doctor fires both sass diagnostics; `tool import` with a third positional errors with the `-o` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)