### PR TITLE
fix(scaffold): 5 init/new/doctor defects found by dogfooding every scaffold

### DIFF
--- a/docs/content/start/cli.ko.md
+++ b/docs/content/start/cli.ko.md
@@ -133,14 +133,17 @@ API 요청 제한을 피하려면 `GITHUB_TOKEN` 환경 변수를 설정합니�
 | --scaffold TYPE | 내장 스캐폴드(`simple`, `bare`, `blog`, `docs`, `book`) 또는 원격 소스(`github:user/repo[/path]`, URL) |
 | --wizard | 대화형 위저드 실행 (TTY 전용) |
 | --agents MODE | AGENTS.md 콘텐츠 모드: `remote`(가벼움, 기본값) 또는 `local`(전체 레퍼런스 내장) |
-| -f, --force | 디렉터리가 비어 있지 않아도 강제로 생성 |
+| -f, --force | 디렉터리가 비어 있지 않아도 강제로 생성 (기존 파일은 유지) |
+| --clean | 스캐폴드 전에 대상의 기존 파일을 삭제 (`--force` 포함, 대상에 `.git/`이 있으면 거부) |
 | --skip-agents-md | AGENTS.md 파일 생성 생략 |
 | --skip-sample-content | 샘플 콘텐츠 파일 생성 생략 |
 | --skip-taxonomies | 택소노미 설정과 템플릿 생략 |
-| --include-multilingual LANGS | 다국어 지원 활성화 (예: `en,ko,ja`) |
+| --include-multilingual LANGS | 다국어 지원 활성화 (예: `en,ko,ja`). 중복 코드는 경고와 함께 제거됩니다 |
 | --minimal-config | 주석과 선택 섹션 없는 최소 `config.toml` 생성 |
+| --full-config | 모든 주석과 선택 섹션을 포함한 전체 `config.toml` 생성 (탐색성 최대) |
 | --list-scaffolds | 사용 가능한 내장 스캐폴드 목록 출력 후 종료 |
-| --json | 기계가 읽을 수 있는 JSON 출력 (--list-scaffolds와 함께) |
+| -q, --quiet | 정보 출력과 배너 숨김 (오류는 stderr로 계속 출력) |
+| -j, --json | 기계가 읽을 수 있는 JSON 출력: `--list-scaffolds`와 함께면 스캐폴드 목록, 그 외에는 `{"status","path","scaffold","files_created"}` 결과 |
 
 ### new
 

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -131,14 +131,17 @@ Remote scaffolds fetch `config.toml`, `templates/`, `static/`, and content struc
 | --scaffold TYPE | Built-in (`simple`, `bare`, `blog`, `docs`, `book`) or remote source (`github:user/repo[/path]`, URL) |
 | --wizard | Run the interactive wizard (TTY only) |
 | --agents MODE | AGENTS.md content mode: `remote` (lightweight, default) or `local` (full embedded reference) |
-| -f, --force | Force creation even if directory is not empty |
+| -f, --force | Force creation even if directory is not empty (keeps existing files) |
+| --clean | Remove existing files in the target before scaffolding (implies `--force`; refuses if the target contains `.git/`) |
 | --skip-agents-md | Skip creating AGENTS.md file |
 | --skip-sample-content | Skip creating sample content files |
 | --skip-taxonomies | Skip taxonomies configuration and templates |
-| --include-multilingual LANGS | Enable multilingual support (e.g., `en,ko,ja`) |
+| --include-multilingual LANGS | Enable multilingual support (e.g., `en,ko,ja`). Repeated codes are dropped with a warning |
 | --minimal-config | Generate minimal `config.toml` without comments or optional sections |
+| --full-config | Generate full `config.toml` with every comment and optional section (maximum discoverability) |
 | --list-scaffolds | List available built-in scaffolds and exit |
-| --json | Emit machine-readable JSON output (with --list-scaffolds) |
+| -q, --quiet | Suppress info output and the banner (errors still go to stderr) |
+| -j, --json | Emit machine-readable JSON output: the scaffold list with `--list-scaffolds`, otherwise a `{"status","path","scaffold","files_created"}` result |
 
 ### new
 

