### PR TITLE
fix(nix): repair the flake, which had never produced a working build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ on:
       - docker/entrypoint.sh
       - action.yml
       - "**/*.cr"
+      # The Nix packaging silently rotted for several releases because nothing
+      # built it; build-nix exists to catch that, so it has to run when these
+      # change too.
+      - flake.nix
+      - flake.lock
+      - shards.nix
   push:
     branches: [main]
   workflow_dispatch:
@@ -135,6 +141,43 @@ jobs:
         run: shards build
       - name: Run tests
         run: crystal spec
+  build-nix:
+    # One runner per system flake.nix declares: a bad tarball hash or a
+    # platform-specific link failure must not reach a user's `nix profile
+    # install` just because CI only ever built x86_64-linux.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            runner: ubuntu-latest
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
+          - system: aarch64-darwin
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      # Builds the package and runs its `hwaro --help` install check. shards.nix
+      # is consumed offline inside the sandbox, so a dependency missing from it
+      # fails here rather than in a user's `nix profile install`.
+      - name: Build flake package
+        run: nix build --print-build-logs .#packages.${{ matrix.system }}.hwaro
+      - name: Smoke test
+        run: ./result/bin/hwaro --version
+      - name: Check flake outputs
+        run: nix flake check --print-build-logs
+      # A stale shards.nix still builds -- it just builds against the wrong
+      # dependency revisions -- so drift from shard.lock has to be checked
+      # explicitly. `nix develop -c` runs the crystal2nix pinned by flake.lock,
+      # the same one `just nix-update` uses, so this gate cannot fail on a
+      # crystal2nix version the author never ran.
+      - name: shards.nix matches shard.lock
+        if: matrix.system == 'x86_64-linux'
+        run: |
+          nix develop --command crystal2nix
+          git diff --exit-code -- shards.nix
   build-snapcraft:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ Run the suite as a **single** `crystal spec` process. `crystal spec` links every
 
 Dependencies (shard.yml): `markd` (Markdown), `toml` (TOML parsing), `crinja` (Jinja2 templates), `emoji`.
 
+Anything that changes `shard.lock` must be followed by `just nix-update` — the Nix build resolves dependencies offline from `shards.nix`, so a stale one silently compiles against the wrong revisions. CI's `build-nix` job checks both. `flake.nix` reads the version and the minimum Crystal straight out of `shard.yml`, so release bumps never touch it.
+
 Hwaro requires Crystal >= 1.21 and gets its parallelism from Crystal's **execution contexts**: `src/main.cr` resizes the default `Fiber::ExecutionContext::Parallel` to `default_workers_count` (which honours `CRYSTAL_WORKERS`, defaulting to the CPU count). Do NOT reintroduce `-Dpreview_mt` — Crystal 1.21 deprecated it, and its legacy MT scheduler can spin forever at process exit (all `CRYSTAL-MT-*` threads stuck in `Crystal::SpinLock#lock` inside the event loop), so `hwaro build` never returns. Every `spawn` lands in the default context, so the build still runs fibers across cores: new code that mutates shared state from worker fibers must guard with a `Mutex` or use the existing `@crinja_cache_mutex`; new directory creation must go through `Hwaro::Utils::FileSafe.mkdir_p` rather than `FileUtils.mkdir_p` (the latter has a check-then-create race that fires under parallelism).
 
 ## Directory Structure

