### PR TITLE
fix(tools-deploy): honor [build] output_dir in platform configs, gate section feeds, name convert failures

### DIFF
--- a/docs/content/start/tools/check-links.ko.md
+++ b/docs/content/start/tools/check-links.ko.md
@@ -72,8 +72,10 @@ JSON의 `skipped_external` 항목 모두에 "건너뜀"으로 보고됩니다.
 
 - `/sitemap.xml`, `/robots.txt`, `/llms.txt`, 검색 인덱스, `404.html` — 각각
   설정된 `filename`을 따릅니다
-- 피드(`/rss.xml`, `/atom.xml`) — 섹션별·언어별 사본(`/posts/rss.xml`,
-  `/ko/rss.xml`) 포함
+- 피드(`/rss.xml`, `/atom.xml`) — 언어별 사본(`/ko/rss.xml`)과 섹션별
+  사본(`/posts/rss.xml`) 포함. 섹션 피드는 해당 섹션의 `_index.md`가
+  `generate_feeds = true`를 선언했을 때만 인정합니다. 빌드가 그때만 파일을
+  쓰기 때문입니다
 - 분류 목록·용어 페이지(`/tags/`, `/categories/rust/`)
 - 페이지네이션 경로(`/posts/page/2/`) — `paginate_by`를 실제로 선언한 섹션에만
   해당하므로, 페이지네이션이 없는 섹션의 `/page/N/` 링크는 여전히 보고됩니다

--- a/docs/content/start/tools/check-links.md
+++ b/docs/content/start/tools/check-links.md
@@ -75,8 +75,10 @@ build (the order a lint-then-build CI pipeline uses):
 
 - `/sitemap.xml`, `/robots.txt`, `/llms.txt`, the search index, and `404.html`,
   each honouring its configured `filename`
-- Feeds (`/rss.xml`, `/atom.xml`), including the per-section and per-language
-  copies (`/posts/rss.xml`, `/ko/rss.xml`)
+- Feeds (`/rss.xml`, `/atom.xml`), including the per-language copies
+  (`/ko/rss.xml`) and the per-section ones (`/posts/rss.xml`) — a section feed
+  only counts when the section's `_index.md` sets `generate_feeds = true`,
+  since that is what makes the build write it
 - Taxonomy listing and term pages (`/tags/`, `/categories/rust/`)
 - Paginated listings (`/posts/page/2/`) — only for a section that actually
   declares `paginate_by`, so a `/page/N/` link under a non-paginated section

--- a/docs/content/start/tools/platform.ko.md
+++ b/docs/content/start/tools/platform.ko.md
@@ -53,7 +53,10 @@ hwaro tool platform vercel --stdout
 각 설정에는 다음이 포함됩니다.
 
 - **빌드 명령**: `hwaro build`
-- **출력 디렉터리**: `public/`
+- **출력 디렉터리**: 설정한 `[build] output_dir` (기본값 `public/`) — 값을
+  바꾸면 생성되는 모든 설정 파일에 그대로 반영되므로, 호스팅 서비스가
+  `hwaro build`가 실제로 쓰는 디렉터리를 배포합니다. `gitlab-ci`는 기본값이
+  아닐 때 `pages` 잡에 `publish:`도 함께 추가합니다.
 - **리다이렉트**: 프론트 매터에 정의한 페이지 [`aliases`](/ko/writing/pages/)에서 만든 301 리다이렉트 (예: `aliases: ["/old-url/"]`)
 - **캐시 헤더**: 정적 에셋의 장기 캐싱
 

--- a/docs/content/start/tools/platform.md
+++ b/docs/content/start/tools/platform.md
@@ -53,7 +53,10 @@ If the output file already exists, use `--force` to overwrite.
 Each config includes:
 
 - **Build command**: `hwaro build`
