### PR TITLE
fix: 27 review follow-ups on today's merges (#767-#780)

### DIFF
--- a/docs/content/start/tools/doctor.ko.md
+++ b/docs/content/start/tools/doctor.ko.md
@@ -191,6 +191,7 @@ ignore = [
 | `default-language-undefined` | config | default_language에 대응하는 `[languages.<code>]` 없음 |
 | `markdown-math-engine-invalid` | config | 지원하지 않는 markdown.math_engine |
 | `pwa-cache-strategy-invalid` | config | 지원하지 않는 pwa.cache_strategy |
+| `pwa-display-invalid` | config | 지원하지 않는 pwa.display |
 | `image-processing-widths-empty` | config | image_processing이 켜져 있으나 widths가 비어 있음 (무음 no-op) |
 | `deployment-target-undefined` | config | deployment.target에 대응하는 `[[deployment.targets]]` 없음 |
 | `related-taxonomy-undefined` | config | `[related]`가 정의되지 않은 택소노미를 참조 |

--- a/docs/content/start/tools/doctor.md
+++ b/docs/content/start/tools/doctor.md
@@ -195,6 +195,7 @@ Rows marked ✗ are error level and **cannot** be ignored.
 | `default-language-undefined` | config | default_language has no `[languages.<code>]` block |
 | `markdown-math-engine-invalid` | config | Unsupported markdown.math_engine |
 | `pwa-cache-strategy-invalid` | config | Unsupported pwa.cache_strategy |
+| `pwa-display-invalid` | config | Unsupported pwa.display |
 | `image-processing-widths-empty` | config | image_processing enabled but widths is empty (silent no-op) |
 | `deployment-target-undefined` | config | deployment.target names no `[[deployment.targets]]` |
 | `related-taxonomy-undefined` | config | `[related]` references an undefined taxonomy |

--- a/spec/functional/build_output_dir_guard_spec.cr
+++ b/spec/functional/build_output_dir_guard_spec.cr
@@ -325,6 +325,49 @@ describe "build: output directory that already holds unrelated files" do
     end
   end
 
+  # Ownership was recorded only on non-incremental builds, so a `dist/` that
+  # `build --cache` had just CREATED was never recorded: every later cold
+  # build warned "entries hwaro did not write" about hwaro's own files and
+  # kept the stale ones forever.
+  it "records a directory it created on a --cache build so the next cold build clears it" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        guard_project(dir)
+        run_build_cached("dist").should be_true
+        File.write("dist/stale.html", "stale")
+
+        log = with_captured_log { run_build("dist").should be_true }
+
+        File.exists?("dist/stale.html").should be_false
+        log.should_not contain("did not write")
+      end
+    end
+  end
+
+  it "still never hands over a pre-existing directory on a --cache build" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        guard_project(dir)
+        FileUtils.mkdir_p("shared")
+        File.write("shared/notes.txt", "keep")
+        run_build_cached("shared").should be_true
+        log = with_captured_log { run_build("shared").should be_true }
+        File.read("shared/notes.txt").should eq("keep")
+        log.should contain("did not write")
+      end
+    end
+  end
+
+  it "leaves no .hwaro/ workspace behind for the conventional public/ directory" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        guard_project(dir)
+        run_build("public").should be_true
+        Dir.exists?(".hwaro").should be_false
+      end
+    end
+  end
+
   it "clears a directory it found empty on an earlier build" do
     Dir.mktmpdir do |dir|
       Dir.cd(dir) do

--- a/spec/functional/cache_generate_outputs_spec.cr
+++ b/spec/functional/cache_generate_outputs_spec.cr
@@ -132,6 +132,30 @@ describe "cache: generated outputs converge on the clean build" do
     end
   end
 
+  # Feeds never join the Generate skip while a user feed template exists, so
+  # an all-hit warm build regenerates rss.xml from `page.content` — which
+  # nothing hydrated: the feed carried raw shortcode markup again.
+  it "hydrates cache hits on a warm all-hit build when a user feed template forces feed regeneration" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        shortcode_project
+        File.write("templates/rss.xml.jinja", "<feed>{% for p in pages %}<item>{{ p.content }}</item>{% endfor %}</feed>")
+        clean_build
+        expected = File.read("public/rss.xml")
+        expected.should contain("<div class=\"gal\">")
+        expected.should contain("http://localhost/sub/")
+        expected.should_not contain("{%")
+
+        FileUtils.rm_rf("public")
+        FileUtils.rm_rf(".hwaro_cache.json")
+        run_builder(true, false) # cold
+        File.read("public/rss.xml").should eq(expected)
+        run_builder(true, false) # warm, every page a cache hit
+        File.read("public/rss.xml").should eq(expected)
+      end
+    end
+  end
+
   # `serve` keeps the Builder alive and regenerates search/feeds from the
   # in-memory page set after every edit. A `serve --cache` whose start was
   # an all-hit build had every page's content empty, so the first

--- a/spec/functional/cli_tool_subcommands_spec.cr
+++ b/spec/functional/cli_tool_subcommands_spec.cr
@@ -292,6 +292,9 @@ describe "hwaro tool ci" do
       # Co-signal: the actual workflow content was also generated to stdout,
       # confirming the deprecation log didn't short-circuit the command.
       output.should contain("workflow")
+      # The spacer under the notice belongs to stderr too: `--stdout >
+      # deploy.yml` must not start the file with a blank line.
+      output.should_not start_with("\n")
     end
   end
 end

--- a/spec/functional/edge_cases_spec.cr
+++ b/spec/functional/edge_cases_spec.cr
@@ -734,6 +734,42 @@ describe "Edge Cases: Duplicate output path detection" do
     log.should contain("Not publishing posts/traversal.md")
   end
 
+  # The section feed and the taxonomy term feed/page only deduped by URL, so
+  # the traversal page's UNIQUE `/posts/../../escape/` still rode into
+  # `posts/rss.xml`, `tags/t/rss.xml` and the term listing.
+  it "keeps a refused page out of section feeds, taxonomy feeds and term pages" do
+    with_captured_log do
+      build_site(
+        <<-TOML,
+          title = "Test Site"
+          base_url = "http://localhost"
+          [feeds]
+          enabled = true
+          [[taxonomies]]
+          name = "tags"
+          feed = true
+          TOML
+        content_files: {
+          "posts/_index.md"    => "---\ntitle: Posts\ngenerate_feeds: true\n---\n",
+          "posts/ok.md"        => "---\ntitle: Ok\ntags: [t]\n---\nOK-BODY",
+          "posts/traversal.md" => "---\ntitle: Traversal\ntags: [t]\nslug: ../../escape\n---\nESCAPE-BODY",
+        },
+        template_files: {
+          "page.html"          => "{{ content }}",
+          "section.html"       => "{{ content }}",
+          "taxonomy.html"      => "{{ content }}",
+          "taxonomy_term.html" => "{{ content }}",
+        },
+      ) do
+        section_feed = File.read("public/posts/rss.xml")
+        section_feed.should contain("Ok")
+        section_feed.should_not contain("escape")
+        File.read("public/tags/t/rss.xml").should_not contain("escape")
+        File.read("public/tags/t/index.html").should_not contain("escape")
+      end
+    end
+  end
+
   # A Markdown link destination cannot hold a raw space, so a page whose slug
   # has one rendered as `- [T](http://localhost/posts/custom slug/)` — not a
   # link at all. The sitemap already percent-encoded; llms.txt and the alias

--- a/spec/functional/serve_bind_error_spec.cr
+++ b/spec/functional/serve_bind_error_spec.cr
@@ -76,6 +76,19 @@ describe "hwaro serve bind failures" do
     error.hint.to_s.should contain("-b/--bind")
   end
 
+  # An address that resolves but this machine does not hold fails INSIDE
+  # bind (EADDRNOTAVAIL) — a `Socket::BindError` like port-in-use, which used
+  # to get the "another process is listening" hint. 192.0.2.1 is TEST-NET-1,
+  # never assigned to a real interface.
+  it "classifies an address this machine does not hold as a --bind usage error" do
+    error = expect_raises(Hwaro::HwaroError) do
+      Hwaro::Services::Server.new.bind_error_bind(bind_error_probe_server, "192.0.2.1", 0)
+    end
+    error.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+    error.hint.to_s.should contain("-b/--bind")
+    error.hint.to_s.should_not contain("--port")
+  end
+
   it "still classifies a port already in use as an IO error" do
     taken = TCPServer.new("127.0.0.1", 0)
     port = taken.local_address.port

--- a/spec/functional/template_error_location_spec.cr
+++ b/spec/functional/template_error_location_spec.cr
@@ -166,7 +166,7 @@ describe "Template error location reporting" do
 
     err.code.should eq(Hwaro::Errors::HWARO_E_TEMPLATE)
     message = err.message.not_nil!
-    message.should contain("step must not be zero")
+    message.should contain("step must be a non-zero integer")
     message.should contain("templates/page.html:3:")
   end
 
@@ -188,5 +188,54 @@ describe "Template error location reporting" do
     message = err.message.not_nil!
     message.should contain("templates/page.html:2:1")
     message.should_not contain("templates/page.html:1:")
+  end
+end
+
+# Review follow-ups on #775: the located-error wrap covered filters, tests and
+# calls, but not operators, and `Crinja::TemplateNotFoundError` inherits
+# `Exception` so a missing include/extends target escaped every rescue.
+describe "Template error location: operators and missing templates" do
+  it "locates a division by zero in a binary expression" do
+    err = expect_raises(Hwaro::HwaroError) do
+      build_site(
+        BASIC_CONFIG,
+        content_files: {"index.md" => "---\ntitle: Home\n---\nhello"},
+        template_files: {"page.html" => "<html>\n\n{{ 10 // 0 }}\n</html>"},
+      ) { }
+    end
+
+    err.code.should eq(Hwaro::Errors::HWARO_E_TEMPLATE)
+    message = err.message.not_nil!
+    message.should contain("Division by 0")
+    message.should contain("templates/page.html:3:")
+  end
+
+  it "locates a missing {% include %} target at the referencing tag" do
+    err = expect_raises(Hwaro::HwaroError) do
+      build_site(
+        BASIC_CONFIG,
+        content_files: {"index.md" => "---\ntitle: Home\n---\nhello"},
+        template_files: {"page.html" => "<html>\n\n{% include \"missing.html\" %}\n</html>"},
+      ) { }
+    end
+
+    err.code.should eq(Hwaro::Errors::HWARO_E_TEMPLATE)
+    message = err.message.not_nil!
+    message.should contain("missing.html")
+    message.should contain("templates/page.html:3:")
+  end
+
+  it "prints a wrapped cause once, not as message plus cause" do
+    err = expect_raises(Hwaro::HwaroError) do
+      build_site(
+        BASIC_CONFIG,
+        content_files: {"index.md" => "---\ntitle: Home\n---\nhello"},
+        template_files: {"page.html" => "<html>\n\n{{ [1, 2] | slice(0) }}\n</html>"},
+      ) { }
+    end
+
+    message = err.message.not_nil!
+    message.should contain("Division by 0")
+    message.should_not contain("cause: Division by 0")
   end
 end

--- a/spec/unit/builder_shortcode_spec.cr
+++ b/spec/unit/builder_shortcode_spec.cr
@@ -25,6 +25,11 @@ module Hwaro::Core::Build
       render_shortcode_jinja(template, args, context, crinja_env_override: crinja_env_override, warnings: warnings)
     end
 
+    def test_control_tag_open?(tag : String) : Bool
+      m = BLOCK_OPEN_RE.match(tag) || raise "#{tag.inspect} does not match BLOCK_OPEN_RE"
+      control_tag_open?(m)
+    end
+
     def test_warn_hugo_shortcode_syntax(raw, path)
       warn_hugo_shortcode_syntax(raw, path)
     end
@@ -1145,5 +1150,40 @@ describe Hwaro::Core::Build::Builder do
       end
       io.to_s.should be_empty
     end
+  end
+end
+
+describe "Jinja control tags with parenthesized expressions" do
+  # `{% if (a and b) or (c) %}` matches BLOCK_OPEN_RE's `name(...)` branch, and
+  # the classifier used to take any parenthesized form for a shortcode call.
+  # The blog scaffold's post.html carries exactly that condition, so every
+  # build of it logged a bogus "Block shortcode '{% if %}' is never closed".
+  it "classifies a keyword with a parenthesized condition as a Jinja control tag" do
+    builder = Hwaro::Core::Build::Builder.new
+    builder.test_control_tag_open?("{% if (page.lower and page.lower.section == page.section) or (page.higher) %}").should be_true
+    builder.test_control_tag_open?("{% if (x and (y or z)) %}").should be_true
+    builder.test_control_tag_open?("{% elif (a) %}").should be_true
+    builder.test_control_tag_open?("{% if(a) or (b) %}").should be_true
+    builder.test_control_tag_open?("{% endif %}").should be_true
+  end
+
+  it "still classifies a keyword-named shortcode in call syntax as a shortcode" do
+    builder = Hwaro::Core::Build::Builder.new
+    builder.test_control_tag_open?("{% include(name=\"promo\") %}").should be_false
+    builder.test_control_tag_open?("{% include(name=\"promo\", kind=\"(x)\") %}").should be_false
+    builder.test_control_tag_open?("{% include(label=\"a) b\") %}").should be_false
+    builder.test_control_tag_open?("{% if-banner(type=\"i\") %}").should be_false
+    builder.test_control_tag_open?("{% note() %}").should be_false
+  end
+
+  it "leaves a parenthesized Jinja if-expression alone and still expands a later block shortcode" do
+    builder = Hwaro::Core::Build::Builder.new
+    env = Crinja.new
+    templates = {"shortcodes/note" => "<div class=\"note\">{{ body }}</div>"}
+    context = {} of String => Crinja::Value
+
+    content = "{% if (page.lower and page.lower.section == page.section) or (page.higher) %}nav{% endif %}\n{% note() %}Body{% end %}"
+    result = builder.test_process_shortcodes_jinja(content, templates, context, crinja_env_override: env)
+    result.should eq("{% if (page.lower and page.lower.section == page.section) or (page.higher) %}nav{% endif %}\n<div class=\"note\">Body</div>")
   end
 end

--- a/spec/unit/deadlink_regression_spec.cr
+++ b/spec/unit/deadlink_regression_spec.cr
@@ -18,6 +18,14 @@ class Hwaro::CLI::Commands::Tool::DeadlinkCommand
   def translation_language_codes_for_test(config : Hwaro::Models::Config?) : Array(String)
     translation_language_codes(config)
   end
+
+  def routes_for_test(config : Hwaro::Models::Config?) : GeneratedRoutes
+    generated_routes(config)
+  end
+
+  def resolve_with_routes_for_test(links : Array(Link), content_dir : String, routes : GeneratedRoutes) : Array(Result)
+    check_internal_links(links, content_dir, [] of String, "", [] of String, routes)
+  end
 end
 
 describe "check-links regressions" do
@@ -233,6 +241,57 @@ describe "check-links regressions" do
         cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
         cmd.scan_internal_for_test(dir).should be_empty
       end
+    end
+  end
+end
+
+# Section feeds are gated by the section's own `generate_feeds` and always
+# written as rss.xml/atom.xml (see Seo::Feeds); the checker used to key them
+# on the ROOT feed's `enabled` flag and `filename`.
+private def feed_link(dir : String, url : String)
+  Hwaro::CLI::Commands::Tool::DeadlinkCommand::Link.new(file: File.join(dir, "index.md"), url: url, kind: :internal)
+end
+
+describe "check-links section feed routes" do
+  it "accepts /<section>/rss.xml when the section opts in even though the root feed is disabled" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "posts"))
+      File.write(File.join(dir, "posts", "_index.md"), "---\ntitle: Posts\ngenerate_feeds: true\n---\n")
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = false
+
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      routes = cmd.routes_for_test(config)
+      cmd.resolve_with_routes_for_test([feed_link(dir, "/posts/rss.xml")], dir, routes).should be_empty
+      # The root feed really is off.
+      cmd.resolve_with_routes_for_test([feed_link(dir, "/rss.xml")], dir, routes).should_not be_empty
+    end
+  end
+
+  it "keeps section feeds at rss.xml when the root feed uses a custom filename" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "posts"))
+      File.write(File.join(dir, "posts", "_index.md"), "---\ntitle: Posts\ngenerate_feeds: true\n---\n")
+      config = Hwaro::Models::Config.new
+      config.feeds.enabled = true
+      config.feeds.filename = "feed.xml"
+
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      routes = cmd.routes_for_test(config)
+      cmd.resolve_with_routes_for_test([feed_link(dir, "/feed.xml")], dir, routes).should be_empty
+      cmd.resolve_with_routes_for_test([feed_link(dir, "/posts/rss.xml")], dir, routes).should be_empty
+      cmd.resolve_with_routes_for_test([feed_link(dir, "/posts/feed.xml")], dir, routes).should_not be_empty
+    end
+  end
+
+  it "still rejects a section feed for a section that did not opt in" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "posts"))
+      File.write(File.join(dir, "posts", "_index.md"), "---\ntitle: Posts\n---\n")
+      config = Hwaro::Models::Config.new
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      routes = cmd.routes_for_test(config)
+      cmd.resolve_with_routes_for_test([feed_link(dir, "/posts/rss.xml")], dir, routes).should_not be_empty
     end
   end
 end