--- a/spec/functional/init_json_contract_spec.cr
+++ b/spec/functional/init_json_contract_spec.cr
@@ -1,0 +1,69 @@
+require "../spec_helper"
+
+# `hwaro init --json` used to print the human receipt (banner, create/exist
+# tree, "created: N files") on stdout and emit no JSON at all, while its
+# error path already emitted a machine payload. A scripted caller therefore
+# got an unparseable stream on success. `run` writes straight to STDOUT and
+# `--json` has to take effect before option parsing, so these drive the real
+# binary rather than the command object.
+private HWARO_BIN = File.expand_path("../../bin/hwaro", __DIR__)
+
+Spec.before_suite do
+  unless File.exists?(HWARO_BIN) && File::Info.executable?(HWARO_BIN)
+    raise "Binary #{HWARO_BIN} is missing or not executable. Run `shards build` first."
+  end
+end
+
+private def init_run(dir : String, args : Array(String))
+  stdout = IO::Memory.new
+  stderr = IO::Memory.new
+  status = Process.run(HWARO_BIN, args, chdir: dir, output: stdout, error: stderr)
+  {status.exit_code, stdout.to_s, stderr.to_s}
+end
+
+describe "hwaro init --json" do
+  it "emits a single parseable result document and no human output" do
+    Dir.mktmpdir do |dir|
+      code, doc, _ = init_run(dir, ["init", ".", "--json"])
+
+      code.should eq(Hwaro::Errors::EXIT_SUCCESS)
+      doc.should_not contain("hwaro: init")
+      doc.should_not contain("created:")
+
+      payload = JSON.parse(doc)
+      payload["status"].as_s.should eq("ok")
+      payload["path"].as_s.should eq(".")
+      payload["scaffold"].as_s.should eq("simple")
+      payload["files_created"].as_i.should be > 0
+    end
+  end
+
+  it "reports the requested scaffold" do
+    Dir.mktmpdir do |dir|
+      _, doc, _ = init_run(dir, ["init", ".", "-j", "--scaffold", "blog"])
+      JSON.parse(doc)["scaffold"].as_s.should eq("blog")
+    end
+  end
+
+  it "keeps the scaffold-list hint off stdout when --scaffold is unknown" do
+    Dir.mktmpdir do |dir|
+      # The invalid-scaffold path logs "Available scaffolds:" before raising;
+      # with JSON mode enabled only after parsing, that human list shared
+      # stdout with the JSON error payload.
+      code, doc, _ = init_run(dir, ["init", ".", "--scaffold", "zzz", "--json"])
+
+      code.should eq(Hwaro::Errors::EXIT_USAGE)
+      doc.should_not contain("Available scaffolds:")
+      JSON.parse(doc)["status"].as_s.should eq("error")
+    end
+  end
+
+  it "still lists scaffolds as JSON with --list-scaffolds" do
+    Dir.mktmpdir do |dir|
+      _, doc, _ = init_run(dir, ["init", "--list-scaffolds", "--json"])
+      names = JSON.parse(doc).as_a.map(&.["name"].as_s)
+      names.should contain("simple")
+      names.should contain("book")
+    end
+  end
+end

--- a/spec/unit/creator_spec.cr
+++ b/spec/unit/creator_spec.cr
@@ -1485,12 +1485,42 @@ describe Hwaro::Services::Creator do
       end
     end
 