-- **Output directory**: `public/`
+- **Output directory**: your `[build] output_dir` (`public/` by default) —
+  a customized value is carried into every generated config, so the host
+  publishes the directory `hwaro build` actually writes. For `gitlab-ci` a
+  non-default directory also adds `publish:` to the `pages` job.
 - **Redirects**: 301 redirects from page [`aliases`](/writing/pages/) defined in frontmatter (e.g., `aliases: ["/old-url/"]`)
 - **Cache headers**: Long-lived caching for static assets
 

--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -578,7 +578,9 @@ describe "hwaro tool check-links (generated routes)" do
         [feeds]
         enabled = true
         TOML
-      File.write(File.join(blog_dir, "_index.md"), "+++\ntitle = \"Blog\"\npaginate_by = 2\n+++\n")
+      # `generate_feeds` is what makes `/blog/rss.xml` a route at all — the
+      # case under test is the PREFIX check, so the section opts in.
+      File.write(File.join(blog_dir, "_index.md"), "+++\ntitle = \"Blog\"\npaginate_by = 2\ngenerate_feeds = true\n+++\n")
       File.write(File.join(blog_dir, "p1.md"), "+++\ntitle = \"P1\"\n+++\n")
       File.write(File.join(blog_dir, "p2.md"), "+++\ntitle = \"P2\"\n+++\n")
       File.write(File.join(blog_dir, "links.md"), <<-MD)
@@ -596,6 +598,64 @@ describe "hwaro tool check-links (generated routes)" do
       status.success?.should be_false
       dead = JSON.parse(output)["dead_internal"].as_a.map(&.["link"].["url"].as_s)
       dead.sort!.should eq(["/blog/page/99/", "/nowhere/rss.xml"])
+    end
+  end
+
+  # A per-section feed exists only when the section sets
+  # `generate_feeds = true`. `feed_route?` accepted `/<section>/rss.xml` for
+  # ANY section with an `_index.md`, so the checker waved through a link that
+  # 404s on the deployed site — including on `hwaro init --scaffold blog`,
+  # whose `[feeds] sections = ["posts"]` only filters the SITE feed's items.
+  it "reports a section feed for a section that never opted into feeds" do
+    with_initialized_project do |project_dir|
+      content_dir = File.join(project_dir, "content")
+      posts_dir = File.join(content_dir, "posts")
+      FileUtils.rm_rf(content_dir)
+      Dir.mkdir_p(posts_dir)
+      File.write(File.join(project_dir, "config.toml"), <<-TOML)
+        title = "Site"
+        base_url = "https://example.com"
+
+        [feeds]
+        enabled = true
+        sections = ["posts"]
+        TOML
+      File.write(File.join(posts_dir, "_index.md"), "+++\ntitle = \"Posts\"\n+++\n")
+      File.write(File.join(posts_dir, "links.md"), <<-MD)
+        +++
+        title = "Links"
+        +++
+
+        [site feed](/rss.xml)
+        [section feed](/posts/rss.xml)
+        MD
+
+      status, output, _ = run_hwaro(["tool", "check-links", "--internal-only", "--json"], chdir: project_dir)
+      status.success?.should be_false
+      dead = JSON.parse(output)["dead_internal"].as_a.map(&.["link"].["url"].as_s)
+      dead.should eq(["/posts/rss.xml"])
+    end
+  end
+
+  it "accepts a section feed once the section declares generate_feeds" do
+    with_initialized_project do |project_dir|
+      content_dir = File.join(project_dir, "content")
+      posts_dir = File.join(content_dir, "posts")
+      FileUtils.rm_rf(content_dir)
+      Dir.mkdir_p(posts_dir)
+      File.write(File.join(project_dir, "config.toml"), <<-TOML)
+        title = "Site"
+        base_url = "https://example.com"
+
+        [feeds]
+        enabled = true
+        TOML
+      File.write(File.join(posts_dir, "_index.md"), "+++\ntitle = \"Posts\"\ngenerate_feeds = true\n+++\n")
+      File.write(File.join(posts_dir, "links.md"), "+++\ntitle = \"Links\"\n+++\n\n[section feed](/posts/rss.xml)\n")
+
+      status, output, _ = run_hwaro(["tool", "check-links", "--internal-only", "--json"], chdir: project_dir)
+      status.success?.should be_true
+      JSON.parse(output)["dead_internal"].as_a.should be_empty
     end
   end
 