--- a/spec/unit/filters_spec.cr
+++ b/spec/unit/filters_spec.cr
@@ -1485,3 +1485,12 @@ describe "now() function" do
     ex.message.not_nil!.should contain("invalid date format")
   end
 end
+
+describe "first/last filters on undefined input" do
+  # `{{ get_section(path='nope').pages | first }}` or a missing
+  # `page.extra.images | first`: Jinja2 iterates an Undefined as nothing, so
+  # `first` yields Undefined instead of a fatal TypeError.
+  it "returns undefined instead of raising when the target is undefined" do
+    render_filter("<{{ nope | first }}|{{ nope | last }}>").should eq("<|>")
+  end
+end

--- a/spec/unit/initializer_spec.cr
+++ b/spec/unit/initializer_spec.cr
@@ -52,9 +52,9 @@ describe Hwaro::Services::Initializer do
           Hwaro::Services::Initializer.new.run(target)
 
           gitignore = File.read(File.join(target, ".gitignore"))
-          gitignore.lines.should contain("public/")
-          gitignore.lines.should contain(".hwaro/")
-          gitignore.lines.should contain(".hwaro_cache.json")
+          gitignore.lines.should contain("/public/")
+          gitignore.lines.should contain("/.hwaro/")
+          gitignore.lines.should contain("/.hwaro_cache.json")
         end
       end
 

--- a/spec/unit/inline_markdown_spec.cr
+++ b/spec/unit/inline_markdown_spec.cr
@@ -103,6 +103,19 @@ describe Hwaro::Content::Processors::InlineMarkdown do
       (Time.monotonic - started).should be < 5.seconds
       out.should eq(input)
     end
+
+    # The placeholder restore ran one whole-string `gsub` per code span, so a
+    # cell with N spans was O(N²) even after the scan itself became linear:
+    # 20k spans took ~10 s. One pass per token kind now.
+    it "restores many code spans in linear time" do
+      input = Array.new(20_000) { |i| "`c#{i}`" }.join(" ")
+      started = Time.monotonic
+      out = Hwaro::Content::Processors::InlineMarkdown.render(input)
+      (Time.monotonic - started).should be < 3.seconds
+      out.should start_with("<code>c0</code> <code>c1</code>")
+      out.should end_with("<code>c19999</code>")
+      out.should_not contain("\x00")
+    end
   end
 end
 