--- a/docs/content/start/installation.ko.md
+++ b/docs/content/start/installation.ko.md
@@ -70,6 +70,27 @@ nix run github:hahwul/hwaro -- --version
 nix develop github:hahwul/hwaro
 ```
 
+개발 셸에는 Crystal, `shards`, `just`, `crystal2nix`가 함께 들어 있어 다른 것을
+설치하지 않아도 `just build`와 `just test`를 바로 실행할 수 있습니다.
+
+### 플레이크 입력으로 사용하기
+
+```nix
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.hwaro.url = "github:hahwul/hwaro";
+
+  outputs = { nixpkgs, hwaro, ... }: {
+    # `hwaro.packages.<system>.hwaro`를 쓰거나, `hwaro.overlays.default`를
+    # nixpkgs 오버레이에 추가한 뒤 `pkgs.hwaro`로 사용하세요.
+  };
+}
+```
+
+지원 시스템은 `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`입니다
+(nixpkgs-unstable가 Intel macOS 지원을 중단했습니다). 플레이크가 공식 Crystal
+툴체인을 고정해 두므로 컴파일러를 소스에서 빌드할 필요가 없습니다.
+
 ## 사전 빌드 바이너리
 
 macOS와 Linux용 사전 빌드 바이너리를 [GitHub Releases](https://github.com/hahwul/hwaro/releases) 페이지에서 받을 수 있습니다.

--- a/docs/content/start/installation.md
+++ b/docs/content/start/installation.md
@@ -70,6 +70,27 @@ nix run github:hahwul/hwaro -- --version
 nix develop github:hahwul/hwaro
 ```
 