--- a/spec/unit/frontmatter_converter_spec.cr
+++ b/spec/unit/frontmatter_converter_spec.cr
@@ -1030,6 +1030,34 @@ describe Hwaro::Services::ConversionResult do
       end
     end
 
+    # A conversion that failed to PARSE reported a bare
+    # "Failed to convert: <file>" and nothing else, while `hwaro build` and
+    # `hwaro tool validate` both named the same error for the same file.
+    # The per-format converters swallowed the reason into Logger.debug.
+    it "names the parse error that made a conversion fail" do
+      Dir.mktmpdir do |dir|
+        converter = Hwaro::Services::FrontmatterConverter.new(dir)
+        file_path = File.join(dir, "mixed.md")
+        # TOML 1.0 allows mixed-type arrays; the parser Hwaro vendors does
+        # not — whatever the cause, the author has to be told what it was.
+        File.write(file_path, "+++\ntitle = \"T\"\nmixed = [\"a\", 1, true]\n+++\n\nBody")
+
+        captured = IO::Memory.new
+        previous = Hwaro::Logger.err_io
+        Hwaro::Logger.err_io = captured
+        begin
+          converter.convert_file(file_path, Hwaro::Services::FrontmatterFormat::YAML).should be_false
+        ensure
+          Hwaro::Logger.err_io = previous
+        end
+
+        reported = captured.to_s
+        reported.should contain("Failed to convert")
+        reported.should contain("mixed.md")
+        reported.should contain("cannot mix types in array")
+      end
+    end
+
     it "escapes control characters with TOML-legal sequences" do
       Dir.mktmpdir do |dir|
         converter = Hwaro::Services::FrontmatterConverter.new(dir)

--- a/spec/unit/platform_config_output_dir_spec.cr
+++ b/spec/unit/platform_config_output_dir_spec.cr
@@ -1,0 +1,78 @@
+require "../spec_helper"
+require "../../src/services/platform_config"
+
+# `hwaro tool platform` hardcoded "public" as the publish directory, so a site
+# with a customized `[build] output_dir` generated a config pointing at a
+# directory the build never writes. Nothing errored anywhere: the build
+# succeeded, the host published an empty (or stale) tree, and the only symptom
+# was a blank site.
+private def platform_config_with(output_dir : String?) : Hwaro::Services::PlatformConfig
+  config = Hwaro::Models::Config.new
+  config.build.output_dir = output_dir
+  Hwaro::Services::PlatformConfig.new(config)
+end
+
+describe "PlatformConfig honors [build] output_dir" do
+  it "points netlify's publish at the configured output_dir" do
+    generator = platform_config_with("dist")
+    generator.generate("netlify").should contain(%(publish = "dist"))
+  end
+
+  it "points vercel's outputDirectory at the configured output_dir" do
+    generator = platform_config_with("dist")
+    JSON.parse(generator.generate("vercel"))["outputDirectory"].as_s.should eq("dist")
+  end
+
+  it "points cloudflare's bucket and dashboard note at the configured output_dir" do
+    generator = platform_config_with("dist")
+    result = generator.generate("cloudflare")
+    result.should contain(%(bucket = "./dist"))
+    result.should contain("# Build output directory: /dist")
+  end
+
+  it "publishes the configured output_dir from the gitlab-ci pages job" do
+    generator = platform_config_with("dist")
+    result = generator.generate("gitlab-ci")
+    # `pages.publish` is what points GitLab Pages away from `public/`;
+    # the artifact has to carry the same directory.
+    result.should contain("  publish: dist")
+    result.should contain("      - dist")
+    result.should_not contain("      - public")
+  end
+
+  it "cds into the configured output_dir in the codeberg-pages workflow" do
+    generator = platform_config_with("dist")
+    result = generator.generate("codeberg-pages")
+    result.should contain("cd dist")
+    result.should_not contain("cd public")
+  end
+
+  # The default site must keep generating exactly what it generated before,
+  # including staying free of the `pages.publish` key that older GitLab
+  # instances do not understand.
+  it "leaves the default (unset) output_dir rendering as public" do
+    generator = platform_config_with(nil)
+    generator.generate("netlify").should contain(%(publish = "public"))
+    JSON.parse(generator.generate("vercel"))["outputDirectory"].as_s.should eq("public")
+    generator.generate("cloudflare").should contain(%(bucket = "./public"))
+    generator.generate("codeberg-pages").should contain("cd public")
+
+    gitlab = generator.generate("gitlab-ci")
+    gitlab.should contain("      - public")
+    gitlab.should_not contain("publish:")
+  end
+
+  # `[build] output_dir` is trusted config, but a directory name may still
+  # legitimately contain a space or a quote — the emitted file has to stay
+  # parseable/runnable rather than splitting mid-value.
+  it "quotes an awkward output_dir for each output format" do
+    generator = platform_config_with(%(my "site" out))
+
+    netlify_fm = generator.generate("netlify").match!(/\A(.*?)\n\[build\.environment\]/m)[1]
+    TOML.parse(netlify_fm)["build"].as_h["publish"].as_s.should eq(%(my "site" out))
+
+    JSON.parse(generator.generate("vercel"))["outputDirectory"].as_s.should eq(%(my "site" out))
+    generator.generate("codeberg-pages").should contain(%(cd 'my "site" out'))
+    generator.generate("gitlab-ci").should contain(%(      - "my \\"site\\" out"))
+  end
+end

