### PR TITLE
fix(markdown): empty-heading id shift, multi-backtick code spans, container closer

### DIFF
--- a/spec/unit/inline_markdown_spec.cr
+++ b/spec/unit/inline_markdown_spec.cr
@@ -43,6 +43,42 @@ describe Hwaro::Content::Processors::InlineMarkdown do
       out.should contain(%(<img src="/caf%E9.png" alt="a">))
     end
   end
+
+  # Code spans in this renderer used to be single-backtick-only, so a
+  # multi-backtick span (the CommonMark way to show a literal backtick) had
+  # its INNER backticks matched instead — shredding the span into stray
+  # <code> tags and leaving the real delimiters as visible text.
+  describe ".render code spans" do
+    it "renders a double-backtick span containing single backticks" do
+      out = Hwaro::Content::Processors::InlineMarkdown.render("x `` `tick` `` y")
+      out.should eq("x <code>`tick`</code> y")
+    end
+
+    it "renders a double-backtick span with an interior backtick" do
+      out = Hwaro::Content::Processors::InlineMarkdown.render("``a`b``")
+      out.should eq("<code>a`b</code>")
+    end
+
+    it "renders a triple-backtick span" do
+      out = Hwaro::Content::Processors::InlineMarkdown.render("```x``y```")
+      out.should eq("<code>x``y</code>")
+    end
+
+    it "still renders plain single-backtick spans unchanged" do
+      out = Hwaro::Content::Processors::InlineMarkdown.render("a `b` c `d` e")
+      out.should eq("a <code>b</code> c <code>d</code> e")
+    end
+
+    it "keeps an all-space code span padded" do
+      out = Hwaro::Content::Processors::InlineMarkdown.render("`` ``")
+      out.should eq("<code> </code>")
+    end
+
+    it "leaves an unpaired backtick run alone" do
+      out = Hwaro::Content::Processors::InlineMarkdown.render("x `` y")
+      out.should eq("x `` y")
+    end
+  end
 end
 
 # `redirect_to` front matter reaches `safe_url?` verbatim, with no markdown

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -1049,6 +1049,43 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       html.should contain("</div>")
     end
 
+    # The generated `</div>` opens a type-6 HTML block that runs to the next
+    # blank line. Without one, the first line after the container was
+    # swallowed into that block and emitted as raw, unparsed markdown.
+    it "parses the line immediately after the closer as markdown" do
+      cfg = make_config
+      cfg.containers = true
+      html, _ = Hwaro::Processor::Markdown.render(
+        ":::note\nbody\n:::\nAfter with **bold**.",
+        markdown_config: cfg,
+      )
+      html.should contain("<p>After with <strong>bold</strong>.</p>")
+      html.should_not contain("After with **bold**.")
+    end
+
+    it "parses a heading immediately after the closer" do
+      cfg = make_config
+      cfg.containers = true
+      html, _ = Hwaro::Processor::Markdown.render(
+        ":::tip\nbody\n:::\n## Real Heading",
+        markdown_config: cfg,
+      )
+      html.should contain("<h2")
+      html.should contain("Real Heading</h2>")
+      html.should_not contain("## Real Heading")
+    end
+
+    it "parses a list immediately after the closer" do
+      cfg = make_config
+      cfg.containers = true
+      html, _ = Hwaro::Processor::Markdown.render(
+        ":::warning\nbody\n:::\n- one\n- two",
+        markdown_config: cfg,
+      )
+      html.should contain("<li>one</li>")
+      html.should contain("<li>two</li>")
+    end
+
     it "is off by default and skipped in safe mode" do
       html, _ = Hwaro::Processor::Markdown.render(":::note\nx\n:::", markdown_config: make_config)
       html.should_not contain("admonition")

--- a/spec/unit/markdown_toc_spec.cr
+++ b/spec/unit/markdown_toc_spec.cr
@@ -153,4 +153,48 @@ describe Hwaro::Content::Processors::Markdown do
       html.should_not contain(%(href="#old"))
     end
   end
