### PR TITLE
fix: harden five crash paths found by fuzzing the CLI surfaces

### DIFF
--- a/spec/unit/crash_hardening_spec.cr
+++ b/spec/unit/crash_hardening_spec.cr
@@ -1,0 +1,121 @@
+require "../spec_helper"
+require "../../src/hwaro"
+
+# Regression coverage for the crash-hardening pass: inputs that used to abort a
+# command with an UNCLASSIFIED exception (a bare stdlib ArgumentError /
+# OverflowError surfacing as `Error: <stdlib message>` — no code, no file, no
+# hint) now produce a classified error or a defined fallback.
+
+private def load_config(toml : String) : Hwaro::Models::Config
+  File.tempfile("hwaro-nul-config", ".toml") do |file|
+    file.print(toml)
+    file.flush
+    return Hwaro::Models::Config.load(file.path)
+  end
+  raise "unreachable"
+end
+
+# As written in a config file: a well-formed TOML escape that decodes to a NUL.
+TOML_NUL = "x\\u0000z"
+# The decoded string a Crystal caller would hold.
+RAW_NUL = "x#{Char::ZERO}z"
+
+describe "crash hardening" do
+  # ---------------------------------------------------------------------------
+  # NUL bytes in config strings.
+  #
+  # The escape survives TOML parsing, so the NUL reached every consumer of the
+  # value. Anything that then built a Path from it raised
+  # `ArgumentError: String contains null byte` out of stdlib's
+  # check_no_null_byte — reported as the unclassified
+  # `Error: String contains null byte`, naming neither the key nor the file.
+  # `validate_output_filename!` could not catch it either: its own
+  # `File.basename(value)` operand raised before the NUL test it guarded ran.
+  # ---------------------------------------------------------------------------
+  describe "Config.load with a NUL byte in a string value" do
+    {
+      "build.output_dir"         => %([build]\noutput_dir = "#{TOML_NUL}"\n),
+      "sitemap.filename"         => %([sitemap]\nenabled = true\nfilename = "#{TOML_NUL}"\n),
+      "robots.filename"          => %([robots]\nfilename = "#{TOML_NUL}"\n),
+      "llms.filename"            => %([llms]\nfilename = "#{TOML_NUL}"\n),
+      "llms.full_filename"       => %([llms]\nfull_filename = "#{TOML_NUL}"\n),
+      "feeds.filename"           => %([feeds]\nfilename = "#{TOML_NUL}"\n),
+      "search.filename"          => %([search]\nfilename = "#{TOML_NUL}"\n),
+      "og.auto_image.output_dir" => %([og.auto_image]\noutput_dir = "#{TOML_NUL}"\n),
+    }.each do |key, toml|
+      it "raises a classified config error naming #{key}" do
+        err = expect_raises(Hwaro::HwaroError) { load_config(toml) }
+        err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+        (err.message || "").should contain(key)
+        (err.message || "").should contain("NUL")
+      end
+    end
+
+    it "reports a NUL inside an array element with its index" do
+      err = expect_raises(Hwaro::HwaroError) do
+        load_config(%([sitemap]\nenabled = true\nexclude = ["ok", "#{TOML_NUL}"]\n))
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+      (err.message || "").should contain("sitemap.exclude[1]")
+    end
+
+    it "reports a NUL in a plain (non-path) string too" do
+      err = expect_raises(Hwaro::HwaroError) { load_config(%(title = "#{TOML_NUL}"\n)) }
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+      (err.message || "").should contain("title")
+    end
+
+    it "leaves NUL-free configs untouched" do
+      config = load_config(%(title = "ok"\n[sitemap]\nenabled = true\nfilename = "sitemap.xml"\n))
+      config.title.should eq("ok")
+      config.sitemap.filename.should eq("sitemap.xml")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # OutputGuard: a SAFETY predicate must answer, never raise. File.expand_path
+  # builds a Path, so a NUL made both entry points abort the build instead of
+  # reporting "not inside the output directory".
+  # ---------------------------------------------------------------------------
+  describe Hwaro::Utils::OutputGuard do
+    it "returns nil for an output path containing a NUL byte" do
+      Hwaro::Utils::OutputGuard.safe_output_path("public/#{RAW_NUL}.html", "public").should be_nil
+    end
+
+    it "returns nil when the output DIRECTORY contains a NUL byte" do
+      Hwaro::Utils::OutputGuard.safe_output_path("public/a.html", RAW_NUL).should be_nil
+    end
+
+    it "answers false instead of raising for a NUL path" do
+      Hwaro::Utils::OutputGuard.within_output_dir?("public/#{RAW_NUL}.html", "public").should be_false
+      Hwaro::Utils::OutputGuard.within_output_dir?("public/a.html", RAW_NUL).should be_false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TextUtils formatting helpers: both raised on out-of-range integer inputs.
+  # truncate_error runs while REPORTING another failure, so a raise there
+  # replaces a real diagnostic with a stdlib message.
+  # ---------------------------------------------------------------------------
+  describe Hwaro::Utils::TextUtils do
+    it "clamps a negative truncate_error budget instead of raising" do
+      result = Hwaro::Utils::TextUtils.truncate_error("template failed", -1)
+      result.should contain("truncated")
+      result.should contain("15 characters")
+    end
+
+    it "keeps a zero budget usable" do
+      Hwaro::Utils::TextUtils.truncate_error("abc", 0).should start_with("…")
+    end
+
+    it "does not overflow pad_display at the Int32 extremes" do
+      Hwaro::Utils::TextUtils.pad_display("ab", Int32::MIN).should eq("ab")
+      Hwaro::Utils::TextUtils.pad_display("ab", Int32::MAX).size.should be <= 10_002 # 2 + MAX_PAD_COLUMNS
+    end
+
+    it "still pads normally" do
+      Hwaro::Utils::TextUtils.pad_display("ab", 5).should eq("ab   ")
+      Hwaro::Utils::TextUtils.pad_display("abcdef", 3).should eq("abcdef")
+    end
+  end
+end

