### PR TITLE
feat(config): implement the documented [build] output_dir/drafts/parallel/cache

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -131,6 +131,31 @@ main() {
         echo "Note: -o/--output in build_flags is overridden; the output_dir input (${OUT_DIR}) is what gets deployed."
     fi
 
+    # `[build] output_dir` in config.toml loses to the flag above, which would
+    # otherwise make the config key look effective while the action quietly
+    # built somewhere else. Say so. Deliberately a heuristic — it reads the
+    # `[build]` table only, and an exotic spelling (inline table, quoted key)
+    # just means no note, never a wrong build.
+    if [[ -f config.toml ]]; then
+        config_out=$(awk '
+            /^[[:space:]]*\[/ { in_build = ($0 ~ /^[[:space:]]*\[build\][[:space:]]*$/); next }
+            in_build && /^[[:space:]]*output_dir[[:space:]]*=/ {
+                line = $0
+                sub(/^[^=]*=[[:space:]]*/, "", line)
+                sub(/[[:space:]]*#.*$/, "", line)
+                sub(/[[:space:]]+$/, "", line)
+                # One quote at each end, never `["'\'']. *$` — that alternative
+                # wins leftmost-longest and eats the whole value.
+                gsub(/^["'\'']|["'\'']$/, "", line)
+                print line
+                exit
+            }
+        ' config.toml 2>/dev/null)
+        if [[ -n "$config_out" && "$config_out" != "$OUT_DIR" ]]; then
+            echo "Note: config.toml sets [build] output_dir = \"${config_out}\", but this action builds and deploys \"${OUT_DIR}\". Set the action's output_dir input to \"${config_out}\" to use it."
+        fi
+    fi
+
     # Build the site
     echo "Building with flags: ${BUILD_FLAGS:-(none)} -o ${OUT_DIR}"
     hwaro build $BUILD_FLAGS -o "$OUT_DIR"

--- a/docs/content/start/config.ko.md
+++ b/docs/content/start/config.ko.md
@@ -80,7 +80,9 @@ hooks.post = ["npm run minify"]
 
 즉 `hwaro build -o dist`는 config의 `output_dir`를 덮어쓰고, `drafts = false`여도 `hwaro build --drafts`를 쓰면 초안이 포함됩니다. 반대 방향은 없습니다 — config 값을 다시 끄는 `--no-drafts`나 `--no-cache`는 존재하지 않으므로, 모든 빌드에 항상 적용할 때만 이 키들을 켜세요. `--no-parallel`만 예외로, `parallel = true`를 덮어씁니다.
 
-이 설정들은 `hwaro serve`에도 적용됩니다. serve는 `output_dir`로 빌드하고 그 디렉터리를 서빙합니다.
+이 설정들은 `hwaro serve`에도 적용됩니다. serve는 `output_dir`로 빌드하고 그 디렉터리를 서빙합니다. `hwaro deploy`도 이를 따릅니다 — `[deployment] source_dir`가 설정되지 않았다면 `public`을 가정하지 않고 `output_dir`를 배포합니다.
+
+`output_dir`에는 프로젝트 상대 경로와 절대 경로를 모두 쓸 수 있습니다. 프로젝트 밖으로 벗어나는 경로(`../out`)는 거부됩니다. 개발 서버가 프로젝트 밖에서는 서빙하지 않기 때문에, 그대로 두면 빌드는 serve가 읽지 않는 곳에 결과를 쓰게 됩니다.
 
 오류 처리와 활용 사례는 [빌드 훅](/ko/features/build-hooks/)을 참고합니다.
 

--- a/docs/content/start/config.ko.md
+++ b/docs/content/start/config.ko.md
@@ -68,8 +68,19 @@ hooks.post = ["npm run minify"]
 | drafts | bool | false | 초안 콘텐츠 포함 |
 | parallel | bool | true | 병렬 처리 |
 | cache | bool | false | 빌드 캐시 사용 |
+| template_deps | bool | true | 템플릿 의존성을 추적해 템플릿 편집 시 해당 템플릿을 렌더링하는 페이지만 재빌드 |
 | hooks.pre | array | [] | 빌드 전에 실행할 명령 |
 | hooks.post | array | [] | 빌드 후에 실행할 명령 |
+
+`output_dir`, `drafts`, `parallel`, `cache`는 각각 `hwaro build` 플래그에 대응하며, 플래그가 우선합니다.
+
+```
+명령줄 플래그  >  config.toml  >  기본값
+```
+
+즉 `hwaro build -o dist`는 config의 `output_dir`를 덮어쓰고, `drafts = false`여도 `hwaro build --drafts`를 쓰면 초안이 포함됩니다. 반대 방향은 없습니다 — config 값을 다시 끄는 `--no-drafts`나 `--no-cache`는 존재하지 않으므로, 모든 빌드에 항상 적용할 때만 이 키들을 켜세요. `--no-parallel`만 예외로, `parallel = true`를 덮어씁니다.
+
+이 설정들은 `hwaro serve`에도 적용됩니다. serve는 `output_dir`로 빌드하고 그 디렉터리를 서빙합니다.
 
 오류 처리와 활용 사례는 [빌드 훅](/ko/features/build-hooks/)을 참고합니다.
 

--- a/docs/content/start/config.md
+++ b/docs/content/start/config.md
@@ -68,8 +68,19 @@ hooks.post = ["npm run minify"]
 | drafts | bool | false | Include draft content |
 | parallel | bool | true | Parallel processing |
 | cache | bool | false | Enable build caching |
+| template_deps | bool | true | Track template dependencies so a template edit only rebuilds the pages that render it |
 | hooks.pre | array | [] | Commands to run before build |
 | hooks.post | array | [] | Commands to run after build |
+
+`output_dir`, `drafts`, `parallel` and `cache` each back a `hwaro build` flag, and the flag wins:
+
+```
+command-line flag  >  config.toml  >  built-in default
+```
+
+So `hwaro build -o dist` overrides `output_dir` in config, and `hwaro build --drafts` still includes drafts when `drafts = false`. The reverse does not exist — there is no `--no-drafts` or `--no-cache` to turn a config value back off, so set those keys only when you want them on for every build. `--no-parallel` is the one exception, and it overrides `parallel = true`.
+
+These apply to `hwaro serve` as well, which builds into (and serves from) `output_dir`.
 
 See [Build Hooks](/features/build-hooks/) for error handling and use cases.
 

--- a/docs/content/start/config.md
+++ b/docs/content/start/config.md
@@ -80,7 +80,9 @@ command-line flag  >  config.toml  >  built-in default
 
 So `hwaro build -o dist` overrides `output_dir` in config, and `hwaro build --drafts` still includes drafts when `drafts = false`. The reverse does not exist — there is no `--no-drafts` or `--no-cache` to turn a config value back off, so set those keys only when you want them on for every build. `--no-parallel` is the one exception, and it overrides `parallel = true`.
 
-These apply to `hwaro serve` as well, which builds into (and serves from) `output_dir`.
+These apply to `hwaro serve` as well, which builds into (and serves from) `output_dir`. `hwaro deploy` follows it too: when `[deployment] source_dir` is not set, it deploys `output_dir` rather than assuming `public`.
+
+`output_dir` may be relative to the project or absolute. A path that escapes the project (`../out`) is refused, because the dev server will not serve from outside the project and the build would otherwise write somewhere serve never reads.
 
 See [Build Hooks](/features/build-hooks/) for error handling and use cases.
 

--- a/spec/unit/build_command_spec.cr
+++ b/spec/unit/build_command_spec.cr
@@ -5,11 +5,10 @@ describe Hwaro::CLI::Commands::BuildCommand do
   describe "#parse_options" do
     it "returns default options" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, input_dir = cmd.parse_options([] of String)
-      options, output_dir_explicit = result
+      options, input_dir = cmd.parse_options([] of String)
 
       input_dir.should be_nil
-      output_dir_explicit.should be_false
+      options.output_dir_explicit.should be_false
       options.output_dir.should eq("public")
       options.base_url.should be_nil
       options.drafts.should be_false
@@ -27,21 +26,18 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
     it "parses output directory" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["--output", "dist"])
-      options, output_dir_explicit = result
+      options, _ = cmd.parse_options(["--output", "dist"])
       options.output_dir.should eq("dist")
-      output_dir_explicit.should be_true
+      options.output_dir_explicit.should be_true
 
-      result, _ = cmd.parse_options(["-o", "out"])
-      options, output_dir_explicit = result
+      options, _ = cmd.parse_options(["-o", "out"])
       options.output_dir.should eq("out")
-      output_dir_explicit.should be_true
+      options.output_dir_explicit.should be_true
     end
 
     it "parses base url" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["--base-url", "https://example.com"])
-      options, _ = result
+      options, _ = cmd.parse_options(["--base-url", "https://example.com"])
       options.base_url.should eq("https://example.com")
     end
 
@@ -64,7 +60,7 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
     it "parses boolean flags" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options([
+      options, _ = cmd.parse_options([
         "--drafts",
         "--minify",
         "--cache",
@@ -72,7 +68,6 @@ describe Hwaro::CLI::Commands::BuildCommand do
         "--profile",
         "--debug",
       ])
-      options, _ = result
 
       options.drafts.should be_true
       options.minify.should be_true
@@ -84,8 +79,7 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
     it "parses short boolean flags" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["-d", "-v"])
-      options, _ = result
+      options, _ = cmd.parse_options(["-d", "-v"])
 
       options.drafts.should be_true
       options.verbose.should be_true
@@ -93,8 +87,7 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
     it "parses negative flags" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["--no-parallel", "--skip-highlighting"])
-      options, _ = result
+      options, _ = cmd.parse_options(["--no-parallel", "--skip-highlighting"])
 
       options.parallel.should be_false
       options.highlight.should be_false
@@ -102,16 +95,14 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
     it "parses --jobs into the worker count" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["--jobs", "2"])
-      options, _ = result
+      options, _ = cmd.parse_options(["--jobs", "2"])
       options.workers.should eq(2)
     end
 
     it "warns that --jobs is ignored when combined with --no-parallel" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
       log = with_captured_log do
-        result, _ = cmd.parse_options(["--no-parallel", "--jobs", "4"])
-        options, _ = result
+        options, _ = cmd.parse_options(["--no-parallel", "--jobs", "4"])
         options.parallel.should be_false
         options.workers.should eq(4)
       end
@@ -140,47 +131,41 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
     it "defaults skip_og_image to false" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options([] of String)
-      options, _ = result
+      options, _ = cmd.parse_options([] of String)
       options.skip_og_image.should be_false
     end
 
     it "parses --skip-og-image flag" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["--skip-og-image"])
