### PR TITLE
fix(serve): stop identical data/ rewrites by pre-build hooks from looping full rebuilds

### DIFF
--- a/spec/functional/serve_data_hook_loop_spec.cr
+++ b/spec/functional/serve_data_hook_loop_spec.cr
@@ -1,0 +1,280 @@
+require "../spec_helper"
+require "../../src/services/server/server"
+
+# Regression coverage for #755: a `build.hooks.pre` command that rewrites an
+# unchanged payload into data/ (the workflow #752 documents — `curl -o
+# data/x.json`) used to retrigger a full rebuild forever. Any data/i18n
+# change forces a full rebuild, a full rebuild re-runs the pre hooks, and the
+# watcher compared mtime+size only — so the hook's byte-identical rewrite
+# registered as a modification, once per debounce interval, for the lifetime
+# of the serve session.
+#
+# The watcher now carries a content digest in the FileStamp for the
+# full-rebuild buckets (data/**, i18n/**) and drops stamp changes whose
+# bytes are unchanged. Genuinely changed payloads must still force the full
+# rebuild they always did, and content/ / templates/ / static/ must stay
+# mtime-based (their rebuild paths never re-run hooks, so they cannot loop).
+
+# Reopened for the private seams; names are prefixed so they can't collide
+# with the shims other spec files install.
+module Hwaro
+  module Services
+    class Server
+      def data_loop_builder : Hwaro::Core::Build::Builder
+        @builder
+      end
+
+      def data_loop_capture_baseline
+        capture_watch_baseline
+      end
+
+      def data_loop_initial_watch_mtimes : Hash(String, FileStamp)
+        initial_watch_mtimes
+      end
+
+      def data_loop_scan(prev : Hash(String, FileStamp)? = nil) : Hash(String, FileStamp)
+        scan_mtimes(prev)
+      end
+
+      def data_loop_detect_changes(old_mtimes : Hash(String, FileStamp), new_mtimes : Hash(String, FileStamp)) : ChangeSet
+        detect_changes(old_mtimes, new_mtimes)
+      end
+    end
+  end
+end
+
+private def data_loop_options : Hwaro::Config::Options::BuildOptions
+  options = Hwaro::Config::Options::BuildOptions.new(
+    output_dir: "public",
+    parallel: false,
+    highlight: false,
+  )
+  options.serve_mode = true
+  options
+end
+
+private def write_data_loop_site
+  File.write("config.toml", <<-TOML
+    title = "Data Hook Loop"
+    base_url = "https://example.com"
+    TOML
+  )
+  FileUtils.mkdir_p("content")
+  FileUtils.mkdir_p("templates")
+  FileUtils.mkdir_p("data")
+  File.write("templates/page.html", "<html><body>{{ content }}</body></html>")
+  File.write("content/foo.md", "---\ntitle: Foo\n---\nBody")
+end
+
+# A rewrite whose bytes are `content` but whose stamp is guaranteed to move:
+# the explicit future mtime makes the FileStamp differ even under coarse
+# mtime granularity, exactly like a hook's `curl -o` landing between polls.
+private def rewrite_with_fresh_mtime(path : String, content : String)
+  File.write(path, content)
+  File.touch(path, Time.utc + 5.seconds)
+end
+
+describe "serve data/i18n hook-loop regression (#755)" do
+  it "drops a byte-identical data/ rewrite with a fresh mtime" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_data_loop_site
+        File.write("data/site.json", %({"answer": 42}))
+
+        server = Hwaro::Services::Server.new
+        old = server.data_loop_scan
+        rewrite_with_fresh_mtime("data/site.json", %({"answer": 42}))
+
+        changes = server.data_loop_detect_changes(old, server.data_loop_scan)
+        changes.empty?.should be_true
+      end
+    end
+  end
+
+  it "still full-rebuilds on a same-size data/ change" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_data_loop_site
+        File.write("data/site.json", %({"answer": 42}))
+
+        server = Hwaro::Services::Server.new
+        old = server.data_loop_scan
+        rewrite_with_fresh_mtime("data/site.json", %({"answer": 43}))
+
+        changes = server.data_loop_detect_changes(old, server.data_loop_scan)
+        changes.modified_data.should eq(["data/site.json"])
+        changes.needs_full_rebuild?.should be_true
+      end
+    end
+  end
+
+  it "still full-rebuilds on a size-changing data/ change" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_data_loop_site
+        File.write("data/site.json", %({"answer": 42}))
+
+        server = Hwaro::Services::Server.new
+        old = server.data_loop_scan
+        rewrite_with_fresh_mtime("data/site.json", %({"answer": 42, "more": true}))
+
+        changes = server.data_loop_detect_changes(old, server.data_loop_scan)
+        changes.modified_data.should eq(["data/site.json"])
+        changes.needs_full_rebuild?.should be_true
+      end
+    end
+  end
+
+  it "drops a byte-identical i18n/ rewrite with a fresh mtime" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_data_loop_site
+        FileUtils.mkdir_p("i18n")
+        File.write("i18n/en.toml", %(hello = "Hello"))
+
+        server = Hwaro::Services::Server.new
+        old = server.data_loop_scan
+        rewrite_with_fresh_mtime("i18n/en.toml", %(hello = "Hello"))
+
+        changes = server.data_loop_detect_changes(old, server.data_loop_scan)
+        changes.empty?.should be_true
+      end
+    end
+  end
+
+  it "still full-rebuilds on a changed i18n/ file" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_data_loop_site
+        FileUtils.mkdir_p("i18n")
+        File.write("i18n/en.toml", %(hello = "Hello"))
+
+        server = Hwaro::Services::Server.new
+        old = server.data_loop_scan
+        rewrite_with_fresh_mtime("i18n/en.toml", %(hello = "Howdy"))
+
+        changes = server.data_loop_detect_changes(old, server.data_loop_scan)
+        changes.modified_data.should eq(["i18n/en.toml"])
+        changes.needs_full_rebuild?.should be_true
+      end
+    end
+  end
+
+  # Structural events must be untouched by the digest comparison: a new data
+  # file is genuinely new content, and a deleted one genuinely gone — both
+  # keep forcing the full rebuild they always did.
+  it "keeps added and removed data/ files as full-rebuild events" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_data_loop_site
+
+        server = Hwaro::Services::Server.new
+        old = server.data_loop_scan
+        File.write("data/new.json", %({"fresh": true}))
+
+        added = server.data_loop_detect_changes(old, server.data_loop_scan)
+        added.added_files.should eq(["data/new.json"])
+        added.needs_full_rebuild?.should be_true
+
+        with_file = server.data_loop_scan
+        File.delete("data/new.json")
+        removed = server.data_loop_detect_changes(with_file, server.data_loop_scan)
+        removed.removed_files.should eq(["data/new.json"])
+        removed.needs_full_rebuild?.should be_true
+      end
+    end
+  end
+
+  # content/, templates/ and static/ stay mtime-based on purpose: their
+  # rebuild paths are incremental (or a plain copy) and never re-run
+  # build.hooks.pre, so they cannot produce the #755 loop — and hashing
+  # them would tax every save of every page.
+  it "keeps content/ and static/ touches mtime-based (no content comparison)" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_data_loop_site
+        FileUtils.mkdir_p("static")
+        File.write("static/site.css", "body{}")
+
+        server = Hwaro::Services::Server.new
+        old = server.data_loop_scan
+        rewrite_with_fresh_mtime("content/foo.md", "---\ntitle: Foo\n---\nBody")
+        rewrite_with_fresh_mtime("static/site.css", "body{}")
+
+        changes = server.data_loop_detect_changes(old, server.data_loop_scan)
+        changes.modified_content.should eq(["content/foo.md"])
+        changes.modified_static.should eq(["static/site.css"])
+      end
+    end
+  end
+
+  # The prefilter contract: scanning against a previous snapshot must not
+  # re-read files whose mtime+size are unchanged, and a quiet tree must
+  # produce a snapshot EQUAL to the previous one — the watch loop's
+  # `current != last` quick check and the debounce settle test both compare
+  # whole snapshots, digests included, so an unstable digest would spin them.
+  it "carries digests forward for unchanged stamps and yields equal snapshots" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_data_loop_site
+        File.write("data/site.json", %({"answer": 42}))
+
+        server = Hwaro::Services::Server.new
+        old = server.data_loop_scan
+        server.data_loop_scan(old).should eq(old)
+
+        # A same-size edit with the mtime forced back onto the old stamp is
+        # invisible: the digest is carried, not recomputed. That is the
+        # documented FileStamp tradeoff (bytes can't change without moving
+        # mtime or size in any real editor/tool flow), and it is what keeps
+        # steady-state polls read-free for large data files.
+        mtime = File.info("data/site.json").modification_time
+        File.write("data/site.json", %({"answer": 24}))
+        File.touch("data/site.json", mtime)
+        server.data_loop_scan(old)["data/site.json"].should eq(old["data/site.json"])
+      end
+    end
+  end
+
+  # The end-to-end #752 pattern: a pre hook that "fetches" an identical
+  # payload into data/ on every build. The first build legitimately adds the
+  # file (full rebuild); the full rebuild re-runs the hook, whose
+  # byte-identical rewrite must now settle to an empty changeset instead of
+  # scheduling the next full rebuild.
+  it "breaks the pre-hook rewrite loop after the legitimate added-file rebuild" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_data_loop_site
+        File.write("payload_seed.json", %({"answer": 42}))
+        File.write("config.toml", <<-TOML
+          title = "Data Hook Loop"
+          base_url = "https://example.com"
+
+          [build.hooks]
+          pre = ["cp payload_seed.json data/payload.json"]
+          TOML
+        )
+
+        server = Hwaro::Services::Server.new
+        options = data_loop_options
+        server.data_loop_capture_baseline
+        server.data_loop_builder.run(options).should be_true
+
+        # First poll after the initial build: the hook's file is new — a
+        # legitimate full-rebuild trigger.
+        baseline = server.data_loop_initial_watch_mtimes
+        current = server.data_loop_scan
+        first = server.data_loop_detect_changes(baseline, current)
+        first.added_files.should contain("data/payload.json")
+        first.needs_full_rebuild?.should be_true
+
+        # The watcher runs that full rebuild; the pre hook re-runs and
+        # rewrites the identical payload with a fresh mtime.
+        server.data_loop_builder.run(options).should be_true
+
+        second = server.data_loop_detect_changes(current, server.data_loop_scan(current))
+        second.empty?.should be_true
+      end
+    end
+  end
+end

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -1529,8 +1529,8 @@ module Hwaro
     class Server
       def test_detect_changes(old_mtimes : Hash(String, Time), new_mtimes : Hash(String, Time)) : ChangeSet
         detect_changes(
-          old_mtimes.transform_values { |t| {t, 0_i64} },
-          new_mtimes.transform_values { |t| {t, 0_i64} },
+          old_mtimes.transform_values { |t| {t, 0_i64, nil.as(String?)} },
+          new_mtimes.transform_values { |t| {t, 0_i64, nil.as(String?)} },
         )
       end
 
