### PR TITLE
feat(markdown): admonition custom titles and tables inside blockquotes

### DIFF
--- a/docs/content/writing/pages.ko.md
+++ b/docs/content/writing/pages.ko.md
@@ -364,9 +364,14 @@ GitHub 스타일 알림 블록(admonition)이 스타일이 적용된 콜아웃�
 > [!WARNING]
 >
 > Body can also live in its own paragraph.
+
+> [!TIP] 커스텀 제목
+> 마커와 같은 줄에 적은 텍스트는 제목이 됩니다(Obsidian / Hugo 문법).
 ```
 
-출력은 `<div class="admonition admonition-{type}">`이며, 제목 문단(`<p class="admonition-title">`) 뒤에 본문이 이어집니다. 스타일은 사이트 CSS에서 지정합니다 — Hwaro는 시맨틱 마크업만 내보냅니다.
+출력은 `<div class="admonition admonition-{type}">`이며, 제목 문단(`<p class="admonition-title">`) 뒤에 본문이 이어집니다. 커스텀 제목이 없으면 타입 이름(`Note`, `Tip`, …)이 제목으로 쓰입니다. 스타일은 사이트 CSS에서 지정합니다 — Hwaro는 시맨틱 마크업만 내보냅니다.
+
+어드모니션과 일반 인용문 안에서도 테이블을 쓸 수 있습니다. 평소처럼 각 행 앞에 `>`를 붙이면 됩니다(`> | a | b |`, `> |---|---|`).
 
 `config.toml`의 `[markdown]` 아래에 `admonitions = false`를 두면 비활성화됩니다.
 

--- a/docs/content/writing/pages.md
+++ b/docs/content/writing/pages.md
@@ -363,9 +363,14 @@ GitHub-style alert blocks render as styled callouts. Recognised types: `NOTE`, `
 > [!WARNING]
 >
 > Body can also live in its own paragraph.
+
+> [!TIP] Custom title
+> Text after the marker on the same line becomes the title (Obsidian / Hugo syntax).
 ```
 
-The output is a `<div class="admonition admonition-{type}">` with a title paragraph (`<p class="admonition-title">`) followed by the body. Style it from your CSS — Hwaro emits semantic markup only.
+The output is a `<div class="admonition admonition-{type}">` with a title paragraph (`<p class="admonition-title">`) followed by the body. Without a custom title the type name is used (`Note`, `Tip`, …). Style it from your CSS — Hwaro emits semantic markup only.
+
+Tables work inside admonitions and plain blockquotes: prefix every row with `>` as usual (`> | a | b |`, `> |---|---|`).
 
 Disable by setting `admonitions = false` under `[markdown]` in `config.toml`.
 

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -660,6 +660,47 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
       result.should eq(html)
     end
+
+    # Regression: text after the marker on the same line (`> [!NOTE] Custom
+    # Title`, Obsidian / Hugo syntax) was swallowed into the first body
+    # paragraph under the default "Note" heading.
+    it "uses text on the marker line as the title" do
+      html = "<blockquote>\n<p>[!NOTE] Custom <em>Title</em>\nBody here.</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title">Custom <em>Title</em></p>))
+      result.should contain("<p>Body here.</p>")
+      result.should_not contain("Custom <em>Title</em>\nBody")
+    end
+
+    it "uses a custom title with a separate-paragraph body" do
+      html = "<blockquote>\n<p>[!WARNING] Read me</p>\n<p>Body paragraph</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title">Read me</p>))
+      result.should contain("<p>Body paragraph</p>")
+    end
+
+    it "supports a custom title with no body" do
+      html = "<blockquote>\n<p>[!TIP] Only a title</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title">Only a title</p>))
+      result.should_not contain("<blockquote>")
+    end
+
+    it "accepts and drops Obsidian fold markers" do
+      html = "<blockquote>\n<p>[!TIP]+ Folded\nbody</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title">Folded</p>))
+      html = "<blockquote>\n<p>[!TIP]-\nbody</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title">Tip</p>))
+      result.should contain("<p>body</p>")
+    end
+
+    it "keeps the default title for a bare marker with trailing spaces" do
+      html = "<blockquote>\n<p>[!NOTE]   \nbody</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title">Note</p>))
+    end
   end
 
   describe "heading ids" do

--- a/spec/unit/table_parser_spec.cr
+++ b/spec/unit/table_parser_spec.cr
@@ -808,6 +808,30 @@ describe Hwaro::Content::Processors::TableParser do
       out.should_not contain("<table")
     end
 
