### PR TITLE
fix(review): configure forwarded modules from the importer's globals on @import (#773 review)

### DIFF
--- a/spec/unit/sass/import_forward_config_spec.cr
+++ b/spec/unit/sass/import_forward_config_spec.cr
@@ -1,0 +1,168 @@
+require "../../spec_helper"
+require "../../../src/assets/sass"
+require "file_utils"
+
+# `@import` of a sheet that `@forward`s modules: the importing file's
+# globals configure the forwarded modules' `!default` variables (dart-sass
+# "implicit configuration"), and the members land in the importing SCOPE.
+#
+# Regression guard for the fix in #773: binding the forwarded members into
+# the importer's root after loading the module unconfigured overwrote the
+# importer's own `$btn-pad: 99px` with the module's `8px !default` — the
+# classic "set the variables, then @import the library" pattern lost its
+# overrides. Every expectation here was verified against dart-sass 1.103.
+
+private def with_sass_tree(files : Hash(String, String), &)
+  dir = File.tempname("hwaro-sass-import-config")
+  Dir.mkdir_p(dir)
+  begin
+    files.each do |rel, body|
+      path = File.join(dir, rel)
+      Dir.mkdir_p(File.dirname(path))
+      File.write(path, body)
+    end
+    yield dir
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end
+
+private def compile_entry(files : Hash(String, String)) : String
+  with_sass_tree(files) do |dir|
+    entry = File.join(dir, "entry.scss")
+    return Hwaro::Assets::Sass.compile(File.read(entry), path: entry, root: dir)
+  end
+end
+
+private FORWARDING_INDEX = {
+  "components/_index.scss"  => %(@forward "button";\n),
+  "components/_button.scss" => %($btn-pad: 8px !default;\n$btn-pad2: $btn-pad * 2 !default;\n@mixin btn { padding: $btn-pad; }\n),
+}
+
+describe "Sass @import of a forwarding partial: importer globals configure !default" do
+  it "keeps a global the importer set before the import (the override pattern)" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %($btn-pad: 99px;\n@import "components";\n.z { padding: $btn-pad; @include btn; }\n),
+    }))
+    css.should contain("padding: 99px;\n  padding: 99px;")
+    css.should_not contain("8px")
+  end
+
+  it "feeds the configured value into derived !default declarations" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %($btn-pad: 10px;\n@import "components";\n.z { padding: $btn-pad $btn-pad2; }\n),
+    }))
+    css.should contain("padding: 10px 20px;")
+  end
+
+  it "still takes the module default when the importer set nothing" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %(@import "components";\n.z { padding: $btn-pad $btn-pad2; }\n),
+    }))
+    css.should contain("padding: 8px 16px;")
+  end
+
+  it "does not let an importer global override an unguarded module assignment" do
+    css = compile_entry({
+      "components/_index.scss"  => %(@forward "button";\n),
+      "components/_button.scss" => %($btn-pad: 8px;\n),
+      "entry.scss"              => %($btn-pad: 99px;\n@import "components";\n.z { padding: $btn-pad; }\n),
+    })
+    css.should contain("padding: 8px;")
+  end
+
+  it "treats a null importer global as unset" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %($btn-pad: null;\n@import "components";\n.z { padding: $btn-pad; }\n),
+    }))
+    css.should contain("padding: 8px;")
+  end
+
+  it "strips a forward prefix before configuring the module" do
+    css = compile_entry({
+      "components/_index.scss"  => %(@forward "button" as btn-*;\n),
+      "components/_button.scss" => %($pad: 8px !default;\n@mixin box { padding: $pad; }\n),
+      "entry.scss"              => %($btn-pad: 99px;\n@import "components";\n.z { @include btn-box; }\n),
+    })
+    css.should contain("padding: 99px;")
+  end
+
+  it "does not configure a variable the forward hides" do
+    css = compile_entry({
+      "components/_index.scss"  => %(@forward "button" hide $pad;\n),
+      "components/_button.scss" => %($pad: 8px !default;\n@mixin box { padding: $pad; }\n),
+      "entry.scss"              => %($pad: 99px;\n@import "components";\n.z { @include box; }\n),
+    })
+    css.should contain("padding: 8px;")
+  end
+
+  it "passes the configuration through a chain of forwards" do
+    css = compile_entry({
+      "lib/_index.scss"       => %(@forward "inner";\n),
+      "lib/inner/_index.scss" => %(@forward "vars";\n),
+      "lib/inner/_vars.scss"  => %($size: 1px !default;\n),
+      "entry.scss"            => %($size: 77px;\n@import "lib";\n.z { width: $size; }\n),
+    })
+    css.should contain("width: 77px;")
+  end
+
+  it "never configures a module the imported sheet reaches through @use" do
+    css = compile_entry({
+      "lib/_index.scss" => %(@use "vars";\n.lib { width: vars.$size; }\n),
+      "lib/_vars.scss"  => %($size: 1px !default;\n),
+      "entry.scss"      => %($size: 77px;\n@import "lib";\n.z { width: $size; }\n),
+    })
+    css.should contain(".lib {\n  width: 1px;")
+    css.should contain(".z {\n  width: 77px;")
+  end
+
+  it "silently keeps an already-loaded module's configuration" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %(@use "components/button" with ($btn-pad: 5px);\n@import "components";\n.z { padding: $btn-pad; }\n),
+    }))
+    css.should contain("padding: 5px;")
+  end
+
+  it "does not reconfigure on a second import after the importer reassigned the variable" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %(@import "components";\n$btn-pad: 42px;\n@import "components";\n.z { padding: $btn-pad; }\n),
+    }))
+    css.should contain("padding: 42px;")
+  end
+
+  it "configures from the enclosing module's globals when the import sits inside a @use'd module" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "_theme.scss" => %($btn-pad: 33px;\n@import "components";\n.m { padding: $btn-pad; }\n),
+      "entry.scss"  => %(@use "theme";\n.z { padding: theme.$btn-pad; }\n),
+    }))
+    css.should contain(".m {\n  padding: 33px;")
+    css.should contain(".z {\n  padding: 33px;")
+  end
+end
+
+describe "Sass @import of a forwarding partial: members bind into the importing scope" do
+  it "scopes members of a nested import to the enclosing block" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %(.wrap { @import "components"; .z { padding: $btn-pad; @include btn; } }\n),
+    }))
+    css.should contain(".wrap .z {\n  padding: 8px;\n  padding: 8px;")
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /undefined variable/) do
+      compile_entry(FORWARDING_INDEX.merge({
+        "entry.scss" => %(.wrap { @import "components"; }\n.after { padding: $btn-pad; }\n),
+      }))
+    end
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /undefined mixin/) do
+      compile_entry(FORWARDING_INDEX.merge({
+        "entry.scss" => %(.wrap { @import "components"; }\n.after { @include btn; }\n),
+      }))
+    end
+  end
+
+  it "shadows an importer global inside the block without touching it outside" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %($btn-pad: 50px;\n.wrap { @import "components"; .z { padding: $btn-pad; } }\n.after { padding: $btn-pad; }\n),
+    }))
+    css.should contain(".wrap .z {\n  padding: 50px;")
+    css.should contain(".after {\n  padding: 50px;")
+  end
+end

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -137,6 +137,12 @@ module Hwaro
           @forward_variables = {} of String => String
           @forward_mixins = {} of String => MixinClosure
           @forward_functions = {} of String => SassFn