+    it "collapses a literal hyphen into the surrounding synthesized run" do
+      # Regression: the run-collapse only tracked hyphens it synthesized
+      # itself, so a literal `-` next to unsafe characters reset the flag
+      # and each side emitted its own hyphen — `a - b.md` became
+      # `a---b.md`, and a trailing emoji left `emoji-.md` dangling.
+      Hwaro::Services::Creator.sanitize_url_path("posts/a - b.md").should eq("posts/a-b.md")
+      Hwaro::Services::Creator.sanitize_url_path("hello - world - again.md").should eq("hello-world-again.md")
+      Hwaro::Services::Creator.sanitize_url_path("posts/emoji-\u{1F389}.md").should eq("posts/emoji.md")
+      Hwaro::Services::Creator.sanitize_url_path("- lead/trail -.md").should eq("lead/trail.md")
+    end
+
     it "drops segments that sanitize to pure dots instead of synthesizing `..`" do
       # `>.>.` → `-.-.` → hyphen/dot collapse → `..` — a traversal segment
       # fabricated AFTER validate_and_normalize_path! already ran. It must
       # vanish like any empty segment, never join the on-disk path.
       Hwaro::Services::Creator.sanitize_url_path("posts/>.>./foo.md").should eq("posts/foo.md")
       Hwaro::Services::Creator.sanitize_url_path("a/>.>./>.>./b.md").should eq("a/b.md")
+    end
+  end
+
+  describe ".titleize" do
+    it "title-cases hyphen-separated words" do
+      Hwaro::Services::Creator.titleize("my-first-post").should eq("My First Post")
+    end
+
+    it "drops empty pieces so no doubled or trailing space reaches the title" do
+      # Regression: `split("-").map(&.capitalize).join(" ")` turned the stem
+      # `emoji-` into the front-matter title "Emoji " and `a---b` into
+      # "A   B".
+      Hwaro::Services::Creator.titleize("emoji-").should eq("Emoji")
+      Hwaro::Services::Creator.titleize("-lead").should eq("Lead")
+      Hwaro::Services::Creator.titleize("a---b").should eq("A B")
+    end
+
+    it "keeps a hyphen-only stem verbatim rather than producing an empty title" do
+      Hwaro::Services::Creator.titleize("---").should eq("---")
     end
   end
 end

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -59,6 +59,18 @@ describe Hwaro::Services::Doctor do
         issues.any? { |i| i.id == "title-default" }.should be_true
       end
 
+      # Regression: the placeholder list was the literal
+      # {"Hwaro Site", "My Hwaro Site"}, which exempted every
+      # `--scaffold blog|docs|book` site — they ship "My Blog" / "My Docs" /
+      # "My Book" and never got the nudge. Sourced from the registry now, so
+      # a new scaffold joins the check without touching Doctor.
+      it "warns for every built-in scaffold's placeholder title" do
+        Hwaro::Services::Scaffolds::Registry.all.each do |scaffold|
+          issues = run_doctor(%(title = "#{scaffold.config_title}"\nbase_url = "https://example.com"\n))
+          issues.any? { |i| i.id == "title-default" }.should be_true
+        end
+      end
+
       it "does not warn when title is custom" do
         issues = run_doctor(base_config)
         issues.any? { |i| i.id == "title-default" }.should be_false

--- a/spec/unit/init_command_spec.cr
+++ b/spec/unit/init_command_spec.cr
@@ -103,6 +103,29 @@ describe Hwaro::CLI::Commands::InitCommand do
       options.multilingual_languages.should eq(["en-US", "pt-BR", "zh-Hant"])
     end
 
+    it "drops duplicate language codes in --include-multilingual" do
+      # Regression: a repeated code emitted two `[languages.<code>]` tables
+      # into config.toml. The exact repeat is invalid TOML ("duplicated
+      # key"), so `hwaro init` exited 0 having written a config that build,
+      # serve and doctor all refuse to parse.
+      cmd = Hwaro::CLI::Commands::InitCommand.new
+
+      options = cmd.parse_options(["--include-multilingual", "en,en"])
+      options.multilingual_languages.should eq(["en"])
+
+      options = cmd.parse_options(["--include-multilingual", "en,ko,en"])
+      options.multilingual_languages.should eq(["en", "ko"])
+
+      # BCP 47 tags are case-insensitive: `EN` and `en` are the same
+      # language, and emitting both produced a duplicated language subtree.
+      # The first spelling the author typed wins.
+      options = cmd.parse_options(["--include-multilingual", "EN,en"])
+      options.multilingual_languages.should eq(["EN"])
+
+      options = cmd.parse_options(["--include-multilingual", "en,pt-BR,PT-br"])
+      options.multilingual_languages.should eq(["en", "pt-BR"])
+    end
+
     it "rejects invalid language codes in --include-multilingual" do
       cmd = Hwaro::CLI::Commands::InitCommand.new
       expect_raises(Hwaro::HwaroError, /Invalid language code: '@@@'/) do

