### PR TITLE
fix(templates): stop three template-engine crashes that abort the whole build

### DIFF
--- a/docs/content/templates/filters.ko.md
+++ b/docs/content/templates/filters.ko.md
@@ -48,8 +48,8 @@ Hwaro는 표준 Crinja(Jinja2) 내장 필터 — `upper`, `lower`, `join`, `map`
 | 필터 | 설명 | 예시 |
 |--------|-------------|---------|
 | length | 길이 | {{ items \| length }} |
-| first | 첫 요소 | {{ items \| first }} |
-| last | 마지막 요소 | {{ items \| last }} |
+| first | 첫 요소(빈 컬렉션이면 빈 값) | {{ items \| first }} |
+| last | 마지막 요소(빈 컬렉션이면 빈 값) | {{ items \| last }} |
 | reverse | 순서 뒤집기 | {{ items \| reverse }} |
 | sort | 배열 정렬 | {{ items \| sort }} |
 | join | 요소 이어 붙이기 | {{ tags \| join(", ") }} |

--- a/docs/content/templates/filters.md
+++ b/docs/content/templates/filters.md
@@ -48,8 +48,8 @@ same text renders in page bodies. The rest of the extension pipeline
 | Filter | Description | Example |
 |--------|-------------|---------|
 | length | Get length | {{ items \| length }} |
-| first | First element | {{ items \| first }} |
-| last | Last element | {{ items \| last }} |
+| first | First element (empty on an empty collection) | {{ items \| first }} |
+| last | Last element (empty on an empty collection) | {{ items \| last }} |
 | reverse | Reverse order | {{ items \| reverse }} |
 | sort | Sort array | {{ items \| sort }} |
 | join | Join elements | {{ tags \| join(", ") }} |

--- a/spec/functional/template_error_location_spec.cr
+++ b/spec/functional/template_error_location_spec.cr
@@ -61,6 +61,54 @@ describe "Template error location reporting" do
     err.message.not_nil!.should contain("templates/page.html")
   end
 