--- a/spec/unit/crash_hardening_spec.cr
+++ b/spec/unit/crash_hardening_spec.cr
@@ -65,6 +65,24 @@ describe "crash hardening" do
       (err.message || "").should contain("title")
     end
 
+    # `[a.b.c…]` builds one nested table per dotted segment and never enters
+    # `parse_value`, so ext/toml_nesting_limit_fix.cr's cap does not apply: the
+    # parser accepts a 50k-segment header. A RECURSIVE scan of the result
+    # overflowed the stack — unrescuable, and on a config the section loaders
+    # never descend into. The scan is iterative for exactly this reason.
+    it "scans a pathologically deep dotted-key table without overflowing" do
+      deep = Array.new(20_000) { |i| "k#{i}" }.join('.')
+      config = load_config("[#{deep}]\nx = 1\n")
+      config.title.should_not be_nil
+    end
+
+    it "still finds a NUL buried in a pathologically deep table" do
+      deep = Array.new(20_000) { |i| "k#{i}" }.join('.')
+      err = expect_raises(Hwaro::HwaroError) { load_config(%([#{deep}]\nx = "#{TOML_NUL}"\n)) }
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+      (err.message || "").should contain("NUL")
+    end
+
     it "leaves NUL-free configs untouched" do
       config = load_config(%(title = "ok"\n[sitemap]\nenabled = true\nfilename = "sitemap.xml"\n))
       config.title.should eq("ok")

--- a/spec/unit/crash_hardening_spec.cr
+++ b/spec/unit/crash_hardening_spec.cr
@@ -6,13 +6,18 @@ require "../../src/hwaro"
 # OverflowError surfacing as `Error: <stdlib message>` — no code, no file, no
 # hint) now produce a classified error or a defined fallback.
 
+# `File.tempfile`'s block form closes the file but does NOT delete it, and the
+# deep-dotted-key examples below write multi-megabyte configs — so clean up
+# explicitly rather than leaving a pile of them in the system temp dir.
 private def load_config(toml : String) : Hwaro::Models::Config
-  File.tempfile("hwaro-nul-config", ".toml") do |file|
-    file.print(toml)
-    file.flush
-    return Hwaro::Models::Config.load(file.path)
+  file = File.tempfile("hwaro-nul-config", ".toml")
+  begin
+    File.write(file.path, toml)
+    Hwaro::Models::Config.load(file.path)
+  ensure
+    file.close
+    File.delete?(file.path)
   end
-  raise "unreachable"
 end
 
 # As written in a config file: a well-formed TOML escape that decodes to a NUL.
@@ -81,6 +86,29 @@ describe "crash hardening" do
       err = expect_raises(Hwaro::HwaroError) { load_config(%([#{deep}]\nx = "#{TOML_NUL}"\n)) }
       err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
       (err.message || "").should contain("NUL")
+    end
+
+    # A quoted TOML key carries the escape exactly as a value does, and both
+    # `[languages.<code>]` and `[menus.<name>]` keys are joined into output
+    # paths downstream.
+    it "rejects a NUL in a quoted table key" do
+      err = expect_raises(Hwaro::HwaroError) do
+        load_config(%([languages."e#{TOML_NUL}n"]\nlanguage_name = "En"\n))
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+      (err.message || "").should contain("NUL")
+    end
+
+    it "rejects a NUL in a top-level key" do
+      err = expect_raises(Hwaro::HwaroError) { load_config(%("a#{TOML_NUL}b" = 1\n)) }
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
+    end
+
+    it "rejects a NUL in an inline-table key" do
+      err = expect_raises(Hwaro::HwaroError) do
+        load_config(%([markdown]\nx = { "k#{TOML_NUL}y" = 1 }\n))
+      end
+      err.code.should eq(Hwaro::Errors::HWARO_E_CONFIG)
     end
 
     it "leaves NUL-free configs untouched" do

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -1043,13 +1043,13 @@ module Hwaro
             #
             # Exactly one result per dequeued URL — the same send-guarantee the
             # build's pools carry (see Core::Build::Parallel#process_parallel).
-            # The collector below blocks on `urls.size` receives, so a worker
-            # that died mid-URL would hang `hwaro tool check-links` forever
-            # with no output and no timeout; and an exception escaping a
-            # `spawn` body kills the PROCESS, since the CLI's top-level rescue
-            # only wraps the main fiber. `check_external_url` rescues its own
-            # network errors today — this makes surviving a raise a property of
-            # the pool rather than of one callee.
+            # A raise here does not kill the process (Crystal's `Fiber#run`
+            # prints `Unhandled exception in spawn` and carries on); it kills
+            # this WORKER, which is worse: the collector below blocks on
+            # `urls.size` receives with no timeout, so one lost result hangs
+            # `hwaro tool check-links` forever. `check_external_url` rescues
+            # its own network errors today — this makes surviving a raise a
+            # property of the pool rather than of one callee.
             max_concurrency.times do
               spawn do
                 while url = work_channel.receive?

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -1039,11 +1039,27 @@ module Hwaro
             results_channel = Channel({String, Int32, String?}).new(urls.size)
             work_channel = Channel(String?).new(max_concurrency)
 
-            # Spawn bounded worker pool
+            # Spawn bounded worker pool.
+            #
+            # Exactly one result per dequeued URL — the same send-guarantee the
+            # build's pools carry (see Core::Build::Parallel#process_parallel).
+            # The collector below blocks on `urls.size` receives, so a worker
+            # that died mid-URL would hang `hwaro tool check-links` forever
+            # with no output and no timeout; and an exception escaping a
+            # `spawn` body kills the PROCESS, since the CLI's top-level rescue
+            # only wraps the main fiber. `check_external_url` rescues its own
+            # network errors today — this makes surviving a raise a property of
+            # the pool rather than of one callee.
             max_concurrency.times do
               spawn do
                 while url = work_channel.receive?
-                  status, error_message = check_external_url(url, timeout_seconds)
+                  status, error_message = begin
+                    check_external_url(url, timeout_seconds)
+                  rescue ex
+                    # Pure construction — nothing here can raise — so the send
+                    # below always runs, exactly once per dequeued URL.
+                    {-1, ex.message || ex.class.name}
+                  end
                   results_channel.send({url, status, error_message})
                 end
               end

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1476,7 +1476,7 @@ module Hwaro
 
       # Reject a NUL byte anywhere in a config STRING value, naming the key.
       #
-      # A NUL survives TOML parsing (`"a\\u0000b"` is a well-formed escape) but
+      # A NUL survives TOML parsing (the `\u0000` escape is well-formed) but
       # every filesystem call built from that string raises a bare
       # `ArgumentError: String contains null byte` from deep inside stdlib —
       # `Path.new`'s `check_no_null_byte`. That reached the CLI as the
@@ -1489,27 +1489,43 @@ module Hwaro
       #
       # No config string can legitimately contain a NUL, so this rejects them
       # once, at the boundary, for every current and future key.
-      private def self.reject_null_bytes!(value : TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any), path : String, key : String = "")
-        case value
-        when Hash(String, TOML::Any)
-          value.each { |k, v| reject_null_bytes!(v, path, key.empty? ? k : "#{key}.#{k}") }
-        when Array(TOML::Any)
-          value.each_with_index { |v, i| reject_null_bytes!(v, path, "#{key}[#{i}]") }
-        when TOML::Any
-          raw = value.raw
-          case raw
-          when String
-            if raw.includes?(Char::ZERO)
+      #
+      # ITERATIVE, not recursive: `[a.b.c…]` builds one nested table per dotted
+      # segment and bypasses the `parse_value` nesting cap in
+      # ext/toml_nesting_limit_fix.cr (that cap counts array/inline-table
+      # values, which a table HEADER never enters). A 50k-segment header is
+      # accepted by the parser, so a recursive walk over the result overflowed
+      # the stack — an unrescuable crash on a config the loaders themselves
+      # never descend into.
+      private def self.reject_null_bytes!(root : Hash(String, TOML::Any), path : String) : Nil
+        pending = [] of {TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any), String}
+        root.each { |k, v| pending << {v.as(TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any)), k} }
+
+        while entry = pending.pop?
+          node, key = entry
+          case node
+          when Hash(String, TOML::Any)
+            node.each { |k, v| pending << {v.as(TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any)), "#{key}.#{k}"} }
+          when Array(TOML::Any)
+            node.each_with_index { |v, i| pending << {v.as(TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any)), "#{key}[#{i}]"} }
+          when TOML::Any
+            raw = node.raw
+            case raw
+            when String
+              next unless raw.includes?(Char::ZERO)
               raise Hwaro::HwaroError.new(
                 code: Hwaro::Errors::HWARO_E_CONFIG,
-                message: "#{key.empty? ? "A value" : key} in #{path} contains a NUL byte (\\u0000).",
+                # The key is capped: a `[a.b.c…]` header can be arbitrarily
+                # long, and an unreadable wall of segments is a worse
+                # diagnostic than a truncated one.
+                message: "#{Utils::TextUtils.truncate_error(key, 200)} in #{path} contains a NUL byte (\\u0000).",
                 hint: "Remove the \\u0000 escape from the value; NUL is not valid in a path, filename, URL, or title.",
               )
+            when Hash(String, TOML::Any)
+              pending << {raw, key}
+            when Array(TOML::Any)
+              pending << {raw, key}
             end
-          when Hash(String, TOML::Any)
-            reject_null_bytes!(raw, path, key)
-          when Array(TOML::Any)
-            reject_null_bytes!(raw, path, key)
           end
         end
       end

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1396,6 +1396,7 @@ module Hwaro
         end
 
         warn_unknown_top_level_keys(config.raw, config_path)
+        reject_null_bytes!(config.raw, config_path)
 
         config.title = config.raw["title"]?.try(&.as_s?) || config.title
         config.description = config.raw["description"]?.try(&.as_s?) || config.description
@@ -1470,6 +1471,46 @@ module Hwaro
           next if KNOWN_TOP_LEVEL_KEYS.includes?(key)
           hint = Utils::CommandSuggester.suggest(key, KNOWN_TOP_LEVEL_KEYS).try { |s| " Did you mean '#{s}'?" } || ""
           Logger.warn "Unknown key '#{key}' in #{config_path} — hwaro does not read it.#{hint}"
+        end
+      end
+
+      # Reject a NUL byte anywhere in a config STRING value, naming the key.
+      #
+      # A NUL survives TOML parsing (`"a\\u0000b"` is a well-formed escape) but
+      # every filesystem call built from that string raises a bare
+      # `ArgumentError: String contains null byte` from deep inside stdlib —
+      # `Path.new`'s `check_no_null_byte`. That reached the CLI as the
+      # unclassified `Error: String contains null byte`, with no file, no key
+      # and no hint, from at least seven keys (`[build] output_dir`, the five
+      # `filename`/`full_filename` output keys, `[og.auto_image] output_dir`).
+      # Individual guards could not catch it: `validate_output_filename!` was
+      # itself defeated because its `File.basename(value)` operand raised
+      # before the NUL check it guarded could run.
+      #
+      # No config string can legitimately contain a NUL, so this rejects them
+      # once, at the boundary, for every current and future key.
+      private def self.reject_null_bytes!(value : TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any), path : String, key : String = "")
+        case value
+        when Hash(String, TOML::Any)
+          value.each { |k, v| reject_null_bytes!(v, path, key.empty? ? k : "#{key}.#{k}") }
+        when Array(TOML::Any)
+          value.each_with_index { |v, i| reject_null_bytes!(v, path, "#{key}[#{i}]") }
+        when TOML::Any
+          raw = value.raw
+          case raw
+          when String
+            if raw.includes?(Char::ZERO)
+              raise Hwaro::HwaroError.new(
+                code: Hwaro::Errors::HWARO_E_CONFIG,
+                message: "#{key.empty? ? "A value" : key} in #{path} contains a NUL byte (\\u0000).",
+                hint: "Remove the \\u0000 escape from the value; NUL is not valid in a path, filename, URL, or title.",
+              )
+            end
+          when Hash(String, TOML::Any)
+            reject_null_bytes!(raw, path, key)
+          when Array(TOML::Any)
+            reject_null_bytes!(raw, path, key)
+          end
         end
       end
 
@@ -1593,7 +1634,11 @@ module Hwaro
         return if allow_empty && value.empty?
         # A NUL byte survives both TOML and File.basename, and then raises a
         # bare `ArgumentError: String contains null byte` out of the writer.
-        return unless NON_FILE_BASENAMES.includes?(File.basename(value)) || value.includes?(Char::ZERO)
+        # NUL FIRST: `File.basename` builds a `Path`, whose `check_no_null_byte`
+        # raises a bare ArgumentError before the `||` could ever reach the NUL
+        # test on its right. Ordering the cheap, non-raising check first is
+        # what makes this guard able to report the case it was written for.
+        return unless value.includes?(Char::ZERO) || NON_FILE_BASENAMES.includes?(File.basename(value))
 
         raise Hwaro::HwaroError.new(
           code: Hwaro::Errors::HWARO_E_CONFIG,

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -1474,21 +1474,26 @@ module Hwaro
         end
       end
 
-      # Reject a NUL byte anywhere in a config STRING value, naming the key.
+      # Reject a NUL byte anywhere in a config string — value OR key.
       #
-      # A NUL survives TOML parsing (the `\u0000` escape is well-formed) but
-      # every filesystem call built from that string raises a bare
-      # `ArgumentError: String contains null byte` from deep inside stdlib —
-      # `Path.new`'s `check_no_null_byte`. That reached the CLI as the
-      # unclassified `Error: String contains null byte`, with no file, no key
-      # and no hint, from at least seven keys (`[build] output_dir`, the five
-      # `filename`/`full_filename` output keys, `[og.auto_image] output_dir`).
-      # Individual guards could not catch it: `validate_output_filename!` was
-      # itself defeated because its `File.basename(value)` operand raised
-      # before the NUL check it guarded could run.
+      # A NUL survives TOML parsing (the `\u0000` escape is well-formed, in a
+      # quoted key just as in a value) but every filesystem call built from
+      # that string raises a bare `ArgumentError: String contains null byte`
+      # from deep inside stdlib — `Path.new`'s `check_no_null_byte`. That
+      # reached the CLI as the unclassified `Error: String contains null
+      # byte`, with no file, no key and no hint, from seven keys
+      # (`[build] output_dir`, the five `filename`/`full_filename` output
+      # keys, `[og.auto_image] output_dir`). Individual guards could not catch
+      # it: `validate_output_filename!` was itself defeated because its
+      # `File.basename(value)` operand raised before the NUL check it guarded
+      # could run.
       #
-      # No config string can legitimately contain a NUL, so this rejects them
-      # once, at the boundary, for every current and future key.
+      # KEYS are checked too, not just values: `[languages."e\u0000n"]` puts a
+      # NUL into a language code, and `[menus."a\u0000b"]` into a menu name —
+      # both of which downstream code joins into output paths. No CLI input
+      # reaches that particular `File.join` today, but a key is a config
+      # string like any other and the point of a boundary check is not to
+      # depend on which consumer happens to be wired up.
       #
       # ITERATIVE, not recursive: `[a.b.c…]` builds one nested table per dotted
       # segment and bypasses the `parse_value` nesting cap in
@@ -1498,36 +1503,78 @@ module Hwaro
       # the stack — an unrescuable crash on a config the loaders themselves
       # never descend into.
       private def self.reject_null_bytes!(root : Hash(String, TOML::Any), path : String) : Nil
-        pending = [] of {TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any), String}
-        root.each { |k, v| pending << {v.as(TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any)), k} }
+        pending = [] of {TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any), KeyTrail}
+        root.each do |k, v|
+          reject_null_key!(k, nil, path)
+          pending << {v.as(TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any)), KeyTrail.new(k, nil)}
+        end
 
         while entry = pending.pop?