--- a/spec/unit/markdown_extensions_spec.cr
+++ b/spec/unit/markdown_extensions_spec.cr
@@ -696,10 +696,40 @@ describe Hwaro::Content::Processors::MarkdownExtensions do
       result.should contain("<p>body</p>")
     end
 
+    # markd turns two or more trailing spaces into a hard break, so the real
+    # shape of a bare marker with trailing spaces is `[!NOTE]<br />\n`, not
+    # `[!NOTE]   \n` — the earlier spec fed a shape markd never produces.
     it "keeps the default title for a bare marker with trailing spaces" do
-      html = "<blockquote>\n<p>[!NOTE]   \nbody</p>\n</blockquote>"
+      html = "<blockquote>\n<p>[!NOTE]<br />\nbody</p>\n</blockquote>"
       result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
       result.should contain(%(<p class="admonition-title">Note</p>))
+      result.should_not contain("<br")
+      result.should contain("<p>body</p>")
+    end
+
+    it "drops the hard break left by trailing spaces after a custom title" do
+      html = "<blockquote>\n<p>[!NOTE] Title<br />\nbody</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title">Title</p>))
+      result.should_not contain("<br")
+    end
+
+    it "keeps an inline element that wraps past the marker line in the body" do
+      html = "<blockquote>\n<p>[!WARNING] see <a href=\"https://x\">the\ndocs</a> now\nbody</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title">Warning</p>))
+      result.should contain(%(<p>see <a href="https://x">the\ndocs</a> now\nbody</p>))
+      html = "<blockquote>\n<p>[!NOTE] **Bold\ntitle**</p>\n</blockquote>".sub("**Bold\ntitle**", "<strong>Bold\ntitle</strong>")
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title">Note</p>))
+      result.should contain(%(<p><strong>Bold\ntitle</strong></p>))
+    end
+
+    it "still accepts a title whose inline elements close on the marker line" do
+      html = "<blockquote>\n<p>[!TIP] <em>Read</em> <a href=\"/x\">this</a><br />\nbody</p>\n</blockquote>"
+      result = Hwaro::Content::Processors::MarkdownExtensions.postprocess_admonitions(html)
+      result.should contain(%(<p class="admonition-title"><em>Read</em> <a href="/x">this</a></p>))
+      result.should contain("<p>body</p>")
     end
   end
 

--- a/spec/unit/platform_config_output_dir_spec.cr
+++ b/spec/unit/platform_config_output_dir_spec.cr
@@ -76,3 +76,29 @@ describe "PlatformConfig honors [build] output_dir" do
     generator.generate("gitlab-ci").should contain(%(      - "my \\"site\\" out"))
   end
 end
+
+describe "PlatformConfig normalizes [build] output_dir" do
+  it "treats ./public and public/ as the default directory" do
+    %w[./public public/ ./public/].each do |dir|
+      generator = platform_config_with(dir)
+      generator.generate("gitlab-ci").should_not contain("publish:")
+      generator.generate("cloudflare").should contain(%(bucket = "./public"))
+      generator.generate("netlify").should contain(%(publish = "public"))
+    end
+  end
+
+  it "normalizes a ./-prefixed custom directory" do
+    generator = platform_config_with("./build/out/")
+    generator.generate("netlify").should contain(%(publish = "build/out"))
+    generator.generate("cloudflare").should contain(%(bucket = "./build/out"))
+  end
+
+  it "falls back to public for an absolute output_dir and says so" do
+    generator = platform_config_with("/tmp/hwaro-abs-out")
+    log = with_captured_log do
+      generator.generate("netlify").should contain(%(publish = "public"))
+    end
+    log.should contain("absolute")
+    generator.generate("gitlab-ci").should_not contain("/tmp/hwaro-abs-out")
+  end
+end

--- a/spec/unit/sass/hunt_fixes_spec.cr
+++ b/spec/unit/sass/hunt_fixes_spec.cr
@@ -118,3 +118,17 @@ describe "Sass color.hwb" do
     compile(%(@use "sass:color";\n.x { color: color.hwb(210 20% 30%); })).should contain("color: #3373b3")
   end
 end
+
+describe "review follow-ups on #773 built-ins" do
+  it "accepts color.hwb with a fourth alpha argument, positional or keyword" do
+    compile(%(@use "sass:color";\no { c: color.hwb(210, 20%, 30%, 0.5); })).should contain("c: rgba(51, 115, 179, 0.5);")
+    compile(%(@use "sass:color";\no { c: color.hwb(210, 20%, 30%, $alpha: 0.5); })).should contain("c: rgba(51, 115, 179, 0.5);")
+    compile(%(@use "sass:color";\no { c: color.hwb($hue: 0, $whiteness: 0%, $blackness: 0%); })).should contain("c: red;")
+  end
+
+  it "accepts map.deep-remove keyword arguments" do
+    css = compile(%(@use "sass:map";\n$m: (a: (b: 1, c: 2), d: 3);\n.x { content: "\#{map.deep-remove($map: $m, $key: a)}"; }))
+    css.should contain(%(content: "(d: 3)";))
+    css.should_not contain("map.deep-remove")
+  end
+end

--- a/spec/unit/sass/import_forward_config_spec.cr
+++ b/spec/unit/sass/import_forward_config_spec.cr
@@ -166,3 +166,71 @@ describe "Sass @import of a forwarding partial: members bind into the importing 
     css.should contain(".after {\n  padding: 50px;")
   end
 end
+
+# Review follow-up on #778: the import used to diff the module-wide staging
+# maps before/after, so a SECOND import of the same forwarding index (another
+# block, a second @include, root after nested, or after the importer's own
+# @forward of the partial) saw "nothing new" and bound nothing — undefined
+# variable/mixin on valid Sass. The implicit configuration also read only the
+# root scope, so a block-local override was overwritten by the module default.
+describe "Sass @import of a forwarding partial: repeated imports and nested scopes" do
+  it "binds the forwarded members again when a second block imports the same index" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %(.wrap { @import "components"; }\n.other { @import "components"; padding: $btn-pad; @include btn; }\n),
+    }))
+    css.should contain(".other {\n  padding: 8px;\n  padding: 8px;")
+  end
+
+  it "binds at the root after the same index was imported inside a block" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %(.wrap { @import "components"; }\n@import "components";\n.z { padding: $btn-pad; }\n),
+    }))
+    css.should contain(".z {\n  padding: 8px;")
+  end
+
+  it "binds on every @include of a mixin that imports the index" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %(@mixin wrap { @import "components"; padding: $btn-pad; }\n.z { @include wrap; }\n.y { @include wrap; }\n),
+    }))
+    css.should contain(".z {\n  padding: 8px;")
+    css.should contain(".y {\n  padding: 8px;")
+  end
+
+  it "binds after the importer already @forward-ed the same partial" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %(@forward "components/button";\n@import "components";\n.z { padding: $btn-pad; }\n),
+    }))
+    css.should contain(".z {\n  padding: 8px;")
+  end
+
+  it "configures the forwarded module from a block-local variable" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %(.wrap { $btn-pad: 99px; @import "components"; .z { padding: $btn-pad; @include btn; } }\n),
+    }))
+    css.should contain("padding: 99px;\n  padding: 99px;")
+    css.should_not contain("8px")
+  end
+
+  it "lets the innermost scope win over a global for the implicit configuration" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "entry.scss" => %($btn-pad: 99px;\n.wrap { $btn-pad: 50px; @import "components"; .z { padding: $btn-pad; } }\n),
+    }))
+    css.should contain("padding: 50px;")
+  end
+
+  it "does not re-export members a nested @import forwarded inside a @use-d module" do
+    files = FORWARDING_INDEX.merge({
+      "_theme.scss" => %(.m { @import "components"; padding: $btn-pad; }\n),
+      "entry.scss"  => %(@use "theme";\n.z { padding: theme.$btn-pad; }\n),
+    })
+    expect_raises(Hwaro::Assets::Sass::SyntaxError, /btn-pad/) { compile_entry(files) }
+  end
+
+  it "still re-exports members a root-level @import forwarded inside a @use-d module" do
+    css = compile_entry(FORWARDING_INDEX.merge({
+      "_theme.scss" => %(@import "components";\n),
+      "entry.scss"  => %(@use "theme";\n.z { padding: theme.$btn-pad; }\n),
+    }))
+    css.should contain(".z {\n  padding: 8px;")
+  end
+end

--- a/src/assets/sass/evaluator.cr
+++ b/src/assets/sass/evaluator.cr
@@ -143,6 +143,8 @@ module Hwaro
           # variables from it (see `forward_config`); nil outside an import
           # and inside any `@use` (which never inherits it).
           @import_config = nil.as(Hash(String, String)?)
+          @last_load_cached = false
+          @reimported_forward_vars = Set(String).new
           # @extend requests, applied document-wide as a post-pass —
           # deliberately NOT saved/restored around module loads.
           @extends = [] of Extend::Request
@@ -1681,6 +1683,7 @@ module Hwaro
             mod = BUILTIN_MODULES[name]?
             error_at(line, column, "unknown built-in module \"sass:#{name}\"") unless mod
             error_at(line, column, "built-in modules can't be configured") unless config.empty? || implicit
+            @last_load_cached = true
             return mod
           end
 
@@ -1690,8 +1693,10 @@ module Hwaro
               error_at(line, column,
                 "#{@importer.display_path(canonical)} was already loaded and can't be configured a second time")
             end
+            @last_load_cached = true
             return mod
           end
+          @last_load_cached = false
 
           check_cycle(canonical, line, column)
           display = @importer.display_path(canonical)
