### PR TITLE
fix(serve): restore the request path after index rewrite and classify bind failures

### DIFF
--- a/docs/content/start/cli.ko.md
+++ b/docs/content/start/cli.ko.md
@@ -358,7 +358,7 @@ hwaro serve -i /path/to/my-site -p 8080
 | --include-future | 미래 날짜 콘텐츠 포함 |
 | -v, --verbose | 상세 출력 |
 | --debug | 재빌드마다 디버그 정보 출력 |
-| --access-log | HTTP 접근 로그 표시 (예: GET 요청) |
+| --access-log | HTTP 접근 로그 표시 (예: GET 요청). 각 줄에는 브라우저가 요청한 경로가 그대로 기록됩니다 — 개발 서버가 내부적으로 찾아가는 `/index.html`이 아니라 `/` |
 | --no-error-overlay | 브라우저 내 오류 오버레이 끄기 (기본값: 활성화) |
 | --live-reload | 파일 변경 시 브라우저 라이브 리로드 켜기 (기본값: 활성화; 하위 호환용으로 유지) |
 | --no-live-reload | 파일 변경 시 브라우저 라이브 리로드 끄기 |

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -354,7 +354,7 @@ hwaro serve -i /path/to/my-site -p 8080
 | --include-future | Include future-dated content |
 | -v, --verbose | Show detailed output |
 | --debug | Print debug information after each rebuild |
-| --access-log | Show HTTP access log (e.g. GET requests) |
+| --access-log | Show HTTP access log (e.g. GET requests). Each line reports the path the browser requested — `/`, not the `/index.html` the dev server resolves it to |
 | --no-error-overlay | Disable in-browser error overlay (default: enabled) |
 | --live-reload | Enable browser live reload on file changes (default: enabled; kept for backwards compatibility) |
 | --no-live-reload | Disable browser live reload on file changes |

--- a/spec/functional/serve_access_log_spec.cr
+++ b/spec/functional/serve_access_log_spec.cr
@@ -1,0 +1,106 @@
+require "../spec_helper"
+require "../../src/services/server/server"
+require "http/client"
+require "socket"
+
+# Regression coverage for a `hwaro serve --access-log` defect: the log
+# reported a path the client never sent. IndexRewriteHandler rewrites `/` to
+# `/index.html` so the static handler can find the file, but it never put the
+# request back — and `HTTP::LogHandler` sits outermost and reads
+# `request.resource` AFTER call_next. Every directory request was therefore
+# logged as its index file, so the access log could not be correlated with the
+# browser's own network panel. (BasePathHandler already restores its strip for
+# exactly this reason; nothing was undoing this rewrite.)
+#
+# Reopened with prefixed names so they cannot collide with the shims other
+# server specs install.
+module Hwaro
+  module Services
+    class Server
+      def access_log_build_handlers(output_dir : String) : Array(HTTP::Handler)
+        build_handlers(output_dir, "127.0.0.1", false, true, {} of String => String, "")
+      end
+    end
+  end
+end
+
+# Stands in for `HTTP::LogHandler`: same position (outermost) and the same
+# read — `request.resource` after `call_next` has returned.
+private class ResourceProbeHandler
+  include HTTP::Handler
+
+  getter seen = [] of String
+
+  def call(context)
+    call_next(context)
+  ensure
+    @seen << context.request.resource
+  end
+end
+
+private def with_logging_dev_server(&)
+  Dir.mktmpdir do |dir|
+    FileUtils.mkdir_p(File.join(dir, "about"))
+    File.write(File.join(dir, "index.html"), "<html><body>HOME</body></html>")
+    File.write(File.join(dir, "404.html"), "<html><body>NOT FOUND</body></html>")
+    File.write(File.join(dir, "about", "index.html"), "<html><body>ABOUT</body></html>")
+    File.write(File.join(dir, "robots.txt"), "User-agent: *\n")
+
+    Hwaro::Services::Server.register_utf8_mime_types
+    probe = ResourceProbeHandler.new
+    handlers = [probe.as(HTTP::Handler)]
+    handlers.concat(Hwaro::Services::Server.new.access_log_build_handlers(dir))
+    server = Hwaro::Services::DevHTTPServer.new(handlers)
+    address = server.bind_unused_port("127.0.0.1")
+    spawn { server.listen }
+    until server.listening?
+      Fiber.yield
+    end
+
+    begin
+      yield address.port, probe
+    ensure
+      server.close
+    end
+  end
+end
+
+private def access_log_get(port : Int32, path : String) : HTTP::Client::Response
+  client = HTTP::Client.new("127.0.0.1", port)
+  client.read_timeout = 5.seconds
+  client.connect_timeout = 2.seconds
+  begin
+    client.get(path)
+  ensure
+    client.close
+  end
+end
+
+describe "hwaro serve access log fidelity" do
+  it "logs the request path the client sent, not the rewritten index file" do
+    with_logging_dev_server do |port, probe|
+      access_log_get(port, "/").status_code.should eq(200)
+      access_log_get(port, "/about/").status_code.should eq(200)
+
+      probe.seen.should eq(["/", "/about/"])
+    end
+  end
+
+  it "keeps the query string on a rewritten directory request" do
+    with_logging_dev_server do |port, probe|
+      access_log_get(port, "/?q=hwaro+serve").status_code.should eq(200)
+
+      probe.seen.should eq(["/?q=hwaro+serve"])
+    end
+  end
+
+  it "leaves non-directory requests untouched" do
+    with_logging_dev_server do |port, probe|
+      access_log_get(port, "/robots.txt").status_code.should eq(200)
+      access_log_get(port, "/about").status_code.should eq(302)
+      access_log_get(port, "/missing").status_code.should eq(404)
+
+      probe.seen.should eq(["/robots.txt", "/about", "/missing"])
+    end
+  end
+end