--- a/src/cli/commands/tool/ci_command.cr
+++ b/src/cli/commands/tool/ci_command.cr
@@ -49,7 +49,9 @@ module Hwaro
 
           def run(args : Array(String))
             Logger.warn "DEPRECATED: 'tool ci' is deprecated. Use 'tool platform github-pages' instead."
-            Logger.warn ""
+            # A blank spacer, not a second warning: `Logger.warn ""` rendered
+            # as an empty, prefix-only `[WARN] ` line above the usage output.
+            Logger.info ""
             provider : String? = nil
             output_file : String? = nil
             stdout_mode = false

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -816,7 +816,50 @@ module Hwaro
               prefix = "/#{segments.join("/")}"
             end
 
-            !section_index_path(prefix, content_dir, base_dir).nil?
+            return false unless index_path = section_index_path(prefix, content_dir, base_dir)
+            section_generates_feeds?(File.dirname(index_path))
+          end
+
+          # A per-section feed exists only when the section opts in with
+          # `generate_feeds = true` (see `Seo::Feeds`); `[feeds] sections`
+          # merely filters the SITE feed's items and emits nothing per
+          # section. Requiring a section index alone accepted
+          # `/posts/rss.xml` on every site with a `content/posts/_index.md`
+          # — a link the build never writes, waved through by the very check
+          # meant to catch it. Same discipline as `paginated_route?`, which
+          # reads `paginate_by` off the index before trusting `/page/N/`.
+          #
+          # Every `_index*` in the directory counts, not just `_index.md`:
+          # a multilingual section may declare the flag only in
+          # `_index.ko.md`, and `/ko/posts/rss.xml` is a real route then.
+          private def section_generates_feeds?(dir : String) : Bool
+            Dir.glob(File.join(dir, "_index*.{md,markdown}")).any? do |path|
+              frontmatter_flag?(path, "generate_feeds")
+            end
+          end
+
+          # True when a content file's front matter sets `key` to boolean
+          # true, in any of the three supported front-matter formats. An
+          # unreadable or malformed file reads as "not set" — the checker
+          # degrades to reporting the link rather than crashing the run.
+          private def frontmatter_flag?(path : String, key : String) : Bool
+            content = Utils::TextUtils.strip_bom(File.read(path))
+
+            if match = content.match(Utils::FrontmatterScanner::TOML_FRONTMATTER_RE)
+              return TOML.parse(match[1])[key]?.try(&.raw) == true
+            elsif match = content.match(Utils::FrontmatterScanner::YAML_FRONTMATTER_RE)
+              if h = YAML.parse(match[1]).as_h?
+                return h[YAML::Any.new(key)]?.try(&.raw) == true
+              end
+            elsif content.starts_with?('{') && (end_idx = Utils::FrontmatterScanner.find_json_end(content))
+              if h = JSON.parse(content.byte_slice(0, end_idx)).as_h?
+                return h[key]?.try(&.raw) == true
+              end
+            end
+
+            false
+          rescue
+            false
           end
 
           # Mirrors `Seo::Feeds.safe_feed_filename` for an unset filename.