--- a/src/cli/commands/init_command.cr
+++ b/src/cli/commands/init_command.cr
@@ -72,6 +72,17 @@ module Hwaro
         @scaffold_given = false
 
         def run(args : Array(String))
+          # `--json` has to take effect BEFORE parsing. `parse_options` prints
+          # the scaffold list through `Logger.info` on an unknown `--scaffold`
+          # and `Initializer` prints the whole create/exist tree, so leaving
+          # JSON mode until after the parse let human text share stdout with
+          # the machine payload. Detected from the raw argv the same way
+          # `Runner.emit_hwaro_error` does.
+          if args.includes?("--json") || args.includes?("-j")
+            @json_output = true
+            Runner.enable_json_mode!
+          end
+
           # Parse first: introspection and wizard eligibility are decided from
           # parsed state, so an unknown flag is rejected in every mode.
           options = parse_options(args)
@@ -98,11 +109,31 @@ module Hwaro
               Logger.info "Cancelled."
               return
             end
-            Services::Initializer.new.run(wizard_options)
+            run_initializer(wizard_options)
             return
           end
 
-          Services::Initializer.new.run(options)
+          run_initializer(options)
+        end
+
+        # Run the initializer and, under `--json`, emit the single result
+        # document. Without it `hwaro init --json` printed the human receipt
+        # and no JSON at all, so a scripted caller got an unparseable stream
+        # on success while errors already arrived as JSON — every other
+        # `--json` command (`new`, `build`, `deploy`, `tool *`) emits a
+        # result object.
+        private def run_initializer(options : Config::Options::InitOptions)
+          initializer = Services::Initializer.new
+          initializer.run(options)
+          return unless @json_output
+
+          payload = {
+            "status"        => "ok",
+            "path"          => options.path,
+            "scaffold"      => options.scaffold_remote || options.scaffold.to_s,
+            "files_created" => initializer.created_count,
+          }
+          STDOUT.puts payload.to_json
         end
 
         private def wizard_eligible? : Bool
@@ -215,7 +246,19 @@ module Hwaro
                   hint: "Examples: 'en', 'ko', 'en,ko', 'pt-BR', 'zh-Hant'.",
                 )
               end
-              multilingual_languages = parsed
+              # A repeated code (`en,en`, or a case variant like `EN,en`)
+              # emits two `[languages.<code>]` tables into config.toml. The
+              # exact repeat is invalid TOML ("duplicated key"), so `hwaro
+              # init` exited 0 having written a config that no later command
+              # — build, serve, doctor — can parse. BCP 47 tags are
+              # case-insensitive, so dedupe on the folded code and keep the
+              # first spelling the author typed.
+              deduped = parsed.uniq(&.downcase)
+              if deduped.size != parsed.size
+                dropped = parsed.size - deduped.size
+                Logger.warn "  --include-multilingual: dropped #{dropped} duplicate language code(s); using #{deduped.join(", ")}."
+              end
+              multilingual_languages = deduped
             end
             parser.on("--minimal-config", "Generate minimal config.toml without comments and optional sections") { minimal_config = true }
             parser.on("--full-config", "Generate full config.toml with all comments and optional sections (maximum discoverability)") { full_config = true }

--- a/src/services/creator.cr
+++ b/src/services/creator.cr
@@ -138,6 +138,20 @@ module Hwaro
         title.downcase.gsub(/[^\p{L}\p{N}]+/, "-").strip("-")
       end
 
