### PR TITLE
chore(deps): pin ameba to the released 1.7.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.7.0-dev+git.commit.d4533b13b6470d08b49982defdcc3ac8231a028c
+    version: 1.7.0
 
   baked_file_system:
     git: https://github.com/ralsina/baked_file_system.git

--- a/shard.yml
+++ b/shard.yml
@@ -28,4 +28,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    branch: master
+    version: ~> 1.7.0


### PR DESCRIPTION
## Summary

`development_dependencies.ameba` tracked the `master` branch, which was necessary while no tagged ameba release supported the Crystal version this project targets. [ameba v1.7.0](https://github.com/crystal-ameba/ameba/releases/tag/v1.7.0) shipped on 2026-08-26, so the pin moves to `~> 1.7.0` and the lockfile drops the `1.7.0-dev+git.commit.d4533b13` pseudo-version.

## Changes

- `shard.yml`: `branch: master` → `version: ~> 1.7.0`
- `shard.lock`: ameba `1.7.0-dev+git.commit.d4533b13…` → `1.7.0`

No other locked dependency moved.

## Verification

Built ameba 1.7.0 locally and ran it against this repo:

- `./lib/ameba/bin/ameba` → **506 inspected, 0 failures**
- `crystal tool format --check src spec` → clean
- `shards build` → binary builds

The repo has no `.ameba.yml`, so this runs on 1.7.0's default rule set — no new rules trip on the current source.

Note: CI's lint job uses `crystal-ameba/github-action@master`, which installs its own ameba and is unaffected by this pin; the pin governs local runs and `shards install`.