--- a/spec/functional/serve_bind_error_spec.cr
+++ b/spec/functional/serve_bind_error_spec.cr
@@ -1,0 +1,92 @@
+require "../spec_helper"
+require "../../src/services/server/server"
+require "socket"
+
+# Regression coverage for an unclassified `hwaro serve` failure.
+#
+# `HTTP::Server#bind_tcp` does two things: it resolves `host`, then binds.
+# Only the bind half raises `Socket::BindError`, and that was the only
+# exception serve rescued — so a `-b/--bind` value the resolver cannot answer
+# for (`-b 300.1.1.1`, a typo'd hostname) raised `Socket::Addrinfo::Error`
+# straight out of `run_with_options` and reached the user as a bare
+# `Error: Hostname lookup for 300.1.1.1 failed: No address found`: no error
+# code, no hint, and nothing naming the flag that produced it.
+#
+# The CLI-level example is the one that matters — it compiles and fails
+# against pre-fix sources, where the seam below did not exist yet.
+private HWARO_BIND_BIN = File.expand_path("../../bin/hwaro", __DIR__)
+
+Spec.before_suite do
+  unless File.exists?(HWARO_BIND_BIN) && File::Info.executable?(HWARO_BIND_BIN)
+    raise "Binary #{HWARO_BIND_BIN} is missing or not executable. Run `shards build` first."
+  end
+end
+
+module Hwaro
+  module Services
+    class Server
+      def bind_error_bind(server : HTTP::Server, host : String, port : Int32)
+        bind_dev_server(server, host, port)
+      end
+    end
+  end
+end
+
+# A server that never listens — these examples only drive the bind step. It
+# still needs a handler: `HTTP::Server.new` refuses an empty chain.
+private def bind_error_probe_server : HTTP::Server
+  HTTP::Server.new(&.response.status_code=(204))
+end
+
+private def bind_error_site(dir : String)
+  %w[content templates].each { |d| FileUtils.mkdir_p(File.join(dir, d)) }
+  File.write(File.join(dir, "config.toml"), %(title = "Bind"\nbase_url = "https://example.com"\n))
+  File.write(File.join(dir, "content", "_index.md"), "---\ntitle: Home\n---\nBody")
+  File.write(File.join(dir, "templates", "index.html"), "{{ page.title }}")
+  File.write(File.join(dir, "templates", "page.html"), "{{ page.title }}")
+end
+
+describe "hwaro serve bind failures" do
+  it "reports an unresolvable --bind host as a classified error" do
+    Dir.mktmpdir do |dir|
+      bind_error_site(dir)
+      stdout = IO::Memory.new
+      stderr = IO::Memory.new
+      # Port 0 would bind fine; the resolver refuses the host first. Pre-fix
+      # this printed an unprefixed `Error: Hostname lookup …` line.
+      status = Process.run(
+        HWARO_BIND_BIN,
+        ["serve", "-b", "300.1.1.1", "-p", "4399", "--no-open"],
+        chdir: dir, output: stdout, error: stderr
+      )
+
+      combined = stdout.to_s + stderr.to_s
+      status.success?.should be_false
+      combined.should contain("Error [#{Hwaro::Errors::HWARO_E_USAGE}]")
+      combined.should contain("300.1.1.1")
+      combined.should contain("-b/--bind")
+    end
+  end
+
+  it "classifies an unresolvable host at the bind seam" do
+    error = expect_raises(Hwaro::HwaroError) do
+      Hwaro::Services::Server.new.bind_error_bind(bind_error_probe_server, "300.1.1.1", 0)
+    end
+    error.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+    error.hint.to_s.should contain("-b/--bind")
+  end
+
+  it "still classifies a port already in use as an IO error" do
+    taken = TCPServer.new("127.0.0.1", 0)
+    port = taken.local_address.port
+    begin
+      error = expect_raises(Hwaro::HwaroError) do
+        Hwaro::Services::Server.new.bind_error_bind(bind_error_probe_server, "127.0.0.1", port)
+      end
+      error.code.should eq(Hwaro::Errors::HWARO_E_IO)
+      error.hint.to_s.should contain("--port")
+    ensure
+      taken.close
+    end
+  end
+end