@@ -1620,8 +1620,8 @@ describe "Server#detect_changes" do
     server = Hwaro::Services::Server.new
     t1 = Time.utc(2025, 1, 1, 0, 0, 0)
 
-    old = {"content/posts/hello.md" => {t1, 10_i64}}
-    new_m = {"content/posts/hello.md" => {t1, 42_i64}}
+    old = {"content/posts/hello.md" => {t1, 10_i64, nil.as(String?)}}
+    new_m = {"content/posts/hello.md" => {t1, 42_i64, nil.as(String?)}}
 
     cs = server.test_detect_changes(old, new_m)
     cs.modified_content.should eq(["content/posts/hello.md"])

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -10,6 +10,7 @@
 # - Static-only copy when only static files change
 
 require "http/server"
+require "digest/md5"
 require "json"
 require "mime"
 require "socket"
@@ -815,7 +816,15 @@ module Hwaro
       # same-tick rewrites on coarse-mtime filesystems (Docker bind mounts,
       # NFS/SMB shares, exFAT) where two quick saves can share a timestamp —
       # an mtime-only comparison would permanently miss the second save.
-      alias FileStamp = {Time, Int64}
+      #
+      # The third slot is a content digest, carried ONLY for the full-rebuild
+      # buckets (data/**, i18n/** — nil everywhere else). Those buckets force
+      # a full rebuild, and a full rebuild re-runs `build.hooks.pre` — so a
+      # hook that rewrites an identical payload into data/ (the pattern #752
+      # documents) retriggered itself forever under a stamp-only comparison
+      # (#755). The digest lets detect_changes drop stamp movement whose
+      # bytes are unchanged. See watch_digest for when it is (re)computed.
+      alias FileStamp = {Time, Int64, String?}
 
       @builder : Core::Build::Builder
       @live_reload_handler : LiveReloadHandler?