-          node, key = entry
+          node, trail = entry
           case node
           when Hash(String, TOML::Any)
-            node.each { |k, v| pending << {v.as(TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any)), "#{key}.#{k}"} }
+            node.each do |k, v|
+              reject_null_key!(k, trail, path)
+              pending << {v.as(TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any)), KeyTrail.new(".#{k}", trail)}
+            end
           when Array(TOML::Any)
-            node.each_with_index { |v, i| pending << {v.as(TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any)), "#{key}[#{i}]"} }
+            node.each_with_index do |v, i|
+              pending << {v.as(TOML::Any | Hash(String, TOML::Any) | Array(TOML::Any)), KeyTrail.new("[#{i}]", trail)}
+            end
           when TOML::Any
             raw = node.raw
             case raw
             when String
               next unless raw.includes?(Char::ZERO)
-              raise Hwaro::HwaroError.new(
-                code: Hwaro::Errors::HWARO_E_CONFIG,
-                # The key is capped: a `[a.b.c…]` header can be arbitrarily
-                # long, and an unreadable wall of segments is a worse
-                # diagnostic than a truncated one.
-                message: "#{Utils::TextUtils.truncate_error(key, 200)} in #{path} contains a NUL byte (\\u0000).",
-                hint: "Remove the \\u0000 escape from the value; NUL is not valid in a path, filename, URL, or title.",
-              )
+              raise null_byte_error(trail.to_s, path)
             when Hash(String, TOML::Any)
