### PR TITLE
fix(build): identify the dev marker by content, not by filename

### DIFF
--- a/spec/functional/serve_output_isolation_spec.cr
+++ b/spec/functional/serve_output_isolation_spec.cr
@@ -2,6 +2,7 @@ require "digest/md5"
 require "../spec_helper"
 require "../../src/services/server/server"
 require "../../src/services/deployer"
+require "../../src/utils/dev_marker"
 require "../../src/config/options/deploy_options"
 
 # Regression coverage for issue #756: deploying serve output leaked the dev
@@ -26,6 +27,10 @@ module Hwaro
 
       def isolation_serve_build_options(options : Config::Options::ServeOptions) : Config::Options::BuildOptions
         serve_build_options(options)
+      end
+
+      def isolation_copy_static(changeset : ChangeSet, build_options : Config::Options::BuildOptions) : Bool
+        copy_static(changeset, build_options)
       end
     end
   end
@@ -190,7 +195,7 @@ describe "serve output isolation (issue #756)" do
       Dir.cd(dir) do
         write_isolation_site
         FileUtils.mkdir_p("public")
-        File.write("public/.hwaro-dev", "leftover from an old serve session")
+        File.write("public/.hwaro-dev", Hwaro::Utils::DevMarker::CONTENT)
 
         log = with_captured_log do
           isolation_production_builder.run(isolation_build_options).should be_true
@@ -209,7 +214,7 @@ describe "serve output isolation (issue #756)" do
       Dir.cd(dir) do
         write_isolation_site
         FileUtils.mkdir_p("public")
-        File.write("public/.hwaro-dev", "leftover from an old serve session")
+        File.write("public/.hwaro-dev", Hwaro::Utils::DevMarker::CONTENT)
         File.write("public/keep.txt", "cached artifact")
 
         options = isolation_build_options
@@ -247,7 +252,7 @@ describe "serve output isolation (issue #756)" do
         source = File.join(dir, "site")
         FileUtils.mkdir_p(source)
         File.write(File.join(source, "index.html"), "x")
-        File.write(File.join(source, ".hwaro-dev"), "dev output")
+        File.write(File.join(source, ".hwaro-dev"), Hwaro::Utils::DevMarker::CONTENT)
 
         config = Hwaro::Models::Config.new
         target = Hwaro::Models::DeploymentTarget.new
@@ -279,7 +284,7 @@ describe "serve output isolation (issue #756)" do
         source = File.join(dir, "site")
         FileUtils.mkdir_p(source)
         File.write(File.join(source, "index.html"), "x")
-        File.write(File.join(source, ".hwaro-dev"), "dev output")
+        File.write(File.join(source, ".hwaro-dev"), Hwaro::Utils::DevMarker::CONTENT)
 
         config = Hwaro::Models::Config.new
         target = Hwaro::Models::DeploymentTarget.new
@@ -321,6 +326,186 @@ describe "serve output isolation (issue #756)" do
           Hwaro::Services::Deployer.new.run(options, config).should be_true
         end
         File.exists?(File.join(dir, "dest", "index.html")).should be_true