@@ -1823,10 +1828,12 @@ module Hwaro
           prefix = node.prefix
           config = forward_config(node, prefix)
           mod = load_module(node.url, node.line, node.column, config, implicit: !config.empty?)
+          cached = @last_load_cached
           mod.variables.each do |name, value|
             exported = prefix ? prefix + name : name
             next unless forward_visible?(node, "$" + exported)
             @forward_variables[exported] = value
+            @reimported_forward_vars << exported if cached
           end
           mod.mixins.each do |name, closure|
             exported = prefix ? prefix + name : name
@@ -1959,16 +1966,29 @@ module Hwaro
           # in the importer's own scope: `@import "components"` — the classic
           # spelling for a `components/_index.scss` that only `@forward`s its
           # partials — left every forwarded `$var`/mixin/function undefined.
-          # dart-sass gives the importing file access to them, so diff the
-          # staging maps across the import and bind what it added.
-          fwd_vars_before = @forward_variables.dup
-          fwd_mixins_before = @forward_mixins.dup
-          fwd_fns_before = @forward_functions.dup
+          # dart-sass gives the importing file access to them. Stage the
+          # import's forwards into FRESH maps, bind everything it staged, and
+          # only then fold them into the enclosing module's re-exports.
+          #
+          # Fresh maps rather than a before/after diff of the module-wide
+          # ones: the diff saw a second import of the same index (another
+          # block, a second `@include`, root after nested, or after the
+          # importer's own `@forward` of the same partial) as "nothing new"
+          # and bound nothing, so `$btn-pad` was undefined on the very
+          # pattern #773 set out to fix.
+          saved_fwd_vars = @forward_variables
+          saved_fwd_mixins = @forward_mixins
+          saved_fwd_fns = @forward_functions
+          staged_vars = @forward_variables = {} of String => String
+          staged_mixins = @forward_mixins = {} of String => MixinClosure
+          staged_fns = @forward_functions = {} of String => SassFn
+          saved_reimported = @reimported_forward_vars
+          reimported = @reimported_forward_vars = Set(String).new
           saved_import_config = @import_config
-          # dart-sass "implicit configuration": the importer's globals, as
+          # dart-sass "implicit configuration": the importer's variables, as
           # they stand when the import runs, configure the `!default`
           # variables of every module the imported sheet `@forward`s.
-          @import_config = @env.root.variables.dup
+          @import_config = implicit_import_config
           begin
             # Classic import: evaluated inline in the current scope/sink.
             eval_nodes(sheet.children)
@@ -1976,35 +1996,72 @@ module Hwaro
             @load_stack.pop
             @path = saved_path
             @import_config = saved_import_config
+            @forward_variables = saved_fwd_vars
+            @forward_mixins = saved_fwd_mixins
+            @forward_functions = saved_fwd_fns
+            @reimported_forward_vars = saved_reimported
           end
-          bind_imported_forwards(fwd_vars_before, fwd_mixins_before, fwd_fns_before)
+          bind_imported_forwards(staged_vars, staged_mixins, staged_fns, reimported)
+          # Only a root-level import re-exports what it forwarded (dart-sass
+          # `importForwards`: nested imports go to `_nestedForwardedModules`
+          # and never leave the module), so `.m { @import "components"; }`
+          # inside a `@use`d sheet does not publish `$btn-pad` on it.
+          if @env.root?
+            @forward_variables.merge!(staged_vars)
+            @forward_mixins.merge!(staged_mixins)
+            @forward_functions.merge!(staged_fns)
+          end
         end
 
-        # Bind members newly staged by `@forward`s inside a classic `@import`
-        # into the importing scope. Only additions/changes are bound, so a
-        # `@forward` the importing file wrote itself (staged before this
-        # import ran) is left alone.
+        # The variables visible where an `@import` runs, innermost scope
+        # winning — dart-sass `Environment#toImplicitConfiguration` walks
+        # every enclosing scope, not just the root, so a block-local
+        # `.wrap { $btn-pad: 99px; @import "components"; }` configures the
+        # forwarded module the same way a global does. Snapshotting only the
+        # root missed that override, and `bind_imported_forwards` then wrote
+        # the module's `8px` default over the author's block-local value.
+        private def implicit_import_config : Hash(String, String)
+          chain = [] of Environment
+          env : Environment? = @env
+          while env
+            chain << env
+            env = env.parent
+          end
+          config = {} of String => String
+          chain.reverse_each { |scope| config.merge!(scope.variables) }
+          config
+        end
+
+        # Bind the members an `@import` staged through its `@forward`s into
+        # the importing scope.
         #
         # The CURRENT scope, not the root: a nested import (`.wrap { @import
         # "components"; }`) scopes its members to the block in dart-sass,
         # exactly as this evaluator already scopes the variables of a plain
         # nested import. Binding to the root leaked `$btn-pad` to rules
         # after the block that dart-sass rejects as undefined.
-        private def bind_imported_forwards(vars_before : Hash(String, String),
-                                           mixins_before : Hash(String, MixinClosure),
-                                           fns_before : Hash(String, SassFn)) : Nil
-          @forward_variables.each do |name, value|
-            next if vars_before[name]? == value
+        #
+        # `reimported` names the variables that came from a module this
+        # compilation had ALREADY loaded. In dart-sass a root assignment to a
+        # forwarded variable writes through to the module, so re-importing
+        # the module hands back the importer's own latest value; modules
+        # here are immutable snapshots, so emulate that by keeping the value
+        # the importer can already see. A name that is not in scope (another
+        # block, a fresh mixin call, the root after a nested import) still
+        # binds — that is the "second import binds nothing" bug.
+        private def bind_imported_forwards(vars : Hash(String, String),
+                                           mixins : Hash(String, MixinClosure),
+                                           fns : Hash(String, SassFn),
+                                           reimported : Set(String)) : Nil
+          vars.each do |name, value|
+            if reimported.includes?(name) && (current = @env.lookup_var(name))
+              vars[name] = current
+              next
+            end
             @env.assign_var(name, value, default: false, global: false)
           end
-          @forward_mixins.each do |name, closure|
-            next if mixins_before[name]? == closure
-            @env.declare_mixin(name, closure)
-          end
-          @forward_functions.each do |name, fn|
-            next if fns_before[name]? == fn
-            @env.declare_function(name, fn)
-          end
+          mixins.each { |name, closure| @env.declare_mixin(name, closure) }
+          fns.each { |name, fn| @env.declare_function(name, fn) }
         end
 
         private def check_cycle(canonical : String, line : Int32, column : Int32) : Nil

--- a/src/assets/sass/functions.cr
+++ b/src/assets/sass/functions.cr
@@ -841,7 +841,9 @@ module Hwaro
           # `deep-merge` shipped, so `@use "sass:map"` sheets that used it
           # fell through to the literal-text fallback and emitted invalid CSS.
           "deep-remove" => Fn.new do |args, kwargs|
-            no_kwargs!("map.deep-remove", kwargs)
+            # `deep-remove($map, $key, $keys...)` — `$map:`/`$key:` are legal
+            # keyword spellings, as for `map.remove`.
+            args = args_with_kwargs("map.deep-remove", args, kwargs, %w[map key])
             arity!("map.deep-remove", args, 2, Int32::MAX)
             map_deep_remove(map!("map.deep-remove", args[0]), args[1..])
           end,
@@ -1232,19 +1234,24 @@ module Hwaro
 
         # `color.hwb($hue $whiteness $blackness)` — the space-separated
         # channels form — and the separate-argument spelling
-        # `color.hwb($hue, $whiteness, $blackness)`, which dart-sass also
-        # accepts and which used to fail arity here. A slash-alpha
-        # (`… / 0.5`) is not modeled; use `color.change($c, $alpha: …)`.
+        # `color.hwb($hue, $whiteness, $blackness, $alpha: 1)`, which
+        # dart-sass also accepts and which used to fail arity here (first
+        # for any separate spelling, then for the fourth `$alpha`). A
+        # slash-alpha in the channels form (`… / 0.5`) is not modeled; use
+        # `color.change($c, $alpha: …)`.
         COLOR_FNS["hwb"] = Fn.new do |args, kwargs|
-          known_kwargs!("color.hwb", kwargs, ["channels", "hue", "whiteness", "blackness"])
-          arity!("color.hwb", args, 0, 3)
-          separate = args.size == 3 ||
+          known_kwargs!("color.hwb", kwargs, ["channels", "hue", "whiteness", "blackness", "alpha"])
+          arity!("color.hwb", args, 0, 4)
+          separate = args.size >= 3 ||
                      kwargs.has_key?("hue") || kwargs.has_key?("whiteness") || kwargs.has_key?("blackness")
+          alpha : Value? = nil
           items =
             if separate
-              bound = bind!("color.hwb", args, kwargs, ["hue", "whiteness", "blackness"], required: 3)
-              bound.map(&.as(Value))
+              bound = bind!("color.hwb", args, kwargs, ["hue", "whiteness", "blackness", "alpha"], required: 3)
+              alpha = bound[3]
+              bound[0, 3].map(&.as(Value))
             else
+              arity!("color.hwb", args, 0, 1)
               channels = args[0]? || kwargs["channels"]? ||
                          raise SoftEvalError.new("color.hwb() is missing required argument $channels")
               case channels
@@ -1256,7 +1263,8 @@ module Hwaro
           hue = finite!("color.hwb", number!("color.hwb", items[0]))
           whiteness = amount!("color.hwb", items[1])
           blackness = amount!("color.hwb", items[2])
-          Builtins.hwb_color(hue, whiteness, blackness)
+          color = Builtins.hwb_color(hue, whiteness, blackness)
+          alpha ? color.with_alpha(alpha!("color.hwb", alpha)) : color
         end
 
         # `ie-hex-str($color)` — the legacy `#AARRGGBB` spelling IE filters