+          # The importing file's globals while a classic `@import` is being
+          # evaluated — dart-sass's "implicit configuration". A `@forward`
+          # reached through the import configures its module's `!default`
+          # variables from it (see `forward_config`); nil outside an import
+          # and inside any `@use` (which never inherits it).
+          @import_config = nil.as(Hash(String, String)?)
           # @extend requests, applied document-wide as a post-pass —
           # deliberately NOT saved/restored around module loads.
           @extends = [] of Extend::Request
@@ -1661,19 +1667,26 @@ module Hwaro
 
         # Loads (or returns the cached) module for a @use/@forward url.
         # `sass:` urls resolve to the built-in modules.
+        #
+        # `implicit` marks a configuration that came from an importing
+        # file's globals rather than a `with (...)` clause (see
+        # `@import_config`). dart-sass applies such a configuration only to
+        # the names the module declares with `!default`, never errors on
+        # names it does not declare, and silently ignores it when the
+        # module was already loaded — an explicit `with` does all three.
         private def load_module(url : String, line : Int32, column : Int32,
-                                config : Hash(String, String)) : SassModule
+                                config : Hash(String, String), implicit : Bool = false) : SassModule
           if url.starts_with?("sass:")
             name = url.lchop("sass:")
             mod = BUILTIN_MODULES[name]?
             error_at(line, column, "unknown built-in module \"sass:#{name}\"") unless mod