+      end
+    end
+  end
+  # Post-merge review of #758: the marker was identified by FILENAME alone, so
+  # a legitimate user file `static/.hwaro-dev` was mistaken for one. Build 1
+  # published it and `hwaro deploy` refused the tree blaming a serve session
+  # that never ran; build 2 saw it pre-wipe and deleted the user's published
+  # file after the static copy, with a warning about dev output. A marker is
+  # now only a marker when its first line is the documented contract line.
+  describe "a user-owned static/.hwaro-dev" do
+    it "is published, survives consecutive builds, and never warns" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          write_isolation_site
+          FileUtils.mkdir_p("static")
+          user_content = "my own dotfile\nnothing to do with hwaro serve\n"
+          File.write("static/.hwaro-dev", user_content)
+
+          first_log = with_captured_log do
+            isolation_production_builder.run(isolation_build_options).should be_true
+          end
+          # Pre-fix this already passed — the damage lands on build 2.
+          File.read("public/.hwaro-dev").should eq(user_content)
+          first_log.should_not contain("hwaro serve` session")
+
+          second_log = with_captured_log do
+            isolation_production_builder.run(isolation_build_options).should be_true
+          end
+          # Pre-fix: build 2 read the published copy as a leftover marker and
+          # deleted it after the static copy, warning about dev output.
+          File.exists?("public/.hwaro-dev").should be_true
+          File.read("public/.hwaro-dev").should eq(user_content)
+          second_log.should_not contain("hwaro serve` session")
+        end
+      end
+    end
+
+    it "survives consecutive --cache builds too" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          write_isolation_site
+          FileUtils.mkdir_p("static")
+          File.write("static/.hwaro-dev", "user data\n")
+
+          options = isolation_build_options
+          options.cache = true
+          with_captured_log { isolation_production_builder.run(options).should be_true }
+          File.read("public/.hwaro-dev").should eq("user data\n")
+
+          # The preserved-output path removes a leftover marker explicitly, so
+          # pre-fix build 2 deleted the user's file here as well.
+          log = with_captured_log { isolation_production_builder.run(options).should be_true }
+          File.read("public/.hwaro-dev").should eq("user data\n")
+          log.should_not contain("hwaro serve` session")
+        end
+      end
+    end
+
+    it "does not block deploy" do
+      Dir.mktmpdir do |dir|
+        source = File.join(dir, "site")
+        FileUtils.mkdir_p(source)
+        File.write(File.join(source, "index.html"), "x")
+        File.write(File.join(source, ".hwaro-dev"), "a user file that is not a marker\n")
+
+        config = Hwaro::Models::Config.new
+        target = Hwaro::Models::DeploymentTarget.new
+        target.name = "production"
+        target.url = "file://#{dir}/dest"
+        config.deployment.targets << target
+
+        options = Hwaro::Config::Options::DeployOptions.new(
+          source_dir: source,
+          targets: ["production"],
+        )
+
+        # Pre-fix: raised HWARO_E_CONFIG, blaming a serve session.
+        with_captured_log do
+          Hwaro::Services::Deployer.new.run(options, config).should be_true
+        end
+        File.exists?(File.join(dir, "dest", ".hwaro-dev")).should be_true
+      end
+    end
+
+    it "loses to serve's own stamp inside the dev output dir" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          write_isolation_site
+          FileUtils.mkdir_p("static")
+          File.write("static/.hwaro-dev", "user data\n")
+
+          server = Hwaro::Services::Server.new
+          with_captured_log do
+            server.isolation_builder.run(isolation_session_options).should be_true
+          end
+
+          # The dev dir is never deployable, so serve stamps it regardless —
+          # the static copy runs before the stamp.
+          File.read(".hwaro/serve/.hwaro-dev").should eq(Hwaro::Utils::DevMarker::CONTENT)
+          Hwaro::Utils::DevMarker.present?(".hwaro/serve").should be_true
+        end
+      end
+    end
+
+    it "is not a marker by name, while genuine content is" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, ".hwaro-dev"), "not a marker\n")
+        Hwaro::Utils::DevMarker.present?(dir).should be_false
+
+        # A body that merely mentions serve is still not the contract line.
+        File.write(File.join(dir, ".hwaro-dev"), "written by hwaro serve\n")
+        Hwaro::Utils::DevMarker.present?(dir).should be_false
+
+        Hwaro::Utils::DevMarker.write(dir)
+        Hwaro::Utils::DevMarker.present?(dir).should be_true
+
+        # Only the first line is the contract — the rest of the body may drift
+        # between versions without un-marking an older serve session's output.
+        File.write(File.join(dir, ".hwaro-dev"),
+          "#{Hwaro::Utils::DevMarker::CONTENT.lines.first}\nan older version said something else\n")
+        Hwaro::Utils::DevMarker.present?(dir).should be_true
+
+        Hwaro::Utils::DevMarker.remove(dir)
+        Hwaro::Utils::DevMarker.present?(dir).should be_false
+        File.exists?(File.join(dir, ".hwaro-dev")).should be_false
+      end
+    end
+
+    it "cannot un-stamp the dev dir on a serve static rebuild" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          write_isolation_site
+          FileUtils.mkdir_p("static")
+          File.write("static/.hwaro-dev", "user data\n")
+
+          serve_options = isolation_session_options
+          server = Hwaro::Services::Server.new
+          with_captured_log { server.isolation_builder.run(serve_options).should be_true }
+
+          # A watch-triggered :static rebuild copies the user's file straight
+          # over serve's stamp; only full rebuilds re-stamp, so the dev dir
+          # would stay unmarked (and deployable) for the rest of the session.
+          changeset = Hwaro::Services::ChangeSet.new(
+            modified_content: [] of String,
+            modified_templates: [] of String,
+            modified_static: ["static/.hwaro-dev"],
+            added_files: [] of String,
+            removed_files: [] of String,
+            config_changed: false,
+          )
+          with_captured_log do
+            server.isolation_copy_static(changeset, serve_options).should be_true
+          end
+
+          Hwaro::Utils::DevMarker.present?(".hwaro/serve").should be_true
+        end
+      end
+    end
+
+    it "is left alone by the build that removes a genuine leftover marker" do
+      Dir.mktmpdir do |dir|
+        Dir.cd(dir) do
+          write_isolation_site
+          FileUtils.mkdir_p("static")
+          File.write("static/.hwaro-dev", "user data\n")
+          # A real serve leftover in the deployable tree AND a user file that
+          # the static copy republishes over it: the warning is still owed,
+          # but the file standing there afterwards is the user's.
+          FileUtils.mkdir_p("public")
+          File.write("public/.hwaro-dev", Hwaro::Utils::DevMarker::CONTENT)
+
+          options = isolation_build_options
+          options.cache = true
+          log = with_captured_log do
+            isolation_production_builder.run(options).should be_true
+          end
+
+          log.should contain("previous `hwaro serve` session")
+          File.read("public/.hwaro-dev").should eq("user data\n")
+        end
       end
     end
   end

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -38,7 +38,9 @@ module Hwaro::Core::Build::Phases::Initialize
       keep_output = cache_enabled || ctx.options.preserve_output
       # Read before setup_output_dir — the cold-build wipe would erase the
       # evidence that a serve session (an older hwaro shared the output dir)
