### PR TITLE
fix(build-cache): --cache staleness in the data digest and static-file copy

### DIFF
--- a/spec/functional/cache_invalidation_gaps_spec.cr
+++ b/spec/functional/cache_invalidation_gaps_spec.cr
@@ -282,3 +282,88 @@ describe "cache: alternating output directories" do
     end
   end
 end
+
+describe "cache: data files read through load_data()" do
+  it "re-renders when a data/*.csv changes" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", CACHE_CONFIG)
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates")
+        FileUtils.mkdir_p("data")
+        File.write("content/index.md", "---\ntitle: Home\n---\nHome")
+        # `site.data` deliberately never exposes CSV, so the only way to read
+        # one is load_data() — which is exactly the path the digest missed.
+        File.write("templates/index.html",
+          %({% set rows = load_data(path="data/team.csv") %}) +
+          "{% for row in rows %}CELL:{{ row[0] }};{% endfor %}")
+        File.write("templates/page.html", "{{ content }}")
+        File.write("data/team.csv", "name\nAlice\n")
+
+        cached_build
+        File.read("public/index.html").should contain("CELL:Alice;")
+
+        File.write("data/team.csv", "name\nZORBA\n")
+        cached_build
+        File.read("public/index.html").should contain("CELL:ZORBA;")
+        File.read("public/index.html").should_not contain("CELL:Alice;")
+      end
+    end
+  end
+end
+
+describe "cache: static files edited inside the mtime tolerance" do
+  it "re-copies a same-size static edit made right after the previous build" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", CACHE_CONFIG)
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates")
+        FileUtils.mkdir_p("static")
+        File.write("content/index.md", "---\ntitle: Home\n---\nHome")
+        File.write("templates/index.html", "{{ content }}")
+        File.write("templates/page.html", "{{ content }}")
+        File.write("static/app.css", "body { color: #fff; }\n")
+
+        cached_build
+        File.read("public/app.css").should eq("body { color: #fff; }\n")
+
+        # Same byte size, mtime moved by well under MTIME_SKIP_TOLERANCE —
+        # the shape of any quick edit-save-rebuild cycle. The old tolerance
+        # window swallowed it and kept publishing the previous bytes.
+        source_mtime = File.info("static/app.css").modification_time
+        File.write("static/app.css", "body { color: #eee; }\n")
+        File.touch("static/app.css", source_mtime + 200.milliseconds)
+
+        cached_build
+        File.read("public/app.css").should eq("body { color: #eee; }\n")
+      end
+    end
+  end
+
+  it "still skips a byte-identical static file whose mtime drifted inside the tolerance" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        File.write("config.toml", CACHE_CONFIG)
+        FileUtils.mkdir_p("content")
+        FileUtils.mkdir_p("templates")
+        FileUtils.mkdir_p("static")
+        File.write("content/index.md", "---\ntitle: Home\n---\nHome")
+        File.write("templates/index.html", "{{ content }}")
+        File.write("templates/page.html", "{{ content }}")
+        File.write("static/app.css", "body { color: #fff; }\n")
+
+        cached_build
+        # A coarse destination filesystem stores a truncated copy of the
+        # stamped source mtime; the bytes still match, so the copy must
+        # still be skipped. Simulated by drifting the destination stamp.
+        dest_mtime = File.info("public/app.css").modification_time
+        File.touch("public/app.css", dest_mtime - 1.second)
+        marker = File.info("public/app.css").modification_time
+
+        cached_build
+        File.info("public/app.css").modification_time.should eq(marker)
+      end
+    end
+  end
+end

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -329,6 +329,9 @@ module Hwaro::Core::Build::Phases::Initialize
   # Widest timestamp granularity a destination filesystem is likely to have
   # (FAT/exFAT store 2-second resolution).
   MTIME_SKIP_TOLERANCE = 2.seconds
