### PR TITLE
fix(tool): stop validating against build output that cannot be trusted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - `hwaro serve`: a `build.hooks.pre` command that rewrites the same bytes on every run no longer rebuilds forever. A mixed `templates/` + `static/` rewrite now takes the cheap hook-free rebuild instead of a full one, and a byte-identical `config.toml` rewrite made by the build's own hooks is ignored — a developer's `touch config.toml` still forces a full rebuild (#760)
+- `hwaro doctor` and `hwaro tool check-links` no longer validate routes and pipeline-emitted assets against a build output directory they cannot trust. An absent, empty or `hwaro serve`-written `[build] output_dir` is refused as evidence, and output older than the newest source file is reported as such — doctor as `build-output-unusable` / `build-output-stale`, `check-links` as a note under its report and an `output_hint` field in `--json` (#761)
 
 ## v0.19.0
 

--- a/docs/content/start/tools/check-links.ko.md
+++ b/docs/content/start/tools/check-links.ko.md
@@ -56,7 +56,9 @@ hwaro tool check-links --ignore-url twitter.com --allow-status 403,429
    GET으로 재시도, 리다이렉트는 최대 5회 추적)
 4. 내부 링크 대상이 디스크에 존재하는지 확인 (`.md`, `_index.md`, `index.md` 검사)
 5. 빌드가 생성하는 경로는 소스 파일 없이도 유효한 것으로 인정
-6. 깨졌거나 접근할 수 없는 링크 보고
+6. 파이프라인이 만들어 내는 에셋은 직전 빌드 출력에서 확인
+   ([빌드 출력을 근거로 사용하기](#빌드-출력을-근거로-사용하기) 참고)
+7. 깨졌거나 접근할 수 없는 링크 보고
 
 사설/내부 주소(localhost, RFC 1918 대역, `.local`/`.internal` 호스트)로
 해석되는 외부 링크에는 요청을 보내지 않습니다. 이런 링크는 사람용 출력과
@@ -141,6 +143,42 @@ checked: 50 links, 3 dead
       "error": "Skipped: private/internal address"
     }
   ],
-  "ignored_count": 0
+  "ignored_count": 0,
+  "output_hint": null
 }
 ```
+
+`output_hint`는 빌드 출력 때문에 결과를 다르게 읽어야 할 때만 값이 들어가고,
+그 외에는 `null`입니다(아래 참고). 사람용 출력에도 같은 문장이 나오며, JSON에
+같이 담아 두어 터미널 출력을 보지 않는 CI에서도 놓치지 않게 했습니다.
+
+## 빌드 출력을 근거로 사용하기
+
+컴파일된 스타일시트, 리사이즈된 이미지 변형, `[content.files]`나 에셋
+파이프라인으로 발행된 파일처럼 원본 소스로는 설명되지 않는 링크가 있습니다.
+`check-links`는 이런 경로를 직전 빌드 결과인 `[build] output_dir`(기본값
+`public/`)에서 찾으면 유효한 것으로 인정합니다. 빌드 밖에서 도는 명령에게는
+그것이 유일한 근거이기 때문입니다.
+
+이 디렉터리는 `hwaro build`가 만든 것이어야 합니다. Hwaro 0.19부터
+`hwaro serve`는 `.hwaro/serve/`에 빌드하고 `output_dir`은 건드리지 않으므로,
+serve만 쓰는 작업 흐름에는 아무것도 없습니다. 이제 이유 없이 깨진 링크 목록만
+쏟아내는 대신 그 사실을 알려줍니다:
+
+```
+checked: 4 links, 1 dead
+  [info] public/ holds no build output — run `hwaro build` first; check-links
+         validates build output, not `hwaro serve` output (.hwaro/serve/)
+```
+
+- **없거나 비어 있음** — 그 때문에 죽은 것으로 보고된 링크와 함께 안내가
+  출력됩니다.
+- **`hwaro serve` 출력** (`.hwaro-dev` 마커가 남은 경우) — `hwaro deploy`와 같은
+  규칙으로 근거에서 제외합니다. 마커는 `hwaro build`가 지웁니다.
+- **가장 최근 소스 파일보다 오래됨** — 문제가 없어 보이는 결과 아래에 안내가
+  붙습니다. 삭제한 페이지의 `index.html`이 그 트리에 남아 있으면 링크가 계속
+  통과하기 때문입니다.
+
+CI에서는 `check-links` 전에 `hwaro build`를 돌려 실제 출력과 대조하세요.
+소스만으로 판단되는 경로(`/about/`, `/tags/`, 피드, 사이트맵)는 빌드 출력이
+없어도 됩니다.

--- a/docs/content/start/tools/check-links.md
+++ b/docs/content/start/tools/check-links.md
@@ -58,7 +58,9 @@ failing CI.
    host rejects HEAD with 405/403/501, following up to 5 redirects)
 4. Verifies internal link targets exist on disk (checks `.md`, `_index.md`, `index.md`)
 5. Accepts routes the build generates rather than reads from disk
-6. Reports broken or unreachable links
+6. Accepts pipeline-emitted assets found in the last build's output (see
+   [Build output as evidence](#build-output-as-evidence))
+7. Reports broken or unreachable links
 
 External links that resolve to private or internal addresses (localhost,
 RFC 1918 ranges, `.local`/`.internal` hosts) are never contacted — they are
@@ -145,6 +147,42 @@ command exits non-zero when dead links are found, so it can gate CI.
       "error": "Skipped: private/internal address"
     }
   ],
-  "ignored_count": 0
+  "ignored_count": 0,
+  "output_hint": null
 }
 ```
+
+`output_hint` is `null` unless the build output changed how the result should
+be read — see below. The human report prints the same sentence; `--json`
+carries it so a CI run that never sees the terminal output still gets it.
+
+## Build Output as Evidence
+
+Some links point at files no source explains: a compiled stylesheet, a
+resized image variant, anything published through `[content.files]` or the
+asset pipeline. `check-links` accepts those when it finds them in the last
+build's `[build] output_dir` (`public/` by default) — the only evidence
+available to a command that runs outside the build.
+
+That tree has to come from `hwaro build`. Since Hwaro 0.19, `hwaro serve`
+builds into `.hwaro/serve/` and leaves `output_dir` alone, so a serve-only
+workflow has nothing there. `check-links` now says so instead of reporting a
+pile of dead links with no explanation:
+
+```
+checked: 4 links, 1 dead
+  [info] public/ holds no build output — run `hwaro build` first; check-links
+         validates build output, not `hwaro serve` output (.hwaro/serve/)
+```
+
+- **Absent or empty** — the note is printed alongside the dead links it
+  explains.
+- **`hwaro serve` output** (a leftover `.hwaro-dev` marker) — never used as
+  evidence, the same rule `hwaro deploy` applies. `hwaro build` clears the
+  marker.
+- **Older than your newest source file** — noted under an otherwise healthy
+  report, because a page you deleted still has its `index.html` standing in
+  that tree and its links still resolve against it.
+
+Run `hwaro build` before `check-links` in CI to check against real output;
+source-only routes (`/about/`, `/tags/`, feeds, the sitemap) never need it.