--- a/src/services/frontmatter_converter.cr
+++ b/src/services/frontmatter_converter.cr
@@ -199,7 +199,8 @@ module Hwaro
           end
           ConversionStatus::Converted
         else
-          Logger.error "  Failed to convert: #{file_path}"
+          reason = @last_error
+          Logger.error "  Failed to convert: #{file_path}#{reason ? " — #{reason}" : ""}"
           ConversionStatus::Failed
         end
       rescue ex
@@ -286,7 +287,16 @@ module Hwaro
         files.sort
       end
 
+      # Why the last `convert_content` returned nil. The per-format converters
+      # rescue their own parse errors (a malformed block must not abort a bulk
+      # run), which used to swallow the reason entirely: the command printed a
+      # bare "Failed to convert: <file>" while `hwaro build` and
+      # `hwaro tool validate` both named the same parse error. Set on every
+      # failure path, cleared at the start of each conversion.
+      @last_error : String? = nil
+
       private def convert_content(content : String, from : FrontmatterFormat, to : FrontmatterFormat) : String?
+        @last_error = nil
         case {from, to}
         when {FrontmatterFormat::YAML, FrontmatterFormat::TOML}
           yaml_to_toml(content)
@@ -301,6 +311,15 @@ module Hwaro
         when {FrontmatterFormat::JSON, FrontmatterFormat::TOML}
           json_to_toml(content)
         end
+      end
+
+      # Remember a converter's parse error and signal failure (nil) to the
+      # caller in one step, so every rescue arm stays a single line.
+      private def record_error(ex : Exception) : Nil
+        message = ex.message
+        @last_error = message.presence
+        Logger.debug "Front matter parse error: #{message}"
+        nil
       end
 
       # True when the file's leading delimiter block both closes properly and
@@ -410,8 +429,7 @@ module Hwaro
 
             "#{TOML_DELIMITER}\n#{toml_str}#{TOML_DELIMITER}\n#{body}"
           rescue ex
-            Logger.debug "YAML parse error: #{ex.message}"
-            nil
+            record_error(ex)
           end
         end
       end
@@ -428,8 +446,7 @@ module Hwaro
 
             "#{YAML_DELIMITER}\n#{yaml_str}#{YAML_DELIMITER}\n#{body}"
           rescue ex
-            Logger.debug "TOML parse error: #{ex.message}"
-            nil
+            record_error(ex)
           end
         end
       end
@@ -443,8 +460,7 @@ module Hwaro
             json_str = yaml_to_json_string(yaml_data)
             "#{json_str}\n#{body}"
           rescue ex
-            Logger.debug "YAML parse error: #{ex.message}"
-            nil
+            record_error(ex)
           end
         end
       end
@@ -458,8 +474,7 @@ module Hwaro
             json_str = toml_to_json_string(toml_data)
             "#{json_str}\n#{body}"
           rescue ex
-            Logger.debug "TOML parse error: #{ex.message}"
-            nil
+            record_error(ex)
           end
         end
       end
@@ -472,8 +487,7 @@ module Hwaro
           yaml_body = convert_json_to_yaml_string(json_data)
           "#{YAML_DELIMITER}\n#{yaml_body}#{YAML_DELIMITER}\n#{body}"
         rescue ex