+  # Read size for the byte comparison that resolves that window (see
+  # `same_contents?`).
+  CONTENT_COMPARE_CHUNK = 64 * 1024
 
   private def collect_static_files(
     src_dir : String,
@@ -390,26 +393,63 @@ module Hwaro::Core::Build::Phases::Initialize
       # `info` from above already carries the source mtime — re-statting
       # src_path here tripled the stat count over static/ on watch rebuilds.
       #
-      # Skip on SIZE equality plus mtime equality within a tolerance, the same
-      # shape the Write phase uses for bundle assets. Two reasons it is not an
-      # ordering test and not exact:
-      #   * `source <= destination` skipped any source whose mtime moved
-      #     BACKWARDS — what `git checkout`, `git stash pop` and
-      #     `rsync --times` do — serving the previous revision's asset forever.
-      #   * exact equality never holds when the DESTINATION filesystem stores
-      #     coarser timestamps than the source (exFAT/FAT32 2s, HFS+ 1s, some
-      #     SMB/NFS and Docker bind mounts), which would re-copy the whole
-      #     `static/` tree on every incremental build and every serve rebuild.
+      # Skip on SIZE equality plus mtime equality, the same shape the Write
+      # phase uses for bundle assets. It is not an ordering test:
+      # `source <= destination` skipped any source whose mtime moved
+      # BACKWARDS — what `git checkout`, `git stash pop` and `rsync --times`
+      # do — serving the previous revision's asset forever.
+      #
+      # The copy stamps the destination with the SOURCE mtime, so an EXACT
+      # match proves the destination already holds this exact source version
+      # and nothing is read. A near-match does not prove that: it is equally
+      # a DESTINATION filesystem storing coarser timestamps than the source
+      # (exFAT/FAT32 2s, HFS+ 1s, some SMB/NFS and Docker bind mounts,
+      # where exact equality never holds) and a real edit made within
+      # `MTIME_SKIP_TOLERANCE` of the previous build. Treating the whole
+      # window as "unchanged" silently dropped the second case whenever the
+      # edit kept the byte size — `#fff` → `#eee` in a stylesheet saved a
+      # second after the last build was never published, and stayed
+      # unpublished until some later edit moved the mtime clear of the
+      # window. Compare the bytes in that narrow window instead: coarse
+      # destinations still skip the copy, real edits still land.
       if incremental && (dest_info = File.info?(dest_path)) &&
-         info.size == dest_info.size &&
-         (info.modification_time - dest_info.modification_time).abs <= MTIME_SKIP_TOLERANCE
-        next
+         info.size == dest_info.size
+        delta = (info.modification_time - dest_info.modification_time).abs
+        next if delta.zero?
+        next if delta <= MTIME_SKIP_TOLERANCE && same_contents?(src_path, dest_path)
       end
 
       files_to_copy << {src_path, dest_path, info.modification_time}
     end
 
     files_to_copy
+  end
+
+  # Byte-compare two files already known to be the same size.
+  #
+  # Only reached in the narrow "mtimes differ but sit inside
+  # MTIME_SKIP_TOLERANCE" window, so a warm build on a filesystem that can
+  # store the stamped source mtime exactly (the overwhelmingly common case)
+  # never reads a byte. A read failure answers "not identical" so the caller
+  # falls back to copying — the safe direction.
+  private def same_contents?(src_path : String, dest_path : String) : Bool
+    buffer_src = Bytes.new(CONTENT_COMPARE_CHUNK)
+    buffer_dest = Bytes.new(CONTENT_COMPARE_CHUNK)
+    File.open(src_path, "rb") do |src_io|
+      File.open(dest_path, "rb") do |dest_io|
+        loop do
+          read = src_io.read(buffer_src)
+          break if read == 0
+          window = buffer_dest[0, read]
+          return false unless dest_io.read_fully?(window)
+          return false unless buffer_src[0, read] == window
+        end
+      end
+    end
+    true
+  rescue ex : File::Error | IO::Error
+    Logger.debug "Static copy: failed to compare #{src_path} with #{dest_path}: #{ex.message}"
+    false
   end
 
   # Copy the given `{src, dest}` pairs using a parallel worker pool. Directory
@@ -737,6 +777,15 @@ module Hwaro::Core::Build::Phases::Initialize
     "#{disk}-remote:#{remote}"
   end
 
+  # Extensions the digest below covers. WIDER than `DataDisk.load_tree`'s
+  # glob on purpose: `site.data` never reads CSV, but `load_data()` does
+  # (see the template function's `parse_data_content`), and a template
+  # calling `load_data(path="data/team.csv")` renders from a file that the
+  # digest has to see. Missing it meant editing a `data/*.csv` moved nothing
+  # in the cache key, so `build --cache` re-published every page with the
+  # previous CSV's values — forever, until an unrelated edit.
+  DATA_DIGEST_EXTENSIONS = "yml,yaml,json,toml,csv"
+
   # Compute a content digest of the `data/` directory for cache invalidation.
   #
   # Globs every supported data file, sorts the paths for determinism, and folds
@@ -753,7 +802,7 @@ module Hwaro::Core::Build::Phases::Initialize
     # feed templates — an i18n edit must invalidate cached pages too, or
     # `build --cache` ships stale translations while `serve` (which watches
     # i18n/) rebuilds correctly.
-    Dir.glob("data/**/*.{yml,yaml,json,toml}", "i18n/**/*.{yml,yaml,json,toml}") do |path|
+    Dir.glob("data/**/*.{#{DATA_DIGEST_EXTENSIONS}}", "i18n/**/*.{#{DATA_DIGEST_EXTENSIONS}}") do |path|
       next if File.directory?(path)
       paths << path
     end


### PR DESCRIPTION
Dogfood pass over the build/cache lane: repeated `hwaro build --cache` on
`docs/`, all five `hwaro init` scaffolds and several hand-built odd trees,
mutating content/templates/data/config/static between builds and diffing
`public/` against a fresh no-cache build every time. Two of those diffs were
real staleness bugs; both are fixed here.

## Bug 1 — `data/*.csv` is invisible to the cache invalidation key

**Symptom.** A template that reads a CSV via `load_data()` keeps rendering
the previous file's values after `build --cache`, forever:

```bash
printf 'name\nAlice\n' > data/team.csv
# templates/footer.html: {% set t = load_data(path="data/team.csv") %}...
hwaro build --cache          # renders Alice
printf 'name\nZORBA\n' > data/team.csv
hwaro build --cache          # render: 0 pages, N cached  -> still Alice
```

**Root cause.** `Phases::Initialize#compute_disk_data_hash`
(`src/core/build/phases/initialize.cr`) globs
`data/**/*.{yml,yaml,json,toml}`. That matches `DataDisk.load_tree`, which is
correct for `site.data` (it deliberately never exposes CSV) — but the digest
is not a `site.data` mirror, it is the invalidation key for *everything under
`data/` that can feed a render*, and `load_data()` reads `.csv` (see
`parse_data_content` in `src/content/processors/template.cr`). A CSV edit
therefore moved neither the config hash nor any page's entry, so every page
stayed a cache hit.

**Fix.** Widen the digest glob only (new `DATA_DIGEST_EXTENSIONS`
constant). `site.data` is untouched. Sites that keep a CSV under `data/`
pay one extra invalidation on upgrade.

**Spec.** `spec/functional/cache_invalidation_gaps_spec.cr` —
*"re-renders when a data/*.csv changes"*.

## Bug 2 — a static file edited inside the mtime tolerance is never published

**Symptom.** A same-size edit to a static file made within ~2s of the
previous build is silently dropped, and stays dropped on every later build:

```bash
printf 'body { color: #fff; }\n' > static/css/app.css
hwaro build --cache          # public/css/app.css == #fff
printf 'body { color: #eee; }\n' > static/css/app.css   # same byte size
hwaro build --cache          # public/css/app.css STILL #fff
hwaro build --cache          # ...and still #fff, indefinitely
```

**Root cause.** `collect_static_files` skipped a file when the destination
size matched and the mtimes were within `MTIME_SKIP_TOLERANCE` (2s). The
tolerance is there because the copy stamps the destination with the *source*
mtime and a destination filesystem with coarser timestamps (exFAT/FAT32 2s,
HFS+ 1s, some SMB/NFS and Docker bind mounts) can never reproduce it
exactly. But the same window also covers a genuine edit made shortly after
the last build, and because the comparison is against the mtime stamped at
copy time — not the previous source mtime — the file stays inside the window
and stays stale until an edit lands more than 2s later. The Write phase's
sibling check for bundle assets (`phases/write.cr`) already uses exact
equality; this brings the static copy back in line without losing the
coarse-filesystem protection.

**Fix.** Exact mtime equality still short-circuits with no I/O (the warm
build fast path). A non-zero delta inside the tolerance now byte-compares
the two files instead of assuming they match: coarse destinations still skip
the copy, real edits are published.

**Specs.** `spec/functional/cache_invalidation_gaps_spec.cr` —
*"re-copies a same-size static edit made right after the previous build"*
(the bug) and *"still skips a byte-identical static file whose mtime drifted
inside the tolerance"* (guards the coarse-filesystem behaviour the tolerance
exists for). The pre-existing *"still skips an unchanged static file on a
warm build"* spec still passes untouched.