-      options, _ = result
+      options, _ = cmd.parse_options(["--skip-og-image"])
       options.skip_og_image.should be_true
     end
 
     it "defaults skip_image_processing to false" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options([] of String)
-      options, _ = result
+      options, _ = cmd.parse_options([] of String)
       options.skip_image_processing.should be_false
     end
 
     it "parses --skip-image-processing flag" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["--skip-image-processing"])
-      options, _ = result
+      options, _ = cmd.parse_options(["--skip-image-processing"])
       options.skip_image_processing.should be_true
     end
 
     it "parses mixed flags" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["-o", "build", "--drafts", "--base-url", "http://localhost:3000"])
-      options, output_dir_explicit = result
+      options, _ = cmd.parse_options(["-o", "build", "--drafts", "--base-url", "http://localhost:3000"])
 
       options.output_dir.should eq("build")
       options.drafts.should be_true
       options.base_url.should eq("http://localhost:3000")
-      output_dir_explicit.should be_true
+      options.output_dir_explicit.should be_true
     end
 
     it "parses input directory" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, input_dir = cmd.parse_options(["-i", "/tmp/my-site"])
-      options, _ = result
+      options, input_dir = cmd.parse_options(["-i", "/tmp/my-site"])
 
       input_dir.should eq("/tmp/my-site")
       options.output_dir.should eq("public")