@@ -1392,7 +1401,7 @@ module Hwaro
           # otherwise kill this fiber and silently stop rebuilds for the rest
           # of the serve session while the HTTP server keeps running.
           begin
-            current_mtimes = scan_mtimes
+            current_mtimes = scan_mtimes(last_mtimes)
             if current_mtimes != last_mtimes
               changeset = detect_changes(last_mtimes, current_mtimes)
               last_mtimes = current_mtimes
@@ -1441,7 +1450,7 @@ module Hwaro
           sleep DEBOUNCE_INTERVAL
           iterations += 1
 
-          new_mtimes = scan_mtimes
+          new_mtimes = scan_mtimes(current_mtimes)
           if new_mtimes != current_mtimes
             additional = detect_changes(current_mtimes, new_mtimes)
             current_mtimes = new_mtimes
@@ -1474,13 +1483,19 @@ module Hwaro
         removed_files = [] of String
         config_changed = false
 
-        # --- Files that exist in both snapshots but with different mtime ---
-        new_mtimes.each do |path, new_mtime|
-          if old_mtime = old_mtimes[path]?
-            next if old_mtime == new_mtime # unchanged
+        # --- Files that exist in both snapshots but with different stamps ---
+        new_mtimes.each do |path, new_stamp|
+          if old_stamp = old_mtimes[path]?
+            next if old_stamp == new_stamp # unchanged
 
             if path == "config.toml" || path == @env_config_file
               config_changed = true