+The dev shell brings its own Crystal, `shards`, `just`, and `crystal2nix`, so
+`just build` and `just test` work with nothing else installed.
+
+### As a flake input
+
+```nix
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.hwaro.url = "github:hahwul/hwaro";
+
+  outputs = { nixpkgs, hwaro, ... }: {
+    # `hwaro.packages.<system>.hwaro`, or add `hwaro.overlays.default` to your
+    # nixpkgs overlays and use `pkgs.hwaro`.
+  };
+}
+```
+
+Supported systems are `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`
+(nixpkgs-unstable no longer supports Intel macOS). The flake pins the official
+Crystal toolchain, so no compiler has to be built from source.
+
 ## Pre-built Binary
 
 Pre-built binaries for macOS and Linux are available on the [GitHub Releases](https://github.com/hahwul/hwaro/releases) page.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775639890,
-        "narHash": "sha256-9O9gNidrdzcb7vgKGtff7QiLtr0IsVaCi0pAXm8anhQ=",
+        "lastModified": 1787964612,
+        "narHash": "sha256-0N9nghg3nwzX6b6qc77EzjR9cu/Z+UR66FlfsCqiURs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "456e8a9468b9d46bd8c9524425026c00745bc4d2",
+        "rev": "e8be7818e19ada32105a8af937a6a473b38167ca",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -137,14 +137,20 @@
         # nixpkgs' builder, retargeted at whichever compiler was selected above.
         buildCrystalPackage = pkgs.crystal.buildCrystalPackage.override { inherit crystal; };
 
-        # Crystal's stdlib pulls these in through `compress/*`, `openssl` and
-        # `xml`, and neither toolchain supplies them: the pinned tarball bundles
-        # only pcre2/bdwgc/libyaml/libffi, and nixpkgs' crystal wrapper exports
-        # its own build inputs, not ours.
+        # Crystal's stdlib links these through `compress/*`, `openssl`, `xml`
+        # and `yaml`, and neither toolchain supplies them.
+        #
+        # libyaml looks redundant on macOS and is not: the darwin tarball's
+        # bin/crystal is a wrapper script that appends its bundled embedded/lib
+        # (which does contain libyaml) to CRYSTAL_LIBRARY_PATH, while the Linux
+        # tarballs ship a bare static ELF whose only library directory is
+        # lib/crystal -- and that holds libgc.a alone. Dropping libyaml here
+        # builds fine on darwin and fails Linux with `cannot find -lyaml`.
         linkLibs = [
           pkgs.zlib
           pkgs.openssl
           pkgs.libxml2
+          pkgs.libyaml
         ]
         ++ lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.libiconv;
 

--- a/flake.nix
+++ b/flake.nix
@@ -6,61 +6,268 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    let
+      lib = nixpkgs.lib;
+
+      # shard.yml is the single source of truth for both the package version and
+      # the minimum compiler, so a release bump or a Crystal requirement bump
+      # cannot leave this file behind (scripts/version_update.cr therefore does
+      # not rewrite it).
+      shardYml = lib.splitString "\n" (builtins.readFile ./shard.yml);
+
+      shardField =
+        key:
+        let
+          prefix = "${key}: ";
+          hits = builtins.filter (l: lib.hasPrefix prefix l) shardYml;
+        in
+        if hits == [ ] then
+          throw "hwaro: no `${key}:` line in shard.yml"
+        else
+          lib.removePrefix prefix (builtins.head hits);
+
+      version = shardField "version";
+
+      # `crystal: ">= 1.21.0"` -> `1.21.0`. shards also accepts `~>` and
+      # comma-separated constraints; rather than guess at those, refuse them --
+      # a silently mis-parsed constraint would pick the wrong compiler.
+      crystalMinimum =
+        let
+          raw = lib.removeSuffix "\"" (lib.removePrefix "\"" (shardField "crystal"));
+          parsed = builtins.match "^>= ([0-9]+(\\.[0-9]+)*)$" raw;
+        in
+        if parsed == null then
+          throw "hwaro: flake.nix only understands a `crystal: \">= X.Y.Z\"` constraint in shard.yml, got `${raw}`"
+        else
+          builtins.head parsed;
+
+      # hwaro needs Crystal >= 1.21: src/main.cr resizes the default
+      # `Fiber::ExecutionContext`, which does not exist before that release.
+      # nixpkgs still ships 1.19 (checked 2026-08-30), so until it catches up we
+      # build against the official upstream release tarball -- the same artifact
+      # nixpkgs uses to bootstrap its own Crystal.
+      #
+      # Once `pkgs.crystal.version` reaches crystalMinimum the pin stops being
+      # selected and this whole block can be deleted.
+      crystalRelease = {
+        release = "1.21.0";
+        build = "1";
+        # nix store prefetch-file <url>
+        assets = {
+          x86_64-linux = {
+            arch = "linux-x86_64";
+            hash = "sha256-dEVh7jzuGwbRBs+a6ZuAZLTgF1GKxBTW3SPPr+NlYMk=";
+          };
+          aarch64-linux = {
+            arch = "linux-aarch64";
+            hash = "sha256-TzDan/CD3EhWUuPZsE1+gsxMSftuirO6x2y94k2WB3g=";
+          };
+          # No x86_64-darwin: nixpkgs-unstable dropped that platform in 26.11
+          # and throws on evaluation, so listing it would only produce a broken
+          # flake output. Upstream ships a universal macOS tarball, so adding it
+          # back is a one-line change if this flake ever tracks a release branch
+          # that still supports Intel Macs.
+          aarch64-darwin = {
+            arch = "darwin-universal";
+            hash = "sha256-f8SvVrDLXH6lcD90TGYpuxn/Nro6u/Iy1Q5Aw5og7hY=";
+          };
+        };
+      };
+
+      systems = builtins.attrNames crystalRelease.assets;
+    in
+    flake-utils.lib.eachSystem systems (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
 
-        hwaro = pkgs.crystal.buildCrystalPackage rec {
+        asset = crystalRelease.assets.${system};
+
+        # Upstream ships a self-contained toolchain (its own pcre2, bdwgc,
+        # libyaml and libffi live under embedded/), so unpacking is enough --
+        # `buildCommand` deliberately skips fixupPhase, which would otherwise
+        # try to strip and patchelf statically linked musl binaries.
+        pinnedCrystal = pkgs.stdenv.mkDerivation (finalAttrs: {
+          pname = "crystal-upstream";
+          version = crystalRelease.release;
+
+          src = pkgs.fetchurl {
+            url = "https://github.com/crystal-lang/crystal/releases/download/${crystalRelease.release}/crystal-${crystalRelease.release}-${crystalRelease.build}-${asset.arch}.tar.gz";
+            inherit (asset) hash;
+          };
+
+          buildCommand = ''
+            mkdir -p $out
+            tar --strip-components=1 -C $out -xf ${finalAttrs.src}
+            patchShebangs $out/bin
+            # The macOS tarball keeps shards under embedded/bin and exposes only
+            # bin/crystal; the Linux ones ship both in bin/. The dev shell needs
+            # shards on PATH either way.
+            [ -e $out/bin/shards ] || ln -s ../embedded/bin/shards $out/bin/shards
+          '';
+
+          meta = {
+            description = "Official Crystal ${crystalRelease.release} release build";
+            homepage = "https://crystal-lang.org/";
+            license = lib.licenses.asl20;
+            mainProgram = "crystal";
+            platforms = systems;
+          };
+        });
+
+        useNixpkgsCrystal = lib.versionAtLeast pkgs.crystal.version crystalMinimum;
+
+        crystal =
+          if useNixpkgsCrystal then
+            pkgs.crystal
+          else if lib.versionAtLeast crystalRelease.release crystalMinimum then
+            pinnedCrystal
+          else
+            throw "hwaro: shard.yml requires Crystal >= ${crystalMinimum}, but nixpkgs has ${pkgs.crystal.version} and flake.nix pins ${crystalRelease.release}; bump crystalRelease (URLs + hashes) or drop the pin.";
+
+        # pinnedCrystal carries its own matching shards; nixpkgs' crystal does not.
+        toolchain = [ crystal ] ++ lib.optional useNixpkgsCrystal pkgs.shards;
+
+        # nixpkgs' builder, retargeted at whichever compiler was selected above.
+        buildCrystalPackage = pkgs.crystal.buildCrystalPackage.override { inherit crystal; };
+
+        # Crystal's stdlib pulls these in through `compress/*`, `openssl` and
+        # `xml`, and neither toolchain supplies them: the pinned tarball bundles
+        # only pcre2/bdwgc/libyaml/libffi, and nixpkgs' crystal wrapper exports
+        # its own build inputs, not ours.
+        linkLibs = [
+          pkgs.zlib
+          pkgs.openssl
+          pkgs.libxml2
+        ]
+        ++ lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.libiconv;
+
+        # Everything the compiler reads, and nothing else: docs/ and spec/ are
+        # ~17MB that cannot change the binary, so leaving them out keeps
+        # `nix build` cached across documentation work. CHANGELOG.md is left out
+        # for the same reason -- it is rewritten on every release and would
+        # invalidate the derivation for a byte-identical binary. README.md and
+        # LICENSE stay because nixpkgs' installPhase copies them to
+        # $out/share/doc.
+        src = lib.fileset.toSource {
+          root = ./.;
+          fileset = lib.fileset.unions [
+            ./src
+            ./shard.yml
+            ./shard.lock
+            ./README.md
+            ./LICENSE
+          ];
+        };
+
+        hwaro = buildCrystalPackage {
           pname = "hwaro";
-          version = "0.19.0";
+          inherit version src;
 
-          src = ./.;
+          # Without this the default "make" builder runs, and `crystalBinaries`
+          # below is silently ignored.
+          format = "crystal";
 
+          # Regenerate with `just nix-update` whenever shard.lock changes.
           shardsFile = ./shards.nix;
 
-          crystalBinaries.hwaro.src = "src/main.cr";
+          # Kept in sync with `targets.hwaro.main` in shard.yml by hand -- Nix
+          # has no YAML parser at eval time. A stale path fails the build loudly
+          # ("Error: file 'src/main.cr' does not exist"), it cannot build the
+          # wrong thing silently.
+          crystalBinaries.hwaro = {
+            src = "src/main.cr";
+            # release-binary.yml also passes --static on Linux; a Nix build
+            # links against the store closure instead, so that flag is omitted.
+            options = [
+              "--release"
+              "--no-debug"
+            ];
+          };
 
-          crystalBinaries.hwaro.options = [ "--release" "--no-debug" ];
+          buildInputs = linkLibs;
 
-          nativeBuildInputs = [ pkgs.crystal pkgs.shards ];
-          buildInputs = [ ];
-
-          buildPhase = ''
-            runHook preBuild
-            shards build --release
-            runHook postBuild
-          '';
-
-          installPhase = ''
-            runHook preInstall
-            mkdir -p $out/bin
-            cp bin/hwaro $out/bin/hwaro
-            runHook postInstall
-          '';
-
+          # `crystal spec` needs the spec/ tree and shells out to the built
+          # binary over a real socket; CI covers it on every push instead.
           doCheck = false;
 
-          meta = with pkgs.lib; {
+          meta = {
             description = "A fast, lightweight static site generator built with Crystal";
             homepage = "https://github.com/hahwul/hwaro";
-            license = licenses.mit;
-            maintainers = [ "hahwul" ];
+            changelog = "https://github.com/hahwul/hwaro/blob/main/CHANGELOG.md";
+            license = lib.licenses.mit;
             mainProgram = "hwaro";
+            platforms = systems;
           };
         };
       in
       {
-        packages.default = hwaro;
+        packages = {
+          default = hwaro;
+          inherit hwaro;
+        };
+
+        apps.default = {
+          type = "app";
+          program = lib.getExe hwaro;
+          meta = {
+            inherit (hwaro.meta)
+              description
+              homepage
+              license
+              mainProgram
+              ;
+          };
+        };
+
+        # `nix flake check` builds the package (and runs its --help smoke test).
+        checks.hwaro = hwaro;
+
+        formatter = pkgs.nixfmt-tree;
 
         devShells.default = pkgs.mkShell {
-          inputsFrom = [ hwaro ];
-          nativeBuildInputs = with pkgs; [ crystal shards crystal2nix just ];
+          packages = toolchain ++ [
+            pkgs.crystal2nix
+            pkgs.just
+            pkgs.git
+            pkgs.pkg-config
+          ];
+
+          # `just build` shells out to the real `shards`, so the shell needs the
+          # same link-time libraries the package does.
+          buildInputs = linkLibs;
+
+          # stderr, so `nix develop -c <cmd>` stays pipeable.
           shellHook = ''
-            echo "hwaro development environment loaded (via Nix)"
-            echo "Running shards install..."
-            shards install || true
+            {
+              echo "hwaro dev shell — $(crystal --version | head -n1)"
+              echo "  just build       # shards install && shards build"
+              echo "  just test        # crystal spec"
+              echo "  just nix-update  # regenerate shards.nix after shard.lock changes"
+            } >&2
           '';
         };
-      });
+      }
+    )
+    // {
+      # Lets downstream flakes do `pkgs.hwaro` after adding this overlay. It
+      # reuses this flake's own build (including the pinned compiler) rather
+      # than re-resolving against the consumer's nixpkgs.
+      overlays.default =
+        _final: prev:
+        let
+          inherit (prev.stdenv.hostPlatform) system;
+        in
+        {
+          hwaro =
+            self.packages.${system}.hwaro
+              or (throw "hwaro: no package for ${system}; supported systems are ${lib.concatStringsSep ", " systems}");
+        };
+    };
 }