-            error_at(line, column, "built-in modules can't be configured") unless config.empty?
+            error_at(line, column, "built-in modules can't be configured") unless config.empty? || implicit
             return mod
           end
 
           canonical, source = @importer.load(url, @path, @path, line, column)
           if mod = @loaded_modules[canonical]?
-            unless config.empty?
+            unless config.empty? || implicit
               error_at(line, column,
                 "#{@importer.display_path(canonical)} was already loaded and can't be configured a second time")
             end
@@ -1683,7 +1696,19 @@ module Hwaro
           check_cycle(canonical, line, column)
           display = @importer.display_path(canonical)
           sheet = Parser.parse(source, display)
-          validate_configurable(sheet, config, url, line, column) unless config.empty?
+          seed = config
+          if implicit
+            # Only `!default` declarations consume an implicit configuration;
+            # a name the module assigns unconditionally keeps its own value.
+            # The unfiltered configuration still travels on through this
+            # module's own `@forward`s (a forwarding index declares nothing
+            # itself), so filter the seed, not `config`.
+            defaults = Set(String).new
+            collect_default_decls(sheet.children, defaults)
+            seed = config.select { |name, _| defaults.includes?(name) }
+          elsif !config.empty?
+            validate_configurable(sheet, config, url, line, column)
+          end
 
           saved_env = @env
           saved_sink = @sink
@@ -1697,9 +1722,14 @@ module Hwaro
           saved_fwd_vars = @forward_variables
           saved_fwd_mixins = @forward_mixins
           saved_fwd_fns = @forward_functions
+          saved_import_config = @import_config
+          # A `@forward` inside this module passes the implicit configuration
+          # on (dart-sass `Configuration#throughForward`); a `@use` starts
+          # from nothing, even when reached through an import.
+          @import_config = implicit ? config : nil
 
           module_env = Environment.new
-          config.each { |name, value| module_env.variables[name] = value }
+          seed.each { |name, value| module_env.variables[name] = value }
           module_sink = [] of Css::Node
           @env = module_env
           @sink = module_sink
@@ -1735,6 +1765,7 @@ module Hwaro
             @forward_variables = saved_fwd_vars
             @forward_mixins = saved_fwd_mixins
             @forward_functions = saved_fwd_fns
+            @import_config = saved_import_config
           end
 
           @loaded_modules[canonical] = mod
@@ -1789,8 +1820,9 @@ module Hwaro
         # current module's re-exports. Members do NOT enter local scope.
         # show/hide match the *prefixed* names (dart-sass semantics).
         private def eval_forward(node : Ast::ForwardNode) : Nil
-          mod = load_module(node.url, node.line, node.column, {} of String => String)
           prefix = node.prefix