+      # Derive a display title from a filename stem (`my-first-post` ->
+      # "My First Post"). Empty pieces are dropped so a stem carrying a
+      # doubled or trailing hyphen (`emoji-`, `a---b`) cannot leak a
+      # trailing/doubled space into `title = "..."`. A stem made only of
+      # hyphens has no words to title-case, so it is kept verbatim rather
+      # than collapsing to an empty title.
+      # Single source of truth for the filename->title mapping used by every
+      # `hwaro new` branch that infers a title from the path.
+      def self.titleize(stem : String) : String
+        words = stem.split("-").reject(&.empty?)
+        return stem if words.empty?
+        words.map(&.capitalize).join(" ")
+      end
+
       # True when the build's front-matter date parser can produce a real
       # `Time` from `value`, so `hwaro new` fails fast on a `--date` the
       # build would silently drop (`2026-13-45`, `not-a-date`) or, worse,
@@ -153,8 +167,16 @@ module Hwaro
           last_was_hyphen = false
           segment.each_char do |char|
             if url_safe_char?(char)
-              io << char
-              last_was_hyphen = false
+              io << char unless char == '-' && last_was_hyphen
+              # A literal `-` is URL-safe, but it still opens a hyphen run:
+              # without this the run-collapse only saw the hyphens it
+              # synthesized itself, so a literal hyphen sitting next to
+              # unsafe characters emitted `a - b.md` -> `a---b.md` and
+              # `emoji-<emoji>.md` -> `emoji-.md`. Treating both spellings as
+              # the same run keeps the documented "collapsed to a single -"
+              # contract and matches `.slugify`, which collapses hyphen runs
+              # the same way.
+              last_was_hyphen = (char == '-')
             else
               unless last_was_hyphen
                 io << '-'
@@ -224,7 +246,7 @@ module Hwaro
             base_dir = File.dirname(full_path)
             if title.empty?
               filename_without_ext = File.basename(full_path, ".md")
-              title = filename_without_ext.split("-").map(&.capitalize).join(" ")
+              title = Creator.titleize(filename_without_ext)
             end
           else
             base_dir = File.join("content", section)
@@ -280,7 +302,7 @@ module Hwaro
             # Extract title from filename if not provided
             if title.empty?
               filename_without_ext = File.basename(path, ".md")
-              title = filename_without_ext.split("-").map(&.capitalize).join(" ")
+              title = Creator.titleize(filename_without_ext)
             end
 
             full_path = path.starts_with?("content/") ? path : File.join("content", path)
@@ -291,7 +313,7 @@ module Hwaro
             base_dir = File.dirname(full_path)
             if title.empty?
               filename_without_ext = File.basename(full_path, ".md")
-              title = filename_without_ext.split("-").map(&.capitalize).join(" ")
+              title = Creator.titleize(filename_without_ext)
             end
           else
             base_dir = path || "content/drafts"
@@ -303,7 +325,7 @@ module Hwaro
             # demanded --title while the config-driven `bundle = true` derived
             # it — the explicit flag was strictly stricter than the default.
             if title.empty? && path && options.bundle == true
-              title = File.basename(path).split("-").map(&.capitalize).join(" ")
+              title = Creator.titleize(File.basename(path))
             end
           end
         end

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -16,6 +16,7 @@ require "../content/processors/internal_link_resolver"
 require "../core/build/parallel"
 require "./config_snippets"
 require "./content_lister"
+require "./scaffolds/registry"
 
 module Hwaro
   module Services
@@ -174,12 +175,21 @@ module Hwaro
       KNOWN_SUB_SECTIONS    = ConfigSnippets::KNOWN_SUB_SECTIONS
 
       # The scaffolded placeholder titles. `Models::Config` falls back to
-      # "Hwaro Site" when `title` is absent, but every site `hwaro init`
-      # creates ships "My Hwaro Site" — so checking only the internal
-      # fallback meant the advisory never fired on the sites that actually
-      # have a placeholder title, and it shipped into <title>, OG tags and
-      # feeds unnoticed.
-      DEFAULT_TITLES = {"Hwaro Site", "My Hwaro Site"}
+      # "Hwaro Site" when `title` is absent, and every site `hwaro init`
+      # creates ships its scaffold's placeholder — so checking only the
+      # internal fallback meant the advisory never fired on the sites that
+      # actually have a placeholder title, and it shipped into <title>, OG
+      # tags and feeds unnoticed.
+      #
+      # Sourced from the scaffold registry rather than a hand-kept literal
+      # list: hardcoding "My Hwaro Site" silently exempted every
+      # `--scaffold blog|docs|book` site, which ships "My Blog" / "My Docs" /
+      # "My Book". A new scaffold now joins the check automatically.
+      class_getter default_titles : Set(String) do
+        titles = Set{"Hwaro Site"}
+        Scaffolds::Registry.all.each { |scaffold| titles << scaffold.config_title }
+        titles
+      end
 
       # `missing-config-<section>` ids are generated per config section
       # rather than enumerated, so `[doctor] ignore` validation matches