--- a/spec/unit/server_spec.cr
+++ b/spec/unit/server_spec.cr
@@ -69,9 +69,14 @@ class DummyHandler
   include HTTP::Handler
 
   property called : Bool = false
+  # The request path as the DOWNSTREAM handler saw it. IndexRewriteHandler
+  # rewrites for the handlers below it and puts the request back on the way
+  # out, so the rewrite is only observable from here.
+  property seen_path : String? = nil
 
   def call(context)
     @called = true
+    @seen_path = context.request.path
   end
 end
 
@@ -184,8 +189,14 @@ describe Hwaro::Services::IndexRewriteHandler do
 
       handler.call(context)
 
-      request.path.should eq("/some/path/index.html")
       dummy.called.should be_true
+      # The handlers below see the index file...
+      dummy.seen_path.should eq("/some/path/index.html")
+      # ...and the request is restored on the way out, so `HTTP::LogHandler`
+      # (outermost, reading `resource` after call_next) reports the path the
+      # client actually sent.
+      request.path.should eq("/some/path/")
+      request.resource.should eq("/some/path/")
     end
   end
 

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -38,60 +38,75 @@ module Hwaro
         path = context.request.path
 
         if path.ends_with?("/")
-          context.request.path += "index.html"
-        else
-          # No extname pre-filter here: deciding by extension 404'd every
-          # directory with a dot in its last segment (/docs/v1.2, /node.js)
-          # because stdlib's StaticFileHandler only appends the trailing
-          # slash when directory_listing is on. What's on disk decides.
-          #
-          # Resolve strictly (see DevPath) to prevent directory traversal and
-          # separator smuggling before filesystem access. A nil result is a
-          # path we refuse to route; an empty one is the output root itself,
-          # which must not produce `Location: //`.
-          sanitized = DevPath.safe_relative(path)
-          if sanitized.nil? || sanitized.empty?
+          context.request.path = path + "index.html"
+          begin
             call_next(context)
-            return
+          ensure
+            # Put the request back the way it arrived. `HTTP::LogHandler` sits
+            # outermost and reads `request.resource` AFTER call_next, so
+            # leaving the rewrite in place made `--access-log` report
+            # `GET /index.html` for a request to `/` (and
+            # `GET /about/index.html` for `/about/`) — an access log that no
+            # longer matches what the browser asked for is useless for
+            # correlating with the browser's own network panel. BasePathHandler
+            # already restores its own strip for exactly this reason; without a
+            # mount point nothing was undoing this rewrite.
+            context.request.path = path
           end
-          fs_path = Path[@public_dir, sanitized]
+          return
+        end
 