--- a/src/cli/commands/tool/ci_command.cr
+++ b/src/cli/commands/tool/ci_command.cr
@@ -51,7 +51,10 @@ module Hwaro
             Logger.warn "DEPRECATED: 'tool ci' is deprecated. Use 'tool platform github-pages' instead."
             # A blank spacer, not a second warning: `Logger.warn ""` rendered
             # as an empty, prefix-only `[WARN] ` line above the usage output.
-            Logger.info ""
+            # On STDERR with the notice it spaces — `Logger.info` writes to
+            # stdout, which `--stdout > deploy.yml` captures, and the file
+            # then began with an empty line.
+            STDERR.puts
             provider : String? = nil
             output_file : String? = nil
             stdout_mode = false

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -758,8 +758,12 @@ module Hwaro
             # bare basename anywhere would have declared `/nowhere/rss.xml`
             # live, hiding exactly the dead link this command exists to find.
             getter feed_filename : String?
+            # The filename section and language feeds are written under —
+            # always `rss.xml`/`atom.xml` from `[feeds] type`, regardless of
+            # the root feed's `filename` or `enabled` (see `Seo::Feeds`).
+            getter section_feed_filename : String?
 
-            def initialize(@paths : Set(String) = Set(String).new, @feed_filename : String? = nil)
+            def initialize(@paths : Set(String) = Set(String).new, @feed_filename : String? = nil, @section_feed_filename : String? = nil)
             end
 
             def matches?(url : String) : Bool
@@ -793,21 +797,39 @@ module Hwaro
               end
             end
 
-            GeneratedRoutes.new(paths, feed_filename)
+            GeneratedRoutes.new(paths, feed_filename, default_feed_filename(config.feeds.type))
           end
 
           # `/posts/rss.xml` / `/ko/rss.xml` / `/ko/posts/rss.xml` — a feed the
           # build emits beside a section or under a language prefix. The root
           # feed is already an exact path, so this only has to vouch for the
           # prefixed forms, and only when the prefix resolves to a section.
+          #
+          # Two different filenames are in play (see `Seo::Feeds.generate`):
+          # the ROOT feed honours `[feeds] filename` and `[feeds] enabled`,
+          # while section and language feeds are always written as
+          # `rss.xml`/`atom.xml` (from `[feeds] type`) and a section feed is
+          # gated by the section's own `generate_feeds`, not by the global
+          # switch. Keying the section route on the root feed's name and
+          # switch reported `/posts/rss.xml` dead on a site with `[feeds]
+          # enabled = false` + `generate_feeds = true` (the build writes it)
+          # and live as `/posts/feed.xml` under `filename = "feed.xml"` (the
+          # build never writes it).
           private def feed_route?(url : String, routes : GeneratedRoutes, content_dir : String, base_dir : String, language_codes : Array(String)) : Bool
-            name = routes.feed_filename
-            return false unless name
             return false unless url.starts_with?("/")
-            return false unless File.basename(url) == name
+            basename = File.basename(url)
+            if basename == routes.feed_filename
+              prefix = url[0, url.size - basename.size].rstrip("/")
+              return true if prefix.empty?
+            end
+            name = routes.section_feed_filename
+            return false unless name
+            return false unless basename == name
 
             prefix = url[0, url.size - name.size].rstrip("/")
-            return true if prefix.empty?
+            # `/rss.xml` at the root is only a route when the ROOT feed is
+            # enabled under that name — handled above.
+            return false if prefix.empty?
 
             segments = prefix.lstrip("/").split("/")
             if (code = segments.first?) && language_codes.includes?(code)

--- a/src/content/processors/filters/collection_filter.cr
+++ b/src/content/processors/filters/collection_filter.cr
@@ -123,12 +123,19 @@ module Hwaro
             # renders as "" and is falsy), so do the same; every non-empty
             # input still goes through the upstream code path unchanged, and a
             # non-sequence target still raises Crinja's located `TypeError`.
+            #
+            # A FRESH Undefined each time, never the shared `Value::UNDEFINED`
+            # singleton: the evaluator renames an Undefined in place when it
+            # is stored under a new name (`{% set d = {'a': ([] | first)} %}`
+            # writes `d.a` into it), so handing out the singleton let one
+            # page's variable name leak into another page's error message —
+            # and race across render workers.
             env.filters["first"] = Crinja.filter do
-              CollectionFilters.empty_sequence?(target) ? Crinja::Value::UNDEFINED : target.first.raw
+              CollectionFilters.empty_sequence?(target) ? Crinja::Value.new(Crinja::Undefined.new) : target.first.raw
             end
 
             env.filters["last"] = Crinja.filter do
-              CollectionFilters.empty_sequence?(target) ? Crinja::Value::UNDEFINED : target.last.raw
+              CollectionFilters.empty_sequence?(target) ? Crinja::Value.new(Crinja::Undefined.new) : target.last.raw
             end
 
             # Compact filter — removes nil/empty values from an array
@@ -146,8 +153,13 @@ module Hwaro
           # upstream `first`/`last` crash on. Deliberately narrow: anything
           # that is not a string/hash/indexable (an Int, say) reports `false`
           # so the upstream filter still raises its located `TypeError`.
+          # An Undefined counts as empty: Jinja2 iterates it as nothing, and
+          # `{{ get_section(path='nope').pages | first }}` or a missing
+          # `page.extra.images | first` is the same "ordinary site state" an
+          # empty section is — Crinja's own `raw_each` already treats it so.
           def self.empty_sequence?(value : Crinja::Value) : Bool
             case raw = value.raw
+            when Crinja::Undefined  then true
             when String             then raw.empty?
             when Crinja::SafeString then raw.to_s.empty?
             when Hash               then raw.empty?

--- a/src/content/processors/inline_markdown.cr
+++ b/src/content/processors/inline_markdown.cr
@@ -120,6 +120,8 @@ module Hwaro
         # bodies, and footnotes.
         SHORTCODE_PLACEHOLDER_RE = /<!--HWARO-SHORTCODE-PLACEHOLDER-\d+-->/
         SCPH_TOKEN_RE            = /\x00SCPH(\d+)\x00/
+        MATHSPAN_TOKEN_RE        = /\x00MATHSPAN(\d+)\x00/
+        CODESPAN_TOKEN_RE        = /\x00CODESPAN(\d+)\x00/
 
         # Render a small inline-markdown subset over already-HTML-escaped or
         # raw text. Code spans are extracted first so their content survives
@@ -204,25 +206,35 @@ module Hwaro
           result = result.gsub(INLINE_SUB_RE) { "<sub>#{$1}</sub>" } if flags.sub
           result = result.gsub(INLINE_SUP_RE) { "<sup>#{$1}</sup>" } if flags.sup
 
-          math_spans.each_with_index do |span, idx|
-            result = result.sub("\x00MATHSPAN#{idx}\x00", span)
+          # One pass per token kind, not one `gsub` per span: the per-span
+          # loop rescanned the whole string for every span, so a cell or
+          # footnote with N code spans cost O(N²) — 20k spans took 10 s and
+          # the 200 KB `` `a`a`a… `` pattern minutes, after #779 had made the
+          # code-span REGEX itself linear.
+          unless math_spans.empty?
+            result = result.gsub(MATHSPAN_TOKEN_RE) { math_spans[$1.to_i]? || $0 }
           end
 
-          code_spans.each_with_index do |content, idx|
+          unless code_spans.empty?
             # Tokens inside code spans restore ESCAPED, so a backticked
             # placeholder displays literally instead of being substituted —
             # the same thing Markd's own code-span escaping guarantees for
             # paragraph text.
-            restored = escape_placeholder_tokens(content, placeholders)
-            result = result.gsub("\x00CODESPAN#{idx}\x00", "<code>#{restored}</code>")
+            result = result.gsub(CODESPAN_TOKEN_RE) do
+              if content = code_spans[$1.to_i]?
+                "<code>#{escape_placeholder_tokens(content, placeholders)}</code>"
+              else
+                $0
+              end
+            end
           end
 
           # Remaining tokens sit in element-content positions: restore the
           # raw comment so the post-Markdown replacement pass resolves it
           # (consistent with paragraph text, where the comment also rides
           # through Markd verbatim).
-          placeholders.each_with_index do |comment, idx|
-            result = result.sub("\x00SCPH#{idx}\x00", comment)
+          unless placeholders.empty?
+            result = result.gsub(SCPH_TOKEN_RE) { placeholders[$1.to_i]? || $0 }
           end
 
           result

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -992,6 +992,29 @@ module Hwaro
         ADMONITION_TYPES = {"NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"}
 
         # Captures a blockquote whose first paragraph starts with `[!TYPE]`.
+        # Non-void tags that markd's inline renderer can open on a title line.
+        # Balanced when every opener on the line is closed on the line: a
+        # `<strong>`/`<a>`/`<code>`… opened here and closed on a later line
+        # of the same paragraph means the author wrapped one inline element
+        # across the soft break, not that they wrote a title.
+        INLINE_TAG_RE    = /<(\/?)([a-zA-Z][\w-]*)[^>]*>/
+        VOID_INLINE_TAGS = Set{"br", "img", "wbr", "hr", "input"}
+
+        def inline_html_balanced?(fragment : String) : Bool
+          return true unless fragment.includes?('<')
+          open = [] of String
+          fragment.scan(INLINE_TAG_RE) do |m|
+            name = m[2].downcase
+            next if VOID_INLINE_TAGS.includes?(name) || m[0].ends_with?("/>")
+            if m[1].empty?
+              open << name
+            else
+              return false if open.empty? || open.pop != name
+            end
+          end
+          open.empty?
+        end
+
         # Group 1: type token (uppercased). Group 2: whatever else sat on the
         # marker's own line — the custom title (Obsidian / Hugo syntax:
         # `> [!NOTE] Custom Title`); empty for a bare marker. Group 3: the rest