-              pending << {raw, key}
+              pending << {raw, trail}
             when Array(TOML::Any)
-              pending << {raw, key}
+              pending << {raw, trail}
             end
           end
         end
+      end
+
+      # One segment of a dotted key, linked to its parent.
+      #
+      # The trail is only ever READ on the raise path, so segments are linked
+      # rather than concatenated: building `"#{key}.#{k}"` at every node made
+      # the walk quadratic in depth, which is exactly the shape (a very deep
+      # `[a.b.c…]` header) the iterative rewrite exists to survive — 100k
+      # segments cost 6.3s of string building on top of a 0.9s parse.
+      private class KeyTrail
+        getter segment : String
+        getter parent : KeyTrail?
+
+        def initialize(@segment : String, @parent : KeyTrail?)
+        end
+
+        def to_s(io : IO) : Nil
+          segments = [] of String
+          node : KeyTrail? = self
+          while current = node
+            segments << current.segment
+            node = current.parent
+          end
+          segments.reverse_each { |s| io << s }
+        end
+      end
+
+      private def self.reject_null_key!(key : String, trail : KeyTrail?, path : String) : Nil
+        return unless key.includes?(Char::ZERO)
+        raise null_byte_error(trail ? "#{trail}.#{key}" : key, path)
+      end
+
+      private def self.null_byte_error(key : String, path : String) : Hwaro::HwaroError
+        Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_CONFIG,
+          # The key is capped: a `[a.b.c…]` header can be arbitrarily long, and
+          # an unreadable wall of segments is a worse diagnostic than a
+          # truncated one.
+          message: "#{Utils::TextUtils.truncate_error(key, 200)} in #{path} contains a NUL byte (\\u0000).",
+          hint: "Remove the \\u0000 escape from the value; NUL is not valid in a path, filename, URL, or title.",
+        )
       end
 
       # Parse a TOML string, re-raising any parser failure as a classified

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -1158,10 +1158,12 @@ module Hwaro
           # `watch_for_changes` rescues every iteration of its poll loop, but
           # its one-time setup (`initial_watch_mtimes`, a full stat sweep of
           # the watched roots) runs before that loop and outside any handler.