+            elsif identical_rewrite?(path, old_stamp, new_stamp)
+              # A data/i18n stamp that moved without a byte changing — the
+              # #755 hook loop: reporting it would force a full rebuild,
+              # which re-runs build.hooks.pre, which rewrites the file
+              # again. Dropping it lets the changeset settle to empty.
+              next
             else
               classify_modified(path, modified_content, modified_content_files, modified_templates, modified_static, modified_data)
             end
@@ -1841,7 +1856,11 @@ module Hwaro
         false
       end
 
-      private def scan_mtimes : Hash(String, FileStamp)
+      # `prev` is the previous snapshot, used only to carry data/i18n digests
+      # forward without re-reading files whose stamps are unchanged (see
+      # watch_digest). Passing nil — the baseline scan, or a caller without a
+      # previous snapshot — computes them fresh.
+      private def scan_mtimes(prev : Hash(String, FileStamp)? = nil) : Hash(String, FileStamp)
         mtimes = {} of String => FileStamp
         dirs_to_watch = ["content", "templates", "static", "data", "i18n"]
 
@@ -1878,7 +1897,7 @@ module Hwaro
               next if info.nil?
               info = File.info?(file, follow_symlinks: true) if info.symlink?
               next if info.nil? || !info.type.file?
-              mtimes[file] = {info.modification_time, info.size.to_i64}
+              mtimes[file] = {info.modification_time, info.size.to_i64, watch_digest(file, info, prev)}
             rescue ex
               Logger.debug "Failed to read file info for #{file}: #{ex.message}"
             end
