### PR TITLE
fix(release): re-sign macOS tarballs after install_name_tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,14 @@ on:
       - flake.lock
       - shards.nix
       # package-macos.sh only ever ran during a release before, so a break in
-      # it was discovered by users rather than by CI. package-macos exists to
-      # run it on every PR that touches it.
+      # it was discovered by users rather than by CI. These are the two files
+      # that decide what the macOS tarball contains -- the script itself and
+      # the workflow that chooses its arguments. (This list gates the whole
+      # workflow, not the package-macos job alone, so that job also runs on
+      # the `**/*.cr` PRs above; that is deliberate -- a source change can
+      # alter what the binary links.)
       - scripts/package-macos.sh
+      - .github/workflows/release-binary.yml
   push:
     branches: [main]
   workflow_dispatch:
@@ -209,9 +214,21 @@ jobs:
           export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig"
           mkdir -p build
           crystal build src/main.cr -o build/hwaro --no-debug
+      # The runtime half of this job only means anything on arm64: x86_64
+      # happily executes a stale signature. `macos-latest` is arm64 today but
+      # it is an alias GitHub has re-pointed before, and a silent move would
+      # leave the job green while testing nothing it exists to test.
+      - name: Assert the runner is arm64
+        run: |
+          set -euo pipefail
+          test "$(uname -m)" = arm64 || {
+            echo "::error::package-macos must run on arm64; got $(uname -m)"
+            exit 1
+          }
       - name: Package and smoke test the tarball
         run: |
           set -euo pipefail
+          shopt -s nullglob
           scripts/package-macos.sh build/hwaro build/hwaro-ci-osx.tar.gz hwaro
 
           # package-macos.sh makes these assertions itself; repeating them
@@ -220,12 +237,34 @@ jobs:
           # exists to enforce.
           mkdir -p verify
           tar -xzf build/hwaro-ci-osx.tar.gz -C verify