+
+  # An empty heading (`##` with nothing after it) produces `<h2></h2>`, which
+  # the old `(.+?)` inner group could not match on its own — so the scan slid
+  # past it and paired that opening tag with the NEXT heading's `</h2>`,
+  # handing the empty heading the following heading's id and leaving the real
+  # heading with none. `HookedRenderer#heading` never had this bug, so the
+  # stock and render-hook paths also disagreed.
+  describe "empty headings" do
+    it "does not steal the following heading's id" do
+      content = <<-MARKDOWN
+        ##
+
+        ## Real Heading
+        MARKDOWN
+      html, toc = Hwaro::Content::Processors::Markdown.new.render(content)
+
+      html.should contain(%(<h2 id="heading"></h2>))
+      html.should contain(%(<h2 id="real-heading">Real Heading</h2>))
+      toc.map(&.id).should eq(["heading", "real-heading"])
+    end
+
+    it "gives a lone empty heading an id and a TOC entry" do
+      content = <<-MARKDOWN
+        ##
+
+        text
+        MARKDOWN
+      html, toc = Hwaro::Content::Processors::Markdown.new.render(content)
+
+      html.should contain(%(<h2 id="heading"></h2>))
+      toc.map(&.id).should eq(["heading"])
+    end
+
+    it "dedups repeated empty headings" do
+      content = <<-MARKDOWN
+        ##
+
+        ##
+        MARKDOWN
+      _, toc = Hwaro::Content::Processors::Markdown.new.render(content)
+
+      toc.map(&.id).should eq(["heading", "heading-1"])
+    end
+  end
 end

--- a/src/content/processors/inline_markdown.cr
+++ b/src/content/processors/inline_markdown.cr
@@ -24,7 +24,19 @@ module Hwaro
         UNSAFE_PROTOCOL_RE      = /^\s*(javascript|vbscript|file|data):/i
         UNSAFE_DATA_PROTOCOL_RE = /^\s*data:image\/(?:png|gif|jpeg|webp)/i
 