@@ -188,26 +173,23 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
     it "parses input directory with long flag" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, input_dir = cmd.parse_options(["--input", "/tmp/my-site"])
-      _, _ = result
+      _, input_dir = cmd.parse_options(["--input", "/tmp/my-site"])
 
       input_dir.should eq("/tmp/my-site")
     end
 
     it "parses input and output together" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, input_dir = cmd.parse_options(["-i", "/tmp/my-site", "-o", "dist"])
-      options, output_dir_explicit = result
+      options, input_dir = cmd.parse_options(["-i", "/tmp/my-site", "-o", "dist"])
 
       input_dir.should eq("/tmp/my-site")
       options.output_dir.should eq("dist")
-      output_dir_explicit.should be_true
+      options.output_dir_explicit.should be_true
     end
 
     it "parses --stream flag" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["--stream"])
-      options, _ = result
+      options, _ = cmd.parse_options(["--stream"])
 
       options.stream.should be_true
       options.streaming?.should be_true
@@ -215,8 +197,7 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
     it "parses --memory-limit flag" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["--memory-limit", "512M"])
-      options, _ = result
+      options, _ = cmd.parse_options(["--memory-limit", "512M"])
 
       options.memory_limit.should eq("512M")
       options.streaming?.should be_true
@@ -224,8 +205,7 @@ describe Hwaro::CLI::Commands::BuildCommand do
 
     it "parses --stream with --memory-limit" do
       cmd = Hwaro::CLI::Commands::BuildCommand.new
-      result, _ = cmd.parse_options(["--stream", "--memory-limit", "2G"])
-      options, _ = result
+      options, _ = cmd.parse_options(["--stream", "--memory-limit", "2G"])
 
       options.stream.should be_true
       options.memory_limit.should eq("2G")
@@ -236,8 +216,7 @@ describe Hwaro::CLI::Commands::BuildCommand do
       ENV["HWARO_MEMORYLIMIT"] = "1G"
       begin
         cmd = Hwaro::CLI::Commands::BuildCommand.new
-        result, _ = cmd.parse_options([] of String)
-        options, _ = result
+        options, _ = cmd.parse_options([] of String)
 
         options.memory_limit.should eq("1G")
         options.streaming?.should be_true
@@ -268,8 +247,7 @@ describe Hwaro::CLI::Commands::BuildCommand do
       ENV["HWARO_MEMORYLIMIT"] = "1G"
       begin
         cmd = Hwaro::CLI::Commands::BuildCommand.new
-        result, _ = cmd.parse_options(["--memory-limit", "2G"])
-        options, _ = result
+        options, _ = cmd.parse_options(["--memory-limit", "2G"])
 
         options.memory_limit.should eq("2G")
       ensure

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -1482,6 +1482,135 @@ describe Hwaro::Models::Config do
 
       config.build.output_dir.should be_nil
     end
+
+    # The dev server refuses to serve from outside the project, so honouring a
+    # `..` path would leave serve building one tree and serving another.
+    it "ignores a [build] output_dir that escapes the project" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = "../escape"
+        TOML
+
+      config.build.output_dir.should be_nil
+    end
+
+    it "keeps an absolute [build] output_dir" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = "/srv/www/site"
+        TOML
+
+      config.build.output_dir.should eq("/srv/www/site")
+    end
+
+    # Quoting a bool is an easy TOML slip; treating it as absent would leave
+    # the setting off with no feedback at all.
+    it "ignores non-boolean [build] booleans rather than silently no-opping" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        drafts = "true"
+        parallel = 1
+        cache = "yes"
+        TOML
+
+      config.build.drafts.should be_nil
+      config.build.parallel.should be_nil
+      config.build.cache.should be_nil
+    end
+
+    it "ignores a non-string [build] output_dir" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = 42
+        TOML
+
+      config.build.output_dir.should be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # [deployment] source_dir follows [build] output_dir
+  # ---------------------------------------------------------------------------
+
+  describe "deployment source_dir" do
+    it "defaults to public when neither section says otherwise" do
+      load_config(%(title = "Test")).deployment.source_dir.should eq("public")
+    end
+
+    # Both keys default to "public" independently, so without the fallback a
+    # site building into dist/ would have deploy reading a stale public/.
+    it "follows [build] output_dir when no [deployment] section exists" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = "dist"
+        TOML
+
+      config.deployment.source_dir.should eq("dist")
+    end
+
+    it "follows [build] output_dir when [deployment] omits source_dir" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = "dist"
+
+        [deployment]
+        max_deletes = 10
+        TOML
+
+      config.deployment.source_dir.should eq("dist")
+    end
+
+    it "keeps an explicit [deployment] source_dir over [build] output_dir" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = "dist"
+
+        [deployment]
+        source_dir = "explicit"
+        TOML
+
+      config.deployment.source_dir.should eq("explicit")
+    end
+
+    it "keeps the [deployment] source alias over [build] output_dir" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = "dist"
+
+        [deployment]
+        source = "aliased"
+        TOML
+
+      config.deployment.source_dir.should eq("aliased")
+    end
+
+    # A rejected output_dir must not drag deploy off "public" with it.
+    it "stays at public when [build] output_dir was rejected" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = "../escape"
+        TOML
+
+      config.deployment.source_dir.should eq("public")
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -1436,6 +1436,138 @@ describe Hwaro::Models::Config do
       config.build.hooks.pre.should eq(["npm ci", "npx tsc"])
       config.build.hooks.post.should eq(["./deploy.sh"])
     end