-      # had written here.
+      # had written here. `present?` matches the marker's content, so a user's
+      # own `static/.hwaro-dev` (published by copy_static_files below like any
+      # hidden static file) is not mistaken for one.
       dev_marker_found = !ctx.options.serve_mode && Utils::DevMarker.present?(output_dir)
       setup_output_dir(output_dir, keep_output)
       copy_static_files(output_dir, verbose, keep_output)
@@ -51,7 +53,8 @@ module Hwaro::Core::Build::Phases::Initialize
         # A `--cache`/preserved build keeps existing files, so the stale
         # marker must go explicitly; on a cold build the wipe already took
         # it. Warn either way — the user should know dev output sat in the
-        # deployable tree until now.
+        # deployable tree until now. `remove` re-checks the content, so a
+        # user's `static/.hwaro-dev` just published over the leftover stays.
         Utils::DevMarker.remove(output_dir)
         Logger.warn "  A previous `hwaro serve` session had written dev output into #{output_dir} — this build replaces it with deployable output."
       end

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -1739,6 +1739,12 @@ module Hwaro
       private def copy_static(changeset : ChangeSet, build_options : Config::Options::BuildOptions) : Bool
         output_dir = sanitize_output_dir(build_options.output_dir)
         @builder.copy_changed_static(changeset.modified_static, output_dir, build_options.verbose)
+        # A user's own `static/.hwaro-dev` publishes like any hidden static
+        # file, so the copy above can land on top of serve's stamp. Only the
+        # full-build path re-stamps, so without this the dev dir would sit
+        # unmarked for the rest of the session — and `hwaro deploy` reads the
+        # marker by content, so the user's bytes would not stand in for it.
+        Hwaro::Utils::DevMarker.write(output_dir) unless Hwaro::Utils::DevMarker.present?(output_dir)
         # Changed image BYTES need their resized variants/LQIP regenerated
         # too — the resize hook only runs on full builds, so the copy above
         # alone left variants stale for the whole serve session (A12).

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -1946,14 +1946,20 @@ module Hwaro
       end
 
       # data/** and i18n/** are the only buckets whose FileStamp carries a
-      # content digest. They are the full-rebuild buckets, and only a full
-      # rebuild re-runs build.hooks.pre — the #755 loop needs both halves.
-      # content/ and templates/ stay stamp-only on purpose: their rebuild
-      # paths are incremental and hook-free (so they cannot loop), and
-      # hashing them would tax every save of every page. static/ likewise:
-      # a modified static file takes the :static copy path, which never
-      # re-runs hooks; only its first appearance is a (legitimate,
-      # one-time) added-file full rebuild.
+      # content digest. They are the buckets #755 reported: a full rebuild is
+      # the only thing that re-runs build.hooks.pre, and a hook rewriting
+      # data/ byte-identically then looped forever on its own stamp.
+      #
+      # content/, templates/ and static/ stay stamp-only because hashing them
+      # would tax every save of every page for a rarer case: each has its own
+      # hook-free rebuild path (:incremental, :templates, :static copy), and a
+      # static file's only full rebuild is the one-time added-file case.
+      #
+      # That is a cost trade, not a proof of no-loop. Two constructive routes
+      # remain — a mixed static+template byte-identical rewrite falls to
+      # `rebuild_strategy`'s else branch (:full), and a byte-identical
+      # config.toml rewrite has no digest at all (nil) to compare. Both
+      # predate #757 and are tracked in issue #760.
       private def digest_watched?(path : String) : Bool
         path.starts_with?("data/") || path.starts_with?("i18n/")
       end