--- a/justfile
+++ b/justfile
@@ -17,10 +17,13 @@ build:
     shards install
     shards build
 
-# Update shards.nix.
+# Update shards.nix. Run this whenever shard.lock changes — the Nix build
+# resolves dependencies offline from shards.nix, and CI gates on the two
+# agreeing. `nix develop` pins crystal2nix via flake.lock so the output matches
+# what CI regenerates.
 [group('build')]
 nix-update:
-    nix-shell -p crystal2nix --run crystal2nix
+    nix develop --command crystal2nix
 
 # Clean build artifacts.
 [group('build')]

--- a/scripts/version_check.cr
+++ b/scripts/version_check.cr
@@ -34,14 +34,8 @@ rescue
   nil
 end
 
-# Extract version from flake.nix
-def get_flake_version : String?
-  content = File.read("flake.nix")
-  match = content.match(/version\s*=\s*"([^"]+)"/)
-  match ? match[1] : nil
-rescue
-  nil
-end
+# flake.nix is intentionally absent: it derives both the package version and
+# the minimum Crystal from shard.yml at eval time, so there is nothing to drift.
 
 # Extract pkgver from aur/PKGBUILD
 def get_pkgbuild_version : String?
@@ -57,17 +51,15 @@ shard_v = get_shard_version
 hwaro_v = get_hwaro_version
 snapcraft_v = get_snapcraft_version
 spec_v = get_spec_version