-          # Verify resolved path is within public_dir.
-          # Only attempt realpath if the path exists on disk; otherwise skip
-          # the redirect entirely so non-existent traversal paths cannot
-          # bypass the boundary check (realpath returns nil for missing paths).
-          public_real = begin
-            File.realpath(@public_dir)
-          rescue File::Error
-            @public_dir
-          end
-          resolved = if File.exists?(fs_path.to_s)
-                       begin
-                         File.realpath(fs_path)
-                       rescue File::Error
-                         nil
-                       end
+        # No extname pre-filter here: deciding by extension 404'd every
+        # directory with a dot in its last segment (/docs/v1.2, /node.js)
+        # because stdlib's StaticFileHandler only appends the trailing
+        # slash when directory_listing is on. What's on disk decides.
+        #
+        # Resolve strictly (see DevPath) to prevent directory traversal and
+        # separator smuggling before filesystem access. A nil result is a
+        # path we refuse to route; an empty one is the output root itself,
+        # which must not produce `Location: //`.
+        sanitized = DevPath.safe_relative(path)
+        if sanitized.nil? || sanitized.empty?
+          call_next(context)
+          return
+        end
+        fs_path = Path[@public_dir, sanitized]
+
+        # Verify resolved path is within public_dir.
+        # Only attempt realpath if the path exists on disk; otherwise skip
+        # the redirect entirely so non-existent traversal paths cannot
+        # bypass the boundary check (realpath returns nil for missing paths).
+        public_real = begin
+          File.realpath(@public_dir)
+        rescue File::Error
+          @public_dir
+        end
+        resolved = if File.exists?(fs_path.to_s)
+                     begin
+                       File.realpath(fs_path)
+                     rescue File::Error
+                       nil
                      end
-          if resolved && (resolved == public_real || resolved.starts_with?(public_real + "/")) && Dir.exists?(resolved)
-            # 302, not 301: browsers cache permanent redirects per URL, so a
-            # 301 would keep redirecting to a section long after a rebuild
-            # removed or renamed it (or after a different project reuses the
-            # port) until the user clears their browser cache.
-            context.response.status_code = 302
-            # Build the Location from the already-resolved path to prevent
-            # CRLF injection and path traversal in the redirect target, then
-            # re-encode it: resolution decodes, so `/my page` would otherwise
-            # emit a raw space (and `/한글` raw UTF-8) into the header, which
-            # is not a valid URI reference. Keep the query string — /search?q=term
-            # must land on /search/?q=term, not an empty-query page. (A
-            # request-line query can't contain CR/LF.)
-            location = "/" + DevPath.encode_relative(sanitized) + "/"
-            if (query = context.request.query) && !query.empty?
-              location += "?#{query}"
-            end
-            context.response.headers["Location"] = location
-            return
+                   end
+        if resolved && (resolved == public_real || resolved.starts_with?(public_real + "/")) && Dir.exists?(resolved)
+          # 302, not 301: browsers cache permanent redirects per URL, so a
+          # 301 would keep redirecting to a section long after a rebuild
+          # removed or renamed it (or after a different project reuses the
+          # port) until the user clears their browser cache.
+          context.response.status_code = 302
+          # Build the Location from the already-resolved path to prevent
+          # CRLF injection and path traversal in the redirect target, then
+          # re-encode it: resolution decodes, so `/my page` would otherwise
+          # emit a raw space (and `/한글` raw UTF-8) into the header, which
+          # is not a valid URI reference. Keep the query string — /search?q=term
+          # must land on /search/?q=term, not an empty-query page. (A
+          # request-line query can't contain CR/LF.)
+          location = "/" + DevPath.encode_relative(sanitized) + "/"
+          if (query = context.request.query) && !query.empty?
+            location += "?#{query}"
           end
+          context.response.headers["Location"] = location
+          return
         end
 
         call_next(context)
@@ -1099,17 +1114,7 @@ module Hwaro
         # so a port-conflict error produced misleading output that looked
         # like the server was running before the final `Error: Could not
         # bind …` line.
-        begin
-          server.bind_tcp host, port
-        rescue ex : Socket::BindError
-          # Socket::BindError#message already includes the address, so
-          # use it verbatim rather than re-prefixing.
-          raise Hwaro::HwaroError.new(
-            code: Hwaro::Errors::HWARO_E_IO,
-            message: ex.message || "Could not bind to '#{host}:#{port}'",
-            hint: "Is another process already listening on this port? Try -p/--port with a different value.",
-          )
-        end
+        bind_dev_server(server, host, port)
 
         url = serve_url(host, port, base_path)
         # Calm serve receipt: where it's live, reload state, what's watched,
