### PR TITLE
fix(config): validate pwa.display; docs stop recommending slugify for taxonomy links

### DIFF
--- a/docs/content/features/pwa.ko.md
+++ b/docs/content/features/pwa.ko.md
@@ -38,7 +38,7 @@ cache_strategy = "cache-first"
 | short_name | string | name | 홈 화면용 짧은 이름 |
 | theme_color | string | "#ffffff" | 브라우저 툴바/상태 표시줄 색상 |
 | background_color | string | "#ffffff" | 스플래시 화면 배경색 |
-| display | string | "standalone" | 표시 모드 |
+| display | string | "standalone" | 표시 모드: `fullscreen`, `standalone`, `minimal-ui`, `browser` 중 하나 (알 수 없는 값은 `standalone`으로 대체) |
 | start_url | string | "/" | 앱 실행 시 열리는 URL |
 | icons | array | [] | 아이콘 파일 경로 |
 | offline_page | string | — | 오프라인일 때 보여줄 폴백 페이지 |

--- a/docs/content/features/pwa.md
+++ b/docs/content/features/pwa.md
@@ -38,7 +38,7 @@ cache_strategy = "cache-first"
 | short_name | string | name | Short name for home screen |
 | theme_color | string | "#ffffff" | Browser toolbar / status bar color |
 | background_color | string | "#ffffff" | Splash screen background color |
-| display | string | "standalone" | Display mode |
+| display | string | "standalone" | Display mode: `fullscreen`, `standalone`, `minimal-ui` or `browser` (an unknown value falls back to `standalone`) |
 | start_url | string | "/" | URL when the app launches |
 | icons | array | [] | Icon file paths |
 | offline_page | string | — | Fallback page when offline |

--- a/docs/content/writing/taxonomies.ko.md
+++ b/docs/content/writing/taxonomies.ko.md
@@ -220,11 +220,13 @@ tech = ["crystal", "security"]
 {% if page.tags %}
 <div class="post-tags">
 {% for tag in page.tags %}
-  <a href="/tags/{{ tag | slugify }}/">{{ tag }}</a>
+  <a href="{{ get_taxonomy_url(kind="tags", term=tag) }}">{{ tag }}</a>
 {% endfor %}
 </div>
 {% endif %}
 ```
+
+`{{ tag | slugify }}` 대신 `get_taxonomy_url()`(또는 `get_taxonomy()`의 `term.slug`)을 사용하세요. 두 용어가 같은 슬러그로 충돌하면(`Crystal`과 `crystal`) 생성기는 `/tags/crystal/`과 `/tags/crystal-2/`를 만드는데, 어느 쪽이 어느 용어인지는 함수만 알고 있습니다.
 
 ### 카테고리 내비게이션
 

--- a/docs/content/writing/taxonomies.md
+++ b/docs/content/writing/taxonomies.md
@@ -230,11 +230,13 @@ Generate taxonomy term URL:
 {% if page.tags %}
 <div class="post-tags">
 {% for tag in page.tags %}
-  <a href="/tags/{{ tag | slugify }}/">{{ tag }}</a>
+  <a href="{{ get_taxonomy_url(kind="tags", term=tag) }}">{{ tag }}</a>
 {% endfor %}
 </div>
 {% endif %}
 ```
+
+Use `get_taxonomy_url()` (or `term.slug` from `get_taxonomy()`) rather than `{{ tag | slugify }}`: when two terms collide on a slug (`Crystal` and `crystal`), the generator writes `/tags/crystal/` and `/tags/crystal-2/`, and only the function knows which is which.
 
 ### Category Navigation
 

--- a/spec/unit/config_spec.cr
+++ b/spec/unit/config_spec.cr
@@ -3008,4 +3008,21 @@ describe "Hwaro::Models::Config" do
       end
     end
   end