-        INLINE_CODE_SPAN_RE = /`([^`]+)`/
+        # CommonMark code spans: a run of N backticks opens, and the next run
+        # of EXACTLY N backticks closes. The single-backtick-only form this
+        # replaced could not see `` `tick` `` or ``a`b`` at all — it matched
+        # the inner backticks instead, shredding the span into stray `<code>`
+        # tags and literal delimiters inside table cells, footnote bodies, and
+        # definition lists (the three callers of `render`).
+        #
+        # The opening run is POSSESSIVE (`` `++ ``) and the closer is fenced by
+        # `(?<!`)`/`(?!`)` so both delimiters are whole runs: without those,
+        # `\1` would happily match two of a three-backtick run and pair
+        # mismatched delimiters. `[\s\S]` (not `.`) because a footnote or
+        # definition body may still carry a newline at this point.
+        INLINE_CODE_SPAN_RE = /(`++)([\s\S]+?)(?<!`)\1(?!`)/
         INLINE_IMAGE_RE     = /!\[([^\]]*)\]\(([^)]*)\)/
         INLINE_LINK_RE      = /\[([^\]]+)\]\(([^)]*)\)/
         # Flanking guards (`(?=\S)` … `(?<=\S)`): a delimiter run that touches
@@ -124,7 +136,7 @@ module Hwaro
 
           code_spans = [] of String
           result = result.gsub(INLINE_CODE_SPAN_RE) do
-            code_spans << $1
+            code_spans << strip_code_span_padding($2)
             "\x00CODESPAN#{code_spans.size - 1}\x00"
           end
 
@@ -204,6 +216,17 @@ module Hwaro
           end
 
           result
+        end
+
+        # CommonMark strips ONE leading and ONE trailing space from a code
+        # span when both are present and the content isn't all spaces — that's
+        # what makes `` `tick` `` render as `` `tick` `` rather than
+        # `` ` tick ` ``. Markd already does this on the paragraph path; doing
+        # it here keeps the two paths agreeing.
+        private def strip_code_span_padding(content : String) : String
+          return content unless content.starts_with?(' ') && content.ends_with?(' ')
+          return content if content.each_char.all? { |c| c == ' ' }
+          content[1...-1]
         end
 
         # Replaces stashed placeholder tokens with the HTML-escaped comment

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -41,7 +41,15 @@ module Hwaro
 
         # Regex for post_process_html — lightweight replacements for XML.parse_html
         # Matches <h1>…</h1> through <h6>…</h6>, capturing tag name, level digit, attributes, and inner HTML
-        HEADING_TAG_REGEX = /<(h([1-6]))(\s(?:[^>"']|"[^"]*"|'[^']*')*)?>(.+?)<\/h\2>/mi
+        # The inner group is `.*?`, not `.+?`: an EMPTY heading (`##` with no
+        # text, or one whose only content was a stripped `{#id}` block) must
+        # still match on its own. With `.+?` the empty `<h2></h2>` could not
+        # match, so the scan slid on and paired that opening tag with the NEXT
+        # heading's `</h2>` — handing the empty heading the following
+        # heading's id and leaving the real one with none, which also broke
+        # the render-hooks convergence invariant (HookedRenderer#heading gets
+        # this right).
+        HEADING_TAG_REGEX = /<(h([1-6]))(\s(?:[^>"']|"[^"]*"|'[^']*')*)?>(.*?)<\/h\2>/mi
         # Matches <img ...> tags that do NOT already have a loading= attribute
         # (the lookahead is quote-aware too, so a loading= sitting after a
         # quoted `>` is still seen, and `data-loading=` doesn't count).

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -330,14 +330,21 @@ module Hwaro
               end
               if open_count > 0 && CONTAINER_CLOSE_RE.matches?(stripped)
                 open_count -= 1
-                io << "\n</div>\n"
+                # Trailing blank line: `</div>` opens a type-6 HTML block that
+                # runs until the next blank line, so without one the FIRST line
+                # after the container (`- item`, `## Heading`, a paragraph) was
+                # swallowed into that block and emitted as raw, unparsed
+                # markdown. Markd drops the trailing blank from the block's
+                # literal, so a container followed by a blank line renders
+                # byte-identically.
+                io << "\n</div>\n\n"
                 next
               end
 
               io << line
             end
             # Auto-close unclosed containers at EOF (markdown-it behavior).
-            open_count.times { io << "\n</div>\n" }
+            open_count.times { io << "\n</div>\n\n" }
           end
         end
 


### PR DESCRIPTION
Dogfooding pass over the markdown lane: torture pages covering every feature documented in `docs/content/writing/**` and `docs/content/features/markdown-extensions.md` (footnotes, task lists, math, emoji, `{.class #id}` attributes, tables with alignment/escaped pipes/inline code, admonitions, `:::` containers, definition lists, nested lists with fences, headings with entities/CJK/emoji, autolinks, smart punctuation, shortcodes nested/quoted/in fences, render hooks, fence options), built with `bin/hwaro build`, and the HTML inspected for escaping bugs, lost content, placeholder leakage, and wrong anchor ids.

Three real defects found and fixed. No placeholder (`HWARO-…`) or NUL leakage was found, and no XSS: `javascript:`/`data:` destinations, raw HTML in table cells, and shortcode args all escape correctly.

## Bug 1 — an empty heading steals the next heading's id

**Symptom.** A page containing an empty heading (`##` with nothing after it) renders

```html
<h2 id="ünïcödé-áccênts"></h2>
<h2>Ünïcödé Áccênts</h2>
```

The empty heading gets the *following* heading's id and TOC entry; the real heading gets no id at all, so it falls out of the TOC, out of `insert_anchor_links`, and every `#anchor` link to it 404s in-page.

**Root cause.** `Markdown::HEADING_TAG_REGEX` (`src/content/processors/markdown.cr:44`) captured a heading's inner HTML with `(.+?)`, which cannot match zero characters. `<h2></h2>` therefore never matched on its own; with `/m` the scan slid past it and paired that opening tag with the next `</h2>` in the document.

This also broke the documented render-hooks convergence invariant — `HookedRenderer#heading` never had the bug, so a site with a default-equivalent `templates/hooks/render-heading.html` produced *different* ids than the same site without one:

```
  stock:  <h2 id="ünïcödé-áccênts"></h2> / <h2>Ünïcödé Áccênts</h2>
  hooked: <h2 id="heading"></h2>         / <h2 id="ünïcödé-áccênts">Ünïcödé Áccênts</h2>
```

**Fix.** `(.+?)` → `(.*?)`. `HeadingIds.assign` already maps an empty slug to `heading` (and dedups `heading-1`, …), so the empty heading now gets the same id the hook path gives it and the two paths converge again.

**Specs.** `spec/unit/markdown_toc_spec.cr` — "does not steal the following heading's id", "gives a lone empty heading an id and a TOC entry", "dedups repeated empty headings". All three proven failing on pre-fix `markdown.cr`.

## Bug 2 — multi-backtick code spans shredded in table cells, footnotes, and definition lists

**Symptom.** `` `tick` `` in a table cell renders as

```html
<td>`<code> </code>tick<code> </code>`</td>
```

and ``` ``a`b`` ``` as `` `<code>a</code>b`` ``. Same in footnote bodies and `<dd>` bodies — the three callers of `InlineMarkdown.render`. The markd paragraph path handles these correctly, so the same source produced different HTML depending on where it sat.

This is not hypothetical: **hwaro's own docs and the `blog` scaffold's sample post both hit it.** `docs/content/start/config.md` renders `` ```mermaid `` blocks as ``Render <code> </code>`<code>mermaid </code> blocks as …``, and `docs/content/templates/render-hooks.md` mangles the `` ```python `` cell the same way.

**Root cause.** `INLINE_CODE_SPAN_RE` was `` /`([^`]+)`/ `` — single-backtick only. Given a double-backtick span it matched the *inner* backticks instead of the delimiters.

**Fix.** `` /(`++)([\s\S]+?)(?<!`)\1(?!`)/ ``: a run of N backticks opens and the next run of exactly N closes. The opening run is possessive and the closer is fenced by lookarounds so `\1` cannot match part of a longer run and pair mismatched delimiters. Added CommonMark's "strip one leading and one trailing space when both are present and the content isn't all spaces" rule so the cell path agrees with markd's paragraph path.

**Specs.** `spec/unit/inline_markdown_spec.cr` — a new `.render code spans` block (double-backtick containing single backticks, interior backtick, triple-backtick, all-space span kept padded, plus two guards that plain single-backtick spans and an unpaired run are unchanged). Four proven failing pre-fix; the two guards pass both ways by design.

## Bug 3 — `:::` containers swallow the line right after the closer

**Symptom.** With `containers = true`,

```markdown
:::note
body
:::
This paragraph should render **bold**.
```

emits `This paragraph should render **bold**.` as raw, unparsed markdown after the `</div>`. Same for a heading (`## Should Be A Heading` leaks literally) and a list. Inside a list it corrupts the list: `- item2` after a container ends up as literal text in the page.

**Root cause.** `preprocess_containers` emitted `"\n</div>\n"` for the closer. `</div>` starts a CommonMark type-6 HTML block that runs until the next blank line, so the first following line was absorbed into that block and passed through verbatim.

**Fix.** Emit `"\n</div>\n\n"` (closer and the EOF auto-close). Markd drops the trailing blank line from the block's literal, so a container that already had a blank line after it renders byte-identically.

**Specs.** `spec/unit/markdown_extensions_spec.cr` — "parses the line immediately after the closer as markdown", "parses a heading immediately after the closer", "parses a list immediately after the closer". All three proven failing pre-fix.

## Verification

- `crystal spec`: **8383 examples, 0 failures, 0 errors**.
- `crystal tool format --check` clean; `./bin/ameba` clean (524 inspected, 0 failures).
- Pre-fix proof: for each fix, the touched source file was replaced with `git show origin/main:<file>` (no stash), the new specs run and confirmed failing, then the fix restored. 10 of the 12 new examples fail pre-fix; the two that pass both ways are deliberate "still works" guards.

### Byte-identity (origin/main binary vs this branch)

| Site | Result |
|---|---|
| `docs/` (142 pages) | 5 files differ |
| `hwaro init --scaffold blog` | 6 files differ |
| `hwaro init --scaffold docs` | **byte-identical** |

Every diff is bug 2 correcting previously-corrupt output. In full:

```diff
- <td>Render <code> </code>`<code>mermaid </code> blocks as <code>&lt;div class=&quot;mermaid&quot;&gt;</code></td>
+ <td>Render <code>```mermaid</code> blocks as <code>&lt;div class=&quot;mermaid&quot;&gt;</code></td>

- <td>The fence&#39;s language token, escaped (<code>python</code> in `<code> </code>`<code>python </code>`). …</td>
+ <td>The fence&#39;s language token, escaped (<code>python</code> in <code>```python</code>). …</td>

- <td>`<code> </code>code<code> </code>`</td>       (blog scaffold sample post)
+ <td><code>`code`</code></td>
```

plus the `ko` translations of the first two and the derived `search.json` / `rss.xml` for each. Bugs 1 and 3 produce no diff on these sites (neither has an empty heading or a container).

No documented behaviour changed — all three were defects against what the docs already promise — so no docs update.

## Considered and deliberately not changed

- **Ragged table rows keep overflow cells.** A row with more cells than the header emits a `<tr>` wider than the `<thead>`; GFM says the excess is ignored. `spec/unit/table_parser_spec.cr:220` explicitly locks the keep-overflow contract ("not dropped as GFM would"), so this is a characterized decision, not a defect. I implemented the GFM behaviour, saw that spec fail, and reverted.

## Out-of-lane findings (NOT fixed)

None in other workers' files. Two lane-adjacent limitations worth recording but not worth a speculative fix in this pass:

1. **Tables don't work inside blockquotes or admonitions** (`src/content/processors/table_parser.cr`, `TableParser.process` only sees unprefixed lines). `> | a | b |` / `> |---|---|` stays a paragraph — and with `smart_punctuation = true` the delimiter row's `---` is additionally rewritten to an em dash (`|—|—|`), so the source looks even less like a table in the output. Repro: any `> [!NOTE]` admonition containing a GFM table. Fixing this needs block-aware table detection, not a regex tweak.
2. **`> [!NOTE] Custom Title` merges the title into the body** (`src/content/processors/markdown_extensions.cr:1001`, `postprocess_admonitions`) — output is `<p class="admonition-title">Note</p>` with `Custom Title\nBody here.` as the first body paragraph. Hugo treats the trailing text as a custom title; GitHub declines the marker entirely. hwaro does neither, and the docs don't cover it. Needs a product decision on which parity to pick.