@@ -1016,8 +1039,23 @@ module Hwaro
 
           html.gsub(ADMONITION_BLOCKQUOTE_RE) do |_|
             type = $1
-            custom_title = $2.strip
+            title_line = $2
             rest = $3
+            # Two or more trailing spaces on the marker line become a hard
+            # break in markd (`[!NOTE]  ` → `[!NOTE]<br />\n`), and the break
+            # tag sits before the newline group 2 stops at — so it landed in
+            # the title and a bare marker lost its "Note" heading to an empty
+            # `<br />`. It is line-end residue, never title text.
+            title_line = title_line.sub(/\s*<br\s*\/?>\s*\z/, "")
+            # An inline element that wraps from the marker line onto the next
+            # (`[!WARNING] see [the\n> docs](…)`) cannot be a title: cutting
+            # it at the soft break split `<a>` between title and body. Treat
+            # the whole paragraph as body, as before custom titles existed.
+            unless inline_html_balanced?(title_line)
+              rest = "#{title_line}\n#{rest}"
+              title_line = ""
+            end
+            custom_title = title_line.strip
             type_lower = type.downcase
             # The custom title is already inline-rendered (and escaped) by
             # markd — it was part of the paragraph — so it is emitted as-is.

--- a/src/content/seo/feeds.cr
+++ b/src/content/seo/feeds.cr
@@ -74,7 +74,7 @@ module Hwaro
           # 2. Generate Section Feeds — pre-group pages by section for O(1) lookup
           pages_by_section = {} of String => Array(Models::Page)
           pages.each do |p|
-            next if p.draft || p.unpublished || !p.render || p.is_a?(Models::Section)
+            next if p.draft || p.unpublished || !p.render || p.output_suppressed || p.is_a?(Models::Section)
             (pages_by_section[p.section] ||= [] of Models::Page) << p
           end
 
@@ -244,16 +244,23 @@ module Hwaro
         # one URL (path-sort-first winner, matching
         # render.cr#compute_output_url_winners). Used for main, section,
         # language, and taxonomy feeds so no surface advertises a loser.
+        #
+        # A page the build refused to write at all (`output_suppressed`: a
+        # URL that traverses out of the output directory, a collision loser
+        # already flagged upstream) is dropped first — its URL is unique, so
+        # the URL dedupe alone let `/posts/../../escape/` into every section
+        # and taxonomy feed while sitemap/search/llms correctly omitted it.
         def self.dedupe_by_output_url(pages : Array(Models::Page)) : Array(Models::Page)
           url_winners = {} of String => Models::Page
           pages.each do |p|
+            next if p.output_suppressed
             if prev = url_winners[p.url]?
               url_winners[p.url] = p if p.path < prev.path
             else
               url_winners[p.url] = p
             end
           end
-          pages.select { |p| url_winners[p.url].same?(p) }
+          pages.select { |p| (winner = url_winners[p.url]?) && winner.same?(p) }
         end
 
         # Config `feeds.filename` and empty custom names resolve to a single

--- a/src/content/seo/pwa.cr
+++ b/src/content/seo/pwa.cr
@@ -295,8 +295,9 @@ module Hwaro
         private def self.icon_size(icon_path : String, output_dir : String) : String
           ext = File.extname(icon_path).downcase
           # A scalable icon has no pixel size; `any` is the manifest spec's
-          # spelling for it and is what makes it eligible at every size.
-          return "any" if ext == ".svg" && !external_url?(icon_path)
+          # spelling for it and is what makes it eligible at every size. That
+          # holds for a remote SVG too — no bytes are needed to know it.
+          return "any" if ext == ".svg"
           # A remote icon (http(s)://) has no local file to read — use the
           # filename heuristic directly instead of warning on every build.
           if MEASURABLE_ICON_EXTS.includes?(ext) && !external_url?(icon_path)

--- a/src/content/taxonomies.cr
+++ b/src/content/taxonomies.cr
@@ -215,6 +215,10 @@ module Hwaro
 
         site.pages.each do |page|
           next if page.excluded_from_listings?
+          # Set by the render phase for pages it refused to write (URL
+          # traverses out of the output dir): the term page would link a
+          # 404 and the term feed would advertise it.
+          next if page.output_suppressed
 
           enabled_taxonomy_names.each do |tax_name|
             values = page.taxonomy_values(tax_name)
@@ -251,6 +255,9 @@ module Hwaro
 
         site.pages.each do |page|
           next if page.excluded_from_listings?
+          # Runs at generate time, after the render phase flagged the pages
+          # it refused to write — keep them off the term pages and feeds.
+          next if page.output_suppressed
 
           config.taxonomies.each do |taxonomy|
             name = taxonomy.name

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -1675,6 +1675,10 @@ module Hwaro
           # one filesystem timestamp tick does not move; a build must read
           # the data files as they are now, not as a previous build saw them.
           Content::Processors::TemplateEngine.clear_load_data_cache
+          # Same lifetime for the once-per-BUILD shortcode warnings (missing
+          # template, unclosed block): a `serve` session that never cleared them
+          # reported each name only for the first rebuild it appeared in.
+          @shortcode_warnings_seen = nil
 
           # Execute build phases through lifecycle. The live status region
           # animates the current phase on a TTY; `ensure` guarantees the

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -133,9 +133,10 @@ module Hwaro::Core::Build::Phases::Initialize
     # incremental branch, and `build --cache -o content` used to exit 0 after
     # scattering `index.html` files through the source tree.
     guard_output_dir!(output_dir)
+    existed_before = Dir.exists?(output_dir)
     # In incremental mode (--cache), keep existing output to avoid
     # re-generating unchanged pages and re-copying unchanged static files.
-    if !incremental && Dir.exists?(output_dir)
+    if !incremental && existed_before
       # The guard above only refuses the catastrophic targets. Any OTHER
       # pre-existing directory — `-o ~/Documents/site`, a `dist/` shared
       # with a bundler — was emptied silently, exit 0. Only clear what hwaro
@@ -187,10 +188,15 @@ module Hwaro::Core::Build::Phases::Initialize
     end
     ensure_output_dir(output_dir)
     # Created, found empty, or cleared: from here on the directory is hwaro's
-    # to clear on the next cold build. Not recorded on the incremental paths
-    # (`--cache`, `serve`), which never clear anything and must not hand a
-    # foreign directory over.
-    unless incremental
+    # to clear on the next cold build. The incremental paths (`--cache`,
+    # `serve`) never clear anything and must not hand a PRE-EXISTING
+    # directory over — but one that did not exist a moment ago is hwaro's
+    # own creation, whatever mode created it. Without that, `build --cache -o
+    # dist` on a fresh checkout left `dist/` unrecorded, and every later cold
+    # build warned "entries hwaro did not write" about hwaro's own files and
+    # kept the stale ones forever. The conventional `public/` needs no record
+    # (`clearable?` accepts it by name), so plain builds leave no `.hwaro/`.
+    if (!incremental || !existed_before) && !Hwaro::Utils::OutputOwnership.conventional?(output_dir)
       Hwaro::Utils::OutputOwnership.record(
         Hwaro::Utils::PathUtils.resolved_real_path(File.expand_path(output_dir)),
         Hwaro::Utils::PathUtils.resolved_real_path(File.expand_path(Dir.current)),

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -1009,9 +1009,16 @@ module Hwaro::Core::Build::Phases::Render
   #     search.json / feeds / taxonomy pages from the in-memory page set
   #     after every edit, so a `serve --cache` whose start was an all-hit
   #     build served corrupted search.json and feeds from the first edit on.
+  #   * `generate_seo_outputs` never lets the feeds join the skip while a
+  #     user feed template exists (`feed_template_present?`), so an all-hit
+  #     warm build still regenerates rss.xml — from `page.content`. Without
+  #     hydration that feed carried raw shortcode markup, unresolved `@/`
+  #     links and no base_path: the exact corruption #775 fixed, back on the
+  #     one site shape that overrides the feed template.
   private def cached_content_needed?(ctx : Lifecycle::BuildContext, site : Models::Site) : Bool
     return true unless generate_outputs_unchanged?(ctx)
     return true if ctx.options.serve_mode
+    return true if feed_template_present?
     site.config.taxonomies.any?(&.feed)
   end
 
@@ -1049,7 +1056,11 @@ module Hwaro::Core::Build::Phases::Render
       render_page_content(page, site, templates, highlight, safe, global_vars,
         crinja_env_override: env, template_cache_override: cache)
   rescue ex
-    Logger.debug "  Could not hydrate cached content for #{page.path}: #{ex.message}"
+    # Loud, not debug: the page's HTML is already correct (it was a cache
+    # hit), but its search.json / feed entry now comes from the raw-markdown
+    # fallback — the corruption this pass exists to prevent — and the build
+    # still exits 0, so the log line is the only trace.
+    Logger.warn "Could not re-render cached content for #{page.path}: #{ex.message}. Its search index and feed entries fall back to unprocessed markdown for this build; run without --cache to refresh them."
     end
 
     if parallel && pages.size > 1

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -460,14 +460,55 @@ module Hwaro
         }
 
         # True when a BLOCK_OPEN_RE match is really a Jinja control tag, not a
-        # shortcode opener. Parenthesized args are decisive: no Jinja control
-        # form matching BLOCK_OPEN_RE carries `name(...)` (Jinja's own
-        # `{% include "x.html" %}` / `{% call(u) m(l) %}` don't match the
-        # regex at all), so `{% include(name="promo") %}` is a user shortcode
-        # named `include` and must keep expanding.
+        # shortcode opener. `{% include(name="promo") %}` — the keyword hugging
+        # one balanced argument group — is a user shortcode named `include`
+        # and must keep expanding; Jinja's own `{% include "x.html" %}` never
+        # matches the regex. But a keyword's CONDITION can be parenthesized
+        # too (`{% if (a and b) or (c) %}` in the blog scaffold), and the
+        # regex's `name(...)` branch swallows it whole, so the group shape is
+        # what decides.
         private def control_tag_open?(m : Regex::MatchData) : Bool