+
+  describe "[pwa] display" do
+    it "accepts every Web App Manifest display mode" do
+      %w[fullscreen standalone minimal-ui browser].each do |mode|
+        config = load_config(%(title = "x"\nbase_url = "https://example.com"\n\n[pwa]\nenabled = true\ndisplay = "#{mode}"\n))
+        config.pwa.display.should eq(mode)
+      end
+    end
+
+    # A typo used to flow straight into manifest.json, where browsers
+    # silently fall back to `browser`. Coerce with a warning, like
+    # `cache_strategy` already does, so the manifest stays valid.
+    it "falls back to standalone on an unknown display mode" do
+      config = load_config(%(title = "x"\nbase_url = "https://example.com"\n\n[pwa]\nenabled = true\ndisplay = "weird"\n))
+      config.pwa.display.should eq("standalone")
+    end
+  end
 end

--- a/spec/unit/doctor_spec.cr
+++ b/spec/unit/doctor_spec.cr
@@ -208,6 +208,23 @@ describe Hwaro::Services::Doctor do
         end
       end
 
+      # Same shape for `pwa.display`: the manifest `display` member has four
+      # valid values and browsers silently fall back to `browser` on
+      # anything else, so a typo shipped a broken manifest with no signal.
+      it "warns on invalid pwa.display when pwa enabled" do
+        config = base_config(%(\n[pwa]\nenabled = true\ndisplay = "weird"\n))
+        issues = run_doctor(config)
+        issues.any? { |i| i.id == "pwa-display-invalid" && i.message.includes?("weird") }.should be_true
+      end
+
+      it "does not warn on valid pwa.display values" do
+        ["fullscreen", "standalone", "minimal-ui", "browser"].each do |display|
+          config = base_config(%(\n[pwa]\nenabled = true\ndisplay = "#{display}"\n))
+          issues = run_doctor(config)
+          issues.any?(&.id.==("pwa-display-invalid")).should be_false
+        end
+      end
+
       # `[deployment].target` selects which `[[deployment.targets]]`
       # block `hwaro deploy` uses. Pointing at an undefined name fails
       # at runtime; surfacing it here saves an actual deploy attempt.

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -991,6 +991,10 @@ module Hwaro
       property cache_strategy : String
 
       VALID_STRATEGIES = %w[cache-first network-first stale-while-revalidate]
+      # Web App Manifest `display` members. Anything else makes browsers
+      # silently fall back to `browser`, so an unknown value is coerced (with
+      # a warning) the same way `cache_strategy` is.
+      VALID_DISPLAYS = %w[fullscreen standalone minimal-ui browser]
 
       def initialize
         @enabled = false
@@ -2630,7 +2634,13 @@ module Hwaro
         config.pwa.short_name = s["short_name"]?.try(&.as_s?)
         config.pwa.theme_color = s["theme_color"]?.try(&.as_s?) || config.pwa.theme_color
         config.pwa.background_color = s["background_color"]?.try(&.as_s?) || config.pwa.background_color