+    # Regression: the parser only ever saw unprefixed lines, so a GFM table
+    # inside a blockquote — which is how every admonition body is written —
+    # stayed a paragraph of literal pipes (and smart punctuation then turned
+    # its `|---|---|` row into em dashes).
+    it "converts a table inside a single-level blockquote and keeps it quoted" do
+      md = "> intro\n> | a | b |\n> |---|---|\n> | 1 | 2 |"
+      out = Hwaro::Content::Processors::TableParser.process(md)
+      out.should contain("> <table>")
+      out.should contain("> <td>1</td>")
+      out.each_line(chomp: true, &.should(start_with(">")))
+    end
+
+    it "ends the quoted table's HTML block so a following quoted paragraph is still markdown" do
+      md = "> | a | b |\n> |---|---|\n> | 1 | 2 |\n> after **bold**"
+      out = Hwaro::Content::Processors::TableParser.process(md)
+      out.should contain("> </table>\n>\n> after **bold**")
+    end
+
+    it "leaves a nested `> >` quote's pipes to the paragraph path" do
+      md = "> > | a | b |\n> > |---|---|\n> > | 1 | 2 |"
+      out = Hwaro::Content::Processors::TableParser.process(md)
+      out.should_not contain("<table")
+    end
+
     it "does not convert a 4-space-indented table example after a blank line" do
       # CommonMark renders this as an indented code block, not a table.
       md = "Example:\n\n    | a | b |\n    |---|---|\n    | 1 | 2 |"

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -992,11 +992,20 @@ module Hwaro
         ADMONITION_TYPES = {"NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"}
 
         # Captures a blockquote whose first paragraph starts with `[!TYPE]`.
-        # Group 1: type token (uppercased). Group 2: the rest of the blockquote
-        # body, possibly starting with `</p>` (when the marker was on its own
-        # paragraph) or with the inline body content (when the marker shared a
-        # paragraph with body text via a soft break).
-        ADMONITION_BLOCKQUOTE_RE = /<blockquote>\s*<p>\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*(.*?)<\/blockquote>/m
+        # Group 1: type token (uppercased). Group 2: whatever else sat on the
+        # marker's own line — the custom title (Obsidian / Hugo syntax:
+        # `> [!NOTE] Custom Title`); empty for a bare marker. Group 3: the rest
+        # of the blockquote body, possibly starting with `</p>` (when the
+        # marker line was a paragraph of its own) or with the inline body
+        # content (when body text followed the marker via a soft break).
+        #
+        # Group 2 stops at the line break, so a same-line title can never be
+        # confused with a soft-broken body. It used to be `\s*(.*?)`, which
+        # swallowed the title into the first body paragraph — `Custom Title`
+        # rendered as body text under the default "Note" heading. Obsidian's
+        # optional fold marker (`[!NOTE]+` / `[!NOTE]-`) is accepted and
+        # dropped; folding itself is not modeled.
+        ADMONITION_BLOCKQUOTE_RE = /<blockquote>\s*<p>\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][+-]?([^\n]*?)(?:\n|(?=<\/p>))\s*(.*?)<\/blockquote>/m
 
         # Post-processing: rewrite GitHub `> [!TYPE]` blockquotes as admonition divs.
         # Note: the lazy match against `</blockquote>` means a nested blockquote
@@ -1007,9 +1016,12 @@ module Hwaro
 
           html.gsub(ADMONITION_BLOCKQUOTE_RE) do |_|
             type = $1
-            rest = $2
+            custom_title = $2.strip
+            rest = $3
             type_lower = type.downcase
-            type_title = type[0].to_s + type[1..].downcase
+            # The custom title is already inline-rendered (and escaped) by
+            # markd — it was part of the paragraph — so it is emitted as-is.
+            type_title = custom_title.empty? ? type[0].to_s + type[1..].downcase : custom_title
 
             body = if rest.lstrip.starts_with?("</p>")
                      # Marker was alone on its paragraph; remaining content

--- a/src/content/processors/table_parser.cr
+++ b/src/content/processors/table_parser.cr
@@ -147,6 +147,41 @@ module Hwaro
               next
             end
 
+            # A table inside a single-level blockquote (`> | a | b |`), which is
+            # also how every admonition body is written. The parser only ever
+            # saw unprefixed lines, so a quoted table stayed a paragraph — and
+            # with smart_punctuation on, its `|---|---|` delimiter row was
+            # rewritten to em dashes on top. Strip the marker, parse the run
+            # of quoted lines as an ordinary table, and re-prefix the emitted
+            # HTML so it stays inside the quote.
+            # (FenceTracker already understands quoted fences — `> ```` — so a
+            # verbatim example inside a quote never reaches this branch.)
+            if quote = blockquote_prefix(lines[i])
+              inner = strip_blockquote(lines[i])
+              if table_row?(inner) && i + 1 < lines.size &&
+                 blockquote_prefix(lines[i + 1]) && separator_row?(strip_blockquote(lines[i + 1]))
+                quoted = [] of String
+                j = i
+                while j < lines.size && blockquote_prefix(lines[j])
+                  quoted << strip_blockquote(lines[j])
+                  j += 1
+                end
+                table, consumed = parse_table(quoted, 0)
+                if table
+                  table.to_html(flags: effective, hooks: hooks).each_line(chomp: true) do |html_line|
+                    result << "#{quote}#{html_line}"
+                  end
+                  # A `<table>` starts a type-6 HTML block that runs until a
+                  # blank line; the bare marker is a blank line inside the
+                  # quote, so a quoted paragraph right after the table is
+                  # parsed as markdown instead of being swallowed verbatim.
+                  result << quote.rstrip
+                  i += consumed
+                  next
+                end
+              end
+            end
+
             # Check if this could be the start of a table
             if table_row?(lines[i]) && i + 1 < lines.size && separator_row?(lines[i + 1])
               # Try to parse the table