-          # An exception escaping a `spawn` body is fatal to the PROCESS — the
-          # CLI's top-level rescue only wraps the main fiber — so a file that
-          # vanished or a permission flip during startup killed the whole dev
-          # server. Degrade to a server that still serves, and say so.
+          # An exception there does not kill the process — Crystal's
+          # `Fiber#run` prints `Unhandled exception in spawn` and the server
+          # keeps serving — which is precisely the bad outcome: a raw
+          # backtrace scrolls past, and from then on saves silently stop
+          # rebuilding for the rest of the session with nothing to say why.
+          # Report it as what it is, and name the way out.
           Logger.error "[Watch] Watcher could not start: #{error.message}. File changes will not trigger rebuilds; restart 'hwaro serve' to retry."
           Logger.debug "[Watch] Backtrace: #{error.backtrace?.try(&.first(5).join("\n    ")) || "unavailable"}"
         end

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -1154,6 +1154,16 @@ module Hwaro
           # `nil` without blocking.
           deferred_done.receive?
           watch_for_changes(watch_options)
+        rescue error
+          # `watch_for_changes` rescues every iteration of its poll loop, but
+          # its one-time setup (`initial_watch_mtimes`, a full stat sweep of
+          # the watched roots) runs before that loop and outside any handler.
+          # An exception escaping a `spawn` body is fatal to the PROCESS — the
+          # CLI's top-level rescue only wraps the main fiber — so a file that
+          # vanished or a permission flip during startup killed the whole dev
+          # server. Degrade to a server that still serves, and say so.
+          Logger.error "[Watch] Watcher could not start: #{error.message}. File changes will not trigger rebuilds; restart 'hwaro serve' to retry."
+          Logger.debug "[Watch] Backtrace: #{error.backtrace?.try(&.first(5).join("\n    ")) || "unavailable"}"
         end
 
         emit_ready_signal(host, port, json_output, base_path)