-flake_v = get_flake_version
 pkgbuild_v = get_pkgbuild_version
 
 puts "Shard version: #{shard_v || "Not found"}"
 puts "Hwaro version: #{hwaro_v || "Not found"}"
 puts "Snapcraft version: #{snapcraft_v || "Not found"}"
 puts "Spec version: #{spec_v || "Not found"}"
-puts "Flake version: #{flake_v || "Not found"}"
 puts "PKGBUILD version: #{pkgbuild_v || "Not found"}"
 
-versions = [shard_v, hwaro_v, snapcraft_v, spec_v, flake_v, pkgbuild_v].compact
+versions = [shard_v, hwaro_v, snapcraft_v, spec_v, pkgbuild_v].compact
 
 if versions.empty?
   puts "No versions found!"

--- a/scripts/version_update.cr
+++ b/scripts/version_update.cr
@@ -5,7 +5,6 @@ SHARD_FILE     = "shard.yml"
 HWARO_FILE     = "src/hwaro.cr"
 SNAPCRAFT_FILE = "snap/snapcraft.yaml"
 SPEC_FILE      = "spec/hwaro_spec.cr"
-FLAKE_FILE     = "flake.nix"
 PKGBUILD_FILE  = "aur/PKGBUILD"
 
 # Extract version from shard.yml