--- a/src/utils/dev_marker.cr
+++ b/src/utils/dev_marker.cr
@@ -8,6 +8,10 @@ require "./logger"
 # marker; `hwaro build` removes a marker left behind by a serve session (older
 # versions shared the output dir), and `hwaro deploy` refuses a source
 # directory that still carries one.
+#
+# A file is a marker by its CONTENT, never by its name alone: `static/.hwaro-dev`
+# is a file a user may legitimately keep, and the build publishes it like any
+# other hidden static file.
 
 module Hwaro
   module Utils
@@ -17,19 +21,53 @@ module Hwaro
       FILENAME = ".hwaro-dev"
 
       # What the file says to whoever finds it in a directory listing or a
-      # deploy artifact. The first line is the greppable contract; CI can
-      # `test -f` the filename alone.
+      # deploy artifact. The first line is the greppable contract — it is what
+      # hwaro itself matches on (see `present?`), so CI can grep for it too.
       CONTENT =
         "This directory was written by `hwaro serve` and is not deployable.\n" \
         "Its pages carry the dev server's base_url (e.g. http://127.0.0.1:3000).\n" \
         "Run `hwaro build` and deploy that output instead.\n"
 
+      # The greppable contract from CONTENT's first line, and the ONLY thing
+      # that makes a `.hwaro-dev` file a marker.
+      FIRST_LINE = CONTENT.lines.first
+
       def path(output_dir : String) : String
         File.join(output_dir, FILENAME)
       end
 
+      # Content check, not just existence: `static/.hwaro-dev` is a legitimate
+      # (if unusual) file for a user to keep, and the build publishes it like
+      # any other hidden static file. Identifying the marker by FILENAME alone
+      # meant the published copy made `hwaro deploy` refuse the whole tree
+      # blaming a serve session that never ran, and the next build deleted the
+      # user's file right after the static copy put it there.
+      #
+      # Only the FIRST line is compared: it is the documented contract, so a
+      # marker written by an older (or newer) hwaro whose explanatory body has
+      # drifted still counts. A user file whose first line happens to be
+      # exactly that sentence is treated as a marker — it is announcing itself
+      # as one, and that is the deliberate trade for not hashing whole bodies.
       def present?(output_dir : String) : Bool
-        File.exists?(path(output_dir))
+        marker = path(output_dir)
+        return false unless File.exists?(marker)
+
+        # Bounded read: a file under this name can be arbitrarily large and a
+        # single line of it just as large, so never slurp it to compare one
+        # sentence. The +2 leaves room for the delimiter (and a CRLF marker
+        # written on Windows) so `chomp` can strip it.
+        first = File.open(marker) { |io| io.gets(FIRST_LINE.bytesize + 2, chomp: true) }
+        first == FIRST_LINE
+      rescue File::NotFoundError
+        # Deleted between the stat and the open — absent, not a marker.
+        false
+      rescue ex : IO::Error
+        # Unreadable (permissions, an exotic mount): fail closed. The safety
+        # property this file exists for is "never deploy dev output", so a
+        # file we cannot rule out keeps its old existence-only meaning rather
+        # than silently unblocking a deploy.
+        Logger.debug "Could not read dev marker #{marker}: #{ex.message}"
+        true
       end
 
       def write(output_dir : String) : Nil
@@ -41,9 +79,13 @@ module Hwaro
         Logger.debug "Could not write dev marker #{path(output_dir)}: #{ex.message}"
       end
 
+      # Guarded by `present?` for the same reason it now checks content: the
+      # build reads the marker BEFORE the static copy runs, so by the time it
+      # removes one the file standing there may be the user's own
+      # `static/.hwaro-dev`, freshly published over a genuine leftover.
       def remove(output_dir : String) : Nil
         marker = path(output_dir)
-        File.delete(marker) if File.exists?(marker)
+        File.delete(marker) if present?(output_dir)
       rescue ex : IO::Error
         Logger.debug "Could not remove dev marker #{path(output_dir)}: #{ex.message}"
       end


### PR DESCRIPTION
Two post-merge review findings from #758 / #757. One is a real user-data bug; the other is a comment that overclaims. No `Closes` lines — #760 stays open.

## 1. `static/.hwaro-dev` was mistaken for the dev marker (fix)