-          return false if m[2]? # `name(...)` form — unambiguously a shortcode call
-          CRINJA_CONTROL_KEYWORDS.includes?(m[1].downcase)
+          return false unless CRINJA_CONTROL_KEYWORDS.includes?(m[1].downcase)
+          args = m[2]?
+          return true unless args # bare / `key=value` form of a keyword
+          # `name(...)` form on a keyword. A shortcode call hugs its name and
+          # encloses every argument in ONE balanced group; a Jinja condition
+          # such as `{% if (a and b) or (c) %}` or `{% elif (x) %}` puts
+          # whitespace between the keyword and the group, or closes the group
+          # before the tag's last `)`. Either shape is Jinja, not a shortcode.
+          return true if m.byte_begin(2) - 1 > m.byte_end(1)
+          !single_paren_group?(args)
+        end
+
+        # True when `args` (the text between a tag's first `(` and last `)`)
+        # never returns to depth zero before its end, i.e. the surrounding
+        # parens form one group. Parens inside quoted strings are skipped.
+        private def single_paren_group?(args : String) : Bool
+          depth = 0
+          quote : Char? = nil
+          escaped = false
+          args.each_char do |ch|
+            if quote
+              if escaped
+                escaped = false
+              elsif ch == '\\'
+                escaped = true
+              elsif ch == quote
+                quote = nil
+              end
+              next
+            end
+            case ch
+            when '"', '\''
+              quote = ch
+            when '('
+              depth += 1
+            when ')'
+              return false if depth == 0
+              depth -= 1
+            end
+          end
+          true
         end
 
         # Next BLOCK_OPEN_RE match at or after byte offset `from` that is a

--- a/src/ext/crinja_error_location_fix.cr
+++ b/src/ext/crinja_error_location_fix.cr
@@ -2,13 +2,14 @@
 #
 # Two upstream gaps threw away the location for whole classes of failures:
 #
-#   1. A plain Crystal exception raised inside a filter, test or function
-#      (`{{ [1, 2] | slice(0) }}` → `Division by 0`, `{{ [] | random }}` →
-#      `Can't sample empty collection`, any custom filter that trips on its
-#      input) is not a `Crinja::Error`, so `Evaluator`'s per-node rescue never
-#      attaches the node, hwaro's `rescue ex : Crinja::Error` sites never see
-#      it, and the build dies with `Render failed ...: Division by 0` and no
-#      template name or line.
+#   1. A plain Crystal exception raised inside a filter, test, function or
+#      operator (`{{ [1, 2] | slice(0) }}` → `Division by 0`, `{{ [] | random }}`
+#      → `Can't sample empty collection`, `{{ n // 0 }}`, any custom filter
+#      that trips on its input) is not a `Crinja::Error`, so `Evaluator`'s
+#      per-node rescue never attaches the node, hwaro's `rescue ex :
+#      Crinja::Error` sites never see it, and the build dies with `Render
+#      failed ...: Division by 0` and no template name or line. Same for a
+#      missing `{% include %}`/`{% extends %}` target.
 #
 #   2. A template whose FIRST character is a newline reported every location
 #      one line early (`templates/page.html:1:2` for a tag on line 2, caret
@@ -22,25 +23,40 @@
 #      `Int#step(by: 0)` and Python's `range()` do.
 #
 # Patch order matters for nothing here; all three are independent of the
-# other Crinja patches under src/ext/.
+# other Crinja patches under src/ext/ (crinja_render_perf reopens Renderer
+# for PrintStatement/FixedString only, so `previous_def` on TagNode binds to
+# the upstream visitor).
 require "crinja"
 
-# === 1. Non-Crinja exceptions inside filters/tests/functions get a node ====
+# === 1. Non-Crinja exceptions inside expressions get a node =================
 #
-# Wrap at the three evaluator visitors that invoke user/builtin code. The
-# wrapped error is a `Crinja::RuntimeError`, so the surrounding `visit`
+# Wrap at every evaluator visitor that can run code: the three that invoke
+# user/builtin callables (filters, tests, functions) and the operator
+# visitors — `{{ total // per_page }}` with a zero divisor, `{{ big + 1 }}`
+# past Int64::MAX and `{{ 2 ** 64 }}` raise plain `DivisionByZeroError` /
+# `OverflowError` and used to escape unlocated just like a filter's did.
+# The wrapped error is a `Crinja::RuntimeError`, so the surrounding `visit`
 # rescue (which only knows `Crinja::Error`) attaches the expression's
 # location exactly as it does for Crinja's own errors, and every hwaro
 # rescue site classifies it as HWARO_E_TEMPLATE with the source excerpt.
 # Crinja errors pass through untouched — an inner wrap must not be re-wrapped
 # by an outer filter expression.
+#
+# The wrapper carries NO message of its own: `SourceAttached#message`
+# already prints the cause as `<Class>:  <message>` when the message is nil,
+# whereas a message plus a cause printed the same text twice
+# (`Division by 0 (DivisionByZeroError)` / `cause: Division by 0`).
 class Crinja::Evaluator
+  private def locate_plain_error(ex : Exception, expression : AST::ExpressionNode) : Crinja::RuntimeError
+    Crinja::RuntimeError.new(nil, cause: ex).at(expression)
+  end
+
   def evaluate(expression : AST::FilterExpression)
     previous_def
   rescue ex : Crinja::Error
     raise ex
   rescue ex : Exception
-    raise Crinja::RuntimeError.new("#{ex.message} (#{ex.class})", cause: ex).at(expression)
+    raise locate_plain_error(ex, expression)
   end
 
   def evaluate(expression : AST::TestExpression)
@@ -48,7 +64,7 @@ class Crinja::Evaluator
   rescue ex : Crinja::Error
     raise ex
   rescue ex : Exception
-    raise Crinja::RuntimeError.new("#{ex.message} (#{ex.class})", cause: ex).at(expression)
+    raise locate_plain_error(ex, expression)
   end
 
   def evaluate(expression : AST::CallExpression)
@@ -56,7 +72,39 @@ class Crinja::Evaluator
   rescue ex : Crinja::Error
     raise ex
   rescue ex : Exception
-    raise Crinja::RuntimeError.new("#{ex.message} (#{ex.class})", cause: ex).at(expression)
+    raise locate_plain_error(ex, expression)
+  end
+
+  def evaluate(expression : AST::BinaryExpression | AST::ComparisonExpression)
+    previous_def
+  rescue ex : Crinja::Error
+    raise ex
+  rescue ex : Exception
+    raise locate_plain_error(ex, expression)
+  end
+
+  def evaluate(expression : AST::UnaryExpression)
+    previous_def
+  rescue ex : Crinja::Error
+    raise ex
+  rescue ex : Exception
+    raise locate_plain_error(ex, expression)
+  end
+end
+
+# `Crinja::TemplateNotFoundError` inherits `Exception`, not `Crinja::Error`,
+# so `{% include "missing.html" %}` / `{% extends %}` / `{% import %}` /
+# `{% from %}` naming a template that does not exist escaped every
+# `rescue Crinja::Error` — the renderer's per-tag rescue, hwaro's engine
+# rescue sites — as a raw, unlocated error that named neither the referencing
+# template nor the line. Wrap it at the tag node the same way. `{% include …
+# ignore missing %}` rescues the error inside the tag before it gets here, so
+# that contract is untouched.
+class Crinja::Renderer
+  def render(node : AST::TagNode)
+    previous_def
+  rescue ex : Crinja::TemplateNotFoundError
+    raise Crinja::RuntimeError.new(nil, cause: ex).at(node)
   end
 end
 
@@ -94,7 +142,9 @@ end
 # above turns it into a located template error at the `range(...)` call.
 class Crinja::Function::RangeIterator(B, N)
   def initialize(@range, step, @current = range.begin, @reached_end = false)
-    raise ArgumentError.new("range() step must not be zero") if step == 0
+    # `step` arrives truncated to Int (`as_number.to_i`), so a fractional
+    # 0.5 lands here as 0 too — say "integer" so that case is not a riddle.
+    raise ArgumentError.new("range() step must be a non-zero integer") if step == 0
     @step = step.abs
     @direction_reversed = step < 0
   end

--- a/src/services/initializer.cr
+++ b/src/services/initializer.cr
@@ -475,15 +475,20 @@ module Hwaro
       # workspace (serve output and remote-data cache — also self-ignoring
       # via Utils::HwaroDir, so pre-existing repos are covered too), and the
       # incremental-build cache, which lives at the root NEXT TO `.hwaro/`.
+      #
+      # Every pattern is root-anchored (leading `/`): git matches a
+      # slash-free pattern at ANY depth, so a bare `public/` also ignored a
+      # `content/public/` section and `.hwaro_cache.json` any nested file of
+      # that name.
       private def gitignore_content(config_content : String) : String
         String.build do |io|
           if output_dir = scaffold_output_dir(config_content)
             io << "# Build output (`hwaro build`)\n"
-            io << output_dir << "/\n\n"
+            io << '/' << output_dir << "/\n\n"
           end
           io << "# Hwaro workspace (`hwaro serve` output, remote-data cache) and build cache\n"
-          io << ".hwaro/\n"
-          io << ".hwaro_cache.json\n"
+          io << "/.hwaro/\n"
+          io << "/.hwaro_cache.json\n"
         end
       end
 
@@ -501,6 +506,9 @@ module Hwaro
         dir = dir.strip.rstrip('/')
         return if dir.empty? || dir == "." || dir.starts_with?('/') || dir.starts_with?('\\')
         return if dir.split('/').includes?("..")