@@ -42,14 +41,8 @@ rescue
   nil
 end
 
-# Extract version from flake.nix
-def get_flake_version : String?
-  content = File.read(FLAKE_FILE)
-  match = content.match(/version\s*=\s*"([^"]+)"/)
-  match ? match[1] : nil
-rescue
-  nil
-end
+# flake.nix is intentionally absent: it derives both the package version and
+# the minimum Crystal from shard.yml at eval time, so there is nothing to bump.
 
 # Extract pkgver from aur/PKGBUILD
 def get_pkgbuild_version : String?
@@ -104,17 +97,6 @@ rescue ex
   false
 end
 
-# Update flake.nix version
-def update_flake_version(new_version : String) : Bool
-  content = File.read(FLAKE_FILE)
-  updated = content.gsub(/^(\s*version\s*=\s*")[\d.]+(";\s*)$/m, "\\1#{new_version}\\2")
-  File.write(FLAKE_FILE, updated)
-  true
-rescue ex
-  puts "  Error updating #{FLAKE_FILE}: #{ex.message}"
-  false
-end
-
 # Update aur/PKGBUILD pkgver (and reset pkgrel to 1)
 def update_pkgbuild_version(new_version : String) : Bool
   content = File.read(PKGBUILD_FILE)
@@ -143,7 +125,6 @@ shard_v = get_shard_version
 hwaro_v = get_hwaro_version
 snapcraft_v = get_snapcraft_version
 spec_v = get_spec_version
-flake_v = get_flake_version
 pkgbuild_v = get_pkgbuild_version
 
 puts "Current versions:"
@@ -151,12 +132,11 @@ puts "  #{SHARD_FILE.ljust(25)} #{shard_v || "Not found"}"
 puts "  #{HWARO_FILE.ljust(25)} #{hwaro_v || "Not found"}"
 puts "  #{SNAPCRAFT_FILE.ljust(25)} #{snapcraft_v || "Not found"}"
 puts "  #{SPEC_FILE.ljust(25)} #{spec_v || "Not found"}"