@@ -772,7 +782,7 @@ module Hwaro
         if config.raw["title"]?.try(&.as_s?).nil?
           issues << Issue.new(id: "title-default", level: :warning, category: "config", file: @config_path,
             message: "title is not set (the site falls back to \"#{config.title}\")")
-        elsif DEFAULT_TITLES.includes?(config.title)
+        elsif Doctor.default_titles.includes?(config.title)
           issues << Issue.new(id: "title-default", level: :warning, category: "config", file: @config_path,
             message: "title is still the placeholder value \"#{config.title}\"")
         end

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -27,7 +27,9 @@ module Hwaro
 
       # Counts files/directories actually created so the closing receipt can
       # report "N files" (existing entries left in place are not counted).
-      @created_count = 0
+      # Exposed so `hwaro init --json` can report the same number the human
+      # receipt prints instead of maintaining a second tally.
+      getter created_count = 0
 
       @entries = [] of ScaffoldEntry
 

--- a/src/services/scaffolds/base.cr
+++ b/src/services/scaffolds/base.cr
@@ -364,8 +364,11 @@ module Hwaro
         # placeholder.
         abstract def config_content(skip_taxonomies : Bool = false, multilingual_languages : Array(String) = [] of String) : String
 
-        # Returns the site title used in config (overridable per scaffold)
-        protected def config_title : String
+        # Returns the site title used in config (overridable per scaffold).
+        # Public so `hwaro doctor` can source its placeholder-title advisory
+        # from the scaffolds themselves instead of a hand-kept literal list
+        # that only ever covered "My Hwaro Site".
+        def config_title : String
           "My Hwaro Site"
         end
 

--- a/src/services/scaffolds/blog.cr
+++ b/src/services/scaffolds/blog.cr
@@ -19,7 +19,7 @@ module Hwaro
           "Blog-focused structure with posts, archives, and taxonomies"
         end
 
-        protected def config_title : String
+        def config_title : String
           "My Blog"
         end
 

--- a/src/services/scaffolds/book.cr
+++ b/src/services/scaffolds/book.cr
@@ -18,7 +18,7 @@ module Hwaro
           "Book-style structure with chapters, prev/next navigation, and keyboard shortcuts"
         end
 
-        protected def config_title : String
+        def config_title : String
           "My Book"
         end
 

--- a/src/services/scaffolds/docs.cr
+++ b/src/services/scaffolds/docs.cr
@@ -17,7 +17,7 @@ module Hwaro
           "Documentation-focused structure with organized sections and sidebar"
         end
 
-        protected def config_title : String
+        def config_title : String
           # Distinct from the homepage `title = "Documentation"` so the
           # rendered <title> and the `{{ site.title }} <span>Documentation</span>`
           # logo don't collapse into "Documentation - Documentation".


### PR DESCRIPTION
Dogfooding pass over the scaffold lane: `hwaro init` / `hwaro new` / the five built-in scaffolds / `hwaro doctor`. I inited every scaffold across a 90-combination flag matrix (`{simple,bare,blog,docs,book}` × `{default,--minimal-config,--full-config}` × `{none,en/ko,en/ko/ja}` × `{--skip-taxonomies}`), built and served each, ran `doctor`, `doctor --fix`, `doctor --full`, `tool check-links`, a link checker over the built `public/` trees (including a `/sub/path` `base_url` and multilingual variants), and drove `hwaro new` with unicode, emoji, spaces, dots, `..`, nested and brand-new sections.