+
+    it "leaves the flag-backed keys nil when [build] omits them" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        template_deps = false
+        TOML
+
+      # Nil is what lets BuildOptions#apply_build_config! keep its hands off a
+      # field the command line or the defaults already settled.
+      config.build.output_dir.should be_nil
+      config.build.drafts.should be_nil
+      config.build.parallel.should be_nil
+      config.build.cache.should be_nil
+    end
+
+    it "loads output_dir, drafts, parallel and cache from [build]" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = "dist"
+        drafts = true
+        parallel = false
+        cache = true
+        TOML
+
+      config.build.output_dir.should eq("dist")
+      config.build.drafts.should be_true
+      # `false` must survive as false, not collapse to nil — the whole point of
+      # the key is to turn parallel rendering off.
+      config.build.parallel.should be_false
+      config.build.cache.should be_true
+    end
+
+    it "ignores a blank [build] output_dir instead of aiming the build at the site root" do
+      config = load_config(<<-TOML)
+        title = "Test"
+
+        [build]
+        output_dir = "   "
+        TOML
+
+      config.build.output_dir.should be_nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # [build] -> BuildOptions merge (CLI flag > config.toml > built-in default)
+  # ---------------------------------------------------------------------------
+
+  describe "BuildOptions#apply_build_config!" do
+    it "fills fields the command line left at their defaults" do
+      build = Hwaro::Models::BuildConfig.new
+      build.output_dir = "dist"
+      build.drafts = true
+      build.parallel = false
+      build.cache = true
+
+      options = Hwaro::Config::Options::BuildOptions.new
+      options.apply_build_config!(build)
+
+      options.output_dir.should eq("dist")
+      options.drafts.should be_true
+      options.parallel.should be_false
+      options.cache.should be_true
+    end
+
+    it "keeps an explicit -o over [build] output_dir" do
+      build = Hwaro::Models::BuildConfig.new
+      build.output_dir = "dist"
+
+      options = Hwaro::Config::Options::BuildOptions.new(output_dir: "cli")
+      options.output_dir_explicit = true
+      options.apply_build_config!(build)
+
+      options.output_dir.should eq("cli")
+    end
+
+    # `-o public` is indistinguishable from the default by value alone, which
+    # is why explicitness is tracked rather than inferred.
+    it "keeps an explicit -o even when it names the default directory" do
+      build = Hwaro::Models::BuildConfig.new
+      build.output_dir = "dist"
+
+      options = Hwaro::Config::Options::BuildOptions.new(output_dir: "public")
+      options.output_dir_explicit = true
+      options.apply_build_config!(build)
+
+      options.output_dir.should eq("public")
+    end
+
+    it "keeps CLI flags that moved a boolean off its default" do
+      build = Hwaro::Models::BuildConfig.new
+      build.drafts = false
+      build.parallel = true
+      build.cache = false
+
+      # As if --drafts --cache --no-parallel were all passed.
+      options = Hwaro::Config::Options::BuildOptions.new(drafts: true, parallel: false, cache: true)
+      options.apply_build_config!(build)
+
+      options.drafts.should be_true
+      options.parallel.should be_false
+      options.cache.should be_true
+    end
+
+    it "changes nothing when [build] omits every key" do
+      options = Hwaro::Config::Options::BuildOptions.new
+      options.apply_build_config!(Hwaro::Models::BuildConfig.new)
+
+      options.output_dir.should eq("public")
+      options.drafts.should be_false
+      options.parallel.should be_true
+      options.cache.should be_false
+    end
+
+    # serve merges config into its own copy and the Builder merges again on
+    # every rebuild, so a second application must not drift.
+    it "is idempotent" do
+      build = Hwaro::Models::BuildConfig.new
+      build.output_dir = "dist"
+      build.parallel = false
+
+      options = Hwaro::Config::Options::BuildOptions.new
+      options.apply_build_config!(build)
+      options.apply_build_config!(build)
+
+      options.output_dir.should eq("dist")
+      options.parallel.should be_false
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -107,9 +107,14 @@ describe Hwaro::Services::Server do
       server.test_sanitize_output_dir("../foo").should eq("public")
     end
 
-    it "defaults to 'public' for absolute paths" do
+    # `hwaro build -o /srv/site` and `[build] output_dir = "/srv/site"` both
+    # write there, so rejecting an absolute path here would have serve building
+    # into that directory while serving an empty `public/` — every request a
+    # 404. The build's own guard_output_dir! refuses the dangerous roots.
+    it "keeps absolute paths" do
       server = Hwaro::Services::Server.new
-      server.test_sanitize_output_dir("/foo").should eq("public")
+      server.test_sanitize_output_dir("/foo").should eq("/foo")
+      server.test_sanitize_output_dir("/srv/www/site/").should eq("/srv/www/site")
     end
   end
 