@@ -1245,6 +1250,37 @@ module Hwaro
           )
           raise classified
         end
+      end
+
+      # Bind the dev server's listening socket, classifying every way that can
+      # fail. Extracted from `run_with_options` so specs can drive the real
+      # bind without standing up a whole serve session.
+      #
+      # `bind_tcp` does TWO things: it resolves `host`, then binds. Only the
+      # second half raises `Socket::BindError` — a `-b/--bind` value the
+      # resolver cannot answer for (a typo'd hostname, `-b 300.1.1.1`) raises
+      # `Socket::Addrinfo::Error`, which fell straight through the old
+      # BindError-only rescue and reached the user as a bare, code-less
+      # `Error: Hostname lookup for 300.1.1.1 failed: No address found` with no
+      # hint and nothing naming the flag that produced it.
+      protected def bind_dev_server(server : HTTP::Server, host : String, port : Int32)
+        server.bind_tcp host, port
+      rescue ex : Socket::BindError
+        # Socket::BindError#message already includes the address, so
+        # use it verbatim rather than re-prefixing.
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_IO,
+          message: ex.message || "Could not bind to '#{host}:#{port}'",
+          hint: "Is another process already listening on this port? Try -p/--port with a different value.",
+        )
+      rescue ex : Socket::Error
+        # Resolution failures and anything else the socket layer reports.
+        # `host` is only ever the `-b/--bind` value, so the hint can name it.
+        raise Hwaro::HwaroError.new(
+          code: Hwaro::Errors::HWARO_E_USAGE,
+          message: "Could not bind to '#{host}:#{port}': #{ex.message}",
+          hint: "Check -b/--bind: pass an address this machine holds (127.0.0.1, 0.0.0.0, ::1) or a hostname it can resolve.",
+        )
       end
 
       # Path component of `base_url`, mirroring `Models::Config#base_path`


### PR DESCRIPTION
Two `hwaro serve` defects found by dogfooding the dev server for ~90 minutes: the docs site plus three `hwaro init` scaffolds (simple, blog + multilingual `en,ko`, subpath mount), edited live while curling the served URLs.

## Bug 1 — `--access-log` reported a path the client never sent

**Symptom.** With `hwaro serve --access-log`, every directory request was logged as its index file:

```
GET /index.html HTTP/1.1 - 200        # the browser asked for /
GET /about/index.html HTTP/1.1 - 200  # the browser asked for /about/
GET /?q=1  →  GET /index.html?q=1
```

The access log therefore could not be lined up with the browser's own network panel — which is the one thing an access log is for.

**Root cause.** `IndexRewriteHandler` (`src/services/server/server.cr:36`) does `context.request.path += "index.html"` so `HTTP::StaticFileHandler` can find the file, and never puts the request back. `HTTP::LogHandler` sits outermost and reads `request.resource` in an `ensure` **after** `call_next` returns, so it observes the rewrite. `HTTP::Request#path=` mutates the shared `URI`, and `#resource` is derived from it.

The repo already fixed exactly this for the other path-mutating handler — `BasePathHandler` restores `context.request.path = path` after `call_next` with a comment naming `--access-log` — so with a `--base-url` subpath mount the log was already correct. Without a mount, nothing was undoing this rewrite.

**Fix.** Rewrite, `call_next`, and restore in an `ensure`. The query string rides along on the same `URI`, so `/?q=1` logs as `/?q=1`. Downstream handlers still see `/index.html`; only the outbound view changes.

**Specs.** `spec/functional/serve_access_log_spec.cr` (new) binds the real `Server#build_handlers` chain with a probe handler in `HTTP::LogHandler`'s position and asserts what it observes after `call_next`. `spec/unit/server_spec.cr` had an example asserting the *old* behaviour (`request.path.should eq("/some/path/index.html")` after `call`); it now asserts the real contract — the downstream handler sees the index file, the request is restored on the way out.

## Bug 2 — an unusable `-b/--bind` value escaped the CLI unclassified

**Symptom.**

```
$ hwaro serve -b 300.1.1.1
...
built: 4 content pages in 22ms
Error: Hostname lookup for 300.1.1.1 failed: No address found
```

A bare `Error: ` line — no `HWARO_E_*` code, no hint, and nothing naming the flag that produced it. Compare the port-conflict path, which is fully classified.