## Verification

- **Proven to fail pre-fix.** With `src/core/build/phases/initialize.cr`
  restored from `origin/main` (`git show origin/main:<file> > <file>`) both
  new bug specs fail:
  `re-renders when a data/*.csv changes` (got `CELL:Alice;`) and
  `re-copies a same-size static edit...` (got `#fff`). They pass with the fix.
- **Byte-identity.** Built `docs/` and all five `hwaro init` scaffolds
  (simple/bare/blog/docs/book) with an `origin/main` binary and with this
  branch: `diff -r` clean, no differences.
- **No warm-build perf cost.** docs/ warm `--cache` rebuild: 8.5s on
  `origin/main`, 7.6s / 9.1s on this branch (noise). On a filesystem that
  stores the stamped mtime exactly, the delta is 0 and no bytes are read.
- `crystal tool format` and `ameba` clean; full `crystal spec` green.

## Out-of-lane findings (not fixed here)

1. **`hwaro build --cache` rewrites `search.json` from un-rendered page
   content, corrupting the search index.** Highest-severity thing I found.
   Repro on any site with a block shortcode:

   ```bash
   hwaro init s --scaffold simple && cd s
   echo '<div>{{ body }}</div>' > templates/shortcodes/gal.html
   printf '+++\ntitle="S"\n+++\nIntro.\n\n{%% gal() %%}\nINNER\n{%% end %%}\n\nOutro.\n' > content/shorty.md
   hwaro build --cache      # search.json content: "Intro. INNER Outro."   (correct)
   hwaro build --cache      # search.json content: "Intro. {% gal() %} INNER {% end %} Outro."
   ```

   Root cause: `BuildCommand` registers `Content::Hooks.all`, so
   `SeoHooks` (`src/content/hooks/seo_hooks.cr:20`, `:25`) always has a
   `BeforeGenerate` hook. That makes the entire
   `unless @lifecycle.has_hooks?(BeforeGenerate)` branch in
   `src/core/build/phases/generate.cr:12` — including its `skip_unchanged`
   computation and every `skip_if_unchanged:` argument — dead code in real
   CLI builds. The hook path calls `Sitemap/Feeds/Llms/Search.generate`
   with no skip flag, so on a warm `--cache` build (where `render: 0 pages,
   N cached`) the search index is rebuilt from `ctx.all_pages` whose
   `content` was never shortcode-processed — shortcodes expand during
   render, which cache hits skip. Raw `{% shortcode() %}` / `{% end %}`
   markup then lands in `search.json` and persists. Reproduced on `docs/`
   too (4 pages: `/start/first-site/`, `/features/image-processing/` and
   their `/ko/` twins).
   Suggested fix (one line, in the hook): compute
   `ctx.options.cache && ctx.stats.pages_rendered == 0 &&
   !ctx.page_or_section_set_changed` — both fields already exist on the
   context — and pass it as `skip_if_unchanged:` from `seo_hooks.cr`.
   I left `generate.cr` alone rather than half-fix it from my side.