+          config = forward_config(node, prefix)
+          mod = load_module(node.url, node.line, node.column, config, implicit: !config.empty?)
           mod.variables.each do |name, value|
             exported = prefix ? prefix + name : name
             next unless forward_visible?(node, "$" + exported)
@@ -1806,6 +1838,36 @@ module Hwaro
             next unless forward_visible?(node, exported)
             @forward_functions[exported] = fn
           end
+        end
+
+        # The importing file's globals that reach the module behind this
+        # `@forward` (dart-sass `Configuration#throughForward`): only the
+        # names this rule shows, with its prefix stripped so `$btn-pad`
+        # configures `$pad` behind `@forward "button" as btn-*`. Empty
+        # outside a classic `@import` — a `@use`d forwarding index is never
+        # configured by its user's globals.
+        #
+        # Without this, `$btn-pad: 99px; @import "components";` — the
+        # classic "set the variables, then import the library" pattern —
+        # lost the override: the forwarded module was loaded unconfigured,
+        # its `$btn-pad: 8px !default` took the default, and
+        # `bind_imported_forwards` then wrote that default over the
+        # importer's own value. dart-sass keeps 99px.
+        private def forward_config(node : Ast::ForwardNode, prefix : String?) : Hash(String, String)
+          config = {} of String => String
+          globals = @import_config
+          return config unless globals
+          globals.each do |name, value|
+            next if value == "null"
+            next unless forward_visible?(node, "$" + name)
+            if prefix
+              next unless name.starts_with?(prefix) && name.size > prefix.size
+              config[name[prefix.size..]] = value
+            else
+              config[name] = value
+            end
+          end
+          config
         end
 
         private def forward_visible?(node : Ast::ForwardNode, marker_name : String) : Bool
@@ -1902,35 +1964,46 @@ module Hwaro
           fwd_vars_before = @forward_variables.dup
           fwd_mixins_before = @forward_mixins.dup
           fwd_fns_before = @forward_functions.dup
+          saved_import_config = @import_config
+          # dart-sass "implicit configuration": the importer's globals, as
+          # they stand when the import runs, configure the `!default`
+          # variables of every module the imported sheet `@forward`s.
+          @import_config = @env.root.variables.dup
           begin
             # Classic import: evaluated inline in the current scope/sink.
             eval_nodes(sheet.children)
           ensure
             @load_stack.pop
             @path = saved_path
+            @import_config = saved_import_config
           end
           bind_imported_forwards(fwd_vars_before, fwd_mixins_before, fwd_fns_before)
         end
 
         # Bind members newly staged by `@forward`s inside a classic `@import`
-        # into the importing file's root scope. Only additions/changes are
-        # bound, so a `@forward` the importing file wrote itself (staged
-        # before this import ran) is left alone.
+        # into the importing scope. Only additions/changes are bound, so a
+        # `@forward` the importing file wrote itself (staged before this
+        # import ran) is left alone.
+        #
+        # The CURRENT scope, not the root: a nested import (`.wrap { @import
+        # "components"; }`) scopes its members to the block in dart-sass,
+        # exactly as this evaluator already scopes the variables of a plain
+        # nested import. Binding to the root leaked `$btn-pad` to rules
+        # after the block that dart-sass rejects as undefined.
         private def bind_imported_forwards(vars_before : Hash(String, String),
                                            mixins_before : Hash(String, MixinClosure),
                                            fns_before : Hash(String, SassFn)) : Nil
-          scope = @env.root
           @forward_variables.each do |name, value|
             next if vars_before[name]? == value
-            scope.variables[name] = value
+            @env.assign_var(name, value, default: false, global: false)
           end
           @forward_mixins.each do |name, closure|
             next if mixins_before[name]? == closure
-            scope.mixins[name] = closure
+            @env.declare_mixin(name, closure)
           end
           @forward_functions.each do |name, fn|
             next if fns_before[name]? == fn