--- a/docs/content/start/tools/doctor.ko.md
+++ b/docs/content/start/tools/doctor.ko.md
@@ -63,6 +63,7 @@ hwaro doctor --json
 - 참조한 파일·디렉터리가 존재하지 않음 (`[og] default_image`, `[pwa] icons`,
   `[auto_includes] dirs`, `[[assets.bundles]] files` 등). 자체 origin을 가진 값
   (`https://…`, `//cdn…`, `data:…`)은 원격 URL이라 검증할 수 없으므로 건너뜁니다.
+- 라우트 검사를 뒷받침할 수 없는 빌드 출력 (아래 [빌드 출력을 근거로 사용하기](#빌드-출력을-근거로-사용하기) 참고)
 
 **템플릿 진단:**
 
@@ -94,9 +95,12 @@ hwaro: doctor
     [ok]   search (format)
     [ok]   languages (default_language resolves)
     [ok]   markdown / pwa (valid enums)
+    [ok]   image processing (widths set)
     [ok]   deployment / related (refs resolve)
     [ok]   menus (parent references)
     [ok]   referenced files & dirs
+    [ok]   build output (route evidence)
+    [ok]   sass (sources & enablement)
 
   templates/
     [ok]   required files (page.html, section.html)
@@ -125,6 +129,29 @@ Tip: Use 'hwaro tool validate' for content checks
 색상 터미널에서는 검사 줄이 `hwaro doctor` 헤딩 아래 `✓`/`⚠`/`✗`/`ℹ` 기호로
 표시되고, 요약은 심각도별 색이 입혀진 `✦ checked` 결과 줄로 출력됩니다. 문제가
 없으면 `checked: no issues found — your site looks great`로 끝납니다.
+
+## 빌드 출력을 근거로 사용하기
+
+`[pwa] offline_page`와 `[pwa] precache_urls`는 파일이 아니라 라우트입니다.
+doctor는 먼저 `content/`에서 찾고, 확장자가 있는 값(컴파일된 스타일시트,
+리사이즈된 이미지 변형 등)은 마지막 빌드 결과인 `[build] output_dir`
+(기본값 `public/`)에서 찾습니다.
+
+이 디렉터리는 `hwaro build`가 만든 것이어야 합니다. Hwaro 0.19부터
+`hwaro serve`는 `.hwaro/serve/`에 빌드하고 `output_dir`은 건드리지 않으므로,
+serve만 쓰는 작업 흐름에서는 이 디렉터리가 없거나 예전 빌드에 멈춰 있습니다.
+이제 doctor가 그 사실을 알려줍니다:
+
+- **없거나 비어 있음** — 검증하지 못한 라우트와 함께 `build-output-unusable`로
+  보고합니다: *"public/ holds no build output — run `hwaro build` first"*.
+- **`hwaro serve` 출력** (`.hwaro-dev` 마커가 남은 경우) — `hwaro deploy`와 같은
+  규칙으로 근거에서 제외합니다. 마커는 `hwaro build`가 지웁니다.
+- **가장 최근 소스 파일보다 오래됨** — 그 트리로 통과시킨 라우트가 있으면
+  `build-output-stale`로 보고합니다. 삭제한 페이지의 `index.html`이 아직 남아
+  있을 수 있기 때문입니다.
+
+둘 다 `info` 수준이며, 실제로 그 트리가 필요했을 때만 나타납니다. 빌드가
+생성하는 경로를 참조하지 않는 사이트는 `public/` 이야기를 듣지 않습니다.
 
 ## 알려진 문제 무시
 
@@ -170,6 +197,8 @@ ignore = [
 | `menu-parent-undefined` | config | 메뉴 항목의 `parent`가 같은 메뉴의 identifier와 맞지 않음 |
 | `config-path-missing` | config | 참조한 파일이 존재하지 않음 |
 | `config-dir-missing` | config | 참조한 디렉터리가 존재하지 않음 |
+| `build-output-unusable` | config | `[build] output_dir`로 라우트를 검증할 수 없음 (없거나 `hwaro serve` 출력) |
+| `build-output-stale` | config | 소스보다 오래된 빌드 출력으로 라우트를 통과시킴 |
 | `missing-config-*` | config_missing | 설정 섹션 누락 (예: `missing-config-pwa`) |
 | `template-dir-missing` | template | 템플릿 디렉터리를 찾을 수 없음 ✗ |
 | `template-required-missing` | template | 필수 템플릿 누락 ✗ |

--- a/docs/content/start/tools/doctor.md
+++ b/docs/content/start/tools/doctor.md
@@ -64,6 +64,8 @@ hwaro doctor --json
   `[pwa] icons`, `[auto_includes] dirs`, `[[assets.bundles]] files`, …).
   Values that carry their own origin (`https://…`, `//cdn…`, `data:…`) are
   left alone — doctor can't validate a remote URL.
+- Build output that cannot back a route check (see
+  [Build output as evidence](#build-output-as-evidence))
 
 **Template diagnostics:**
 
@@ -95,9 +97,12 @@ hwaro: doctor
     [ok]   search (format)
     [ok]   languages (default_language resolves)
     [ok]   markdown / pwa (valid enums)
+    [ok]   image processing (widths set)
     [ok]   deployment / related (refs resolve)
     [ok]   menus (parent references)
     [ok]   referenced files & dirs
+    [ok]   build output (route evidence)
+    [ok]   sass (sources & enablement)
 
   templates/
     [ok]   required files (page.html, section.html)
@@ -126,6 +131,31 @@ passing check — for example `template syntax` when `templates/` is missing.
 In a color terminal the check lines use `✓`/`⚠`/`✗`/`ℹ` glyphs under an
 `hwaro doctor` heading, and the summary is a severity-colored `✦ checked` outcome
 line. A clean run ends with `checked: no issues found — your site looks great`.
+
+## Build Output as Evidence
+
+`[pwa] offline_page` and `[pwa] precache_urls` are routes, not files. Doctor
+resolves them against `content/` first, and — for values that carry an
+extension, such as a compiled stylesheet or a resized image variant — against
+the last build in `[build] output_dir` (`public/` by default).
+
+That tree has to come from `hwaro build`. Since Hwaro 0.19, `hwaro serve`
+builds into `.hwaro/serve/` and leaves `output_dir` alone, so in a serve-only
+workflow it is either absent or frozen at an old build. Doctor now says so
+instead of leaving you to guess:
+
+- **Absent or empty** — reported as `build-output-unusable`, alongside the
+  route it could not validate: *"public/ holds no build output — run `hwaro
+  build` first"*.
+- **`hwaro serve` output** (a leftover `.hwaro-dev` marker) — never used as
+  evidence, the same rule `hwaro deploy` applies. `hwaro build` clears the
+  marker.
+- **Older than your newest source file** — reported as `build-output-stale`
+  when a route was accepted from it, because a page you deleted still has its
+  `index.html` standing in that tree.
+
+Both are `info` level and appear only when the tree actually mattered: a site
+that references no build-generated path never hears about `public/`.
 
 ## Ignoring Known Issues
 
@@ -171,6 +201,8 @@ Rows marked ✗ are error level and **cannot** be ignored.
 | `menu-parent-undefined` | config | Menu entry's `parent` matches no identifier in that menu |
 | `config-path-missing` | config | Referenced file does not exist |
 | `config-dir-missing` | config | Referenced directory does not exist |
+| `build-output-unusable` | config | `[build] output_dir` could not validate a route (absent, or `hwaro serve` output) |
+| `build-output-stale` | config | A route was accepted from build output older than the sources |
 | `missing-config-*` | config_missing | Missing config section (e.g. `missing-config-pwa`) |
 | `template-dir-missing` | template | Templates directory not found ✗ |
 | `template-required-missing` | template | Required template missing ✗ |

--- a/spec/unit/build_output_oracle_spec.cr
+++ b/spec/unit/build_output_oracle_spec.cr
@@ -1,0 +1,139 @@
+require "../spec_helper"
+
+# Issue #761: `hwaro doctor` and `hwaro tool check-links` accept paths that no
+# source file explains by looking for them in a previous build's output_dir.
+# Since #758 `hwaro serve` builds into `.hwaro/serve/`, so in a serve-only
+# workflow that tree is absent (pipeline-emitted assets read as missing) or
+# frozen at an old build (paths that no longer exist still validate). This is
+# where both tools' "may I believe this tree?" answer lives.
+describe Hwaro::Utils::BuildOutput do
+  it "never uses a missing output directory as evidence, and says why" do
+    Dir.mktmpdir do |dir|
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [File.join(dir, "content")])
+
+      oracle.state.should eq(Hwaro::Utils::BuildOutput::State::Missing)
+      oracle.usable?.should be_false
+      oracle.exists?("css/app.css").should be_false
+      oracle.consulted?.should be_false
+      oracle.hint.to_s.should contain("hwaro build")
+      oracle.hint.to_s.should contain(".hwaro/serve")
+    end
+  end
+
+  it "treats an output directory with nothing in it as missing" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "public"))
+
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [] of String)
+      oracle.state.should eq(Hwaro::Utils::BuildOutput::State::Missing)
+      oracle.usable?.should be_false
+    end
+  end
+
+  # Same rule `hwaro deploy` applies: a tree stamped by serve carries dev URLs
+  # and draft-inclusive routing, so it is not what a build would produce.
+  it "refuses a tree carrying the dev marker even when it holds the file" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+      Hwaro::Utils::DevMarker.write(File.join(dir, "public"))
+
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [] of String, tool: "check-links")
+      oracle.state.should eq(Hwaro::Utils::BuildOutput::State::DevOutput)
+      oracle.exists?("css/app.css").should be_false
+      oracle.hint.to_s.should contain(Hwaro::Utils::DevMarker::FILENAME)
+      oracle.hint.to_s.should contain("check-links")
+    end
+  end
+
+  it "accepts a real build tree and stays quiet about it" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      FileUtils.mkdir_p(File.join(dir, "content"))
+      File.write(File.join(dir, "content", "post.md"), "x")
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+      File.touch(File.join(dir, "content", "post.md"), Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "content"), Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "public", "css", "app.css"), Time.utc(2026, 1, 2))
+
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [File.join(dir, "content")])
+      oracle.usable?.should be_true
+      oracle.exists?("css/app.css").should be_true
+      oracle.consulted?.should be_true
+      oracle.hint.should be_nil
+    end
+  end
+
+  it "flags a tree older than the newest source once it decided something" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      FileUtils.mkdir_p(File.join(dir, "content"))
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+      File.write(File.join(dir, "content", "post.md"), "x")
+      File.touch(File.join(dir, "public", "css", "app.css"), Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "content"), Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "content", "post.md"), Time.utc(2026, 2, 1))
+
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [File.join(dir, "content")])
+      oracle.exists?("css/app.css").should be_true
+      oracle.hint.to_s.should contain("older than the newest source")
+      oracle.hint.to_s.should contain("hwaro build")
+    end
+  end
+
+  # Staleness is about evidence, not about the directory: a run that never
+  # needed the tree has nothing to warn about, and paying for the source walk
+  # would be pure cost.
+  it "says nothing about a stale tree it never consulted" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "public"))
+      FileUtils.mkdir_p(File.join(dir, "content"))
+      File.write(File.join(dir, "public", "index.html"), "<html></html>")
+      File.write(File.join(dir, "content", "post.md"), "x")
+      File.touch(File.join(dir, "public", "index.html"), Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "content", "post.md"), Time.utc(2026, 2, 1))
+
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [File.join(dir, "content")])
+      oracle.exists?("nothing/here.css").should be_false
+      oracle.consulted?.should be_false
+      oracle.hint.should be_nil
+    end
+  end
+
+  # The false negative in #761: a deleted page leaves its route standing in
+  # the output tree. Deleting only moves the PARENT directory's mtime, so a
+  # file-only scan would call the tree fresh and validate a dead route.
+  it "notices a deleted source through its parent directory's mtime" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "public", "old"))
+      FileUtils.mkdir_p(File.join(dir, "content"))
+      File.write(File.join(dir, "public", "old", "index.html"), "<html></html>")
+      File.write(File.join(dir, "content", "keep.md"), "x")
+      File.touch(File.join(dir, "public", "old", "index.html"), Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "content", "keep.md"), Time.utc(2026, 1, 1))
+      # `content/old.md` was deleted after the build: only the directory moved.
+      File.touch(File.join(dir, "content"), Time.utc(2026, 2, 1))
+
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [File.join(dir, "content")])
+      oracle.exists?("old/index.html").should be_true
+      oracle.hint.to_s.should contain("older than the newest source")
+    end
+  end
+
+  it "does not follow symlinks while scanning sources" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "public"))
+      FileUtils.mkdir_p(File.join(dir, "content"))
+      File.write(File.join(dir, "public", "index.html"), "<html></html>")
+      File.touch(File.join(dir, "public", "index.html"), Time.utc(2026, 1, 1))
+      # A cycle: following it would recurse until the stack (or the budget)
+      # gave out. Stamp the directory afterwards — creating an entry moves it.
+      File.symlink(File.join(dir, "content"), File.join(dir, "content", "loop"))
+      File.touch(File.join(dir, "content"), Time.utc(2026, 1, 1))
+
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [File.join(dir, "content")])
+      oracle.exists?("index.html").should be_true
+      oracle.hint.should be_nil
+    end
+  end
+end

--- a/spec/unit/deadlink_build_output_spec.cr
+++ b/spec/unit/deadlink_build_output_spec.cr
@@ -1,0 +1,98 @@
+require "../spec_helper"
+
+# Test helper: resolve internal links against an explicit build-output oracle
+# (the private path `run` takes), under a name no other deadlink spec defines.
+class Hwaro::CLI::Commands::Tool::DeadlinkCommand
+  def resolve_with_oracle_for_test(links : Array(Link), content_dir : String,
+                                   oracle : Hwaro::Utils::BuildOutput::Oracle) : Array(Result)
+    check_internal_links(links, content_dir, [] of String, "", [] of String, GeneratedRoutes.new, oracle)
+  end
+end
+
+# Issue #761: `check-links` accepts pipeline-emitted assets (compiled Sass,
+# resized image variants, `[content.files]` output) by finding them in the
+# configured output_dir. A serve-only workflow leaves that tree absent, so
+# every such link was reported dead with no explanation.
+private def asset_link(dir : String, url : String)
+  Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(
+    file: File.join(dir, "content", "index.md"), url: url, kind: :internal)
+end
+
+describe "check-links build-output oracle" do
+  it "accepts a pipeline asset from a real build tree" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "content"))
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [File.join(dir, "content")], tool: "check-links")
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      dead = cmd.resolve_with_oracle_for_test([asset_link(dir, "/css/app.css")], File.join(dir, "content"), oracle)
+
+      dead.should be_empty
+      oracle.consulted?.should be_true
+    end
+  end
+
+  it "does not accept a pipeline asset from serve output" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "content"))
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+      Hwaro::Utils::DevMarker.write(File.join(dir, "public"))
+
+      oracle = Hwaro::Utils::BuildOutput.oracle("public", root: dir, sources: [File.join(dir, "content")], tool: "check-links")
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      dead = cmd.resolve_with_oracle_for_test([asset_link(dir, "/css/app.css")], File.join(dir, "content"), oracle)
+
+      dead.size.should eq(1)
+      oracle.hint.to_s.should contain("hwaro build")
+    end
+  end
+
+  # The human report carries the caveat only when it changes how the result
+  # reads. Here every link resolves — through a tree older than the content —
+  # so the run is "healthy" but the verdict rests on stale evidence.
+  it "prints the stale-output caveat under an otherwise healthy report" do
+    Dir.mktmpdir do |dir|
+      content = File.join(dir, "content")
+      FileUtils.mkdir_p(content)
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      File.write(File.join(dir, "config.toml"), %(title = "T"\nbase_url = "http://x"\n))
+      File.write(File.join(content, "index.md"), "---\ntitle: I\n---\n[css](/css/app.css)")
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+      File.touch(File.join(dir, "public", "css", "app.css"), Time.utc(2026, 1, 1))
+      File.touch(File.join(content, "index.md"), Time.utc(2026, 2, 1))
+
+      output = with_captured_log do
+        Hwaro::CLI::Commands::Tool::DeadlinkCommand.new.run(["-c", content, "--internal-only"])
+      end
+
+      output.should contain("all healthy")
+      output.should contain("older than the newest source")
+      output.should contain("public/")
+    end
+  end
+
+  it "leaves the report alone when the build tree is current" do
+    Dir.mktmpdir do |dir|
+      content = File.join(dir, "content")
+      FileUtils.mkdir_p(content)
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      File.write(File.join(dir, "config.toml"), %(title = "T"\nbase_url = "http://x"\n))
+      File.write(File.join(content, "index.md"), "---\ntitle: I\n---\n[css](/css/app.css)")
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+      File.touch(File.join(content, "index.md"), Time.utc(2026, 1, 1))
+      File.touch(content, Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "config.toml"), Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "public", "css", "app.css"), Time.utc(2026, 2, 1))
+
+      output = with_captured_log do
+        Hwaro::CLI::Commands::Tool::DeadlinkCommand.new.run(["-c", content, "--internal-only"])
+      end
+
+      output.should contain("all healthy")
+      output.should_not contain("hwaro build")
+    end
+  end
+end

--- a/spec/unit/doctor_build_output_spec.cr
+++ b/spec/unit/doctor_build_output_spec.cr
@@ -1,0 +1,131 @@
+require "../spec_helper"
+
+# Issue #761: doctor's acceptance oracle for a route with no source file is a
+# previous build's `[build] output_dir`. A serve-only workflow never populates
+# it (since #758 serve builds into `.hwaro/serve/`), so doctor used to report
+# every pipeline-emitted asset missing with no clue why — or validate against
+# a tree frozen at a long-past build.
+private def doctor_for(dir : String) : Hwaro::Services::Doctor
+  Hwaro::Services::Doctor.new(
+    content_dir: File.join(dir, "content"),
+    config_path: File.join(dir, "config.toml"),
+    templates_dir: File.join(dir, "templates"),
+    static_dir: File.join(dir, "static"),
+  )
+end
+
+private def pwa_asset_config(dir : String, output_dir : String? = nil) : Nil
+  build = output_dir ? "[build]\noutput_dir = \"#{output_dir}\"\n" : ""
+  File.write(File.join(dir, "config.toml"),
+    %(title = "T"\nbase_url = "http://x"\n#{build}[pwa]\nenabled = true\nprecache_urls = ["/css/app.css"]\n))
+end
+
+describe "doctor build-output oracle" do
+  it "explains an absent output tree instead of only reporting the asset missing" do
+    Dir.mktmpdir do |dir|
+      pwa_asset_config(dir)
+
+      Dir.cd(dir) do
+        issues = doctor_for(dir).run
+        issues.any? { |i| i.id == "config-path-missing" && i.message.includes?("precache") }.should be_true
+
+        advisory = issues.find { |i| i.id == "build-output-unusable" }
+        advisory.should_not be_nil
+        advisory.try(&.level).should eq(:info)
+        advisory.try(&.message.includes?("hwaro build")).should be_true
+        advisory.try(&.message.includes?(".hwaro/serve")).should be_true
+      end
+    end
+  end
+
+  # `hwaro serve --output public` still stamps the configured directory. Dev
+  # output is not what a build produces, so it is not evidence — the same rule
+  # `hwaro deploy` applies.
+  it "refuses serve output as evidence and names the marker" do
+    Dir.mktmpdir do |dir|
+      pwa_asset_config(dir)
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+      Hwaro::Utils::DevMarker.write(File.join(dir, "public"))
+
+      Dir.cd(dir) do
+        issues = doctor_for(dir).run
+        issues.any? { |i| i.id == "config-path-missing" && i.message.includes?("precache") }.should be_true
+        advisory = issues.find { |i| i.id == "build-output-unusable" }
+        advisory.try(&.message.includes?(Hwaro::Utils::DevMarker::FILENAME)).should be_true
+      end
+    end
+  end
+
+  it "stays silent when a real build tree answers the route" do
+    Dir.mktmpdir do |dir|
+      pwa_asset_config(dir)
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+
+      Dir.cd(dir) do
+        issues = doctor_for(dir).run
+        issues.any? { |i| i.id == "config-path-missing" && i.message.includes?("precache") }.should be_false
+        issues.any?(&.id.starts_with?("build-output-")).should be_false
+      end
+    end
+  end
+
+  it "says nothing about a missing output tree when no route needed it" do
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "config.toml"), %(title = "T"\nbase_url = "http://x"\n))
+
+      Dir.cd(dir) do
+        issues = doctor_for(dir).run
+        issues.any?(&.id.starts_with?("build-output-")).should be_false
+      end
+    end
+  end
+
+  it "flags a route accepted only from output older than the sources" do
+    Dir.mktmpdir do |dir|
+      pwa_asset_config(dir)
+      FileUtils.mkdir_p(File.join(dir, "public", "css"))
+      FileUtils.mkdir_p(File.join(dir, "content"))
+      File.write(File.join(dir, "public", "css", "app.css"), "body{}")
+      File.write(File.join(dir, "content", "post.md"), "+++\ntitle = \"P\"\n+++\n")
+      File.touch(File.join(dir, "public", "css", "app.css"), Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "content"), Time.utc(2026, 1, 1))
+      File.touch(File.join(dir, "content", "post.md"), Time.utc(2026, 2, 1))
+
+      Dir.cd(dir) do
+        issues = doctor_for(dir).run
+        issues.any? { |i| i.id == "config-path-missing" && i.message.includes?("precache") }.should be_false
+        stale = issues.find { |i| i.id == "build-output-stale" }
+        stale.try(&.message.includes?("older than the newest source")).should be_true
+      end
+    end
+  end
+
+  # `[build] output_dir` is followed rather than assumed, and the hint names
+  # the directory the site actually configures.
+  it "follows a custom output_dir in both the probe and the hint" do
+    Dir.mktmpdir do |dir|
+      pwa_asset_config(dir, output_dir: "dist")
+
+      Dir.cd(dir) do
+        issues = doctor_for(dir).run
+        issues.find { |i| i.id == "build-output-unusable" }.try(&.message.includes?("dist/")).should be_true
+      end
+
+      FileUtils.mkdir_p(File.join(dir, "dist", "css"))
+      File.write(File.join(dir, "dist", "css", "app.css"), "body{}")
+      Dir.cd(dir) do
+        issues = doctor_for(dir).run
+        issues.any? { |i| i.id == "config-path-missing" && i.message.includes?("precache") }.should be_false
+      end
+    end
+  end
+
+  # `[doctor] ignore` validates entries against the ids derived from
+  # CHECK_GROUPS, so an unregistered advisory could never be silenced.
+  it "registers both advisory ids as known doctor rules" do
+    Hwaro::Services::Doctor.known_issue_id?("build-output-unusable").should be_true
+    Hwaro::Services::Doctor.known_issue_id?("build-output-stale").should be_true
+  end
+end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -13,6 +13,7 @@ require "../../../utils/frontmatter_scanner"
 require "../../../utils/text_utils"
 require "../../../utils/errors"
 require "../../../utils/logger"
+require "../../../utils/build_output"
 
 module Hwaro
   module CLI
@@ -199,6 +200,9 @@ module Hwaro
                   "dead_external"    => [] of Result,
                   "skipped_external" => [] of Result,
                   "ignored_count"    => ignored_count,
+                  # Same key on every payload: a consumer reads one schema,
+                  # and "nothing to check" has no build-output caveat.
+                  "output_hint" => nil,
                 }.to_json)
               else
                 Logger.outcome("checked", ignored_count > 0 ? "no links to check (#{ignored_count} ignored)" : "no links found", :info)
@@ -230,9 +234,23 @@ module Hwaro
             # reported dead.
             language_codes = translation_language_codes(config)
             generated_routes = generated_routes(config)
-            # Follow `[build] output_dir`; "public" only as the fallback.
+            # Follow `[build] output_dir`; "public" only as the fallback. The
+            # tree is consulted through the oracle so a serve-only workflow
+            # (which since #758 never populates it) is told why its
+            # pipeline-emitted assets read as dead, instead of validating
+            # against an absent — or permanently stale — tree (#761).
             output_dir = config.try(&.build.output_dir) || "public"
-            dead_internal = check_internal_links(internal_links, target_dir, taxonomy_names, base_path, language_codes, generated_routes, output_dir)
+            oracle = Utils::BuildOutput.oracle(
+              output_dir,
+              root: project_root,
+              sources: [target_dir] + %w[config.toml templates static data themes].map { |d| File.join(project_root, d) },
+              tool: "check-links",
+            )
+            dead_internal = check_internal_links(internal_links, target_dir, taxonomy_names, base_path, language_codes, generated_routes, oracle)
+            # Say it only where it changes how the result should be read: an
+            # unusable tree explains dead internal links, a stale one explains
+            # links it just accepted.
+            output_hint = oracle.hint if !dead_internal.empty? || oracle.usable?
 
             total = external_links.size + internal_links.size
             dead_total = dead_external.size + dead_internal.size
@@ -247,6 +265,12 @@ module Hwaro
                 "dead_external"    => dead_external,
                 "skipped_external" => skipped_external,
                 "ignored_count"    => ignored_count,
+                # Null unless the build tree changed how this result should be
+                # read (absent/serve output that could not validate pipeline
+                # assets, or stale output that accepted some). The human line
+                # is suppressed under --json, and CI is exactly where a run
+                # against no build output is easiest to miss.
+                "output_hint" => output_hint,
               }.to_json)
               # Exit non-zero so CI can gate on broken links (the JSON payload
               # has already been emitted to stdout for tooling to consume).
@@ -285,6 +309,11 @@ module Hwaro
               else
                 Logger.outcome("checked", "#{total} #{links_noun} · #{dead_total} dead", :err)
               end
+            end
+
+            if hint = output_hint
+              Logger.info "" if Logger.color_enabled?
+              Logger.item(sanitize_for_terminal(hint), glyph: :info)
             end
 
             # A dead-links result must fail the process so `check-links` is
@@ -655,7 +684,7 @@ module Hwaro
             !!(url =~ /\A[a-z][a-z0-9+.\-]*:/i)
           end
 
-          private def check_internal_links(links : Array(Link), content_dir : String, taxonomy_names : Array(String) = [] of String, base_path : String = "", language_codes : Array(String) = [] of String, generated_routes : GeneratedRoutes = GeneratedRoutes.new, output_dir : String = "public") : Array(Result)
+          private def check_internal_links(links : Array(Link), content_dir : String, taxonomy_names : Array(String) = [] of String, base_path : String = "", language_codes : Array(String) = [] of String, generated_routes : GeneratedRoutes = GeneratedRoutes.new, oracle : Utils::BuildOutput::Oracle = Utils::BuildOutput.oracle("public", tool: "check-links")) : Array(Result)
             results = [] of Result
             project_root = find_project_root(content_dir)
 
@@ -677,7 +706,7 @@ module Hwaro
               # (`content/ko/posts/`), and that section outranks any
               # translation reading — stripping unconditionally reported such
               # links dead even though the build publishes them.
-              exists = resolves?(resolved_url, link, content_dir, base_dir, project_root, taxonomy_names, output_dir) ||
+              exists = resolves?(resolved_url, link, content_dir, base_dir, project_root, taxonomy_names, oracle) ||
                        generated_routes.matches?(resolved_url) ||
                        feed_route?(resolved_url, generated_routes, content_dir, base_dir, language_codes) ||
                        paginated_route?(resolved_url, link, content_dir, base_dir, taxonomy_names)
@@ -935,7 +964,7 @@ module Hwaro
           # checker has always performed.
           private def resolves?(url : String, link : Link, content_dir : String, base_dir : String,
                                 project_root : String, taxonomy_names : Array(String),
-                                output_dir : String) : Bool
+                                oracle : Utils::BuildOutput::Oracle) : Bool
             target = content_target(url, content_dir, base_dir)
             # Most internal URLs are written with a trailing slash (`/about/`,
             # `/posts/hello/`) — strip it before computing the leaf-file
@@ -959,10 +988,12 @@ module Hwaro
             # [content.files] or the asset pipeline. The output probe doubles
             # as the oracle for generated routes on an already-built site, and
             # follows `[build] output_dir` so a site that builds elsewhere is
-            # not reported as one big pile of broken links.
+            # not reported as one big pile of broken links — but only while
+            # that tree is trustworthy: absent, empty and `hwaro serve` output
+            # all answer false, and the run reports why (#761).
             asset_path = url.lstrip("/")
             File.exists?(File.join(project_root, "static", asset_path)) ||
-              File.exists?(File.join(project_root, output_dir, asset_path))
+              oracle.exists?(asset_path)
           end
 
           # Language-qualified resolution for a `/<code>/…` URL whose literal

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -10,6 +10,7 @@ require "crinja"
 require "../models/config"
 require "../utils/errors"
 require "../utils/logger"
+require "../utils/build_output"
 require "../content/processors/markdown"
 require "../content/processors/internal_link_resolver"
 require "../core/build/parallel"
@@ -116,6 +117,8 @@ module Hwaro
             ["menu-parent-undefined"]),
           CheckSpec.new("referenced files & dirs",
             ["config-path-missing", "config-dir-missing"]),
+          CheckSpec.new("build output (route evidence)",
+            ["build-output-unusable", "build-output-stale"]),
           CheckSpec.new("sass (sources & enablement)",
             ["sass-dir-not-scanned", "sass-disabled-with-sources"]),
         ],
@@ -1335,6 +1338,20 @@ module Hwaro
       end
 
       private def check_referenced_paths(issues : Array(Issue), config : Models::Config)
+        # A prior build's output is the only evidence doctor has for a route
+        # no source file explains (a pipeline-emitted asset, a generated
+        # listing). Since #758 `hwaro serve` builds into `.hwaro/serve/`, so a
+        # serve-only workflow leaves `output_dir` absent or frozen at an old
+        # build — consult it through the oracle, which refuses a tree it may
+        # not trust and explains itself instead of leaving the route reported
+        # missing with no clue why (#761).
+        oracle = Utils::BuildOutput.oracle(
+          config.build.output_dir || "public",
+          sources: [@config_path, @content_dir, @templates_dir, @static_dir, "data", "themes"],
+          tool: "doctor",
+        )
+        unresolved_routes = 0
+
         emit_file = ->(label : String, value : String) do
           emit_missing(issues, label, value, resolver: ->(s : String) { path_resolves?(s) }, id: "config-path-missing", kind: "file")
         end
@@ -1349,7 +1366,9 @@ module Hwaro
         # found" warnings. Use a route-aware check that also accepts a matching
         # content source or a built output page.
         emit_route = ->(label : String, value : String) do
-          emit_missing(issues, label, value, resolver: ->(s : String) { path_resolves?(s) || route_resolves?(s, config.build.output_dir || "public") }, id: "config-path-missing", kind: "file")
+          before = issues.size
+          emit_missing(issues, label, value, resolver: ->(s : String) { path_resolves?(s) || route_resolves?(s, oracle) }, id: "config-path-missing", kind: "file")
+          unresolved_routes += 1 if issues.size > before
         end
 
         config.og.default_image.try { |v| emit_file.call("[og] default_image", v) }
@@ -1399,6 +1418,22 @@ module Hwaro
               )
             end
           end
+        end
+
+        # One advisory for the whole run, never one per route. `hint` is nil
+        # unless the tree could not be used at all (absent / serve output) or
+        # was used and predates the sources; the extra condition keeps an
+        # unusable tree quiet until a route actually failed because of it —
+        # a site that references no pipeline-emitted path does not need to
+        # hear about `public/`.
+        if (hint = oracle.hint) && (oracle.usable? || unresolved_routes > 0)
+          issues << Issue.new(
+            id: oracle.usable? ? "build-output-stale" : "build-output-unusable",
+            level: :info,
+            category: "config",
+            file: nil,
+            message: hint,
+          )
         end
       end
 
@@ -1472,10 +1507,11 @@ module Hwaro
       #   - a content source exists (`content/about.md` or
       #     `content/about/index.md` for `/about/`), or
       #   - the built output page exists (`<output_dir>/about/index.html`,
-      #     which follows `[build] output_dir` rather than assuming `public/`).
+      #     which follows `[build] output_dir` rather than assuming `public/`,
+      #     and only when that tree is trustworthy — see `Utils::BuildOutput`).
       # This keeps doctor from flagging valid routes as "file not found" while
       # still catching genuinely-missing pages.
-      private def route_resolves?(path : String, output_dir : String) : Bool
+      private def route_resolves?(path : String, oracle : Utils::BuildOutput::Oracle) : Bool
         # Normalize to a slug: drop a leading slash, strip a trailing slash,
         # and remove a trailing `index.html` so `/about/` and
         # `/about/index.html` resolve the same way.
@@ -1502,10 +1538,10 @@ module Hwaro
         # a pretty route lands
         # at `<slug>/index.html`, while an explicit file (an `.html` alias or a
         # pipeline-built asset such as `/css/app.css`) lands at the path itself.
-        if Dir.exists?(output_dir)
-          return true if File.exists?(File.join(output_dir, slug, "index.html"))
-          return true if File.exists?(File.join(output_dir, path.lchop("/")))
-        end
+        # The oracle answers false for a tree doctor may not trust — absent,
+        # empty, or written by `hwaro serve` (#761).
+        return true if oracle.exists?(File.join(slug, "index.html"))
+        return true if oracle.exists?(path.lchop("/"))
 
         # Otherwise it's a pretty route or listing (taxonomy/section page)
         # produced at build time — doctor runs BEFORE the build (often on a clean

--- a/src/utils/build_output.cr
+++ b/src/utils/build_output.cr
@@ -1,0 +1,203 @@
+require "./dev_marker"
+require "./logger"
+
+# Build-output oracle (issue #761)
+#
+# `hwaro doctor` and `hwaro tool check-links` run OUTSIDE the build, so the
+# only evidence they have for a path no source file explains — compiled Sass,
+# resized/LQIP image variants, `[content.files]` output, generated routes — is
+# a previous build's `[build] output_dir`.
+#
+# Since #758 `hwaro serve` builds into `.hwaro/serve/` and never touches that
+# directory, so a serve-only workflow validates against a tree that is either
+# ABSENT (every pipeline-emitted path reads as missing — false positives) or
+# FROZEN at an old `hwaro build` (paths that no longer exist still validate —
+# false negatives). Neither tool used to notice, and neither said so.
+#
+# This wraps the probe so both consult the tree the same way:
+#
+#   * a tree that is absent, empty, or carries the `.hwaro-dev` marker is
+#     never used as evidence (the marker rule `hwaro deploy` already applies),
+#   * a tree that WAS used as evidence and predates the sources says so,
+#   * every case carries a one-sentence hint naming the fix.
+#
+# Staleness is computed lazily and only when the tree actually decided
+# something, so a tool that never consults it pays nothing.
+module Hwaro
+  module Utils
+    module BuildOutput
+      extend self
+
+      # Where `hwaro serve` builds (mirrors `ServeOptions::DEV_OUTPUT_DIR`).
+      # Named in hints so a serve-only workflow understands why its
+      # `output_dir` is empty. Duplicated rather than required so this util
+      # stays free of CLI dependencies.
+      SERVE_OUTPUT_DIR = ".hwaro/serve"
+
+      # Source trees whose newest mtime a trustworthy build output must
+      # postdate. Callers pass their own resolved paths; this is the
+      # convention-named fallback.
+      DEFAULT_SOURCES = %w[config.toml content templates static data themes sass assets]
+
+      # Upper bound on entries stat-ed while answering "is the output stale?".
+      # The walk exits early on the first newer entry, so this only bounds the
+      # FRESH case (a huge `static/` tree of images). Running out of budget
+      # reports "not stale": a hint is advisory, and guessing on partial
+      # evidence would nag sites it cannot actually judge.
+      MAX_SCANNED_ENTRIES = 20_000
+
+      enum State
+        # A real build tree: present, non-empty, no dev marker.
+        Ready
+        # No directory, or nothing in it.
+        Missing
+        # `hwaro serve` output — dev base_url baked into its pages.
+        DevOutput
+      end
+
+      def oracle(dir : String, root : String = ".", sources : Array(String) = DEFAULT_SOURCES,
+                 tool : String = "doctor") : Oracle
+        Oracle.new(dir, root: root, sources: sources, tool: tool)
+      end
+
+      # One build-output tree, examined as an acceptance oracle.
+      #
+      # `dir` is the configured `[build] output_dir` (used verbatim in hints);
+      # `root` is what a relative `dir` resolves against. `sources` are taken
+      # AS GIVEN — the caller already knows where its content/templates/static
+      # directories live, and they do not always sit under `root`.
+      class Oracle
+        getter dir : String
+        getter state : State
+        # True once the tree accepted at least one path — i.e. it was the
+        # deciding evidence, not just present.
+        getter? consulted : Bool
+
+        @base : String
+        @oldest_accepted : Time?
+        @stale : Bool?
+        @budget : Int32 = 0
+
+        def initialize(@dir : String, root : String = ".", @sources : Array(String) = DEFAULT_SOURCES,
+                       @tool : String = "doctor")
+          @base = Path[@dir].absolute? ? @dir : File.join(root, @dir)
+          @consulted = false
+          @oldest_accepted = nil
+          @stale = nil
+          @state = classify
+        end
+
+        # May this tree be used as evidence at all?
+        def usable? : Bool
+          @state.ready?
+        end
+
+        # Does the build tree contain `relative`? Always false for a tree that
+        # may not be used as evidence, so a caller never has to remember to
+        # check `usable?` first.
+        #
+        # Path errors (an embedded NUL from a percent-decoded link target)
+        # propagate exactly as the bare `File.exists?` calls this replaces did
+        # — callers already degrade per link on `ArgumentError`.
+        def exists?(relative : String) : Bool
+          return false unless usable?
+          return false if relative.empty?
+
+          info = File.info?(File.join(@base, relative))
+          return false unless info
+
+          @consulted = true
+          mtime = info.modification_time
+          oldest = @oldest_accepted
+          @oldest_accepted = mtime if oldest.nil? || mtime < oldest
+          true
+        end
+
+        # The one-sentence advisory for this tree, or nil when it has nothing
+        # to say. Callers decide WHEN it is worth showing: an unusable tree
+        # only matters once something failed to resolve, so `hwaro doctor`
+        # and `check-links` surface it alongside their own findings.
+        def hint : String?
+          case @state
+          in State::Missing
+            "#{label} holds no build output — run `hwaro build` first; " \
+            "#{@tool} validates build output, not `hwaro serve` output (#{SERVE_OUTPUT_DIR}/)"
+          in State::DevOutput
+            "#{label} is `hwaro serve` output (#{DevMarker::FILENAME} marker), not a build — " \
+            "#{@tool} is ignoring it; run `hwaro build` first"
+          in State::Ready
+            return unless @consulted && stale?
+            "#{label} is older than the newest source file — #{@tool} accepted paths from stale " \
+            "build output; re-run `hwaro build` to re-check them"
+          end
+        end
+
+        # Display form of the configured directory, always with a trailing
+        # separator so a hint reads as a directory ("public/").
+        def label : String
+          @dir.ends_with?(File::SEPARATOR) ? @dir : "#{@dir}#{File::SEPARATOR}"
+        end
+
+        private def classify : State
+          return State::Missing unless Dir.exists?(@base)
+          # The marker rule `hwaro deploy` applies: a tree stamped by serve
+          # carries dev URLs and draft-inclusive routing, so it is not what a
+          # deployable build would produce.
+          return State::DevOutput if DevMarker.present?(@base)
+          return State::Missing if empty?(@base)
+          State::Ready
+        rescue File::Error
+          # Unreadable (permissions, an exotic mount): no evidence available.
+          State::Missing
+        end
+
+        private def empty?(dir : String) : Bool
+          Dir.each_child(dir) { |_| return false }
+          true
+        end
+
+        # Is any source newer than the OLDEST thing the tree was believed on?
+        # Memoized: `hint` is cheap to call more than once, the walk is not.
+        private def stale? : Bool
+          cached = @stale
+          return cached unless cached.nil?
+
+          oldest = @oldest_accepted
+          return (@stale = false) unless oldest
+
+          @budget = MAX_SCANNED_ENTRIES
+          @stale = @sources.any? { |source| newer_than?(source, oldest) }
+        end
+
+        # Is `path`, or anything under it, newer than `threshold`?
+        #
+        # Directory mtimes count: DELETING a source file — the case that
+        # leaves a route standing in the output tree with nothing behind it,
+        # exactly the false negative this hint exists for — only moves its
+        # parent's mtime. Hidden entries are skipped so an editor's dotfile
+        # or `.DS_Store` cannot nag a site into a permanent "stale" hint.
+        private def newer_than?(path : String, threshold : Time) : Bool
+          return false if @budget <= 0
+          @budget -= 1
+
+          info = File.info?(path, follow_symlinks: false)
+          return false unless info
+          # Never follow: a link's target may sit outside the project (or loop
+          # back into it), and its own mtime already stands in for the link.
+          return false if info.symlink?
+          return true if info.modification_time > threshold
+          return false unless info.directory?
+
+          Dir.each_child(path) do |child|
+            next if child.starts_with?('.')
+            return true if newer_than?(File.join(path, child), threshold)
+          end
+          false
+        rescue ex : File::Error
+          Logger.debug "Build-output staleness scan skipped #{path}: #{ex.message}"
+          false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #761.

## Problem

`hwaro doctor` and `hwaro tool check-links` accept paths that no source file explains — compiled Sass, resized/LQIP image variants, `[content.files]` output, generated routes — by probing the configured `[build] output_dir`. Since #758 `hwaro serve` builds into `.hwaro/serve/` and leaves that directory alone, so a serve-only workflow validates against a tree that is either:

- **absent** → pipeline-emitted assets are reported missing/dead (false positives), with no clue why;
- **frozen at an old `hwaro build`** → routes and assets that no longer exist silently validate (false negatives).

Reproduced on hwaro's own docs site: with `docs/public/` moved aside, `check-links` reports 8 dead links (`/og-images/…png`, `/hwaro_128w.png`, …) that are pure build products.

## Change

New `Utils::BuildOutput` — the one place that answers "may I believe this output tree?" — used by both tools:

- **absent / empty / `.hwaro-dev` marker** → never used as evidence (the same marker rule `hwaro deploy` applies; `hwaro build` clears the marker);
- **used as evidence, but older than the newest source file** → reported. Directory mtimes count, so a *deleted* page — which only moves its parent's mtime while leaving `index.html` standing in the output — is caught;
- every case carries a one-sentence hint naming the fix.

Surfaces:

- `doctor` → `build-output-unusable` / `build-output-stale`, both `info` level (no exit-code change), both registered in `CHECK_GROUPS` so `[doctor] ignore` can name them and they render on the board;
- `check-links` → a `[info]` note under the report, plus `output_hint` in `--json` (CI is where a run against no build output is easiest to miss).

Noise control: an unusable tree stays quiet until a route/link actually failed because of it, and staleness is computed lazily — only when the tree decided something, bounded and early-exiting — so a run that never consults it pays nothing.

```
checked: 4 links, 1 dead
  [info] public/ holds no build output — run `hwaro build` first; check-links validates build output, not `hwaro serve` output (.hwaro/serve/)
```

## Tests

- `spec/unit/build_output_oracle_spec.cr` (8) — states, evidence tracking, lazy staleness, deleted-source detection via directory mtime, symlink-cycle safety
- `spec/unit/doctor_build_output_spec.cr` (7) — advisory emitted only when it mattered, custom `output_dir`, registry wiring
- `spec/unit/deadlink_build_output_spec.cr` (4) — serve output refused, stale caveat under a healthy report, silence on a current tree

Full suite: 8353 examples, 0 failures. `crystal tool format --check` and `ameba` clean. Verified end to end against a scaffolded site (missing → dev-marked → built → edited/stale) and against `docs/`.

Docs: `start/tools/doctor` and `start/tools/check-links` (en + ko) gain a "Build output as evidence" section; the doctor rule-ID table and example board are updated.