2. **Orphaned outputs under `--cache`** (known/documented, listed for
   completeness). A deleted page, a `slug`/`path` rename, a dropped
   `[outputs]` format, a page flipped to `draft`, a `[[content.generate]]`
   record removed from its data, and a taxonomy term that loses its last
   page all leave their old files in `public/`. `docs/features/content-generation.md`
   documents this ("a previously written file may linger"), and the serve
   watcher already prunes via `Builder#stale_outputs_for_removed`. A
   `build --cache` equivalent is feasible — `CacheEntry#output_path` /
   `#output_paths` are already a per-source manifest — but it needs the
   pre-invalidation entry snapshot preserved across
   `Cache#set_global_checksums`'s `@entries.clear`, plus a filter against
   `Builder#owned_output_paths`, and it would not cover generated taxonomy
   pages (no source file, so no cache entry). Deliberately out of scope for
   a bug-fix PR.

3. **`{{ p.content }}` renders empty for pages iterated in a listing.**
   `page_crinja_value` (`src/core/build/phases/render.cr:2076`) exposes
   `summary`, `word_count`, `reading_time` and friends but not `content`, so
   a full-text homepage (`{% for p in site.pages %}{{ p.content }}{% endfor %}`)
   silently renders nothing. Not documented either way; flagging as a
   possible docs or template-lane gap rather than a defect.

Things I checked that were clean: `--jobs 1/2/4/8`, `--stream`,
`--no-parallel` (all byte-identical); cascade edits at depth; template and
shortcode-template add/edit/delete under `--cache`; `--minify` / `--base-url`
/ `--env` invalidation; multilingual sites; `[[data.remote]]` TTL, offline
fallbacks and payload-change invalidation; `[[content.generate]]` slug/section
edge cases (`!!!`, `../escape`, `index`, `_index`, CJK, unicode); corrupt /
empty / directory `.hwaro_cache.json`; deleted output dir; deleted SEO files;
malformed front matter; symlinks in and out of the project; `[build]
output_dir` guards; `--jobs`/`--memory-limit` argument validation.