-            scope.functions[name] = fn
+            @env.declare_function(name, fn)
           end
         end
 


### PR DESCRIPTION
Adversarial review of #770, #772, #773 and #774 (merged to main today). Every PR's regression specs were re-run against the pre-fix sources (only the touched `src/` files reverted, in a scratch tree, never `git stash`): all of them fail pre-fix as claimed (#770: 6/7 + 1 + 1, #772: 1 + compile error + compile error + 2F/1E, #773: 8F/2E + 1 + 3 + compile error, #774: 2 + compile error + 1). One CONFIRMED regression, fixed here; everything else was refuted with evidence below.

## Confirmed: #773 `bind_imported_forwards` clobbers the importer's overrides

**Symptom.** The classic "set the variables, then `@import` the library" pattern lost its overrides after #773. Real site (`[sass] enabled = true`, `static/css/theme.scss`):

```scss
// components/_index.scss:  @forward "button";
// components/_button.scss: $btn-pad: 8px !default; .btn { padding: $btn-pad; }
$btn-pad: 99px;
@import "components";
.z { padding: $btn-pad; }
```

| binary | `theme.css` |
|---|---|
| pre-#773 (a643eebe) | `.btn{padding:8px}.z{padding:99px}` |
| main (post-#773) | `.btn{padding:8px}.z{padding:8px}` — author's 99px gone |
| dart-sass 1.103 | `.btn{padding:99px}.z{padding:99px}` |
| this branch | `.btn{padding:99px}.z{padding:99px}` |

**Root cause.** `src/assets/sass/evaluator.cr` `eval_forward` loaded the forwarded module unconfigured, so `$btn-pad: 8px !default` took the default; `bind_imported_forwards` then wrote that default straight over `@env.root.variables["btn-pad"]`. dart-sass passes the importing file's globals to every module a `@forward`ed sheet reaches as an *implicit configuration* (`Configuration#throughForward`), consumed only by `!default` declarations. Same failure for a derived default (`$btn-pad2: $btn-pad * 2 !default` gives `16px` instead of `20px`), a prefixed forward (`as btn-*`), a forward chain, and an import inside a `@use`d module.

**Fix.** `eval_import` snapshots the importer's globals into `@import_config`; `eval_forward` derives the configuration for the module it loads (show/hide honoured, prefix stripped, nulls skipped); `load_module(..., implicit: true)` seeds only names the module declares with `!default`, never errors on unknown names, passes the unfiltered configuration on through nested `@forward`s, silently ignores it for an already-loaded module, and drops it on `@use`. Members are bound into the importing *scope* (`@env`) rather than the root, so a nested `.wrap { @import "components"; }` no longer leaks `$btn-pad` to later rules — dart-sass rejects those as undefined, and this evaluator already scoped a plain nested import's variables that way.

**Spec.** `spec/unit/sass/import_forward_config_spec.cr` — 14 examples, every expectation verified against dart-sass 1.103 via `npx sass`; **7 fail on main** (override, derived default, prefix, chain, import-inside-module, nested scope, nested shadow). Differential corpus of 25 cases (top-level/nested/mixin/@if imports, `!default` vs unguarded, prefix, hide, chain, `@use` inside import, already-loaded module, second import after reassignment, null global): every case now matches dart-sass except the ones dart rejects outright (`@import` inside `@mixin`/`@if`) and two pre-existing, out-of-scope deviations noted below.

## Refuted (evidence)

**#770**
- *Feed gating false positives via cascade / config / multilingual.* `generate_feeds` is not in `CASCADABLE_KEYS` (`parse_content.cr:472`); a parent `[cascade] generate_feeds = true` warns "not cascadable" and writes nothing. `feeds.cr:83` is the only per-section writer and reads only `Section#generate_feeds` (front matter). Built a blog site with TOML/YAML/JSON/CRLF-TOML/`yes`-YAML section indexes and a cascade parent: check-links reported dead exactly the four feeds the build did not write (`nosec`, `parent`, `parent/child`, `posts`) and passed the six it wrote, including `/tags/writing/rss.xml` (taxonomy leniency, pre-existing). All three front-matter branches of `frontmatter_flag?` work.
- *Platform escaping.* `netlify.toml`/`wrangler.toml` for `dist`, `my site`, `it's`, `out/sub`, `a"b`, `back\slash` all parse with the `toml` shard and round-trip the exact value; `vercel.json` via `json.load`; `.gitlab-ci.yml` via Ruby `YAML.safe_load` (`pages.publish` present only when non-default; `it's`/`a"b`/`$x` quoted); codeberg `cd 'my site'` / `cd 'it'\''s'` parse to one shell word. `github-pages` output unchanged for every value.

**#772**
- `enable_json_mode!` before parse: success/`-j`/non-empty-dir/unknown-scaffold/`--list-scaffolds`/`--quiet`/no-path all emit exactly one JSON document on stdout; the `--include-multilingual en,en` warnings go to stderr. The wizard is disabled under `--json` (`Logger.quiet?` gate), so nothing prompts. `--title --json` is rejected as "Invalid option: --title" (pre-existing parser behaviour).
- `sanitize_url_segment` fuzz: 2000 random mixed unicode/punctuation/space/hyphen strings against the verbatim pre-fix implementation: 388 differences, **0 unexplained** by hyphen-run collapse / `-.` cleanup / end-strip, and 0 outputs containing `--`. `titleize` on `한글-제목`, `émoji-test`, `ǆ-x`, `ß-y` equals the old inline expression.
- `Scaffolds::Registry.all`: scaffolds define no `initialize`, registration happens at require time, and the registry was already linked via `init_command`; `doctor.cr` requiring it builds without a cycle.

**#773**
- `unquote_list_interp` on 19 interpolation shapes (nested lists, bracketed, slash-separated, quoted commas, trailing spaces, `list.join`, mixed quotes): identical to dart-sass except two **pre-existing** deviations that #773 neither introduced nor claims (`#{("a", null, "b")}` via the verbatim path keeps `null`; unquoted `#{("a ", " b")}` collapses one inner space).
- `map.deep-remove` with a missing intermediate key: hwaro leaves the map untouched, dart-sass 1.103 inserts `zz: null` (`_modify` quirk). The PR's "dart-sass semantics" claim is wrong on that edge, but the function did not exist before, so nothing regressed.
- PWA: an SVG icon emits `{"sizes":"any","type":"image/svg+xml"}` (well-formed; `type` was always emitted). OG: a `--cache` build on top of a pre-#773 warm cache regenerates the PNGs exactly once (hash changes on the first warm build, stable on the next two); a 400x300 logo measures 48x36 centred at (80,536) in the PNG.

**#774**
- Live `--access-log`: `/`, `/about` (302), `/about/`, `/?q=1`, `/dir.v1` (302), `/nope/` (404) are logged verbatim; live-reload is still injected on `/`. `StaticFileHandler` and the inject handler read `request.path` before `call_next` and never mutate it.
- `-b 300.1.1.1` and `-b nonexistent.invalid` give `HWARO_E_USAGE` plus the hint (pre: bare `Error:`); `-b 203.0.113.9` and a port conflict still give `HWARO_E_IO`; `::1`, `0.0.0.0` and `-b ""` bind as before.

## Byte-identity

- a643eebe binary vs main: docs/ differs only in `og-images/.og_manifest.json` `config_hash` (#773, documented) and the multi-backtick code-span cells from #771; blog differs only in the same #771 code-span cell (post, feeds, search.json); simple/docs/book/bare identical.
- main binary vs this branch: docs/ and all five scaffolds **0 diff lines**.

## Verification

`crystal spec`: 8468 examples, 0 failures; `crystal tool format --check` clean; ameba clean on the touched files.