**Root cause.** `HTTP::Server#bind_tcp` does two things: it resolves `host`, then binds. Only the bind half raises `Socket::BindError`, and that was the only exception `run_with_options` rescued. A host the resolver cannot answer for (a typo'd hostname, `-b 300.1.1.1`) raises `Socket::Addrinfo::Error`, which is a `Socket::Error` but **not** a `BindError`, so it fell through to the generic CLI handler.

**Fix.** Bind now goes through a new `Server#bind_dev_server`, which keeps the `Socket::BindError` → `HWARO_E_IO` branch verbatim and adds a `Socket::Error` branch → `HWARO_E_USAGE` with a hint that names `-b/--bind`:

```
Error [HWARO_E_USAGE]: Could not bind to '300.1.1.1:4399': Hostname lookup for 300.1.1.1 failed: No address found
Check -b/--bind: pass an address this machine holds (127.0.0.1, 0.0.0.0, ::1) or a hostname it can resolve.
```

**Specs.** `spec/functional/serve_bind_error_spec.cr` (new): one CLI-level example driving `bin/hwaro serve -b 300.1.1.1` in a temp site (this is the one that compiles against pre-fix sources), plus two seam examples covering both branches.

## Proven to fail pre-fix

`git show origin/main:src/services/server/server.cr > src/services/server/server.cr`, `shards build`, then:

- `spec/functional/serve_access_log_spec.cr` — 2 of 3 examples fail: `Expected: ["/", "/about/"] got: ["/index.html", "/about/index.html"]` and `Expected: ["/?q=hwaro+serve"] got: ["/index.html?q=hwaro+serve"]`.
- `serve_bind_error_spec.cr`'s CLI example (run standalone, since the seam it also exercises does not exist on `origin/main`) — fails with `Expected: "…Error: Hostname lookup for 300.1.1.1 failed: No address found\n" to include: "Error [HWARO_E_USAGE]"`.
- `spec/unit/server_spec.cr` — the updated example fails on `origin/main` code the other way round (`dummy.seen_path` / restored `request.path`).

Restored, rebuilt, all green.

## Byte-identity

Built a `blog` scaffold and a copy of `docs/` with the `origin/main` binary and with this one, `diff -r` on both `public/` trees: **no differences**. Both changes are dev-server-only.

## Verification

`crystal tool format` clean, `bin/ameba` clean (526 files, 0 failures), `crystal spec` green (8377 examples, 0 failures). Post-fix smoke test on a live serve session: access log now reports `/`, `/about/`, `/nope`, `/robots.txt`, `/css/main.css` verbatim, and live-reload rebuild on a content edit still lands.

## Docs

`docs/content/start/cli.md` + `.ko.md`: the `--access-log` row now states that each line reports the path the browser requested.

## Out-of-lane findings (not fixed — other workers own these files)

1. **Template error location is off by one line.** `src/core/build/phases/render.cr` / the Crinja error-location renderer. Repro: a `templates/index.html` whose line 1 is empty and line 2 is `{% for x in %}` reports `templates/index.html:1:2 .. 1:16` and paints the caret on a phantom line between 1 and 2; the tag is on line 2. Seen via `[Watch] Build failed:` during a serve session.

## Verified clean during the sweep (no defect found)

Path traversal (`curl --path-as-is` with `..`, `..%2f`, backslashes, `%00`, `%zz`, 3 000-char and 300-segment paths), HEAD/GET framing and `Content-Length` parity, Range requests (206 on static, whole-body on injected HTML by design), malformed `Content-Length` → 400, `OPTIONS`/CORS origin reflection, WebSocket handshake origin checks (101 same-origin with and without the mount prefix, 403 for a foreign or missing `Origin`), unicode/CJK/emoji paths and their redirect encoding, dotfiles, directories named `*.html`, directories without an index, `--base-url` subpath mounting end-to-end (root/prefix redirects, feeds, search index, lazy OG images), `--port`/`-b` validation, `-i` on a missing directory, mid-write partial frontmatter, broken template → fix → recovery, broken `config.toml` → fix → recovery, content delete/rename/section-rename/whole-`content/`-removal and restore, static add/change/delete, data and i18n edits, `[sass]` compile including `@use` partial dependencies, shortcode template edits, and a 25-second idle watch with no spurious rebuild.