Five real defects, each with a regression spec proven to fail on `origin/main`.

## Bugs fixed

### 1. `hwaro init --include-multilingual en,en` writes an unparseable config.toml
**Symptom** — `hwaro init . --scaffold blog --include-multilingual en,en` exits 0 and prints `created: 42 files`, but every later command fails:
```
Error [HWARO_E_CONFIG]: Invalid TOML in config.toml: duplicated key: 'language_name' at 15:19
```
A case variant (`EN,en`) parses but emits two language subtrees for the same language, duplicating the whole site under `/en/`.

**Root cause** — `src/cli/commands/init_command.cr:246`: `--include-multilingual` split, trimmed, rejected empties and validated each code, but never deduped. Each code emits its own `[languages.<code>]` table, and TOML rejects an exact repeat.

**Fix** — dedupe on the case-folded tag (BCP 47 tags are case-insensitive), keeping the first spelling the author typed, with a warning naming how many were dropped. `en,en` now folds to one language and falls through to the existing "needs 2+ languages" advisory.

**Spec** — `spec/unit/init_command_spec.cr` "drops duplicate language codes in --include-multilingual". Pre-fix: `Expected: ["en"] got: ["en", "en"]`.

### 2. `sanitize_url_path` leaves doubled and dangling hyphens
**Symptom**
```
hwaro new "posts/a - b.md"        -> content/posts/a---b.md
hwaro new "posts/emoji-🎉.md"     -> content/posts/emoji-.md
hwaro new "posts/hello - world - again.md" -> content/posts/hello---world---again.md
```

**Root cause** — `src/services/creator.cr:167` `sanitize_url_segment`: `last_was_hyphen` was only set for hyphens the sanitizer synthesized. A literal `-` is URL-safe, so it took the `io << char; last_was_hyphen = false` branch and reset the run, letting the unsafe characters on either side each emit their own hyphen. The `gsub("-.", ".")` dangling-hyphen cleanup is a single non-repeating pass, so `emoji--.md` only collapsed to `emoji-.md`.

**Fix** — a literal `-` now joins the same run. This restores the method's documented "collapsed to a single `-`" contract and matches `Creator.slugify`, which already collapses hyphen runs. Paths that are already URL-safe (`a--b.md`) never enter the sanitizer, so an author's deliberate `--` is untouched.

**Spec** — `spec/unit/creator_spec.cr` "collapses a literal hyphen into the surrounding synthesized run". Pre-fix: `Expected: "posts/a-b.md" got: "posts/a---b.md"`.

### 3. Derived titles carry stray spaces
**Symptom** — `content/posts/emoji-.md` was scaffolded with `title = "Emoji "` (trailing space); a `a---b` stem gave `title = "A   B"`.

**Root cause** — four `hwaro new` branches each inlined `filename.split("-").map(&.capitalize).join(" ")`, which keeps empty pieces from a doubled/leading/trailing hyphen and joins them as spaces.

**Fix** — extracted `Creator.titleize` (drops empty pieces; keeps a hyphen-only stem verbatim rather than producing an empty title) and used it at all four sites. One source of truth for the filename→title mapping.

**Spec** — `spec/unit/creator_spec.cr` `.titleize`. Pre-fix (with a shim reproducing the old inline expression so the spec compiles): `Expected: "Emoji" got: "Emoji "` and `Expected: "---" got: "   "`.

### 4. `hwaro init --json` emits no JSON
**Symptom** — `--help` advertises `-j, --json  Output result as JSON`, but on success `hwaro init . --json` printed the banner, the whole create/exist tree and `created: 25 files` — and no JSON. Its *error* path already emitted a machine payload (`Runner.emit_hwaro_error` falls back to `ARGV.includes?("--json")`), so a scripted caller could parse failures but not successes. With an unknown `--scaffold`, the human "Available scaffolds:" list was printed to stdout ahead of the JSON error payload.

**Root cause** — `InitCommand#run` never called `Runner.enable_json_mode!` and emitted no result document; `@json_output` was only consulted by `--list-scaffolds`. Every other `--json` command (`new`, `build`, `deploy`, `tool *`) does both.