-          Logger.debug "JSON parse error: #{ex.message}"
-          nil
+          record_error(ex)
         end
       end
 
@@ -487,8 +501,7 @@ module Hwaro
           toml_body = Utils::FrontmatterWriter::TomlBuilder.new.build(yaml_any)
           "#{TOML_DELIMITER}\n#{toml_body}#{TOML_DELIMITER}\n#{body}"
         rescue ex
-          Logger.debug "JSON parse error: #{ex.message}"
-          nil
+          record_error(ex)
         end
       end
 

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -3,6 +3,7 @@ require "../hwaro"
 require "../models/config"
 require "../models/page"
 require "../content/processors/markdown"
+require "../utils/frontmatter_writer"
 require "../utils/logger"
 require "./github_actions_workflow"
 
@@ -51,8 +52,24 @@ module Hwaro
         "hwaro build"
       end
 
+      # Directory the build writes to. Follows `[build] output_dir` so every
+      # generated platform config publishes the tree `hwaro build` actually
+      # produced — a hardcoded "public" made a site with a customized
+      # output_dir deploy an empty (or stale) directory, with no error
+      # anywhere: the build succeeded and the host published nothing.
+      # `Config.load` already rejects an empty or project-escaping value, so
+      # the fallback here is only for "not configured".
       private def output_dir : String
-        "public"
+        @config.build.output_dir || "public"
+      end
+
+      # Render a value as a shell word, leaving ordinary directory names bare
+      # so the default workflow is unchanged. `[build] output_dir` is trusted
+      # config, but it may legitimately contain a space — unquoted, that would
+      # split into two `cd` arguments.
+      private def shell_word(value : String) : String
+        return value if value.matches?(/\A[A-Za-z0-9._\/-]+\z/)
+        "'" + value.gsub("'", "'\\''") + "'"
       end
 
       # Escape a value for a TOML basic string. Front-matter aliases are
@@ -93,7 +110,7 @@ module Hwaro
         lines = [] of String
         lines << "[build]"
         lines << "  command = \"#{build_command}\""
-        lines << "  publish = \"#{output_dir}\""
+        lines << "  publish = \"#{toml_escape(output_dir)}\""
         lines << ""
         lines << "[build.environment]"
         lines << "  # Add environment variables here"
@@ -190,7 +207,7 @@ module Hwaro
         lines << "compatibility_date = \"#{Time.utc.to_s("%Y-%m-%d")}\""
         lines << ""
         lines << "[site]"
-        lines << "  bucket = \"./#{output_dir}\""
+        lines << "  bucket = \"./#{toml_escape(output_dir)}\""
         lines << ""
         lines << "# Build configuration (for Cloudflare Pages dashboard)"
         lines << "# Build command: #{build_command}"
@@ -226,9 +243,14 @@ module Hwaro
         lines << "  stage: deploy"
         lines << "  script:"
         lines << "    - hwaro build"
+        # GitLab Pages defaults to publishing `public/`; `pages.publish`
+        # (GitLab 16.1+) points it elsewhere. Emitted only for a customized
+        # `[build] output_dir` so the default pipeline stays compatible with
+        # older GitLab instances.
+        lines << "  publish: #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(output_dir)}" unless output_dir == "public"
         lines << "  artifacts:"
         lines << "    paths:"
-        lines << "      - public"
+        lines << "      - #{Hwaro::Utils::FrontmatterWriter.yaml_scalar(output_dir)}"
         lines << "  rules:"
         lines << "    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"
         lines << ""
@@ -281,7 +303,7 @@ module Hwaro
         lines << "        env:"
         lines << "          CODEBERG_TOKEN: ${{ secrets.CODEBERG_TOKEN }}"
         lines << "        run: |"