`DevMarker.present?` matched on `FILENAME` alone. `static/.hwaro-dev` is a file a user may legitimately keep, and the build publishes it like any other hidden static file (`collect_static_files` globs with `DotFiles`), so the published copy looked exactly like a serve stamp:

- **Build 1** publishes `public/.hwaro-dev`, and `hwaro deploy` then refuses the whole tree — `Refusing to deploy …: it is 'hwaro serve' output` — blaming a serve session that never ran.
- **Build 2** reads the marker before the wipe, republishes the user's file via the static copy, then `DevMarker.remove` **deletes it** and warns about dev output that was never written. Same on the `--cache` path, which removes the marker explicitly.

### The fix

`present?` compares the file's **first line** against `DevMarker::CONTENT`'s first line — the documented greppable contract, which serve's own stamp always carries.

- Only the first line: a marker written by an older (or newer) hwaro whose explanatory body has drifted still counts.
- Bounded read (`gets(FIRST_LINE.bytesize + 2, chomp: true)`): a large file under that name is never slurped, and a CRLF-written marker still matches.
- A read error other than "vanished" fails **closed** — the safety property here is "never deploy dev output", so an unreadable file keeps its old existence-only meaning rather than silently unblocking a deploy.
- A user file whose first line happens to be exactly that sentence is treated as a marker. It is announcing itself as one; the alternative (hashing whole bodies) breaks version drift. The trade is spelled out in a comment.

Two callers needed the same semantics, both checked:

- **`DevMarker.remove` is now guarded by `present?`.** The build reads the marker *before* the static copy runs, so with a genuine leftover in `public/` **and** a user file in `static/`, the file standing there at removal time is the user's, freshly published over the leftover. The warning is still owed; the deletion is not.
- **Serve's `copy_static` re-stamps the dev dir** when the copy lands on its own marker. Only full rebuilds stamped, so a watch-triggered `:static` rebuild copying the user's file would leave `.hwaro/serve` unmarked for the rest of the session — and with a content check the user's bytes no longer stand in for the stamp. `server.cr`'s startup write path needed nothing: it writes `CONTENT` unconditionally, and in `initialize.cr` the stamp already runs *after* the static copy.

`hwaro deploy`'s escape hatch (delete the marker by hand) and the docs are unaffected — a directory carrying a real marker is still refused.

### Regression coverage

Added to `spec/functional/serve_output_isolation_spec.cr`; existing marker fixtures now write the real `DevMarker::CONTENT` instead of arbitrary bytes.

**Pre-fix, on this branch's specs:** `16 examples, 2 failures, 3 errors`

```
1) …is published, survives consecutive builds, and never warns
   Failure/Error: File.exists?("public/.hwaro-dev").should be_true
     Expected: true
          got: false

2) …is not a marker by name, while genuine content is
   Failure/Error: Hwaro::Utils::DevMarker.present?(dir).should be_false
     Expected: false
          got: true

3) …does not block deploy
   Refusing to deploy /…/site: it is `hwaro serve` output (.hwaro-dev marker
   present), with dev URLs baked into its pages. (Hwaro::HwaroError)
     from src/services/deployer.cr:924:11 in 'require_source_dir!'

4) …survives consecutive --cache builds too
   Error opening file with mode 'r': 'public/.hwaro-dev': No such file or directory

5) …is left alone by the build that removes a genuine leftover marker
   Error opening file with mode 'r': 'public/.hwaro-dev': No such file or directory
```

The serve re-stamp spec was verified the same way (fails with that one line removed):

```
…cannot un-stamp the dev dir on a serve static rebuild
  Expected: true
       got: false
```

Post-fix: `17 examples, 0 failures`.

## 2. `digest_watched?` comment overclaimed (comment only)

The comment justified content/, templates/ and static/ being stamp-only as "their rebuild paths are incremental and hook-free (**so they cannot loop**)". Two constructive hook-rewrite loops are still reachable outside data/i18n:

- a **mixed static+template** byte-identical rewrite matches no strategy predicate and falls through `rebuild_strategy` to the `else` branch → `:full`, which re-runs `build.hooks.pre`;
- a **byte-identical `config.toml`** rewrite carries a `nil` digest, so `identical_rewrite?` can never match it.

Both predate #757 and are tracked in #760. The comment now says what is true — data/i18n are the buckets #755 required, stamp-only elsewhere is a cost trade rather than a proof — and points at the tracking issue. **No behavior change**; #760 stays open.

## Verification

- `crystal spec` — **8284 examples, 0 failures, 0 errors** (full suite)
- `crystal tool format --check` — clean
- `./bin/ameba` — **512 inspected, 0 failures**

Refs #758, #757, #760.