@@ -1894,13 +1913,72 @@ module Hwaro
           next unless File.exists?(cfg)
           begin
             info = File.info(cfg)
-            mtimes[cfg] = {info.modification_time, info.size.to_i64}
+            mtimes[cfg] = {info.modification_time, info.size.to_i64, nil}
           rescue ex
             Logger.debug "Failed to read #{cfg} info: #{ex.message}"
           end
         end
 
         mtimes
+      end
+
+      # data/** and i18n/** are the only buckets whose FileStamp carries a
+      # content digest. They are the full-rebuild buckets, and only a full
+      # rebuild re-runs build.hooks.pre — the #755 loop needs both halves.
+      # content/ and templates/ stay stamp-only on purpose: their rebuild
+      # paths are incremental and hook-free (so they cannot loop), and
+      # hashing them would tax every save of every page. static/ likewise:
+      # a modified static file takes the :static copy path, which never
+      # re-runs hooks; only its first appearance is a (legitimate,
+      # one-time) added-file full rebuild.
+      private def digest_watched?(path : String) : Bool
+        path.starts_with?("data/") || path.starts_with?("i18n/")
+      end
+
+      # The digest slot for a scanned file: nil for stamp-only buckets. For
+      # data/i18n, the previous scan's digest is carried forward when
+      # mtime+size are unchanged — the bytes can't differ without moving one
+      # of them, the same assumption the stamp comparison itself makes — so
+      # steady-state polls never re-read content. A read happens only on the
+      # poll that first sees a path or sees its stamp move; that includes
+      # size-only changes (the change decision doesn't need the digest then,
+      # but the next byte-identical hook rewrite does need a fresh baseline
+      # to compare against, and the read is amortized against the full
+      # rebuild the size change is about to trigger anyway).
+      private def watch_digest(file : String, info : File::Info, prev : Hash(String, FileStamp)?) : String?
+        return unless digest_watched?(file)
+
+        if prev && (old = prev[file]?) && old[0] == info.modification_time && old[1] == info.size.to_i64
+          return old[2]
+        end
+
+        digest = Digest::MD5.new
+        buffer = Bytes.new(8192)
+        File.open(file, "r") do |io|
+          while (bytes_read = io.read(buffer)) > 0
+            digest.update(buffer[0, bytes_read])
+          end
+        end
+        digest.final.hexstring
+      rescue ex
+        # Unreadable mid-rewrite (or vanished since the stat): return nil so
+        # identical_rewrite? can never match it — an error must fall back to
+        # the old behavior (rebuild), never silently drop a change.
+        Logger.debug "Failed to hash #{file}: #{ex.message}"
+        nil
+      end
+
+      # True only when a data/i18n stamp difference is PROVABLY
+      # byte-identical: equal sizes (a size change is always a real change —
+      # no digest consulted) and equal non-nil digests. A nil digest — a
+      # hash-read failure — never matches, so the event is reported and the
+      # full rebuild runs, exactly as before the digests existed.
+      private def identical_rewrite?(path : String, old_stamp : FileStamp, new_stamp : FileStamp) : Bool
+        return false unless digest_watched?(path)
+        return false unless old_stamp[1] == new_stamp[1]
+
+        old_digest = old_stamp[2]
+        !old_digest.nil? && old_digest == new_stamp[2]
       end
     end
   end


### PR DESCRIPTION
Closes #755

## Problem

A `build.hooks.pre` command that fetches into `data/` — the exact workflow #752 documents — retriggered a full rebuild in a loop for the lifetime of the serve session:

1. any `data/`/`i18n/` change forces a full rebuild (`ChangeSet#needs_full_rebuild?` — `site.data` is global),
2. a full rebuild re-runs `build.hooks.pre` (`Builder#run` is the only caller of `run_pre_hooks`),
3. the watcher compared mtime+size only, so the hook's byte-identical rewrite registered as a modification,
4. goto 1, once per debounce interval.