-        lines << "          cd #{output_dir}"
+        lines << "          cd #{shell_word(output_dir)}"
         lines << "          git init -b \"$PAGES_BRANCH\""
         lines << "          git config user.name  \"${{ github.actor }}\""
         lines << "          git config user.email \"${{ github.actor }}@noreply.codeberg.org\""


### PR DESCRIPTION
Bug hunt in the `hwaro tool *` / `hwaro deploy` / completions lane. Four
verified defects, each with a regression spec proven to fail on `origin/main`.

## Bugs

### 1. `tool platform` ignored `[build] output_dir` (broken deploys)

**Symptom.** With `[build] output_dir = "dist"` in `config.toml`, every
generated platform config still pointed at `public/`:

```
$ hwaro tool platform netlify --stdout
[build]
  command = "hwaro build"
  publish = "public"        # ← build writes dist/
```

Same for `vercel.json` (`"outputDirectory": "public"`), `wrangler.toml`
(`bucket = "./public"`), `.gitlab-ci.yml` (`artifacts.paths: - public`) and
the codeberg workflow (`cd public`). Nothing errored anywhere — the build
succeeded and the host published an empty or stale directory.

**Root cause.** `PlatformConfig#output_dir` returned the literal `"public"`
(`src/services/platform_config.cr:54`), even though the sibling
`assets_url_dir` right below it already reads `[assets] output_dir` from
config, and `Deployer` already follows `[build] output_dir`.

**Fix.** `output_dir` reads `@config.build.output_dir` with `"public"` as the
"not configured" fallback (`Config.load` already rejects an empty or
project-escaping value). For `gitlab-ci` a non-default directory additionally
emits `pages.publish` — the key that actually points GitLab Pages away from
`public/` — and it is emitted **only** when non-default, so the default
pipeline stays byte-identical and compatible with older GitLab. Values are
escaped per format (TOML string, JSON, YAML scalar, shell word) so a
directory name with a space or quote still produces a parseable/runnable file.

`github-pages` is deliberately unchanged: that workflow delegates to the
external `hahwul/hwaro` action, which has no directory input to pass through.
Noted as a follow-up rather than guessed at.

**Spec.** `spec/unit/platform_config_output_dir_spec.cr` — 7 examples,
**6 fail on origin/main**.

### 2. `tool check-links` passed section feeds the build never writes

**Symptom.** On `hwaro init --scaffold blog` (whose config ships
`[feeds] sections = ["posts"]`):

```
$ hwaro tool check-links --internal-only   # content links /posts/rss.xml
checked: 7 links, all healthy
$ hwaro build && ls public/posts/rss.xml
"public/posts/rss.xml": No such file or directory
```

A dead link waved through by the command whose whole job is catching it.

**Root cause.** `feed_route?` accepted `/<prefix>/rss.xml` whenever `prefix`
resolved to a section with an `_index.md`. But a per-section feed is written
only when the section sets `generate_feeds = true`
(`src/content/seo/feeds.cr:83`); `[feeds] sections` merely filters which items
the **site** feed carries. The sibling `paginated_route?` one function below
already reads `paginate_by` off the section index before trusting
`/page/N/` — `feed_route?` stopped one step short of the same discipline.

**Fix.** `feed_route?` now requires the section to declare the flag. Every
`_index*` in the directory counts, not just `_index.md`, so a multilingual
section that opts in only in `_index.ko.md` keeps `/ko/posts/rss.xml`
resolving.

**Spec.** Two new examples in
`spec/functional/cli_tool_subcommands_spec.cr` — the first
(*"reports a section feed for a section that never opted into feeds"*)
**fails on origin/main** (`Expected: false, got: true`).

> **Note on an existing spec.** `"refuses a feed path whose prefix is not a
> section"` asserted that `/blog/rss.xml` is accepted for a `blog/_index.md`
> that never sets `generate_feeds` — it encoded the bug. Its fixture now sets
> `generate_feeds = true`, so the case still tests what it means to test (the
> *prefix* check) rather than the defect. That is the only pre-existing
> assertion this PR changes.

### 3. `tool convert` reported failures with no cause

**Symptom.**