--- a/src/utils/output_guard.cr
+++ b/src/utils/output_guard.cr
@@ -19,8 +19,9 @@ module Hwaro
         # Canonicalize once — the previous within_output_dir? + canonical
         # sequence expanded output_path twice (a getcwd syscall and several
         # Path allocations each), and this runs for every written file.
-        canonical_output = canonical(output_path)
-        if contains?(canonical(output_dir), canonical_output)
+        canonical_output = canonical?(output_path)
+        canonical_dir = canonical?(output_dir)
+        if canonical_output && canonical_dir && contains?(canonical_dir, canonical_output)
           canonical_output
         else
           Logger.warn "Skipping output outside output directory: #{output_path}"
@@ -31,7 +32,10 @@ module Hwaro
       # Check if a path is within the output directory.
       #
       def within_output_dir?(output_path : String, output_dir : String) : Bool
-        contains?(canonical(output_dir), canonical(output_path))
+        dir = canonical?(output_dir)
+        target = canonical?(output_path)
+        return false unless dir && target
+        contains?(dir, target)
       end
 
       private def contains?(canonical_dir : String, canonical_output : String) : Bool
@@ -42,6 +46,19 @@ module Hwaro
         # this method exists to avoid.
         prefix = canonical_dir.ends_with?(File::SEPARATOR) ? canonical_dir : canonical_dir + File::SEPARATOR
         canonical_output.starts_with?(prefix)