**Fix** — detect `--json` / `-j` from the raw argv *before* `parse_options` (so the mid-parse scaffold hint is silenced too), then emit `{"status","path","scaffold","files_created"}` after the initializer runs. `Initializer#created_count` is now a `getter` so the JSON reports the same number the human receipt prints. `--list-scaffolds --json` is unchanged.

**Spec** — `spec/functional/init_json_contract_spec.cr` (drives the real binary). Pre-fix: 2 failures + 1 error (`JSON::ParseException` on the human receipt).

### 5. Doctor's placeholder-title advisory exempted three scaffolds
**Symptom** — `hwaro init --scaffold blog` ships `title = "My Blog"` and `doctor` says "your site looks great"; the same author with `--scaffold simple` gets warned. `docs` (`My Docs`) and `book` (`My Book`) were likewise silent.

**Root cause** — `src/services/doctor.cr:182` `DEFAULT_TITLES = {"Hwaro Site", "My Hwaro Site"}`, a hand-kept literal whose own comment claimed "every site `hwaro init` creates ships 'My Hwaro Site'" — untrue since the blog/docs/book scaffolds override `config_title`.

**Fix** — sourced from `Scaffolds::Registry` (`config_title` promoted from `protected` to public on `Base` and the three overrides), so a new scaffold joins the check automatically and the list cannot drift again.

**Spec** — `spec/unit/doctor_spec.cr` "warns for every built-in scaffold's placeholder title". Pre-fix: `Expected: true got: false`.

Note for reviewers: this is the one change that *adds* warnings to existing sites — a `blog`/`docs`/`book` project that never renamed its title now gets one `title-default` warning (suppressible via `[doctor] ignore = ["title-default"]`, and it does not affect the default exit code).

## Docs

`docs/content/start/cli.md` + `cli.ko.md`: the `hwaro init` options table was missing `--clean`, `--full-config` and `-q/--quiet`, described `--json` as list-only, and did not mention the duplicate-code behaviour. Updated bilingually.

## Verification

- `crystal spec` — **8381 examples, 0 failures**.
- `crystal tool format --check` clean, `ameba` clean (525 files, 0 failures).
- Every regression spec proven to fail against `origin/main` sources (restored via `git show origin/main:<file>`, never `git stash`), then the fixes restored.
- **Byte-identity**: built `origin/main` and this branch as separate binaries. `diff -r` over the full scaffolded project trees *and* `public/` for all five scaffolds, plus the `docs/` site, plus `blog`/`docs` with `--include-multilingual en,ko` and a `https://example.com/sub/path` `base_url`: **identical, no diffs**. These fixes only touch `hwaro new` filenames, `init --json` stdout, and doctor advisories — never the build.
- Re-ran the 90-combination init/build/doctor/link-check matrix on the fixed binary: 0 build errors, 0 doctor errors, 0 broken links.

## Out-of-lane findings (not fixed)

1. `pwa.display` is never validated. `src/models/config.cr:2633` reads it straight into the manifest with no `VALID_*` set, while `pwa.cache_strategy` right next to it is checked (`src/services/doctor.cr:847`). A typo (`display = "weird"`) writes an invalid `manifest.json` `display` and browsers silently fall back to `browser`. Repro: add `[pwa]\nenabled = true\ndisplay = "weird"` to a scaffold config, `hwaro doctor` reports no issue. The check belongs next to the existing one in doctor, but the valid set has to be defined on `Models::PwaConfig` (out of lane).
2. Every built-in scaffold's `.md` / `.html` / `AGENTS.md` files are written without a trailing newline (heredoc-sourced). Cosmetic, widespread (e.g. 47/51 files for `blog`); left alone because fixing it touches every scaffold heredoc for no functional gain.
3. `hwaro new posts/trailing-dot.` creates `content/posts/trailing-dot..md` and a `public/posts/trailing-dot./` directory. Harmless on POSIX; a directory whose name ends in `.` is not creatable on Windows. Not fixed — no repro of harm on a supported platform.