-        config.pwa.display = s["display"]?.try(&.as_s?) || config.pwa.display
+        if display = s["display"]?.try(&.as_s?)
+          if PwaConfig::VALID_DISPLAYS.includes?(display)
+            config.pwa.display = display
+          else
+            Logger.warn "Unknown pwa.display '#{display}', using 'standalone'"
+          end
+        end
         config.pwa.start_url = s["start_url"]?.try(&.as_s?) || config.pwa.start_url
         config.pwa.offline_page = s["offline_page"]?.try(&.as_s?)
         if icons = s["icons"]?.try(&.as_a?)

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -109,7 +109,7 @@ module Hwaro
           CheckSpec.new("languages (default_language resolves)",
             ["default-language-undefined"]),
           CheckSpec.new("markdown / pwa (valid enums)",
-            ["markdown-math-engine-invalid", "pwa-cache-strategy-invalid"]),
+            ["markdown-math-engine-invalid", "pwa-cache-strategy-invalid", "pwa-display-invalid"]),
           CheckSpec.new("image processing (widths set)",
             ["image-processing-widths-empty"]),
           CheckSpec.new("deployment / related (refs resolve)",
@@ -859,6 +859,16 @@ module Hwaro
           unless Models::PwaConfig::VALID_STRATEGIES.includes?(raw_strategy)
             issues << Issue.new(id: "pwa-cache-strategy-invalid", level: :warning, category: "config", file: @config_path,
               message: "pwa.cache_strategy \"#{raw_strategy}\" is not supported (expected: #{Models::PwaConfig::VALID_STRATEGIES.join(", ")})")
+          end
+        end
+        # Same shape for `display`: `Config.load` coerces an unknown value
+        # back to "standalone" with a build-time warning, so read the raw
+        # TOML value here too. Before this check a typo (`display = "weird"`)
+        # was invisible to doctor while browsers silently fell back.
+        if raw_pwa && (raw_display = raw_pwa["display"]?.try(&.as_s?))
+          unless Models::PwaConfig::VALID_DISPLAYS.includes?(raw_display)
+            issues << Issue.new(id: "pwa-display-invalid", level: :warning, category: "config", file: @config_path,
+              message: "pwa.display \"#{raw_display}\" is not supported (expected: #{Models::PwaConfig::VALID_DISPLAYS.join(", ")})")
           end
         end
 


### PR DESCRIPTION
Two small wave-1 follow-ups (scaffold and templates lanes reported them; coordinator-authored).

## 1. `pwa.display` validation

**Symptom.** `[pwa] display = "weird"` → `hwaro doctor` reports nothing, `hwaro build` writes `"display":"weird"` into `manifest.json`, browsers silently fall back to `browser`. Its sibling `cache_strategy` was already validated in both places.

**Fix.** `Models::PwaConfig::VALID_DISPLAYS = fullscreen | standalone | minimal-ui | browser`; the loader coerces an unknown value to `standalone` with `[WARN] Unknown pwa.display 'weird', using 'standalone'` (same shape as `cache_strategy`); doctor emits `pwa-display-invalid` (warning, config category) from the raw TOML value and the id is registered in `CHECK_GROUPS` under "markdown / pwa (valid enums)". `docs/content/features/pwa.md` + `.ko.md` list the valid values.

Verified on a scaffold:
```
$ hwaro doctor
  [warn] config.toml: pwa.display "weird" is not supported (expected: fullscreen, standalone, minimal-ui, browser)
$ hwaro build && grep -o '"display":"[a-z-]*"' public/manifest.json
"display":"standalone"
```

**Specs.** `spec/unit/doctor_spec.cr` (warns on invalid / does not warn on the four valid values) and `spec/unit/config_spec.cr` (accepts all four / falls back to standalone). The "warns on invalid" and "falls back" examples **fail on origin/main**; the two valid-value examples are guards that pass both ways by design.

## 2. Taxonomy link docs

`docs/content/writing/taxonomies.md:233` (and `.ko.md`) recommended `<a href="/tags/{{ tag | slugify }}/">`. With slug-colliding terms (`Crystal`, `crystal`) the generator writes `/tags/crystal/` and `/tags/crystal-2/`, so the documented pattern mislinks one of them. The example now uses `{{ get_taxonomy_url(kind="tags", term=tag) }}` with a one-line explanation, bilingual. Grepped `docs/content/**` and `src/services/scaffolds/**`: no other `| slugify` taxonomy-link pattern exists.

## Also checked

The templates lane asked whether any doc promises `{{ p.content }}` on pages iterated in a listing (it renders empty — `page_crinja_value` exposes `summary` but not `content`). No doc does; the only `page.content` mentions are in `streaming-build.md` and describe the generate-phase fallback accurately. Left as-is.

## Verification

`crystal spec spec/unit/{doctor,config,pwa}_spec.cr` green; `crystal tool format --check` clean; ameba clean on the touched files. No build-output change for valid configs (the loader branch only fires on an unknown value); the docs site output changes only in the two edited taxonomies pages.