+      end
+
+      # A path that cannot be canonicalized at all is, by definition, not
+      # inside the output directory. `File.expand_path` builds a `Path`, whose
+      # `check_no_null_byte` raises `ArgumentError` for an embedded NUL — so
+      # these two SAFETY predicates used to abort the build with a bare
+      # "String contains null byte" instead of answering "not safe", which is
+      # exactly the outcome a guard exists to produce. Nil means "no canonical
+      # form"; `contains?` treats that as outside.
+      private def canonical?(path : String) : String?
+        canonical(path)
+      rescue ArgumentError
+        nil
       end
 
       # Absolute, comparison-ready form of `path`.

--- a/src/utils/text_utils.cr
+++ b/src/utils/text_utils.cr
@@ -27,6 +27,11 @@ module Hwaro
       # codepoint in the terminal). Returns the message untouched when it fits,
       # which is every ordinary error.
       def truncate_error(message : String, max : Int32 = MAX_ERROR_CHARS) : String
+        # A negative budget is nonsense, but `String#[0, negative]` answers it
+        # with `ArgumentError: Negative count` — turning a caller's bad cap
+        # into a crash while it was busy REPORTING another error, which is the
+        # worst possible moment to raise. Clamp to "keep nothing" instead.
+        max = 0 if max < 0
         return message if message.size <= max
         "#{message[0, max]}… (truncated, #{message.size} characters)"
       end
@@ -227,12 +232,22 @@ module Hwaro
         width
       end
 
+      # Widest padding run `pad_display` will emit. Far past any real terminal,
+      # so alignment is unaffected; it only bounds a nonsense width.
+      MAX_PAD_COLUMNS = 10_000
+
       # Left-align `s` in a field `width` terminal columns across. The
       # display-width counterpart of `String#ljust`; identical to it for
       # ASCII-only input.
       def pad_display(s : String, width : Int32) : String
-        pad = width - display_width(s)
-        pad > 0 ? "#{s}#{" " * pad}" : s
+        # Int64 subtraction: `width - display_width(s)` overflows Int32 for a
+        # width near either extreme (a terminal width read as Int32::MIN, a
+        # column computed from a pathological label), and `String#*` then gets
+        # a negative or absurd count. Both raise out of a pure FORMATTING
+        # helper. Cap the padding at a full screen's worth instead.
+        pad = width.to_i64 - display_width(s).to_i64
+        return s unless pad > 0
+        "#{s}#{" " * pad.clamp(0_i64, MAX_PAD_COLUMNS.to_i64)}"
       end
 
       # Space through `~`: one byte, one codepoint, one column each — the