@@ -165,6 +200,21 @@ module Hwaro
           result.join("\n")
         end
 
+        # The blockquote marker of a single-level quote line: up to three
+        # spaces of indentation, `>`, and the optional following space
+        # (CommonMark's block quote marker). Nil for anything else — including
+        # a nested `> >` quote, whose inner content is left to the paragraph
+        # path as before.
+        BLOCKQUOTE_PREFIX_RE = /\A {0,3}> ?/
+
+        private def blockquote_prefix(line : String) : String?
+          BLOCKQUOTE_PREFIX_RE.match(line).try(&.[0])
+        end
+
+        private def strip_blockquote(line : String) : String
+          line.sub(BLOCKQUOTE_PREFIX_RE, "")
+        end
+
         # Quick check if content might contain tables.
         # Detects the separator row pattern which is the definitive marker of a
         # markdown table (e.g. `|---|---|` or `---|---`).  This avoids false
@@ -176,7 +226,10 @@ module Hwaro
         # paragraph of literal pipes — the plain `|---|---|` form happened to
         # clear the bar, so the bug only showed up once an author added
         # alignment.
-        TABLE_SEPARATOR_CHECK = /^\s*\|?\s*:?-+:?\s*\|/m
+        # The optional `> ` lets a table quoted inside a blockquote (or an
+        # admonition body) past this gate; `process` then parses it through
+        # `blockquote_prefix`.
+        TABLE_SEPARATOR_CHECK = /^\s*(?:> ?)?\s*\|?\s*:?-+:?\s*\|/m
 
         def has_table?(content : String) : Bool
           TABLE_SEPARATOR_CHECK.matches?(content)


### PR DESCRIPTION
Wave-2 follow-up on two gaps the wave-1 markdown worker recorded but did not fix (coordinator-authored; the "custom title" behaviour was a product decision: Obsidian/Hugo parity).

## 1. `> [!NOTE] Custom Title`

**Before:** `<p class="admonition-title">Note</p>` with `Custom Title\nBody here.` as the first body paragraph.
**After:** `<p class="admonition-title">Custom Title</p>` then `<p>Body here.</p>`. A bare `> [!NOTE]` keeps `Note`. The title is whatever markd already inline-rendered on the marker line (so `**bold**` titles work and escaping is markd's). Obsidian's fold markers `[!NOTE]+` / `[!NOTE]-` are accepted and dropped (folding is not modeled).

`ADMONITION_BLOCKQUOTE_RE` now captures the marker line's remainder as its own group that stops at the line break, so a same-line title can never be confused with a soft-broken body — the previous `\s*(.*?)` is exactly what merged them.

## 2. Tables inside blockquotes / admonitions

**Before:**
```markdown
> [!WARNING]
> | a | b |
> |---|---|
> | 1 | 2 |
```
rendered the table rows as a paragraph of literal pipes; with `smart_punctuation = true` the delimiter row became `|—|—|`.

**After:** a real `<table>` inside the admonition (or plain blockquote), alignment included. `TableParser.process` strips a single-level `> ` marker from a run of quoted lines, parses it as an ordinary table, re-emits the HTML line-by-line with the marker, and appends a bare `>` so the `<table>` HTML block (type 6, runs until a blank line) ends before the next quoted paragraph — `> After table **bold**.` still renders as markdown. `has_table?`'s gate regex accepts the quoted delimiter row (it rejected `> |---|` outright, which is why the branch was never reached at first). FenceTracker already understands `> ```` fences, so the existing "does not convert a table example inside a blockquoted fence" spec still passes; nested `> >` quotes are left to the paragraph path.

Rendered probe (simple scaffold):
```html
<div class="admonition admonition-warning">
<p class="admonition-title">Warning</p>
<table>…<td>1</td><td>2</td>…</table>
<p>After table <strong>bold</strong>.</p>
</div>
```

## Docs

`docs/content/writing/pages.md` + `.ko.md`: custom-title example and a line on quoted tables.

## Verification

- 9 new examples (`spec/unit/table_parser_spec.cr` ×3, `spec/unit/markdown_extensions_spec.cr` ×6); **6 fail on origin/main** (the nested-`> >` guard, the trailing-spaces guard and the `[!TIP]-` half of the fold-marker example pass both ways by design).
- Byte-identity against an origin/main binary: `docs/` **0 diffs**, blog scaffold **0 diffs** (neither uses a same-line title or a quoted table).
- `crystal spec`: 8458 examples, 0 failures. `crystal tool format --check` clean, ameba clean on the touched files.