+        # git does not normalize `./`: a `./public/` pattern matches nothing.
+        dir = dir.lchop("./")
+        return if dir.empty? || dir == "."
         dir
       rescue
         # A config.toml that does not parse (possible for a remote scaffold's

--- a/src/services/platform_config.cr
+++ b/src/services/platform_config.cr
@@ -14,6 +14,8 @@ module Hwaro
 
       @config : Models::Config
 
+      @output_dir : String? = nil
+
       def initialize(@config : Models::Config)
       end
 
@@ -57,10 +59,27 @@ module Hwaro
       # produced — a hardcoded "public" made a site with a customized
       # output_dir deploy an empty (or stale) directory, with no error
       # anywhere: the build succeeded and the host published nothing.
-      # `Config.load` already rejects an empty or project-escaping value, so
-      # the fallback here is only for "not configured".
+      # `Config.load` rejects an empty or project-escaping value, but passes
+      # `./public`, `public/` and absolute paths through verbatim. Normalize
+      # here so every emitted key gets one clean relative spelling
+      # (cloudflare's `bucket = "./#{dir}"` produced `././public`, gitlab's
+      # default check missed `./public`); an absolute path is not expressible
+      # in any hosted-build config (netlify `publish`, gitlab `artifacts.paths`
+      # must be project-relative), so it is reported and the conventional
+      # `public` used — the host would otherwise publish nothing, silently.
       private def output_dir : String
-        @config.build.output_dir || "public"
+        @output_dir ||= begin
+          raw = @config.build.output_dir
+          if raw.nil?
+            "public"
+          elsif Path[raw].absolute?
+            Logger.warn "[build] output_dir #{raw.inspect} is an absolute path; platform configs need a project-relative directory. Using \"public\" — set a relative output_dir so the host publishes what hwaro built."
+            "public"
+          else
+            normalized = Path[raw].normalize.to_s.lchop("./").rstrip('/')
+            normalized.empty? || normalized == "." ? "public" : normalized
+          end
+        end
       end
 
       # Render a value as a shell word, leaving ordinary directory names bare

--- a/src/services/server/server.cr
+++ b/src/services/server/server.cr
@@ -1263,16 +1263,38 @@ module Hwaro
       # BindError-only rescue and reached the user as a bare, code-less
       # `Error: Hostname lookup for 300.1.1.1 failed: No address found` with no
       # hint and nothing naming the flag that produced it.
+      #
+      # Resolution is not the only `-b` mistake: an address that resolves but
+      # this machine does not hold (`-b 10.255.255.1`) fails INSIDE bind with
+      # EADDRNOTAVAIL, and a privileged port (`-p 80`) with EACCES — both
+      # arrive as `Socket::BindError`, so both used to get the "another
+      # process is listening, try -p/--port" hint, which is wrong for each.
       protected def bind_dev_server(server : HTTP::Server, host : String, port : Int32)
         server.bind_tcp host, port
       rescue ex : Socket::BindError
         # Socket::BindError#message already includes the address, so
         # use it verbatim rather than re-prefixing.
-        raise Hwaro::HwaroError.new(
-          code: Hwaro::Errors::HWARO_E_IO,
-          message: ex.message || "Could not bind to '#{host}:#{port}'",
-          hint: "Is another process already listening on this port? Try -p/--port with a different value.",
-        )
+        message = ex.message || "Could not bind to '#{host}:#{port}'"
+        case ex.os_error
+        when Errno::EADDRNOTAVAIL
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_USAGE,
+            message: message,
+            hint: "Check -b/--bind: #{host} is not an address this machine holds. Use 127.0.0.1, 0.0.0.0, ::1, or one of its interface addresses.",
+          )
+        when Errno::EACCES
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_IO,
+            message: message,
+            hint: "Port #{port} needs elevated privileges on this system. Try -p/--port with a value above 1023.",
+          )
+        else
+          raise Hwaro::HwaroError.new(
+            code: Hwaro::Errors::HWARO_E_IO,
+            message: message,
+            hint: "Is another process already listening on this port? Try -p/--port with a different value.",
+          )
+        end
       rescue ex : Socket::Error
         # Resolution failures and anything else the socket layer reports.
         # `host` is only ever the `-b/--bind` value, so the hint can name it.


### PR DESCRIPTION
Adversarial re-review of everything merged on 2026-09-02, five lanes
(build core / templates / markdown / Sass+SEO / serve+tools). Every fix
below carries a regression spec proven to fail against the pre-fix
source; the full suite passes; cold-vs-warm --cache and origin/main-vs-
this-branch `diff -r` are byte-identical on all five scaffolds and docs/.

Build core
- A user feed template (rss.xml.jinja) keeps feeds out of the Generate
  skip, but nothing hydrated cache-hit content for it: a warm all-hit
  --cache build shipped raw shortcode markup into rss.xml again (#775's
  defect class on the one site shape that overrides the feed template).
  cached_content_needed? now mirrors feed_template_present?.
- Pages refused at write time (URL traverses out of the output dir) were
  still advertised by section feeds, taxonomy term feeds and term pages:
  those surfaces deduped by URL only. Feeds.dedupe_by_output_url, the
  section grouping and both taxonomy collectors now skip
  output_suppressed. (The dedupe's trailing select must use `[]?` for
  pages the winners loop skipped.)
- OutputOwnership was recorded only on non-incremental builds, so a dir
  that `build --cache -o dist` had just CREATED was never recorded and
  every later cold build warned "entries hwaro did not write" about
  hwaro's own files and kept the stale ones. Record when the dir did not
  exist before this build, and never for the conventional public/ (plain
  builds no longer leave a .hwaro/ behind).
- Once-per-build shortcode warnings were once-per-process (serve showed
  each only on the first rebuild); hydration failures were debug-only.

Shortcodes
- Templates run through the shortcode pass too, and the blog scaffold's
  `{% if (page.lower and ...) or (page.higher ...) %}` matched the
  `name(...)` opener branch, so #780's new "never closed" warning fired
  on every blog build. control_tag_open? now decides by the paren-group
  shape (whitespace before the group, or a group that closes before the
  tag's last `)`, is Jinja); `{% include(name="x") %}` still expands.

Templates / Crinja (src/ext)
- Operator exceptions (`{{ n // 0 }}`, overflow) and a missing
  `{% include %}`/`{% extends %}` target (TemplateNotFoundError inherits
  Exception, not Crinja::Error) escaped every located rescue. Wrap the
  Binary/Comparison/Unary visitors like the callable ones, and wrap
  TemplateNotFoundError at Renderer#render(TagNode).
- The wrapper passed a message AND a cause, so SourceAttached printed the
  cause twice; nil message now.
- first/last handed out the shared Value::UNDEFINED singleton, whose name
  the evaluator mutates in place (one page's `d.a` leaked into another
  page's error, racy across workers); Undefined input still raised a
  TypeError. Fresh Undefined; Undefined counts as an empty sequence.
- range() message says "non-zero integer" (a fractional step truncates
  to 0).

Sass
- #778's before/after diff of the module-wide staging maps saw a SECOND
  import of the same forwarding index (another block, a second @include,
  root after nested, after the importer's own @forward) as "nothing new"
  and bound nothing — undefined variable/mixin on valid Sass. Imports now
  stage into fresh maps and bind everything staged; variables from an
  already-loaded module keep the importer's in-scope value (dart-sass
  write-through); re-export only at module root.
- The implicit configuration read only the root scope; it now walks every
  enclosing scope (block-local override configures the module).
- color.hwb() rejected the fourth $alpha argument; map.deep-remove()
  rejected `$map:`/`$key:` keywords.

Markdown
- A hard break from trailing spaces after `[!NOTE]` landed in the title
  (bare marker lost its "Note" heading; custom titles kept a `<br />`).
- An inline element wrapping from the marker line onto the next was cut
  between title and body → malformed HTML. Unbalanced title lines fall
  back to body-only.
- Placeholder restore ran one whole-string gsub per code span: O(N²)
  after #779 had made the scan linear (20k spans ≈ 10 s). One pass.

serve / tool / scaffold
- `tool ci --stdout` began the captured file with a blank line (the
  spacer moved from stderr to stdout in #770).
- check-links keyed section feeds on the ROOT feed's enabled/filename;
  the build gates them on generate_feeds only and always writes
  rss.xml/atom.xml. `[feeds] enabled = false` + generate_feeds reported a
  live link dead; filename = "feed.xml" reported the dead one live.
- `tool platform` emitted absolute output_dir verbatim (unusable in every
  host config) and missed `./public`/`public/` as the default; normalize,
  warn and fall back on absolute.
- Scaffolded .gitignore patterns were unanchored (`public/` ignored
  content/public/ too) and `./public` produced a pattern git never
  matches; root-anchored now.
- `serve -b` classified EADDRNOTAVAIL and EACCES as "another process is
  listening, try --port"; own hints now.
- PWA: a remote SVG icon got a fake pixel `sizes`; doctor docs table
  gained pwa-display-invalid (en + ko).

## Verification
- `crystal spec`: 8543 examples, 0 failures. 31 new regression specs, each proven to fail against the pre-fix source (per-lane revert runs).
- `crystal tool format --check` and ameba clean on every changed file.
- Build output byte-identical (`diff -r`) to origin/main on all five `hwaro init` scaffolds and docs/; cold vs `--cache` warm (all-hit and partial-hit) byte-identical too. The only log difference is the blog scaffold's spurious "never closed" warning, now gone.

## Deliberately left as-is
`@use … as *` members reaching the implicit import config (rare); a pipe in an admonition title directly above a quoted table; `"" | first` → Undefined (intentional, spec'd in #768); static-copy byte compare cost on coarse-mtime filesystems (documented trade-off); `--stream` never populating `page.content` (pre-existing contract); `page.title[0]` string indexing (pre-existing); `hwaro new` collapsing hyphen runs only when the path also has an unsafe char (doc/behaviour mismatch, policy call).