--- a/src/cli/commands/build_command.cr
+++ b/src/cli/commands/build_command.cr
@@ -65,8 +65,7 @@ module Hwaro
         end
 
         def run(args : Array(String))
-          result, input_dir, json_output = parse_options(args)
-          options, output_dir_explicit = result
+          options, input_dir, json_output = parse_options(args)
 
           # --json implies quiet so only the final JSON document reaches stdout.
           Runner.enable_json_mode! if json_output
@@ -88,7 +87,7 @@ module Hwaro
             # Only resolve output_dir to absolute path when -o was explicitly
             # specified, so it stays relative to the original CWD.
             # The default "public" should remain relative to the input directory.
-            if output_dir_explicit && !Path[options.output_dir].absolute?
+            if options.output_dir_explicit && !Path[options.output_dir].absolute?
               options.output_dir = File.expand_path(options.output_dir)
             end
 
@@ -161,7 +160,7 @@ module Hwaro
           end
         end
 
-        def parse_options(args : Array(String)) : { {Config::Options::BuildOptions, Bool}, String?, Bool }
+        def parse_options(args : Array(String)) : {Config::Options::BuildOptions, String?, Bool}
           # Path & URL
           input_dir = nil.as(String?)
           output_dir = "public"
@@ -243,7 +242,7 @@ module Hwaro
             Logger.warn "--jobs #{workers} is ignored because --no-parallel disables parallel rendering."
           end
 
-          { {Config::Options::BuildOptions.new(
+          build_options = Config::Options::BuildOptions.new(
             output_dir: output_dir,
             base_url: base_url,
             drafts: drafts,
@@ -264,7 +263,11 @@ module Hwaro
             env: env_name,
             skip_og_image: skip_og_image,
             skip_image_processing: skip_image_processing,
-          ), output_dir_explicit}, input_dir, json_output }
+          )
+          # Carried on the struct rather than alongside it: the Builder needs it
+          # to decide whether `[build] output_dir` may override the flag.
+          build_options.output_dir_explicit = output_dir_explicit
+          {build_options, input_dir, json_output}
         end
       end
     end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -230,7 +230,9 @@ module Hwaro
             # reported dead.
             language_codes = translation_language_codes(config)
             generated_routes = generated_routes(config)
-            dead_internal = check_internal_links(internal_links, target_dir, taxonomy_names, base_path, language_codes, generated_routes)
+            # Follow `[build] output_dir`; "public" only as the fallback.
+            output_dir = config.try(&.build.output_dir) || "public"
+            dead_internal = check_internal_links(internal_links, target_dir, taxonomy_names, base_path, language_codes, generated_routes, output_dir)
 
             total = external_links.size + internal_links.size
             dead_total = dead_external.size + dead_internal.size
@@ -653,7 +655,7 @@ module Hwaro
             !!(url =~ /\A[a-z][a-z0-9+.\-]*:/i)
           end
 
-          private def check_internal_links(links : Array(Link), content_dir : String, taxonomy_names : Array(String) = [] of String, base_path : String = "", language_codes : Array(String) = [] of String, generated_routes : GeneratedRoutes = GeneratedRoutes.new) : Array(Result)
+          private def check_internal_links(links : Array(Link), content_dir : String, taxonomy_names : Array(String) = [] of String, base_path : String = "", language_codes : Array(String) = [] of String, generated_routes : GeneratedRoutes = GeneratedRoutes.new, output_dir : String = "public") : Array(Result)
             results = [] of Result
             project_root = find_project_root(content_dir)
 
@@ -675,7 +677,7 @@ module Hwaro
               # (`content/ko/posts/`), and that section outranks any
               # translation reading — stripping unconditionally reported such
               # links dead even though the build publishes them.
-              exists = resolves?(resolved_url, link, content_dir, base_dir, project_root, taxonomy_names) ||
+              exists = resolves?(resolved_url, link, content_dir, base_dir, project_root, taxonomy_names, output_dir) ||
                        generated_routes.matches?(resolved_url) ||
                        feed_route?(resolved_url, generated_routes, content_dir, base_dir, language_codes) ||
                        paginated_route?(resolved_url, link, content_dir, base_dir, taxonomy_names)
@@ -932,7 +934,8 @@ module Hwaro
           # asset, read literally? This is the language-agnostic resolution the
           # checker has always performed.
           private def resolves?(url : String, link : Link, content_dir : String, base_dir : String,
-                                project_root : String, taxonomy_names : Array(String)) : Bool
+                                project_root : String, taxonomy_names : Array(String),
+                                output_dir : String) : Bool
             target = content_target(url, content_dir, base_dir)
             # Most internal URLs are written with a trailing slash (`/about/`,
             # `/posts/hello/`) — strip it before computing the leaf-file
@@ -950,14 +953,16 @@ module Hwaro
                            File.exists?(File.join(target_no_slash, "index.markdown")) ||
                            (link.kind != :image && taxonomy_url?(url, taxonomy_names))
 
-            # Also accept assets that live in static/ (source) or public/ (after
-            # build): images under static/images/, resized/LQIP variants the
-            # image pipeline emits into public/, and anything published via
-            # [content.files] or the asset pipeline. The public/ probe doubles
-            # as the oracle for generated routes on an already-built site.
+            # Also accept assets that live in static/ (source) or the build
+            # output (after build): images under static/images/, resized/LQIP
+            # variants the image pipeline emits, and anything published via
+            # [content.files] or the asset pipeline. The output probe doubles
+            # as the oracle for generated routes on an already-built site, and
+            # follows `[build] output_dir` so a site that builds elsewhere is
+            # not reported as one big pile of broken links.
             asset_path = url.lstrip("/")
             File.exists?(File.join(project_root, "static", asset_path)) ||