+  # Regression: `Crinja::Evaluator#name_for_expression` only handled
+  # identifier/member/index nodes; every other AST node hit a catch-all that
+  # did `raise "not implemented for ..."`. Because that is a bare Exception
+  # (not a Crinja::Error) it escaped the whole located-error path and killed
+  # the build with `not implemented for Crinja::AST::CallExpression` and no
+  # file:line. Attribute access on a call result / literal must behave like
+  # Jinja2 instead: undefined, i.e. empty output.
+  it "renders empty (not a crash) for attribute access on a missing get_page()" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {"index.md" => "---\ntitle: Home\n---\nhello"},
+      template_files: {
+        "page.html" => "<html>[{{ get_page(path=\"nope.md\").title }}]</html>",
+      },
+    ) do
+      File.read("public/index.html").should contain("[]")
+    end
+  end
+
+  it "renders empty for attribute access on none and on literals" do
+    build_site(
+      BASIC_CONFIG,
+      content_files: {"index.md" => "---\ntitle: Home\n---\nhello"},
+      template_files: {
+        "page.html" => "<html>[{{ none.foo }}][{{ none[0] }}][{{ [1, 2].foo }}][{{ {\"a\": 1}.foo }}]</html>",
+      },
+    ) do
+      File.read("public/index.html").should contain("[][][][]")
+    end
+  end
+
+  it "reports file:line:col for attribute access on a string literal" do
+    err = expect_raises(Hwaro::HwaroError) do
+      build_site(
+        BASIC_CONFIG,
+        content_files: {"index.md" => "---\ntitle: Home\n---\nhello"},
+        template_files: {
+          "page.html" => "<html>\n<body>\n{{ \"abc\".foo }}\n</body>\n</html>",
+        },
+      ) { }
+    end
+
+    err.code.should eq(Hwaro::Errors::HWARO_E_TEMPLATE)
+    message = err.message.not_nil!
+    message.should contain("\"abc\".foo is undefined")
+    message.should contain("templates/page.html:3:")
+  end
+
   it "reports the included template's filename when the error is inside an include" do
     err = expect_raises(Hwaro::HwaroError) do
       build_site(

--- a/spec/unit/filters_spec.cr
+++ b/spec/unit/filters_spec.cr
@@ -205,6 +205,28 @@ describe "DateFilters" do
       result.strip.should eq("not a date")
     end
 
+    # Regression: a malformed strftime pattern (a trailing `%`) made
+    # Crystal's `Time#to_s` raise a bare `IndexError`, which is not a
+    # `Crinja::Error` and so escaped TemplateEngine#render's rescue —
+    # the whole build died with `Index out of bounds` and no template
+    # file:line. It must surface as a located template error naming the
+    # bad format instead.
+    it "raises a located Crinja error for a malformed format string" do
+      vars = {"d" => Crinja::Value.new("2024-06-15")}
+      ex = expect_raises(Hwaro::HwaroError) do
+        render_filter("{{ d | date(format='%') }}", vars)
+      end
+      ex.message.not_nil!.should contain("invalid date format")
+    end
+
+    it "raises a located Crinja error for a malformed format on a Time value" do
+      vars = {"d" => Crinja::Value.new(Time.utc(2024, 3, 20))}
+      ex = expect_raises(Hwaro::HwaroError) do
+        render_filter("{{ d | date(format='%') }}", vars)
+      end
+      ex.message.not_nil!.should contain("invalid date format")
+    end
+
     it "converts non-string non-time values to string" do
       vars = {"d" => Crinja::Value.new(12345)}
       result = render_filter("{{ d | date }}", vars)
@@ -1403,5 +1425,63 @@ describe "MenuFilters" do
       vars = {"page_url" => Crinja::Value.new("/posts/")}
       render_filter("{{ '//cdn.example.com/x' | active_path }}", vars).should eq("false")
     end
+  end
+end
+
+# =============================================================================
+# first / last (Crinja built-ins overridden for empty sequences)
+# =============================================================================
+describe "first/last filters" do
+  # Regression: `{{ items | first }}` on an EMPTY array called
+  # `Enumerable#first`, which raises `Empty enumerable` — a plain Crystal
+  # error, so it bypassed the Crinja error path and aborted the entire
+  # build with no template location. `last` did the same with
+  # `Index out of bounds`. An empty section is ordinary site state.
+  it "returns undefined (empty output) for first on an empty array" do
+    render_filter("<{{ [] | first }}>").should eq("<>")
+  end
+
+  it "returns undefined (empty output) for last on an empty array" do
+    render_filter("<{{ [] | last }}>").should eq("<>")
+  end
+
+  it "returns undefined for first/last on an empty string" do
+    vars = {"s" => Crinja::Value.new("")}
+    render_filter("<{{ s | first }}|{{ s | last }}>", vars).should eq("<|>")
+  end
+
+  it "returns undefined for first/last on an empty hash" do
+    vars = {"h" => Crinja::Value.new({} of Crinja::Value => Crinja::Value)}
+    render_filter("<{{ h | first }}|{{ h | last }}>", vars).should eq("<|>")
+  end
+
+  it "is falsy so {% if %} guards work on an empty collection" do
+    render_filter("{% if [] | first %}yes{% else %}no{% endif %}").should eq("no")
+  end
+
+  it "still returns the first/last element of a non-empty array" do
+    render_filter("{{ [1, 2, 3] | first }}-{{ [1, 2, 3] | last }}").should eq("1-3")
+  end
+
+  it "still returns the first/last character of a non-empty string" do
+    render_filter("{{ 'abc' | first }}-{{ 'abc' | last }}").should eq("a-c")
+  end
+end
+
+# =============================================================================
+# now() function
+# =============================================================================
+describe "now() function" do
+  it "formats with a valid format string" do
+    render_filter("{{ now(format='%Y') }}").should eq(Time.local.to_s("%Y"))
+  end
+
+  # Regression: same bare `IndexError` as the `date` filter — a malformed
+  # format killed the build with `Index out of bounds` and no location.
+  it "raises a located Crinja error for a malformed format string" do
+    ex = expect_raises(Hwaro::HwaroError) do
+      render_filter("{{ now(format='%') }}")
+    end
+    ex.message.not_nil!.should contain("invalid date format")
   end
 end

--- a/src/content/processors/filters/collection_filter.cr
+++ b/src/content/processors/filters/collection_filter.cr
@@ -111,6 +111,26 @@ module Hwaro
               end
             end
 
+            # `first` / `last` — override Crinja's built-ins, which call
+            # `Enumerable#first` / `Indexable#last` on the raw value and let
+            # the resulting Crystal exception escape. On an EMPTY sequence
+            # that aborted the whole build with a bare `Empty enumerable` /
+            # `Index out of bounds` and no template file:line, because those
+            # are plain Crystal errors rather than `Crinja::Error`s (see
+            # TemplateEngine#render). An empty section/collection is ordinary
+            # site state — `{{ section.pages | first }}` on a section with no
+            # pages must not be fatal. Jinja2 yields `Undefined` there (which
+            # renders as "" and is falsy), so do the same; every non-empty
+            # input still goes through the upstream code path unchanged, and a
+            # non-sequence target still raises Crinja's located `TypeError`.
+            env.filters["first"] = Crinja.filter do
+              CollectionFilters.empty_sequence?(target) ? Crinja::Value::UNDEFINED : target.first.raw
+            end
+
+            env.filters["last"] = Crinja.filter do
+              CollectionFilters.empty_sequence?(target) ? Crinja::Value::UNDEFINED : target.last.raw
+            end
+
             # Compact filter — removes nil/empty values from an array
             env.filters["compact"] = Crinja.filter do
               safe_array do
@@ -119,6 +139,20 @@ module Hwaro
                   item.raw.nil? || item.to_s.empty?
                 end
               end
+            end
+          end
+
+          # True when `value` is a sequence with no elements — the case
+          # upstream `first`/`last` crash on. Deliberately narrow: anything
+          # that is not a string/hash/indexable (an Int, say) reports `false`
+          # so the upstream filter still raises its located `TypeError`.
+          def self.empty_sequence?(value : Crinja::Value) : Bool
+            case raw = value.raw
+            when String             then raw.empty?
+            when Crinja::SafeString then raw.to_s.empty?
+            when Hash               then raw.empty?
+            when Indexable          then raw.empty?
+            else                         false
             end
           end
 

--- a/src/content/processors/filters/date_filter.cr
+++ b/src/content/processors/filters/date_filter.cr
@@ -5,6 +5,18 @@ module Hwaro
     module Processors
       module Filters
         module DateFilters
+          # `Time#to_s(format)` raises a bare Crystal `IndexError` on a
+          # malformed format string (a trailing `%`, e.g. `date("%")`) — not a
+          # `Crinja::Error`, so it escapes TemplateEngine#render's rescue and
+          # aborts the whole build with `Index out of bounds` and no template
+          # file:line. Re-raise as a Crinja error so the failure names the bad
+          # format AND points at the template line that wrote it.
+          def self.format_time(time : Time, format : String) : String
+            time.to_s(format)
+          rescue ex : IndexError | ArgumentError
+            raise Crinja::TypeError.new("invalid date format #{format.inspect}: #{ex.message}")
+          end
+
           def self.register(env : Crinja)
             # Date formatting filter
             env.filters["date"] = Crinja.filter({format: "%Y-%m-%d"}) do
@@ -13,7 +25,7 @@ module Hwaro
 
               case value
               when Time
-                value.to_s(format)
+                DateFilters.format_time(value, format)
               when String
                 # Detect format heuristically to avoid exception-based control flow
                 parsed = if value.includes?('T')
@@ -33,7 +45,7 @@ module Hwaro
                          else
                            Time.parse(value, "%Y-%m-%d", Time::Location::UTC) rescue nil
                          end
-                parsed ? parsed.to_s(format) : value
+                parsed ? DateFilters.format_time(parsed, format) : value
               else
                 value.to_s
               end

--- a/src/content/processors/template.cr
+++ b/src/content/processors/template.cr
@@ -325,7 +325,11 @@ module Hwaro
             if format.none?
               Crinja::Value.new(time.to_s("%Y-%m-%d %H:%M:%S"))
             else
-              Crinja::Value.new(time.to_s(format.to_s))
+              # Same guard as the `date` filter: a malformed format string
+              # (`now(format="%")`) makes Crystal's `Time#to_s` raise a bare
+              # `IndexError`, which is not a `Crinja::Error` and so kills the
+              # build with `Index out of bounds` and no template file:line.
+              Crinja::Value.new(Filters::DateFilters.format_time(time, format.to_s))
             end
           end
         end

--- a/src/ext/crinja_resolve_fix.cr
+++ b/src/ext/crinja_resolve_fix.cr
@@ -117,3 +117,70 @@ module Crinja::Resolver
     value
   end
 end
+
+# === 4. Attribute access on a non-object no longer kills the build ======
+# `Crinja::Evaluator#name_for_expression` is used to LABEL the value that
+# member/index access produced — either the `Undefined` it returns, or the
+# `UndefinedError` it re-raises. Upstream only implements it for
+# `IdentifierLiteral`, `MemberExpression` and `IndexExpression`; every other
+# node hits a catch-all that does `raise "not implemented for #{...}"`.
+#
+# That catch-all fires on ordinary template code, and because it raises a
+# bare `Exception` (not a `Crinja::Error`) it escapes
+# `TemplateEngine#render`'s rescue: the build dies with
+# `not implemented for Crinja::AST::CallExpression` and NO template
+# file:line. The `Avoid: Multiple lookups` snippet in
+# docs/content/templates/functions.md is exactly this shape:
+#
+#   {{ get_section(path="blog").title }}   # CallExpression   → crash
+#   {{ none.foo }}                          # NullLiteral      → crash
+#   {{ "abc".foo }}                         # StringLiteral    → crash
+#   {{ [1, 2].foo }}                        # ArrayLiteral     → crash
+#
+# whenever the lookup misses. Naming a node must never be fatal, so the
+# catch-all now returns a readable placeholder and the common literal /
+# call shapes get a real name. With this, a missed lookup behaves like
+# Jinja2 (`Undefined`, i.e. empty output) and a genuine error — e.g.
+# `.attr` on a String, see patch 2 above — is reported as a located
+# `Crinja::Error` instead of an unlocatable crash.
+class Crinja::Evaluator
+  private def name_for_expression(expression)
+    expression.class.name.sub("Crinja::AST::", "").downcase
+  end
+
+  private def name_for_expression(expression : AST::CallExpression)
+    "#{name_for_expression(expression.identifier)}(…)"
+  end
+
+  private def name_for_expression(expression : AST::FilterExpression)
+    "#{name_for_expression(expression.target)} | #{expression.identifier.name}"
+  end
+
+  private def name_for_expression(expression : AST::NullLiteral)
+    "none"
+  end
+
+  private def name_for_expression(expression : AST::StringLiteral)
+    expression.value.inspect
+  end
+
+  private def name_for_expression(expression : AST::IntegerLiteral)
+    expression.value.to_s
+  end
+
+  private def name_for_expression(expression : AST::FloatLiteral)
+    expression.value.to_s
+  end
+
+  private def name_for_expression(expression : AST::BooleanLiteral)
+    expression.value.to_s
+  end
+
+  private def name_for_expression(expression : AST::ArrayLiteral)
+    "[…]"
+  end
+
+  private def name_for_expression(expression : AST::DictLiteral)
+    "{…}"
+  end
+end


### PR DESCRIPTION
## What

Dogfooding sweep of the **templates lane** (template engine, filters/functions, taxonomies, pagination, feeds, sitemap, SEO/OG meta, search index, i18n/multilingual, menus, discovery pages) against `docs/content/templates/**`.

Built real sites with `hwaro init` (all five scaffolds), a multilingual en/ko blog on a `base_url` subpath (`https://example.com/myblog`), taxonomies with unicode/CJK/blank/duplicate-case/slug-colliding terms, per-taxonomy feeds + pagination, and a ~90-case filter/function torture template, then compared behaviour to what the docs promise.

Most of the lane held up: sitemap/RSS/Atom XML is well-formed and correctly escaped (`</script>`, quotes, `&`) with percent-encoded non-ASCII paths; JSON-LD escapes `<`/`&` as `<`/`&`; base_path is applied consistently across feeds/sitemap/canonical/menu `href`; taxonomy slug collisions (`Crystal`/`crystal` → `crystal`/`crystal-2`) are disambiguated identically by the generator, `get_taxonomy()` and `get_taxonomy_url()`; per-language feeds/taxonomies/menus/`t` filter scope correctly; pagination boundaries (0/1/N/exact-multiple items) are right.

What did **not** hold up: three ordinary template expressions kill `hwaro build` outright, two of them without even naming the template line at fault.

## Bugs fixed

### 1. `{{ items | first }}` / `{{ items | last }}` on an empty collection aborts the build

**Symptom** — `bin/hwaro build` exits non-zero with

```
Error [HWARO_E_TEMPLATE]: Render failed for 1 page(s); first failure on index.md: Empty enumerable
```

(`last` gives `Index out of bounds`). No template name, no line, no excerpt.

**Root cause** — Crinja's built-ins are `Crinja.filter(:first) { target.first.raw }`, which reach `Enumerable#first` / `Indexable#last` on the raw value. Those raise plain Crystal exceptions, not `Crinja::Error`s, so they slip past `TemplateEngine#render`'s `rescue ex : Crinja::Error` and lose all location information. Both filters are documented in `docs/content/templates/filters.md`, and an empty section (`{{ section.pages | first }}` on a section a user just emptied) is ordinary site state — it must not be fatal.

**Fix** — `src/content/processors/filters/collection_filter.cr`: override both filters to return `Crinja::Value::UNDEFINED` for an empty string/hash/indexable, which is Jinja2's behaviour (empty output, falsy, so `{% if pages | first %}` guards work). Non-empty inputs still go through the upstream code path unchanged, and a non-sequence target still raises Crinja's located `TypeError`.

**Specs** — `spec/unit/filters_spec.cr` "first/last filters" (6 examples).

### 2. A malformed date format string aborts the build

**Symptom** — `{{ page.date | date("%") }}` or `{{ now(format="abc%") }}`:

```
Error [HWARO_E_TEMPLATE]: Render failed for 1 page(s); first failure on index.md: Index out of bounds
```

Nothing points at the format string or at the template.

**Root cause** — Crystal's `Time#to_s(format)` raises a bare `IndexError` on a trailing `%`. Same escape hatch as above.

**Fix** — `src/content/processors/filters/date_filter.cr` adds `DateFilters.format_time`, which re-raises `IndexError`/`ArgumentError` as `Crinja::TypeError.new("invalid date format \"%\": ...")`. Both the `date` filter and the `now()` function in `src/content/processors/template.cr` route through it. The failure now reads:

```
Error [HWARO_E_TEMPLATE]: Template error for index.md: invalid date format "%": Index out of bounds
template: templates/index.html:1:4 .. 1:26
 1 | {{ "2024-01-15" | date("%") }}
 X |    ^~~~~~~~~~~~~~~~~~~~~~~
```

**Specs** — `spec/unit/filters_spec.cr` (2 in `DateFilters date`, 1 in `now() function`).

### 3. Attribute access on a call result or literal aborts the build with no location

**Symptom** — six distinct shapes, all fatal:

| template | error (no file, no line) |
|---|---|
| `{{ get_section(path="blog").title }}` (missing section) | `not implemented for Crinja::AST::CallExpression` |
| `{{ get_page(path="nope.md").title }}` | `not implemented for Crinja::AST::CallExpression` |
| `{{ none.foo }}` / `{{ none[0] }}` | `not implemented for Crinja::AST::NullLiteral` |
| `{{ "abc".foo }}` | `not implemented for Crinja::AST::StringLiteral` |
| `{{ [1, 2].foo }}` | `not implemented for Crinja::AST::ArrayLiteral` |
| `{{ {"a": 1}.foo }}` | `not implemented for Crinja::AST::DictLiteral` |

The first row is literally the snippet `docs/content/templates/functions.md` prints under **"Avoid: Multiple lookups"** — following the docs and having the lookup miss takes the whole build down.

**Root cause** — `Crinja::Evaluator#name_for_expression` (`lib/crinja/src/runtime/evaluator.cr:192`) exists only to *label* the `Undefined` (or `UndefinedError`) that member/index access produced, but upstream implements it only for `IdentifierLiteral`, `MemberExpression` and `IndexExpression`. Every other node hits a catch-all that does `raise "not implemented for #{expression.class}"` — a bare `Exception`, so once again no `Crinja::Error`, no location.

**Fix** — `src/ext/crinja_resolve_fix.cr` (patch 4, per the repo rule that vendored-shard fixes live in `src/ext/`): the catch-all now returns a readable placeholder instead of raising, and `CallExpression`, `FilterExpression`, `NullLiteral` and the scalar/array/dict literals get real names. Result: a missed lookup is `Undefined` → empty output, matching Jinja2 and matching what `{{ page.no_such_key }}` already did; a genuine mistake such as `.attr` on a String is now a **located** error:

```
Error [HWARO_E_TEMPLATE]: Template error for index.md: "abc".foo is undefined.
template: templates/page.html:3:4 .. 3:15
```

**Specs** — `spec/functional/template_error_location_spec.cr` (3 examples).

## Proven to fail pre-fix

Reverted only the four source files to `origin/main` (`git show origin/main:<file> > <file>`) while keeping the new specs, then ran them:

```
191 examples, 4 failures, 7 errors, 0 pending
```

All 11 new examples failed:

- `spec/unit/filters_spec.cr:1440,1444,1448,1453,1458` — first/last on empty (errors: `Empty enumerable`, `Index out of bounds`)
- `spec/unit/filters_spec.cr:214,222,1481` — malformed date/now format (`Index out of bounds`)
- `spec/functional/template_error_location_spec.cr:71,83,95` — `not implemented for Crinja::AST::CallExpression` / `...NullLiteral` / missing location

Restoring the fixes: `191 examples, 0 failures, 0 errors`.

## Byte-identity

Built the same sites with the `origin/main` binary and with this branch's binary and `diff -r`'d the two `public/` trees:

| site | result |
|---|---|
| `docs/` (bilingual en/ko, 143 pages) | **no diff** |
| `hwaro init --scaffold simple` | **no diff** |
| `hwaro init --scaffold bare` | **no diff** |
| `hwaro init --scaffold blog` | **no diff** |
| `hwaro init --scaffold docs` | **no diff** |
| `hwaro init --scaffold book` | **no diff** |
| multilingual en/ko blog, `base_url = "https://example.com/myblog"`, unicode + colliding taxonomy terms | **no diff** |

No output changes; every fix only converts a build-aborting crash into either Jinja2's `Undefined` or a located `Crinja::Error`.

## Docs

`docs/content/templates/filters.md` + `.ko.md`: the `first`/`last` rows now say they yield an empty value on an empty collection (bilingual, per repo rule).

## Verification

- `crystal tool format --check` clean
- `ameba` clean (524 files, 0 failures)
- `crystal spec` full suite green

## Out-of-lane findings (NOT fixed — other workers own these files)

1. **`src/core/build/phases/render.cr:870` (`finalize_render_failures`)** — the generic gap behind all three bugs above: any non-`Crinja::Error` Crystal exception raised inside a filter/function escapes `TemplateEngine#render`'s rescue and is reported as `Render failed for N page(s): <message>` with no template name or line. This PR removes the three biggest sources, but the render phase should attach the template/page context to *any* exception so the next one is diagnosable. Repro (still crashes location-less after this PR): `{{ [1, 2, 3] | slice(0) }}` → `Render failed for 1 page(s); first failure on index.md: Division by 0`.

2. **`lib/crinja` parser — exponent float literals rejected.** `{{ 1e10 }}` and `{{ 1.5e3 }}` fail with `Invalid number. Found char: 'e'(101)`. `{{ 1.5 }}` is fine. Would need a lexer patch in `src/ext/`; left alone as it is not a documented hwaro feature.

3. **`lib/crinja` built-ins with no empty/zero guard**, all location-less crashes: `{{ [] | random }}` → `Can't sample empty collection`; `{{ items | slice(0) }}` → `Division by 0`. Neither filter is documented in `docs/content/templates/filters.md`, so I left them; folding them into finding 1 is probably the better fix.

4. **`docs/content/writing/taxonomies.md:233`** (writing/ docs, outside this lane) recommends linking terms as `/tags/{{ tag | slugify }}/`. That produces a wrong URL whenever two terms collide on a slug: with `tags = ["Crystal", "crystal"]` the generator writes `/tags/crystal/` and `/tags/crystal-2/`, but the documented pattern emits `/tags/crystal/` for both. `get_taxonomy_url(kind="tags", term=...)` and `term.slug` are correct — the doc should recommend those.