## Fix

`FileStamp` grows a third slot — a content digest carried **only** for the two full-rebuild buckets (`data/**`, `i18n/**`; `nil` everywhere else) — and `detect_changes` drops stamp movement that is provably byte-identical: equal sizes and equal non-nil digests. A genuinely changed payload (different size or different bytes) still forces the full rebuild it always did, and any hash-read failure yields a `nil` digest that never matches, falling back to the old behavior (rebuild) rather than ever silently dropping a change.

**Prefilter before hashing** (per the issue's open question):

- size change ⇒ changed — the decision consults no digest;
- unchanged mtime+size ⇒ unchanged — the previous scan's digest is carried forward without re-reading the file, so steady-state polls stay read-free even with large data files;
- a hash read happens only on the poll that first sees a path or sees its stamp move. That includes size-only changes: the decision doesn't need the digest then, but the *next* byte-identical hook rewrite needs a fresh baseline to compare against, and the read is amortized against the full rebuild the size change is about to trigger anyway.

Because digests are carried forward deterministically, a quiet tree still produces snapshots that compare equal — the watch loop's `current != last` quick check and the debounce settle test are untouched, as are all incremental rebuild paths.

## Why hashing stops at data/ and i18n/

- `content/` and `templates/` take incremental/re-render paths that never re-run `build.hooks.pre`, so they cannot produce this loop — and hashing them would tax every save of every page.
- `static/` cannot loop either: a **modified** static file takes the `:static` copy path (`copy_static`), which never re-runs hooks, so a hook rewriting `static/` files settles after one cheap copy. Only a static file's **first appearance** is a full-rebuild trigger (`added_files`), which is legitimate, one-time, and identical to `data/`'s added-file behavior — a hook creating a genuinely new file must rebuild once. Content comparison can't (and shouldn't) change added/removed semantics, so there is nothing for the digest mechanism to cover in `static/`.

## Pre-fix failure evidence

The regression spec was written first and run against pre-fix `src/services/server/server.cr`:

```
$ crystal spec spec/functional/serve_data_hook_loop_spec.cr        # pre-fix
F..F...F

1) serve data/i18n hook-loop regression (#755) drops a byte-identical data/ rewrite with a fresh mtime
   Failure/Error: changes.empty?.should be_true
     Expected: true
          got: false

2) serve data/i18n hook-loop regression (#755) drops a byte-identical i18n/ rewrite with a fresh mtime
   Failure/Error: changes.empty?.should be_true
     Expected: true
          got: false

3) serve data/i18n hook-loop regression (#755) breaks the pre-hook rewrite loop after the legitimate added-file rebuild
   Failure/Error: second.empty?.should be_true
     Expected: true
          got: false

8 examples, 3 failures, 0 errors, 0 pending
```

The three failures are exactly the identical-rewrite drops; the changed-bytes / changed-size / added / removed cases passed pre-fix, pinning that the full-rebuild side is untouched.

## Coverage

`spec/functional/serve_data_hook_loop_spec.cr` (9 examples):

- byte-identical `data/` rewrite with a fresh mtime ⇒ empty changeset (no rebuild);
- same-size changed bytes ⇒ `modified_data` + `needs_full_rebuild?`;
- size-changing edit ⇒ `modified_data` + `needs_full_rebuild?`;
- the same identical/changed pair for `i18n/`;
- added and removed `data/` files still force full rebuilds;
- `content/` and `static/` touches stay mtime-based (no content comparison);
- digest carry-forward yields snapshots that compare equal (the debounce/quick-check settle invariant);
- end-to-end #752 pattern: `pre = ["cp payload_seed.json data/payload.json"]` through real `Builder#run` calls — the first build's new file is a legitimate added-file full rebuild, and the re-run hook's identical rewrite settles to an empty changeset instead of scheduling the next full rebuild.

## Verification

- `crystal spec` — full suite passes
- `crystal tool format --check` — clean
- `./bin/ameba` — 508 inspected, 0 failures