### PR DESCRIPTION
## What

Fuzzed every CLI surface for crashes, fixed the five that turned up, and hardened the guards that let them through.

**~12,000 adversarial cases** across: mutation fuzzing of content / templates / config / shortcodes, malformed and truncated images, hostile filesystem states (symlink loops, FIFOs, unreadable files, missing dirs), HTTP request fuzzing against `serve`, importer source trees for all 8 formats, deep-recursion inputs, invalid UTF-8, and unit fuzzing of the utility layer.

The mainstream build path held throughout — no crash reachable from content or templates. These five did not hold.

## The interesting one: a guard defeated by its own operand

`validate_output_filename!` exists to catch NUL bytes. Its condition was:

```crystal
NON_FILE_BASENAMES.includes?(File.basename(value)) || value.includes?(Char::ZERO)
```

`File.basename` builds a `Path`, and `Path.new` calls `check_no_null_byte` — so the **left** operand raised before the NUL test on its right could ever run. The guard failed on precisely the input it was written for.

`"x\u0000z"` is a well-formed TOML escape, so the NUL reached every consumer of the value, and the CLI's top-level `rescue Exception` printed:

```
Error: String contains null byte
```

No code, no file, no key, no hint, exit 1. Confirmed on **seven keys**: `[build] output_dir`, `[sitemap] filename`, `[robots] filename`, `[llms] filename` / `full_filename`, `[feeds] filename`, `[search] filename`, `[og.auto_image] output_dir`.

Now:

```
Error [HWARO_E_CONFIG]: sitemap.exclude[1] in config.toml contains a NUL byte (\u0000).
Remove the \u0000 escape from the value; NUL is not valid in a path, filename, URL, or title.
```

exit 3. The operand order is fixed, and a `reject_null_bytes!` walk over the parsed TOML tree closes the class once at the boundary — values **and** quoted keys — for every current and future key.

## The rest

| Fix | Was |
|---|---|
| `OutputGuard.safe_output_path` / `within_output_dir?` | Safety predicates that **raised** instead of answering: a NUL path aborted the build rather than reporting "not inside the output directory". A path with no canonical form is now simply outside. |
| `tool check-links` worker pool | The only fiber pool in the tree without the send-guarantee the build's pools carry. A worker that raised mid-URL delivered no result, and the collector blocks on `urls.size` receives with no timeout — an unbounded hang. |
| `serve` watcher | `watch_for_changes` rescues every poll iteration, but its one-time `initial_watch_mtimes` sweep runs before that loop, unguarded, inside a `spawn`. A vanished file or permission flip at startup meant a raw backtrace and then permanently silent rebuilds. Now an actionable message. |
| `truncate_error` / `pad_display` | `ArgumentError: Negative count` while *reporting another failure*; Int32 overflow at either width extreme. |

## Two self-inflicted problems, caught and fixed

Worth calling out rather than burying:

1. **The first NUL scan was recursive** and blew the stack on a 50k-segment `[a.b.c…]` header — a config the pre-change tree built fine. `[a.b.c…]` creates one nested table per dotted segment and never enters `parse_value`, so the nesting cap in `ext/toml_nesting_limit_fix.cr` does not apply to it. Replaced with an explicit work list (verified against a pre-fix binary).
2. **The iterative version was O(depth²)**, rebuilding the full dotted key at every node. Segments are now linked and joined once on the raise path: a 100k-segment header went 6.3s → 0.14s.

## Review

`/code-review high` raised four findings, all valid, all fixed in `2fbe5b80`: NUL in keys, the quadratic key building, and two comments that asserted a `spawn` exception kills the process (it does not — `Fiber#run` rescues and prints; verified on 1.21, comments now state the real failure modes), plus a temp-file leak in the spec helper.

## Verification

- Full suite **8214 examples, 0 failures** — `spec/unit/crash_hardening_spec.cr` adds 23, of which 15 fail against the pre-fix tree
- `crystal tool format --check` clean, `ameba` 0 failures
- Post-fix fuzz re-run (config / content / CLI) — 0 findings
- Smoke: `build`, `tool check-links`, `serve` + live watch rebuild all healthy