-              File.exists?(File.join(project_root, "public", asset_path))
+              File.exists?(File.join(project_root, output_dir, asset_path))
           end
 
           # Language-qualified resolution for a `/<code>/…` URL whose literal

--- a/src/config/options/build_options.cr
+++ b/src/config/options/build_options.cr
@@ -48,6 +48,44 @@ module Hwaro
         # Hooks can use this to change behavior (e.g. lazy OG generation).
         property serve_mode : Bool = false
 
+        # True when `-o/--output` appeared on the command line. Without it a
+        # default `output_dir` is indistinguishable from an explicit
+        # `-o public`, and `[build] output_dir` would override the flag the
+        # user actually typed. Also decides whether the path is resolved
+        # against the original CWD under `-i` (see BuildCommand#run).
+        property output_dir_explicit : Bool = false
+
+        # Fill the config-backed fields from `[build]` in config.toml, leaving
+        # anything the command line set explicitly alone. Precedence is
+        # CLI flag > config.toml > the built-in defaults in `initialize`.
+        #
+        # The three booleans need no explicit-flag tracking because each has
+        # exactly one flag and that flag only ever moves the value away from
+        # its default (`--drafts`/`--cache` set true, `--no-parallel` sets
+        # false). So "still holds the default" and "the flag was absent" are
+        # the same condition. `output_dir` is a string with no such property,
+        # which is what `output_dir_explicit` above exists for.
+        #
+        # Idempotent: applying the same config twice is a no-op, which matters
+        # because `hwaro serve` merges config into its options and the Builder
+        # then merges again on every rebuild.
+        def apply_build_config!(build : Hwaro::Models::BuildConfig) : Nil
+          # Nil checks rather than truthiness: `parallel = false` is a real
+          # value to apply, and `if (v = build.parallel)` would skip it.
+          if (dir = build.output_dir) && !@output_dir_explicit
+            @output_dir = dir
+          end
+          unless (drafts = build.drafts).nil?
+            @drafts = drafts if @drafts == false
+          end
+          unless (parallel = build.parallel).nil?
+            @parallel = parallel if @parallel == true
+          end
+          unless (cache = build.cache).nil?
+            @cache = cache if @cache == false
+          end
+        end
+
         def initialize(
           @output_dir : String = "public",
           @base_url : String? = nil,

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1609,6 +1609,10 @@ module Hwaro
           # build pipeline rewrapping the exception.
           config = Models::Config.load(env: options.env)
           @config = config
+          # `[build]` supplies output_dir/drafts/parallel/cache for anything the
+          # command line left at its default. Applied before the BuildContext is
+          # built so every phase (and the output guard) sees the same values.
+          options.apply_build_config!(config.build)
           pre_hooks = config.build.hooks.pre
           post_hooks = config.build.hooks.post
 

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -680,6 +680,16 @@ module Hwaro
       # behavior: any template change rebuilds every page.
       property template_deps : Bool = true
 
+      # Defaults for the matching `hwaro build` flags. Nil means the key is
+      # absent from config.toml, which is what keeps the precedence chain
+      # honest: a command-line flag beats config.toml, config.toml beats the
+      # built-in default, and an absent key changes nothing. See
+      # `Config::Options::BuildOptions#apply_build_config!` for the merge.
+      property output_dir : String? = nil
+      property drafts : Bool? = nil
+      property parallel : Bool? = nil
+      property cache : Bool? = nil
+
       def initialize
         @hooks = BuildHooksConfig.new
       end
@@ -1971,6 +1981,22 @@ module Hwaro
         return unless s = config.raw["build"]?.try(&.as_h?)
 
         config.build.template_deps = bool_value(s["template_deps"]?, config.build.template_deps)
+
+        # Left nil when absent so the CLI/default layers below stay in charge.
+        # An empty `output_dir = ""` is dropped rather than accepted: it would
+        # otherwise resolve to the site root and hand the output guard a
+        # directory the build is about to wipe.
+        if raw_output = s["output_dir"]?.try(&.as_s?)
+          trimmed = raw_output.strip
+          if trimmed.empty?
+            Logger.warn "Ignoring empty [build] output_dir in config; using #{config.build.output_dir || "the default"}."
+          else
+            config.build.output_dir = trimmed
+          end
+        end
+        config.build.drafts = s["drafts"]?.try(&.as_bool?)
+        config.build.parallel = s["parallel"]?.try(&.as_bool?)
+        config.build.cache = s["cache"]?.try(&.as_bool?)
 
         if hooks_section = s["hooks"]?.try(&.as_h?)
           if pre_hooks = hooks_section["pre"]?.try(&.as_a?)

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1442,6 +1442,7 @@ module Hwaro
         load_doctor(config)
         load_static(config)
         load_deployment(config)
+        resolve_deployment_source_dir(config)
         load_outputs(config)
         load_links(config)
 
@@ -1977,26 +1978,61 @@ module Hwaro
         config.languages = languages
       end
 
+      # A `[build]` boolean, or nil when the key is absent. A present-but-wrong
+      # type warns rather than no-opping: `cache = "true"` (quoting a bool is
+      # an easy TOML slip) would otherwise leave caching off with no feedback,
+      # while the sibling `output_dir` branch does report what it refuses.
+      private def self.build_bool_value(s : Hash(String, TOML::Any), key : String) : Bool?
+        return unless raw = s[key]?
+        if value = raw.as_bool?
+          return value
+        end
+        # `as_bool?` returns nil for `false`, so distinguish a real false from a
+        # type mismatch before warning.
+        return false if raw.raw == false
+        Logger.warn "Ignoring non-boolean [build] #{key} value #{raw.raw.inspect}; expected true or false."
+        nil
+      end
+
+      # A `[build] output_dir`, or nil when it is unusable. Both rejections keep
+      # `hwaro build` and `hwaro serve` pointed at the same directory:
+      # an empty value resolves to the site root, which a cold build wipes, and
+      # a `..` path escapes the project — which the dev server refuses to serve
+      # from (`Server#sanitize_output_dir`) even though the build would write
+      # there, leaving serve publishing one tree and serving another.
+      private def self.build_output_dir_value(raw : TOML::Any) : String?
+        value = raw.as_s?
+        unless value
+          Logger.warn "Ignoring non-string [build] output_dir value #{raw.raw.inspect}; expected a directory path."
+          return
+        end
+
+        trimmed = value.strip
+        if trimmed.empty?
+          Logger.warn "Ignoring empty [build] output_dir in config; using the default."
+          return
+        end
+
+        if Path[trimmed].normalize.to_s.starts_with?("..")
+          Logger.warn "Ignoring [build] output_dir #{trimmed.inspect}: it points outside the project. Using the default."
+          return
+        end
+
+        trimmed
+      end
+
       private def self.load_build(config : Config)
         return unless s = config.raw["build"]?.try(&.as_h?)
 
         config.build.template_deps = bool_value(s["template_deps"]?, config.build.template_deps)
 
         # Left nil when absent so the CLI/default layers below stay in charge.
-        # An empty `output_dir = ""` is dropped rather than accepted: it would
-        # otherwise resolve to the site root and hand the output guard a
-        # directory the build is about to wipe.
-        if raw_output = s["output_dir"]?.try(&.as_s?)
-          trimmed = raw_output.strip
-          if trimmed.empty?
-            Logger.warn "Ignoring empty [build] output_dir in config; using #{config.build.output_dir || "the default"}."
-          else
-            config.build.output_dir = trimmed
-          end
+        if raw_output = s["output_dir"]?
+          config.build.output_dir = build_output_dir_value(raw_output)
         end
-        config.build.drafts = s["drafts"]?.try(&.as_bool?)
-        config.build.parallel = s["parallel"]?.try(&.as_bool?)
-        config.build.cache = s["cache"]?.try(&.as_bool?)
+        config.build.drafts = build_bool_value(s, "drafts")
+        config.build.parallel = build_bool_value(s, "parallel")
+        config.build.cache = build_bool_value(s, "cache")
 
         if hooks_section = s["hooks"]?.try(&.as_h?)
           if pre_hooks = hooks_section["pre"]?.try(&.as_a?)
@@ -2227,6 +2263,23 @@ module Hwaro
         if exclude_any = s["exclude"]?
           config.static.exclude = string_or_array(exclude_any)
         end
+      end
+
+      # Point `hwaro deploy` at whatever `[build] output_dir` made the build
+      # write, unless the user named a source explicitly. `[build] output_dir`
+      # and `[deployment] source_dir` default to "public" independently, so
+      # without this a site that builds to `dist/` would have deploy reading a
+      # stale (or absent) `public/` — uploading nothing, or deleting the
+      # remote's files when max_deletes allows it.
+      #
+      # Runs at the call site rather than inside `load_deployment` because the
+      # common shape is a `[build] output_dir` with no `[deployment]` section
+      # at all, which `load_deployment` returns early on.
+      private def self.resolve_deployment_source_dir(config : Config)
+        return unless build_output = config.build.output_dir
+        explicit = config.raw["deployment"]?.try(&.as_h?).try { |s| s["source_dir"]? || s["source"]? }
+        return if explicit.try(&.as_s?)
+        config.deployment.source_dir = build_output
       end
 
       private def self.load_deployment(config : Config)

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -1349,7 +1349,7 @@ module Hwaro
         # found" warnings. Use a route-aware check that also accepts a matching
         # content source or a built output page.
         emit_route = ->(label : String, value : String) do
-          emit_missing(issues, label, value, resolver: ->(s : String) { path_resolves?(s) || route_resolves?(s) }, id: "config-path-missing", kind: "file")
+          emit_missing(issues, label, value, resolver: ->(s : String) { path_resolves?(s) || route_resolves?(s, config.build.output_dir || "public") }, id: "config-path-missing", kind: "file")
         end
 
         config.og.default_image.try { |v| emit_file.call("[og] default_image", v) }
@@ -1471,10 +1471,11 @@ module Hwaro
       # file exists. A route is considered valid when:
       #   - a content source exists (`content/about.md` or
       #     `content/about/index.md` for `/about/`), or
-      #   - the built output page exists (`public/about/index.html`).
+      #   - the built output page exists (`<output_dir>/about/index.html`,
+      #     which follows `[build] output_dir` rather than assuming `public/`).
       # This keeps doctor from flagging valid routes as "file not found" while
       # still catching genuinely-missing pages.
-      private def route_resolves?(path : String) : Bool
+      private def route_resolves?(path : String, output_dir : String) : Bool
         # Normalize to a slug: drop a leading slash, strip a trailing slash,
         # and remove a trailing `index.html` so `/about/` and
         # `/about/index.html` resolve the same way.
@@ -1497,12 +1498,13 @@ module Hwaro
                              end
         return true if content_candidates.any? { |c| File.exists?(File.join(@content_dir, c)) }
 
-        # A prior build's output (conventionally `public/`): a pretty route lands
+        # A prior build's output (`[build] output_dir`, "public" by default):
+        # a pretty route lands
         # at `<slug>/index.html`, while an explicit file (an `.html` alias or a
         # pipeline-built asset such as `/css/app.css`) lands at the path itself.
-        if Dir.exists?("public")
-          return true if File.exists?(File.join("public", slug, "index.html"))
-          return true if File.exists?(File.join("public", path.lchop("/")))
+        if Dir.exists?(output_dir)
+          return true if File.exists?(File.join(output_dir, slug, "index.html"))
+          return true if File.exists?(File.join(output_dir, path.lchop("/")))
         end
 
         # Otherwise it's a pretty route or listing (taxonomy/section page)

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -1337,9 +1337,16 @@ module Hwaro
         }.to_json
       end
 