+
+          # Every signature check below is vacuous if nothing was bundled, and
+          # the smoke test would still pass because brew's own OpenSSL is
+          # installed on this runner. Assert the archive actually carries the
+          # dylibs before trusting anything else about it.
+          libs=(verify/lib/*.dylib)
+          test "${#libs[@]}" -gt 0 || {
+            echo "::error::tarball bundled no dylibs; packaging silently stopped working"
+            exit 1
+          }
+          for want in libssl libcrypto; do
+            test -n "$(echo "verify/lib/$want".*.dylib)" || {
+              echo "::error::tarball is missing $want"
+              exit 1
+            }
+          done
+
           codesign --verify --strict verify/hwaro
-          for lib in verify/lib/*.dylib; do
+          for lib in "${libs[@]}"; do
             codesign --verify --strict "$lib"
           done
-          # Runs the packaged layout the way a user does: extracted tree, no
-          # brew dylibs on the load path, resolved via @executable_path/lib.
+
+          # Runs the packaged layout the way a user does: extracted tree,
+          # dylibs resolved via @executable_path/lib.
+          test -n "$(verify/hwaro version)" || {
+            echo "::error::packaged binary printed no version"
+            exit 1
+          }
           verify/hwaro version
   build-snapcraft:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ on:
       - flake.nix
       - flake.lock
       - shards.nix
+      # package-macos.sh only ever ran during a release before, so a break in
+      # it was discovered by users rather than by CI. package-macos exists to
+      # run it on every PR that touches it.
+      - scripts/package-macos.sh
   push:
     branches: [main]
   workflow_dispatch:
@@ -178,6 +182,51 @@ jobs:
         run: |
           nix develop --command crystal2nix
           git diff --exit-code -- shards.nix
+  package-macos:
+    # scripts/package-macos.sh rewrites dylib load paths with install_name_tool,
+    # which invalidates the code signature of every Mach-O it touches. The
+    # linker-signed main binary is re-signed automatically; Homebrew's plainly
+    # ad-hoc-signed dylibs are not. arm64 SIGKILLs any process that maps a
+    # dylib with a stale signature, so the breakage is invisible on x86_64 and
+    # fatal for every Apple Silicon user -- that is how v0.20.0 shipped a
+    # tarball that could not run at all (#782). Packaging otherwise happens
+    # only in release-binary.yml, where the tag is already cut.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: 1.21.0
+      - name: Install build dependencies
+        run: brew install openssl@3 pkg-config
+      - name: Install shards
+        run: shards install
+      # Not --release: this job is about linkage and signatures, which are
+      # identical either way, and a release build would triple the runtime.
+      - name: Build binary
+        run: |
+          set -euo pipefail
+          export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig"
+          mkdir -p build
+          crystal build src/main.cr -o build/hwaro --no-debug
+      - name: Package and smoke test the tarball
+        run: |
+          set -euo pipefail
+          scripts/package-macos.sh build/hwaro build/hwaro-ci-osx.tar.gz hwaro
+
+          # package-macos.sh makes these assertions itself; repeating them
+          # against the extracted archive keeps the contract in CI, so a future
+          # edit to the script cannot quietly drop the guard that this job
+          # exists to enforce.
+          mkdir -p verify
+          tar -xzf build/hwaro-ci-osx.tar.gz -C verify
+          codesign --verify --strict verify/hwaro
+          for lib in verify/lib/*.dylib; do
+            codesign --verify --strict "$lib"
+          done
+          # Runs the packaged layout the way a user does: extracted tree, no
+          # brew dylibs on the load path, resolved via @executable_path/lib.
+          verify/hwaro version
   build-snapcraft:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - `.hwaro/` keeps itself out of version control: hwaro writes a self-ignoring `.hwaro/.gitignore` when creating the workspace (serve output, remote-data cache), and `hwaro init` scaffolds a project `.gitignore` covering the output directory, `.hwaro/`, and `.hwaro_cache.json`
 
+### Fixed
+- macOS release tarballs are re-signed ad hoc after their dylib load paths are rewritten. `install_name_tool` invalidated the bundled OpenSSL signatures, and Apple Silicon SIGKILLs a process that maps a dylib with a stale signature — the v0.20.0 `osx-arm64` binary (and the Homebrew formula built from it) was killed at launch on every arm64 Mac. Packaging now verifies every signature and runs the extracted tarball before reporting success, and CI exercises it on an arm64 runner (#782)
+
 ## v0.20.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-### Added
-- `.hwaro/` keeps itself out of version control: hwaro writes a self-ignoring `.hwaro/.gitignore` when creating the workspace (serve output, remote-data cache), and `hwaro init` scaffolds a project `.gitignore` covering the output directory, `.hwaro/`, and `.hwaro_cache.json`
-
 ### Fixed
 - macOS release tarballs are re-signed ad hoc after their dylib load paths are rewritten. `install_name_tool` invalidated the bundled OpenSSL signatures, and Apple Silicon SIGKILLs a process that maps a dylib with a stale signature — the v0.20.0 `osx-arm64` binary (and the Homebrew formula built from it) was killed at launch on every arm64 Mac. Packaging now verifies every signature and runs the extracted tarball before reporting success, and CI exercises it on an arm64 runner (#782)
 
@@ -13,6 +10,7 @@
 ### Added
 - Remote data sources: `[[data.remote]]` in `config.toml` fetches an HTTP(S) endpoint into `site.data.<key>` — format inference (`json`/`toml`/`yaml`/`csv`), `${VAR}` env interpolation, a disk cache with TTL, and `on_error` handling (#753, #759, #763)
 - Content generation from data: `[[content.generate]]` turns each record of a `site.data` array into a first-class content page — listings, permalinks, taxonomies, feeds, search, sitemap and OG images all apply; authored files win a contested path (#764)
+- `.hwaro/` keeps itself out of version control: hwaro writes a self-ignoring `.hwaro/.gitignore` when creating the workspace (serve output, remote-data cache), and `hwaro init` scaffolds a project `.gitignore` covering the output directory, `.hwaro/`, and `.hwaro_cache.json` (#767)
 
 ### Changed
 - `hwaro serve` builds into `.hwaro/serve/` instead of the deployable output directory, and `deploy`/`build` refuse dev-marked output — serve output can no longer poison a production build (#758, #762)

--- a/docs/content/start/installation.ko.md
+++ b/docs/content/start/installation.ko.md
@@ -96,7 +96,8 @@ nix develop github:hahwul/hwaro
 macOS와 Linux용 사전 빌드 바이너리를 [GitHub Releases](https://github.com/hahwul/hwaro/releases) 페이지에서 받을 수 있습니다.
 
 1. [최신 릴리스](https://github.com/hahwul/hwaro/releases/latest)에서 플랫폼에 맞는 바이너리를 내려받습니다.
-2. PATH에 포함된 디렉터리로 바이너리를 옮깁니다.
+2. PATH에 포함된 디렉터리로 바이너리를 옮깁니다. **macOS 배포물은 단일 바이너리가
+   아니라 tarball이므로, 옮기기 전에 아래 [macOS](#macos) 항목을 먼저 확인하세요.**
 
 ```bash
 # Linux(amd64) 예시
@@ -121,11 +122,19 @@ sudo ln -sf /usr/local/libexec/hwaro/hwaro /usr/local/bin/hwaro
 심볼릭 링크는 안전합니다. macOS가 `@executable_path`를 계산하기 전에 링크를
 먼저 해석하므로 dylib을 그대로 찾습니다. Homebrew도 같은 방식으로 설치합니다.
 
-> **v0.20.0 한정.** 이 릴리스의 macOS tarball은 코드 서명이 깨진 상태로
-> 배포되어, Apple Silicon에서는 실행 즉시 프로세스가 종료됩니다
-> (`zsh: killed hwaro`). Gatekeeper가 아니라 서명 검증 문제라 quarantine
-> 속성을 지워도 해결되지 않습니다. 상위 릴리스로 올리거나, 압축을 푼 자리에서
-> 직접 다시 서명하세요: `codesign --force --sign - lib/*.dylib hwaro`
+> **v0.20.0 한정.** 이 릴리스의 macOS tarball은 번들된 dylib의 코드 서명이 깨진
+> 상태로 배포되어, Apple Silicon에서는 실행 즉시 프로세스가 종료됩니다
+> (`zsh: killed hwaro`, 다른 메시지는 나오지 않습니다). quarantine 속성만 지워서는
+> 해결되지 않습니다 — 서명 자체가 깨져 있기 때문입니다. 반대로 다시 서명만 해도
+> 막힐 수 있습니다 — quarantine이 걸린 파일을 재서명하면 승인 상태가 초기화되기
+> 때문입니다. 압축을 푼 디렉터리에서 아래 순서로 둘 다 실행하세요.
+>
+> ```bash
+> xattr -dr com.apple.quarantine hwaro lib
+> codesign --force --sign - lib/*.dylib hwaro
+> ```
+>
+> 패치 릴리스가 나가면 이 과정은 필요 없습니다.
 
 ## 소스 빌드
 

--- a/docs/content/start/installation.ko.md
+++ b/docs/content/start/installation.ko.md
@@ -104,6 +104,29 @@ chmod +x hwaro-v*-linux-x86_64
 sudo mv hwaro-v*-linux-x86_64 /usr/local/bin/hwaro
 ```
 
+### macOS
+
+macOS 배포물은 단일 바이너리가 아니라 tarball입니다. 압축을 풀면 `hwaro`와
+번들된 OpenSSL이 담긴 `lib/` 디렉터리가 나오고, 바이너리는 이 dylib들을
+`@executable_path/lib` 경로로 읽습니다. 따라서 **`lib/`를 항상 바이너리와 함께
+옮겨야 합니다.** 바이너리만 떼어 옮기면 실행되지 않습니다.
+
+```bash
+tar -xzf hwaro-v*-osx-arm64.tar.gz
+sudo mkdir -p /usr/local/libexec/hwaro
+sudo cp -R hwaro lib /usr/local/libexec/hwaro/
+sudo ln -sf /usr/local/libexec/hwaro/hwaro /usr/local/bin/hwaro
+```
+
+심볼릭 링크는 안전합니다. macOS가 `@executable_path`를 계산하기 전에 링크를
+먼저 해석하므로 dylib을 그대로 찾습니다. Homebrew도 같은 방식으로 설치합니다.
+
+> **v0.20.0 한정.** 이 릴리스의 macOS tarball은 코드 서명이 깨진 상태로
+> 배포되어, Apple Silicon에서는 실행 즉시 프로세스가 종료됩니다
+> (`zsh: killed hwaro`). Gatekeeper가 아니라 서명 검증 문제라 quarantine
+> 속성을 지워도 해결되지 않습니다. 상위 릴리스로 올리거나, 압축을 푼 자리에서
+> 직접 다시 서명하세요: `codesign --force --sign - lib/*.dylib hwaro`
+
 ## 소스 빌드
 
 ### 사전 요구 사항

--- a/docs/content/start/installation.md
+++ b/docs/content/start/installation.md
@@ -104,6 +104,29 @@ chmod +x hwaro-v*-linux-x86_64
 sudo mv hwaro-v*-linux-x86_64 /usr/local/bin/hwaro
 ```
 
+### macOS
+
+The macOS download is a tarball, not a bare binary. It extracts to `hwaro`
+plus a `lib/` directory holding the bundled OpenSSL, and the binary loads
+those through `@executable_path/lib` — so **`lib/` has to travel with it**.
+Move the whole extracted directory, not just the binary:
+
+```bash
+tar -xzf hwaro-v*-osx-arm64.tar.gz
+sudo mkdir -p /usr/local/libexec/hwaro
+sudo cp -R hwaro lib /usr/local/libexec/hwaro/
+sudo ln -sf /usr/local/libexec/hwaro/hwaro /usr/local/bin/hwaro
+```
+
+The symlink is safe: macOS resolves it before computing `@executable_path`,
+so the dylibs are still found. Homebrew installs the tarball the same way.
+
+> **v0.20.0 only.** That release's macOS tarball shipped with an invalid code
+> signature, and Apple Silicon kills the process at launch (`zsh: killed
+> hwaro`). Clearing quarantine does not help — it is a signature check, not
+> Gatekeeper. Upgrade to a newer release, or re-sign the extracted files in
+> place: `codesign --force --sign - lib/*.dylib hwaro`.
+
 ## From Source
 
 ### Prerequisites

--- a/docs/content/start/installation.md
+++ b/docs/content/start/installation.md
@@ -96,7 +96,9 @@ Crystal toolchain, so no compiler has to be built from source.
 Pre-built binaries for macOS and Linux are available on the [GitHub Releases](https://github.com/hahwul/hwaro/releases) page.
 
 1. Download the binary for your platform from the [latest release](https://github.com/hahwul/hwaro/releases/latest).
-2. Move the binary to a directory in your PATH.
+2. Move the binary to a directory in your PATH. **On macOS the download is a
+   tarball, not a bare binary — see [macOS](#macos) below before moving
+   anything.**
 
 ```bash
 # Example for Linux (amd64)
@@ -122,10 +124,18 @@ The symlink is safe: macOS resolves it before computing `@executable_path`,
 so the dylibs are still found. Homebrew installs the tarball the same way.
 
 > **v0.20.0 only.** That release's macOS tarball shipped with an invalid code
-> signature, and Apple Silicon kills the process at launch (`zsh: killed
-> hwaro`). Clearing quarantine does not help — it is a signature check, not
-> Gatekeeper. Upgrade to a newer release, or re-sign the extracted files in
-> place: `codesign --force --sign - lib/*.dylib hwaro`.
+> signature on its bundled dylibs, and Apple Silicon kills the process at
+> launch — `zsh: killed hwaro`, with no other diagnostic. Clearing quarantine
+> on its own does not fix it, because the signature is stale as well; re-signing
+> on its own can also leave you stuck, because re-signing a quarantined file
+> resets its approval. Do both, in this order, from the extracted directory:
+>
+> ```bash
+> xattr -dr com.apple.quarantine hwaro lib
+> codesign --force --sign - lib/*.dylib hwaro
+> ```
+>
+> A patch release will carry the fix, after which no manual step is needed.
 
 ## From Source
 

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -62,9 +62,6 @@ while true; do
       fi
       if [[ ! -f "$STAGING/lib/$base" ]]; then
         cp "$dep" "$STAGING/lib/$base"
-        # Homebrew ships dylibs read-only; install_name_tool and codesign
-        # both rewrite them in place.
-        chmod u+w "$STAGING/lib/$base"
         added=1
       fi
     done < <(homebrew_deps "$target")
@@ -116,20 +113,35 @@ for target in "$STAGING/$NAME" "$STAGING"/lib/*.dylib; do
 done
 
 mkdir -p "$(dirname "$OUTPUT")"
-tar -czf "$OUTPUT" -C "$STAGING" "$NAME" lib
+
+# Archive to a scratch path first. A tarball only becomes $OUTPUT once it has
+# proven it runs, so a failed smoke test cannot leave a finished-looking but
+# unrunnable artifact for a later step to upload.
+STAGED_OUTPUT="$VERIFY_DIR/$(basename "$OUTPUT")"
+tar -czf "$STAGED_OUTPUT" -C "$STAGING" "$NAME" lib
 
 # Smoke-test the packaged artifact rather than the staged tree: this is the
 # exact layout a user unpacks, and a stale signature is fatal only at exec
 # time. A silent skip here is what let the arm64 SIGKILL ship in v0.20.0.
-tar -xzf "$OUTPUT" -C "$VERIFY_DIR"
+EXTRACT_DIR="$VERIFY_DIR/extracted"
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$STAGED_OUTPUT" -C "$EXTRACT_DIR"
 smoke_status=0
-VERSION_OUTPUT="$("$VERIFY_DIR/$NAME" --version)" || smoke_status=$?
+VERSION_OUTPUT="$("$EXTRACT_DIR/$NAME" --version)" || smoke_status=$?
 if [[ "$smoke_status" -ne 0 ]]; then
-  echo "error: packaged binary failed to run (exit $smoke_status): $OUTPUT" >&2
+  echo "error: packaged binary failed to run (exit $smoke_status)" >&2
   echo "       arm64 SIGKILLs binaries and dylibs with an invalid signature;" >&2
   echo "       check the codesign step above." >&2
   exit 1
 fi
+# Exit 0 alone is not evidence: a binary that prints nothing has not
+# demonstrated it loaded its dylibs and reached its own CLI.
+if [[ -z "${VERSION_OUTPUT//[[:space:]]/}" ]]; then
+  echo "error: packaged binary ran but printed no version" >&2
+  exit 1
+fi
+
+mv "$STAGED_OUTPUT" "$OUTPUT"
 
 echo "Created $OUTPUT"
 echo "$VERSION_OUTPUT"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -2,6 +2,13 @@
 # Bundle Homebrew-linked dylibs next to a Crystal macOS binary so the
 # release tarball runs without a local OpenSSL (or other brew) install.
 #
+# Rewriting load commands with install_name_tool invalidates a Mach-O code
+# signature. The linker-signed main binary gets re-signed automatically, but
+# Homebrew's plainly ad-hoc-signed dylibs do not: they are left with a stale
+# signature, and arm64 SIGKILLs any process that maps one. So everything is
+# re-signed ad hoc after the last install_name_tool call, and the packaged
+# tarball is smoke-tested before the script reports success.
+#
 # Usage: scripts/package-macos.sh <binary-path> <output-tarball> [staged-name]
 #
 # Archive layout:
@@ -18,13 +25,16 @@ if [[ ! -f "$BINARY" ]]; then
   exit 1
 fi
 
-if ! command -v otool >/dev/null 2>&1 || ! command -v install_name_tool >/dev/null 2>&1; then
-  echo "error: otool and install_name_tool are required (macOS only)" >&2
-  exit 1
-fi
+for tool in otool install_name_tool codesign; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "error: $tool is required (macOS only)" >&2
+    exit 1
+  fi
+done
 
 STAGING="$(mktemp -d)"
-trap 'rm -rf "$STAGING"' EXIT
+VERIFY_DIR="$(mktemp -d)"
+trap 'rm -rf "$STAGING" "$VERIFY_DIR"' EXIT
 
 mkdir -p "$STAGING/lib"
 cp "$BINARY" "$STAGING/$NAME"
@@ -52,6 +62,9 @@ while true; do
       fi
       if [[ ! -f "$STAGING/lib/$base" ]]; then
         cp "$dep" "$STAGING/lib/$base"
+        # Homebrew ships dylibs read-only; install_name_tool and codesign
+        # both rewrite them in place.
+        chmod u+w "$STAGING/lib/$base"
         added=1
       fi
     done < <(homebrew_deps "$target")
@@ -74,16 +87,49 @@ for lib in "$STAGING"/lib/*.dylib; do
   rewrite_paths "$lib"
 done
 
-if otool -L "$STAGING/$NAME" | awk 'NR>1 {print $1}' | grep -Eq "$BREW_PREFIX_RE"; then
-  echo "error: Homebrew paths remain after bundling:" >&2
-  otool -L "$STAGING/$NAME" >&2
-  exit 1
-fi
+# Check the dylibs too, not just the binary: a bundled dylib that still
+# points at /opt/homebrew for one of *its* deps leaves the archive broken on
+# any machine without that brew formula installed.
+for target in "$STAGING/$NAME" "$STAGING"/lib/*.dylib; do
+  [[ -e "$target" ]] || continue
+  if otool -L "$target" | awk 'NR>1 {print $1}' | grep -Eq "$BREW_PREFIX_RE"; then
+    echo "error: Homebrew paths remain after bundling: $target" >&2
+    otool -L "$target" >&2
+    exit 1
+  fi
+done
+
+# Re-sign ad hoc. This must come after every install_name_tool call above,
+# and dylibs must be signed before the binary that loads them.
+for lib in "$STAGING"/lib/*.dylib; do
+  [[ -e "$lib" ]] || continue
+  codesign --force --sign - "$lib"
+done
+codesign --force --sign - "$STAGING/$NAME"
+
+for target in "$STAGING/$NAME" "$STAGING"/lib/*.dylib; do
+  [[ -e "$target" ]] || continue
+  if ! codesign --verify --strict "$target"; then
+    echo "error: invalid code signature after packaging: $target" >&2
+    exit 1
+  fi
+done
 
 mkdir -p "$(dirname "$OUTPUT")"
 tar -czf "$OUTPUT" -C "$STAGING" "$NAME" lib
 
-echo "Created $OUTPUT"
-if "$STAGING/$NAME" --version >/dev/null 2>&1; then
-  "$STAGING/$NAME" --version
+# Smoke-test the packaged artifact rather than the staged tree: this is the
+# exact layout a user unpacks, and a stale signature is fatal only at exec
+# time. A silent skip here is what let the arm64 SIGKILL ship in v0.20.0.
+tar -xzf "$OUTPUT" -C "$VERIFY_DIR"
+smoke_status=0
+VERSION_OUTPUT="$("$VERIFY_DIR/$NAME" --version)" || smoke_status=$?
+if [[ "$smoke_status" -ne 0 ]]; then
+  echo "error: packaged binary failed to run (exit $smoke_status): $OUTPUT" >&2
+  echo "       arm64 SIGKILLs binaries and dylibs with an invalid signature;" >&2
+  echo "       check the codesign step above." >&2
+  exit 1
 fi
+
+echo "Created $OUTPUT"
+echo "$VERSION_OUTPUT"


### PR DESCRIPTION
Fixes #782

## Problem

`scripts/package-macos.sh` rewrites the bundled OpenSSL load paths with `install_name_tool`, which invalidates the code signature of every Mach-O it touches. cctools re-signs the *linker-signed* main binary automatically; Homebrew's plainly ad-hoc-signed dylibs it does not — those are left with a stale signature. arm64 SIGKILLs any process that maps one, so the v0.20.0 `osx-arm64` tarball, and the Homebrew formula that installs it verbatim, died at launch on every Apple Silicon Mac. Clearing quarantine does not help: it is a signature check, not Gatekeeper.

Confirmed against the published v0.20.0 artifact:

```
$ codesign --verify lib/libssl.3.dylib
lib/libssl.3.dylib: invalid signature (code or signature have been modified)
$ codesign --verify hwaro
hwaro: valid on disk          # main binary was fine all along
$ ./hwaro version; echo $?
137                           # SIGKILL

$ codesign --force --sign - lib/*.dylib hwaro
$ ./hwaro version
0.20.0
```

So the actual culprit is the **dylibs**, not the binary the issue focused on. Signing both is still the right fix — the binary's automatic re-signing is a cctools implementation detail we should not depend on.

## Why it shipped

The script's final smoke test was `if "$STAGING/$NAME" --version >/dev/null 2>&1; then ...`. On the arm64 runner the binary was killed, the `if` went false, and the script printed `Created …` and exited 0. Running the old script verbatim on this machine reproduces it exactly:

```
Created …/probe.tar.gz
package-macos.old.sh: line 89: 12165 Killed: 9   "$STAGING/$NAME" --version
script exit=0
```

## Changes

`scripts/package-macos.sh`:
- Re-signs dylibs, then the binary, ad hoc, after the last `install_name_tool` call, and hard-fails if any signature does not verify. The verify gate is arch-independent, so it also catches the breakage on the x86_64 runner, where it is otherwise invisible.
- Extends the leftover-Homebrew-path check to the bundled dylibs, not just the main binary — a dylib still pointing at `/opt/homebrew` for one of *its own* deps would leave the archive broken on a machine without that formula.
- Extracts the finished tarball and runs it, replacing the smoke test that swallowed its own failure.
- Requires `codesign` up front; makes copied dylibs writable (Homebrew ships them `0444`).

`.github/workflows/ci.yml`: a `package-macos` job builds and packages on `macos-latest` (arm64), then verifies signatures and runs the extracted tarball. Packaging previously only ever ran during a release, when the tag is already cut. `scripts/package-macos.sh` is added to the PR path filter.

Docs: the "Pre-built Binary" section only showed a Linux example. macOS ships a tarball whose `lib/` must travel with the binary — the reporter hit that too, moving the binary alone. Added for `en` and `ko`, with the re-signing workaround for anyone stuck on v0.20.0.

## Verification

All on an arm64 Mac (macOS 26.6):

| check | result |
|---|---|
| Old script, real brew-linked binary | packages "successfully", extracted binary exits 137 |
| New script, same binary | all signatures valid, extracted binary runs |
| New script, real `hwaro` build | 5 dylibs + binary signed, `verify/hwaro version` → `0.20.0`, `init --scaffold blog` + `build` produce `public/index.html` |
| Signing step removed, verify gate kept | exits 1 before the tarball is written |
| Signing **and** verify gate removed | smoke test reports `exit 137`, script exits 1 |
| Binary moved without `lib/` | `dyld: Library not loaded: @executable_path/lib/libssl.3.dylib` — documented |
| Installed via symlink (the Homebrew layout) | runs; `@executable_path` resolves through the symlink |
| Docs build | 142 pages, both `installation` pages render |

`shellcheck` and `bash -n` clean. No Crystal sources touched.

## Follow-ups (not in this PR)

- Needs a patch release so `brew upgrade` picks it up; the published v0.20.0 tarball stays broken until then.
- `package-macos` may need adding to the branch's required checks.
- Same script pattern exists in `noir` — worth checking there.

---

## Also in this PR: a misplaced CHANGELOG entry

The `.hwaro/.gitignore` entry sat under **Unreleased** even though it shipped. The `v0.20.0` tag points at `a643eebe` (#767) — the very commit that added both `src/utils/hwaro_dir.cr` and that changelog line, written under "Unreleased" and then immediately tagged. The published GitHub release notes already list it under v0.20.0, so only the file was stale. Moved into the v0.20.0 `Added` list with the `(#767)` ref its neighbours carry.