```
$ hwaro tool convert to-yaml
  Failed to convert: content/t.md
Error [HWARO_E_IO]: 1 file(s) could not be converted to YAML
```

...while `hwaro build` and `hwaro tool validate` both say
`cannot mix types in array at 2:16` for the same file.

**Root cause.** Each `X_to_Y` converter rescued its own parse error into
`Logger.debug` and returned nil, so the caller only knew *that* it failed.
The comment on `frontmatter_mapping?` already claimed parse errors
"surface as Failed (with a message)" — the message was never wired up.

**Fix.** The rescues route through `record_error`, which stores the message;
the Failed line appends it. Now:

```
  Failed to convert: content/t.md — cannot mix types in array at 2:16
```

**Spec.** `spec/unit/frontmatter_converter_spec.cr` —
*"names the parse error that made a conversion fail"*,
**fails on origin/main** (captured stderr has no reason).

### 4. `tool ci` printed an empty `[WARN]` line

`Logger.warn ""` was meant as a blank spacer after the deprecation notice but
rendered as a prefix-only `[WARN] ` line. Changed to `Logger.info ""`.

## Byte-identity

Built `docs/` and all five `hwaro init` scaffolds (`simple`, `blog`, `docs`,
`book`, `bare`) with the `origin/main` binary and with this branch's binary:

```
docs: diff lines=0
simple: 0   blog: 0   docs: 0   book: 0   bare: 0
```

`hwaro tool platform <p> --stdout` on a default config is identical for all
six platforms (netlify, vercel, cloudflare, github-pages, gitlab-ci,
codeberg-pages). The only intentional output changes are gated on a
non-default `[build] output_dir` / a section that declares `generate_feeds`.

## Verification

- `crystal spec` — **8381 examples, 0 failures**
- `crystal tool format` clean, `./bin/ameba` clean (525 inspected, 0 failures)
- Completions still parse: `bash -n`, `zsh -n`, `fish -n` all OK
- Docs updated bilingually (`platform.md`/`.ko.md`, `check-links.md`/`.ko.md`)

## Also exercised, found clean

Frontmatter round-trips (TOML↔YAML↔JSON with datetimes, nested tables,
arrays-of-tables, multiline/literal strings, CJK/emoji); importers
(Hugo/Jekyll/WordPress-WXR/Hexo/Obsidian/Astro/Eleventy/Notion) on adversarial
fixtures — odd/invalid dates, nested taxonomies, unicode slugs, HTML entities,
percent-encoded slugs, page bundles; export→Hugo/Jekyll field mappings and
`--dry-run` manifests; `check-links` with base_path subpaths, unicode URLs,
mailto/tel/data/javascript, `--ignore-url` case-insensitivity and wildcards;
`unused-assets` with percent-encoded and unicode filenames; `deploy --dry-run`
against local/file/s3/gs/az/command targets with symlinks, duplicate target
names and `--max-deletes`; `tool list`/`stats`/`validate` on BOM, CRLF, empty,
unterminated, invalid-UTF-8 and 200 KB-line content; every `--json` payload
parsed as valid JSON.

## Out-of-lane findings

None that reproduce as defects. Two behaviours worth a second opinion from
whoever owns those files, both deliberate-looking:

- `src/services/importers/{notion,obsidian,eleventy}_importer.cr` fall back to
  the file's mtime for a missing `date`, and `FrontmatterWriter.serialize_time`
  preserves fractional seconds — so imports emit
  `date = "2026-09-01T23:35:03.653690652Z"`. Parses fine and it is my own
  lane, but the nanosecond precision is noise; left alone because
  `serialize_time`'s fraction preservation is a stated invariant and no
  behaviour is wrong.
- `check-links` accepts any URL whose first segment is a declared taxonomy
  name, so `/tags/does-not-exist/` passes. That leniency is documented in the
  code comment ("declared taxonomy names and accept it when it lines up") and
  tightening it would need the term set, which the source-only check does not
  have. Left as-is.