+      # An absolute path is allowed: `hwaro build -o /srv/site` and
+      # `[build] output_dir = "/srv/site"` both write there, and rejecting it
+      # here would leave serve building into that directory while serving an
+      # empty `public/` — every request a 404 for the whole session. The build's
+      # own `guard_output_dir!` is what refuses the genuinely dangerous roots.
+      # A `..` path still falls back, and config-loaded values never reach here
+      # with one (`Config::Loader.build_output_dir_value` drops those).
       private def sanitize_output_dir(dir : String) : String
         normalized = Path[dir].normalize.to_s
-        if normalized.starts_with?("..") || normalized.starts_with?("/")
+        if normalized.starts_with?("..")
           Logger.warn "Invalid output directory: #{dir}. Using 'public' instead."
           return "public"
         end

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -931,6 +931,19 @@ module Hwaro
       def run(options : Config::Options::ServeOptions)
         build_options = options.to_build_options
         build_options.serve_mode = true
+        # The dev server derives its document root from `build_options.output_dir`
+        # (see `sanitize_output_dir` call sites), so `[build]` has to be merged
+        # here as well as in the Builder: BuildOptions is a struct, and the copy
+        # the Builder mutates is not this one. Without this, `[build] output_dir`
+        # would have serve building into one directory and serving another.
+        #
+        # A missing or invalid config is not fatal here — serve deliberately
+        # starts on a broken site, and the Builder reports the error on the
+        # initial build.
+        begin
+          build_options.apply_build_config!(Hwaro::Models::Config.load(env: build_options.env).build)
+        rescue Hwaro::HwaroError
+        end
         run_with_options(options.host, options.port, options.open_browser, options.access_log, options.live_reload, build_options, options.json, options.headers)
       end
 