-puts "  #{FLAKE_FILE.ljust(25)} #{flake_v || "Not found"}"
 puts "  #{PKGBUILD_FILE.ljust(25)} #{pkgbuild_v || "Not found"}"
 puts
 
 # Check if versions match
-versions = [shard_v, hwaro_v, snapcraft_v, spec_v, flake_v, pkgbuild_v].compact
+versions = [shard_v, hwaro_v, snapcraft_v, spec_v, pkgbuild_v].compact
 unique_versions = versions.uniq
 
 if unique_versions.size > 1
@@ -234,17 +214,6 @@ if spec_v
   total_count += 1
   print "  Updating #{SPEC_FILE}... "
   if update_spec_version(new_version)
-    puts "✓"
-    success_count += 1
-  else
-    puts "✗"
-  end
-end
-
-if flake_v
-  total_count += 1
-  print "  Updating #{FLAKE_FILE}... "
-  if update_flake_version(new_version)
     puts "✓"
     success_count += 1
   else

--- a/shards.nix
+++ b/shards.nix
@@ -1,13 +1,33 @@
 {
   "ameba" = {
     url = "https://github.com/crystal-ameba/ameba.git";
-    rev = "77bf37bb5d3f7751bb531d2e5e67d66a28474579";
-    sha256 = "0pxak8iqc235xb6khi7s1ynq7zk9psg9hab2bg0dzxd3jy8576rq";
+    rev = "v1.7.0";
+    sha256 = "0blfyizcajyrgbfxhiwnvf1xmz3wfx6kpf9jf8x7daxihany4r9z";
+  };
+  "baked_file_system" = {
+    url = "https://github.com/ralsina/baked_file_system.git";
+    rev = "beb373124c7a235cfb9cd94e36849d8168eaa04b";
+    sha256 = "1vlh7fm8kadk601yynayrmkbi5bgnh7d7jmzh5c0gql3ygq0za3r";
+  };
+  "base58" = {
+    url = "https://github.com/crystal-china/base58.cr.git";
+    rev = "0e2c44d16a8098b00d8bf0b74add8bb9ea2f1c5f";
+    sha256 = "1v3zy6c9j89r5wmij46n011ax4cmci42v6rjfa078h6wg7l4g3xh";
+  };
+  "crimage" = {
+    url = "https://github.com/naqvis/crimage.git";
+    rev = "7d3244a3850646e3d398cef071f7c3e3f52c7518";
+    sha256 = "0f8zh3jyfjbkjv2lshjg8gcib6xdw5ql3x4hrxnccfvmn3w4bbbn";
   };
   "crinja" = {
     url = "https://github.com/straight-shoota/crinja.git";
     rev = "v0.9.0";
     sha256 = "053prl09ldz1p0l85cdx2683h6nn77sy5hb1wqmgh145c02a711r";
+  };
+  "docopt" = {
+    url = "https://github.com/ralsina/docopt.cr.git";
+    rev = "v0.3.1";
+    sha256 = "01kxavr5i6f4xvxhi4kxq8cn0ilq47hz2rybiqx2p20qani31gag";
   };
   "emoji" = {
     url = "https://github.com/veelenga/emoji.cr.git";
@@ -18,6 +38,16 @@
     url = "https://github.com/icyleaf/markd.git";
     rev = "v0.5.0";
     sha256 = "1a677z57kwjq6lp4ws7br1ga8jgpgi8990glhd1r8756bdyd8mg0";
+  };
+  "sixteen" = {
+    url = "https://github.com/ralsina/sixteen.git";
+    rev = "v0.7.0";
+    sha256 = "1p09a26x0wfhsisnpxya0zils050w205mqpbkjpn0173clhm38zv";
+  };
+  "tartrazine" = {
+    url = "https://github.com/ralsina/tartrazine.git";
+    rev = "v0.20.1";
+    sha256 = "15g5w32aqdd2v2r1bjd1x45wg6y8jax8dabx4hch77ffpwl296am";
   };
   "toml" = {
     url = "https://github.com/crystal-community/toml.cr.git";


### PR DESCRIPTION
## Problem

`nix profile install github:hahwul/hwaro` — and every other Nix entry point the install docs advertise — has never worked. Three independent breaks, each sufficient on its own:

1. **The sandbox build could not fetch dependencies.** `flake.nix` overrode `buildPhase` with `shards build --release`, which `git clone`s dependencies at build time and dies on `fatal: unable to access ...: SSL certificate ... unable to get local issuer certificate`. `crystalBinaries` was configured but `format` was not, so `buildCrystalPackage` was silently running its `make` builder and ignoring those attrs — nixpkgs' offline `crystal build` path never ran.
2. **`shards.nix` listed 5 of 11 shards.** Last regenerated in #400, before `tartrazine`, `crimage`, `baked_file_system`, `base58`, `docopt` and `sixteen` entered `shard.lock`.
3. **No nixpkgs release has a new enough Crystal.** `nixpkgs-unstable` ships 1.19.1; `src/main.cr` resizes the default `Fiber::ExecutionContext` (1.21-only) and `shard.yml` requires `>= 1.21.0`.

Nothing in CI built the flake, which is why it rotted across several releases unnoticed.

## Fix

- Drop the custom `buildPhase`/`installPhase`, set `format = "crystal"`, and let nixpkgs resolve dependencies offline from `shards.nix`.
- Regenerate `shards.nix` (all 11 shards).
- Build against the **official upstream Crystal release tarball** — the same artifact nixpkgs uses to bootstrap its own compiler, and self-contained enough (its own pcre2/bdwgc/libyaml/libffi under `embedded/`) that unpacking is the entire derivation. It is selected only while `pkgs.crystal.version` is below the requirement, so the pin retires itself when nixpkgs catches up.
- `buildInputs` carries zlib/openssl/libxml2 (+ libiconv on darwin); without them the link fails on `-lz`.

### Drift guards

`shard.yml` is now the source of truth for the package version **and** the minimum compiler, so a release bump never touches `flake.nix` — `scripts/version_check.cr` and `scripts/version_update.cr` stop tracking it. Both parses refuse what they don't understand instead of guessing:

- an unrecognized `crystal:` constraint form (`~>`, comma lists) throws rather than mis-selecting a compiler;
- a requirement that outruns the pin throws with a message naming the fix.

### Also

- `apps` / `checks` / `formatter` / `overlays.default` outputs; `docs/` and `spec/` out of the source closure.
- The dev shell now carries the pinned toolchain's own **shards 0.20.0** — it was silently borrowing the host's Homebrew copy, so `just build` would have failed on a clean machine despite the docs promising otherwise.
- `just nix-update` runs the flake-pinned `crystal2nix` (the old `nix-shell -p` recipe fails on flakes-only machines).
- `flake.lock` refreshed (nixpkgs was 5 months stale); install docs (EN/KO) gain dev-shell, flake-input and supported-system notes.
- `x86_64-darwin` dropped: nixpkgs-unstable 26.11 throws on evaluation for that platform.

## CI

A new `build-nix` job builds all three declared systems (`x86_64-linux`, `aarch64-linux`, `aarch64-darwin`) and runs `nix flake check`. It also regenerates `shards.nix` and diffs it — a *stale* `shards.nix` builds fine, against the wrong revisions, and nothing else would catch that.

## Verification

- `nix build` / `nix run` / `nix develop` / `nix flake check` all pass on aarch64-darwin.
- The Nix-built binary produces **byte-identical `public/`** to a locally `shards build`-ed binary (blog scaffold with OG images enabled, so the stb C bridge and the baked fonts are exercised).
- `shards install && shards build` works inside `nix develop` using the pinned shards.
- `crystal tool format --check` clean, ameba 507 files / 0 failures, `version_check` green.
- Linux was **not** built locally (no Linux builder available here) — the new CI job is the first real check on those two systems.