### PR TITLE
fix(action): honor the output_dir input, and run the image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
       - shard.yml
       - shard.lock
       - docker/Dockerfile
+      # The image smoke test in build-docker exercises these two, so a PR that
+      # touches only them still has to run it — otherwise the job that exists
+      # to catch entrypoint/action regressions is skipped on exactly the PRs
+      # that can introduce one, and the failure lands on main instead.
+      - docker/entrypoint.sh
+      - action.yml
       - "**/*.cr"
   push:
     branches: [main]
@@ -59,11 +65,54 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: false
-          tags: ${{ steps.meta.outputs.tags }}
+          # A fixed local tag (rather than the metadata tags) so the smoke test
+          # below has a deterministic name to run. `load: true` puts the image
+          # in the runner's docker daemon; each matrix arch builds natively, so
+          # the single-platform load is valid.
+          load: true
+          tags: hwaro:ci
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.arch }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+      # Building the image proves it compiles; it does not prove it runs. The
+      # builder and the runner stage are different distros, so a glibc or
+      # SONAME mismatch (or a missing stage-package) surfaces only on `docker
+      # run` — which, without this, first happened in a user's workflow because
+      # this image is exactly what the composite action executes.
+      - name: Smoke test the image
+        env:
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+
+          # Both containers below run as uid 0 into the bind mount, so the tree
+          # comes out root-owned. Harmless on ephemeral hosted runners, but it
+          # would break the next run's checkout cleanup on a self-hosted one.
+          # Trap rather than a trailing rm so a failed assertion still cleans up.
+          trap 'sudo rm -rf smoke' EXIT
+
+          # 1. The binary links and starts.
+          docker run --rm hwaro:ci --version
+
+          # 2. Without GITHUB_ACTIONS the entrypoint passes through to the CLI.
+          mkdir -p smoke
+          docker run --rm -v "$PWD/smoke":/w -w /w hwaro:ci init --scaffold blog -q
+
+          # 3. With GITHUB_ACTIONS set, run the real action path end to end.
+          #    OUT_DIR is deliberately not the default, so this also covers the
+          #    build writing where the deploy step will look for it.
+          docker run --rm -v "$PWD/smoke":/github/workspace -w /github/workspace \
+            -e GITHUB_ACTIONS=true \
+            -e GITHUB_REPOSITORY="$REPO" \
+            -e GITHUB_ACTOR="$ACTOR" \
+            -e BUILD_ONLY=true \
+            -e OUT_DIR=dist \
+            hwaro:ci
+
+          test -f smoke/dist/index.html
+          echo "Smoke test passed."
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -113,9 +113,27 @@ main() {
         BUILD_FLAGS="--cache"
     fi
 
+    # The deploy step below publishes whatever is in "$OUT_DIR", so the build
+    # has to write there. Without this, the `output_dir` input was accepted and
+    # then ignored: the build wrote to hwaro's own default and deploy died on
+    # `cd "$OUT_DIR"`, while build_only runs exited 0 having produced nothing
+    # at the declared path.
+    #
+    # `-o` is appended last rather than the flags being rewritten, which relies
+    # on hwaro's OptionParser letting the last occurrence win (see the -o/-i
+    # handling in src/cli/commands/build_command.cr). That keeps the build
+    # output and the deploy source the same directory by construction even when
+    # build_flags carries its own -o.
+    #
+    # The pattern matches the glued short form too (`-odist`), which hwaro
+    # accepts — matching only `-o<space>` would skip the note for that spelling.
+    if [[ " $BUILD_FLAGS " =~ [[:space:]](-o[^[:space:]]*|--output)([[:space:]=]|$) ]]; then
+        echo "Note: -o/--output in build_flags is overridden; the output_dir input (${OUT_DIR}) is what gets deployed."
+    fi
+
     # Build the site
-    echo "Building with flags: ${BUILD_FLAGS:-(none)}"
-    hwaro build $BUILD_FLAGS
+    echo "Building with flags: ${BUILD_FLAGS:-(none)} -o ${OUT_DIR}"
+    hwaro build $BUILD_FLAGS -o "$OUT_DIR"
 
     if [[ "$BUILD_ONLY" == "true" ]]; then
         echo "✅ Build complete. Deployment skipped by request."


### PR DESCRIPTION
Pre-release check of 0.19.0 for GitHub Actions impact. The release itself is clean — this fixes the two gaps that check turned up.

## What was checked (and is fine)

- **`-Dpreview_mt` removal.** Verified on Crystal 1.21.0 that the default context is `Fiber::ExecutionContext::Parallel`, `resize()` works with no preview flag, and `CRYSTAL_WORKERS` feeds `default_workers_count`. The docs site builds at 440% CPU natively and 140 pages in ~5s inside the container, with no hang at exit. No build path still passes the flag.
- **Crystal >= 1.21.** `shard.yml`, `docker/Dockerfile` and `release-binary.yml` agree. deb/rpm/apk/AUR/Homebrew consume the prebuilt binary; snapcraft installs latest Crystal via `install.sh`. None are affected.
- **Entrypoint CLI surface.** `hwaro --version` and `hwaro build --cache` are unchanged; the common `build_flags` combinations all exit 0.
- **GHCR tag resolution and the release trigger chain** line up for `v0.19.0`.

## What this PR fixes

### 1. `output_dir` was accepted and ignored

`action.yml` documents `output_dir` and passes it as `OUT_DIR`, but the entrypoint never gave it to `hwaro build`. The build wrote to hwaro's default while the deploy step published `$OUT_DIR`:

| | before | after |
|---|---|---|
| `output_dir: dist` + deploy | `cd dist` -> **exit 1** | builds to `dist`, deploy proceeds |
| `output_dir: dist` + `build_only` | exit 0, nothing at the declared path | `dist/index.html` |
| default (`public`) | worked | unchanged |
| `build_flags: "-o custom"` | build/deploy disagree | note printed, `output_dir` wins |

`-o` is appended last, relying on hwaro's OptionParser last-occurrence-wins, so build output and deploy source are the same directory by construction. The detection covers the glued `-oDIR` spelling that hwaro also accepts.

### 2. CI built the image but never ran it

The builder and runner stages are different distros, so a glibc/SONAME mismatch — the kind the `crystallang/crystal:1.20.0` -> `1.21.0` bump could have introduced — would have first surfaced in a user's workflow, since this image is exactly what the composite action runs.

Adds a three-step smoke test (version / CLI passthrough / full `GITHUB_ACTIONS` path) that also asserts the `output_dir` fix, and extends the `pull_request` paths filter so PRs touching `docker/entrypoint.sh` or `action.yml` actually run it — without that, this PR's own entrypoint change would have skipped the job guarding it.

## Verification

Built the real image locally (arm64, 221MB) and ran the exact smoke sequence: `--version` -> `0.19.0`, `init --scaffold blog` passthrough, full action path with `OUT_DIR=dist` producing `dist/index.html`, default `OUT_DIR` unchanged, and deploy mode reaching `git init` in `/github/workspace/dist` (failing only on a deliberately unresolvable host). No `.cr` files change, so ameba is unaffected.

## Follow-up, not in this PR

`docs/content/start/config.md` (lines 57/67/313, plus the `.ko.md` twins) documents `[build] output_dir` as a supported setting, but `Config::Loader.load_build` reads only `template_deps` and `hooks` and `BuildConfig` has no such property. It is documented and unimplemented — pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)