### PR DESCRIPTION
Follow-up to #744, which noted that `[build] output_dir` was documented but unimplemented. It turned out three neighbours in the same table had the identical defect.

## The problem

`docs/content/start/config.md` documents `output_dir`, `drafts`, `parallel` and `cache` under `[build]`, but `Config::Loader.load_build` only ever read `template_deps` and `hooks`. Setting any of the four did nothing, and nothing said so — unknown-key warnings are top-level only, so a key inside a real `[build]` table passes unnoticed.

## The fix

Read the four keys into `BuildConfig` as nilable (nil = absent from config.toml) and merge them into `BuildOptions` through `apply_build_config!`, which only fills fields the command line left at their defaults:

```
command-line flag  >  config.toml  >  built-in default
```

The three booleans need no explicit-flag tracking: each has exactly one flag and that flag only ever moves the value away from its default (`--drafts`/`--cache` set true, `--no-parallel` sets false), so "still holds the default" and "the flag was absent" are the same condition. `output_dir` is a string with no such property, so `-o/--output` explicitness now rides on `BuildOptions` instead of in a tuple beside it — which also lets `BuildCommand#parse_options` drop its `{{options, bool}, dir, json}` return shape.

Nil checks rather than truthiness in the merge: `parallel = false` is a real value to apply, and `if (v = build.parallel)` would silently skip it.

### Applied in two places, on purpose

`BuildOptions` is a struct, so the copy `Builder#run` mutates is not the one `Server#run` derives its document root from. Merging only in the Builder would have left `hwaro serve` building into one directory and serving another. `apply_build_config!` is idempotent, which is what makes applying it in both safe.

A blank `output_dir = ""` is warned about and ignored rather than accepted — it resolves to the site root, which a cold build wipes.

## Verification

Measured against a real scaffolded site, not just unit tests:

| Case | Result |
|---|---|
| no `[build]` keys | builds to `public` — unchanged |
| `output_dir = "dist"` | builds to `dist`, `public` never created |
| `-o cli` with `output_dir = "dist"` | builds to `cli` — CLI wins |
| `drafts = true` | draft page published (0 -> 1 occurrences in output) |
| `cache = true` | "Cache enabled" appears without `--cache` |
| `parallel = false` | docs build drops **184% -> 99% CPU** |
| `output_dir = "   "` | warns, falls back to `public` |
| `hwaro serve` with `output_dir = "servedir"` | builds to `servedir`, `public` absent, HTTP 200 from it |
| unknown top-level key | `Did you mean 'build'?` still fires |

`just fix`: 506 inspected, 0 failures. Full suite: 8173 examples, 0 failures (with `bin/hwaro` prebuilt).

## Also

Adds `template_deps` to the `[build]` table — implemented for a while, but described only under Incremental Build — and states the precedence rule in both the English and Korean config docs, including that there is no `--no-drafts`/`--no-cache` to turn a config value back off (`--no-parallel` is the one exception).

🤖 Generated with [Claude Code](https://claude.com/claude-code)