### PR TITLE
feat(search): opt-in sharded search index with manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Search: opt-in sharded index — `[search] shards = "section" | "language" | "section-language"` splits `search.json` into `search/<id>.json` files plus a `search/index.json` manifest so clients lazy-load only the shards they need; `single_file = false` drops the classic file, `content_max_length` caps each entry's `content` at a word boundary
+
 ## v0.20.1
 
 ### Added

--- a/docs/content/features/search.ko.md
+++ b/docs/content/features/search.ko.md
@@ -27,6 +27,9 @@ exclude = ["/private", "/drafts"]
 | filename | string | "search.json" | 출력 파일 이름 |
 | exclude | array | [] | 검색 인덱스에서 제외할 경로(접두사) |
 | tokenize_cjk | bool | false | CJK 바이그램 토큰화 활성화 |
+| shards | string | "none" | 인덱스를 지연 로드 가능한 샤드로 분할: `"section"`, `"language"`, `"section-language"` — [샤드 인덱스](#샤드-인덱스) 참고 |
+| single_file | bool | true | `shards` 사용 시 기존 `search.json`도 함께 생성; `false`면 샤드만 생성 |
+| content_max_length | int | 0 | 0보다 크면 각 항목의 `content`를 단어 경계에서 해당 글자 수로 자름; `0`이면 전체 본문 유지 |
 
 ## 생성 파일
 
@@ -228,6 +231,107 @@ input.addEventListener('focus', async () => {
   indexLoaded = true;
 });
 ```
+
+## 샤드 인덱스
+
+`search.json` 하나는 사이트가 커질수록 함께 커지고, 방문자는 첫 검색 전에 파일 전체를 내려받아야 합니다. 샤딩은 인덱스를 여러 JSON 파일과 매니페스트로 나누어, 클라이언트가 필요한 것만(현재 섹션 먼저, 또는 언어별로) 불러올 수 있게 합니다.
+
+```toml
+[search]
+enabled = true
+shards = "section"          # "section" | "language" | "section-language"
+single_file = false         # 샤드만 생성 (기본값 true는 search.json도 유지)
+content_max_length = 500    # 선택: 각 항목의 content 길이 제한
+```
+
+| 모드 | 샤드 | id 예시 |
+|------|------|---------|
+| `"section"` | 최상위 콘텐츠 섹션마다 하나; 섹션 밖의 페이지는 `_root` | `blog`, `docs`, `_root` |
+| `"language"` | 언어마다 하나(다국어 사이트); 기본 언어는 자신의 코드 사용 | `en`, `ko` |
+| `"section-language"` | 언어, 그다음 섹션 | `en/blog`, `ko/blog`, `ko/_root` |
+
+중첩 섹션은 최상위 섹션으로 합쳐집니다. `blog/news/post.md`는 `blog` 샤드에 들어갑니다. 기존 인덱스의 포함 규칙(`fields`, `exclude`, `in_search_index = false`, 초안, `render = false`, 언어별 `build_search_index`, `tokenize_cjk`)은 그대로 적용됩니다.
+
+### 생성 파일
+
+```
+public/
+├── search.json          # single_file = false가 아니면 생성
+└── search/
+    ├── index.json       # 매니페스트
+    ├── _root.json
+    ├── blog.json
+    └── docs.json        # 중첩 id는 디렉터리 사용: search/ko/blog.json
+```
+
+각 샤드는 `search.json`과 완전히 동일한 항목 스키마를 가진 JSON 배열입니다(`format` 설정과 무관하게 샤드는 항상 JSON입니다. `*_javascript` 래퍼는 `<script src>` 로딩 전용입니다). `search/index.json`은 전체 구조를 설명합니다.
+
+```json
+{
+  "version": 1,
+  "fields": ["title", "content", "url", "lang"],
+  "shards": [
+    {"id": "_root", "url": "/search/_root.json", "language": null, "section": "", "count": 2, "bytes": 200},
+    {"id": "blog",  "url": "/search/blog.json",  "language": null, "section": "blog", "count": 42, "bytes": 12345}
+  ]
+}
+```
+
+- `url`은 `base_url`의 하위 경로를 반영하고(`https://example.com/docs` 배포라면 `/docs/search/blog.json`), 섹션 이름은 퍼센트 인코딩됩니다.
+- `language`는 `language`·`section-language` 모드에서, `section`은 `section`·`section-language` 모드에서 채워지고 나머지는 `null`입니다.
+- 샤드는 id 순으로 나열되며 타임스탬프가 없어 출력이 결정적이고 diff하기 좋습니다. 마지막 페이지가 사라진 샤드는 다음 빌드에서 삭제됩니다.
+- `--cache` 빌드와 `hwaro serve`도 `search.json`과 같은 페이지 집합에서 샤드를 다시 생성합니다.
+
+### Fuse.js로 샤드 지연 로드
+
+매니페스트를 한 번 받은 뒤 필요할 때 샤드를 불러옵니다. 전역 검색창은 모든 샤드를, 섹션 인식 검색창은 현재 섹션 샤드를 먼저 받고 나머지는 백그라운드에서 받습니다.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0"></script>
+<script>
+const loaded = new Map();       // 샤드 id → 항목 배열
+let manifest = null;
+let fuse = null;
+
+async function loadManifest() {
+  if (manifest) return manifest;
+  manifest = await (await fetch('/search/index.json')).json();
+  return manifest;
+}
+
+async function loadShard(shard) {
+  if (loaded.has(shard.id)) return;
+  loaded.set(shard.id, await (await fetch(shard.url)).json());
+  fuse = new Fuse([...loaded.values()].flat(), {
+    keys: ['title', 'content', 'description', 'tags'],
+    threshold: 0.3,
+    ignoreLocation: true
+  });
+}
+
+// 이 페이지에 필요한 샤드는? 문서 언어와 URL 첫 세그먼트로
+// 매니페스트를 거르고, 해당 없으면 전체를 불러옵니다.
+async function loadRelevantShards() {
+  const { shards } = await loadManifest();
+  const lang = (document.documentElement.lang || '').split('-')[0];
+  const section = location.pathname.split('/').filter(Boolean)[0] || '';
+  const local = shards.filter(s =>
+    (s.language === null || s.language === lang) &&
+    (s.section === null || s.section === section));
+  await Promise.all((local.length ? local : shards).map(loadShard));
+  // 첫 결과를 막지 않고 나머지 샤드를 미리 받아 둡니다.
+  shards.filter(s => !loaded.has(s.id)).forEach(s => loadShard(s));
+}
+
+function search(query) {
+  return fuse ? fuse.search(query) : [];
+}
+
+document.getElementById('search-input').addEventListener('focus', loadRelevantShards, { once: true });
+</script>
+```
+
+전역 검색만 필요하면 `loadRelevantShards` 대신 `shards.map(loadShard)`를 사용하세요. 로드 이후는 위의 단일 파일 예제와 같은 Fuse.js 코드입니다.
 
 ## 대안: Pagefind
 

--- a/docs/content/features/search.md
+++ b/docs/content/features/search.md
@@ -27,6 +27,9 @@ exclude = ["/private", "/drafts"]
 | filename | string | "search.json" | Output filename |
 | exclude | array | [] | Paths (prefixes) to exclude from search index |
 | tokenize_cjk | bool | false | Enable CJK bigram tokenization |
+| shards | string | "none" | Split the index into lazy-loadable shards: `"section"`, `"language"`, or `"section-language"` — see [Sharded index](#sharded-index) |
+| single_file | bool | true | With `shards` on, keep emitting the classic `search.json` alongside the shards; `false` emits shards only |
+| content_max_length | int | 0 | When > 0, truncate each entry's `content` to that many characters at a word boundary; `0` keeps the full text |
 
 ## Generated Files
 
@@ -228,6 +231,107 @@ input.addEventListener('focus', async () => {
   indexLoaded = true;
 });
 ```
+
+## Sharded Index
+
+A single `search.json` grows with the site, and every visitor pays for the whole file before the first search. Sharding splits the index into several JSON files plus a manifest so a client can load only what it needs — the current section first, or one language at a time.
+
+```toml
+[search]
+enabled = true
+shards = "section"          # "section" | "language" | "section-language"
+single_file = false         # emit shards only (default true keeps search.json too)
+content_max_length = 500    # optional: cap each entry's content
+```
+
+| Mode | Shards | Example ids |
+|------|--------|-------------|
+| `"section"` | One per top-level content section; pages outside any section go to `_root` | `blog`, `docs`, `_root` |
+| `"language"` | One per language (multilingual sites); the default language uses its code | `en`, `ko` |
+| `"section-language"` | Language, then section | `en/blog`, `ko/blog`, `ko/_root` |
+
+Nested sections fold into their top-level section: `blog/news/post.md` lands in the `blog` shard. Every eligibility rule of the classic index applies unchanged (`fields`, `exclude`, `in_search_index = false`, drafts, `render = false`, per-language `build_search_index`, `tokenize_cjk`).
+
+### Generated Files
+
+```
+public/
+├── search.json          # unless single_file = false
+└── search/
+    ├── index.json       # manifest
+    ├── _root.json
+    ├── blog.json
+    └── docs.json        # nested ids use directories: search/ko/blog.json
+```
+
+Each shard is a plain JSON array with exactly the same entry schema as `search.json` (shards are always JSON, whatever `format` says — the `*_javascript` wrapper only serves `<script src>` loading). `search/index.json` describes the layout:
+
+```json
+{
+  "version": 1,
+  "fields": ["title", "content", "url", "lang"],
+  "shards": [
+    {"id": "_root", "url": "/search/_root.json", "language": null, "section": "", "count": 2, "bytes": 200},
+    {"id": "blog",  "url": "/search/blog.json",  "language": null, "section": "blog", "count": 42, "bytes": 12345}
+  ]
+}
+```
+
+- `url` honors `base_url`'s subpath (`/docs/search/blog.json` on a `https://example.com/docs` deploy) and percent-encodes section names.
+- `language` is set in the `language` and `section-language` modes, `section` in the `section` and `section-language` modes; the other is `null`.
+- Shards are listed in id order and the file never carries a timestamp, so the output is deterministic and diff-friendly. A shard whose last page disappears is removed on the next build.
+- `--cache` builds and `hwaro serve` regenerate the shards from the same page set as `search.json`.
+
+### Lazy-Loading Shards with Fuse.js
+
+Fetch the manifest once, then load shards on demand. A global search box loads all of them; a section-aware one loads the current section's shard first and the rest in the background:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0"></script>
+<script>
+const loaded = new Map();       // shard id → entries
+let manifest = null;
+let fuse = null;
+
+async function loadManifest() {
+  if (manifest) return manifest;
+  manifest = await (await fetch('/search/index.json')).json();
+  return manifest;
+}
+
+async function loadShard(shard) {
+  if (loaded.has(shard.id)) return;
+  loaded.set(shard.id, await (await fetch(shard.url)).json());
+  fuse = new Fuse([...loaded.values()].flat(), {
+    keys: ['title', 'content', 'description', 'tags'],
+    threshold: 0.3,
+    ignoreLocation: true
+  });
+}
+
+// Which shards matter for this page? Match the manifest against the
+// document language and the first URL segment; fall back to everything.
+async function loadRelevantShards() {
+  const { shards } = await loadManifest();
+  const lang = (document.documentElement.lang || '').split('-')[0];
+  const section = location.pathname.split('/').filter(Boolean)[0] || '';
+  const local = shards.filter(s =>
+    (s.language === null || s.language === lang) &&
+    (s.section === null || s.section === section));
+  await Promise.all((local.length ? local : shards).map(loadShard));
+  // Warm the remaining shards without blocking the first results.
+  shards.filter(s => !loaded.has(s.id)).forEach(s => loadShard(s));
+}
+
+function search(query) {
+  return fuse ? fuse.search(query) : [];
+}
+
+document.getElementById('search-input').addEventListener('focus', loadRelevantShards, { once: true });
+</script>
+```
+
+For a purely global box replace `loadRelevantShards` with `shards.map(loadShard)`. Everything after loading is the same Fuse.js code as the single-file setup above.
 
 ## Alternative: Pagefind
 

--- a/spec/functional/search_shards_cache_spec.cr
+++ b/spec/functional/search_shards_cache_spec.cr
@@ -1,0 +1,125 @@
+require "./support/build_helper"
+
+# =============================================================================
+# Sharded search index under `--cache`.
+#
+# The shards are cut from the SAME entry list `search.json` is built from,
+# so every guarantee the classic file has under a warm cache (hydrated
+# shortcode content, resolved `@/` links, base_path-prefixed URLs — see
+# cache_generate_outputs_spec) must hold for `search/index.json` and every
+# `search/<id>.json` too, and a warm build that re-renders one page must
+# refresh exactly that page's shard.
+# =============================================================================
+
+private SHARD_CONFIG = <<-TOML
+  title = "Shard Site"
+  base_url = "http://localhost/sub"
+
+  [search]
+  enabled = true
+  fields = ["title", "content", "section"]
+  shards = "section"
+  TOML
+
+private def run_shard_builder(cache : Bool)
+  builder = Hwaro::Core::Build::Builder.new
+  Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+  builder.run(Hwaro::Config::Options::BuildOptions.new(output_dir: "public", parallel: false, cache: cache))
+end
+
+private def shard_project
+  File.write("config.toml", SHARD_CONFIG)
+  FileUtils.mkdir_p("content/blog")
+  FileUtils.mkdir_p("content/docs")
+  FileUtils.mkdir_p("templates/shortcodes")
+  File.write("templates/page.html", "{{ content }}")
+  File.write("templates/index.html", "{{ content }}")
+  File.write("templates/section.html", "{{ content }}")
+  File.write("templates/shortcodes/gal.html", "<div class=\"gal\">{{ body }}</div>")
+  File.write("content/index.md", "---\ntitle: Home\n---\nHome")
+  File.write("content/blog/shorty.md",
+    "---\ntitle: S\n---\nIntro.\n\n{% gal() %}\nINNER\n{% end %}\n\n[home](@/index.md)\n\nOutro.\n")
+  File.write("content/docs/guide.md", "---\ntitle: Guide\n---\nGuide body.\n")
+end
+
+private def search_outputs : Hash(String, String)
+  files = Dir.glob("public/search/**/*.json").sort
+  files << "public/search.json"
+  files.to_h { |f| {f, File.read(f)} }
+end
+
+describe "cache: sharded search index converges on the clean build" do
+  it "keeps the manifest and every shard identical on cold, all-hit and partial-hit --cache builds" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        shard_project
+        FileUtils.rm_rf("public")
+        FileUtils.rm_rf(".hwaro_cache.json")
+        run_shard_builder(false)
+        expected = search_outputs
+        expected.keys.should eq(["public/search/_root.json", "public/search/blog.json", "public/search/docs.json", "public/search/index.json", "public/search.json"])
+        # Sanity: the shard really holds hydrated content and subpath URLs.
+        expected["public/search/blog.json"].should contain("Intro. INNER")
+        expected["public/search/blog.json"].should_not contain("{%")
+        expected["public/search/blog.json"].should contain("\"/sub/blog/shorty/\"")
+        expected["public/search/index.json"].should contain("\"/sub/search/blog.json\"")
+
+        FileUtils.rm_rf("public")
+        FileUtils.rm_rf(".hwaro_cache.json")
+        run_shard_builder(true) # cold cache build
+        search_outputs.should eq(expected)
+
+        run_shard_builder(true) # warm, every page a cache hit
+        search_outputs.should eq(expected)
+
+        # Warm, one page re-rendered: only its shard changes, the shortcode
+        # page (still a cache hit) keeps its hydrated content.
+        File.write("content/docs/guide.md", "---\ntitle: Guide\n---\nGuide body edited.\n")
+        run_shard_builder(true)
+        got = search_outputs
+        got["public/search/docs.json"].should contain("Guide body edited")
+        got["public/search/docs.json"].should_not eq(expected["public/search/docs.json"])
+        got["public/search/blog.json"].should eq(expected["public/search/blog.json"])
+        got["public/search/_root.json"].should eq(expected["public/search/_root.json"])
+        got["public/search/blog.json"].should contain("Intro. INNER")
+
+        # ...and it must match what a clean build of the edited tree gives.
+        FileUtils.rm_rf("public")
+        FileUtils.rm_rf(".hwaro_cache.json")
+        run_shard_builder(false)
+        search_outputs.should eq(got)
+      end
+    end
+  end
+
+  it "drops a shard on a warm --cache build when its last page is removed" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        shard_project
+        FileUtils.rm_rf("public")
+        FileUtils.rm_rf(".hwaro_cache.json")
+        run_shard_builder(true)
+        File.exists?("public/search/docs.json").should be_true
+
+        File.delete("content/docs/guide.md")
+        run_shard_builder(true)
+        File.exists?("public/search/docs.json").should be_false
+        manifest = JSON.parse(File.read("public/search/index.json"))
+        manifest["shards"].as_a.map(&.["id"].as_s).should eq(["_root", "blog"])
+      end
+    end
+  end
+
+  it "emits no search/ directory at the default shards = none" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        shard_project
+        File.write("config.toml", SHARD_CONFIG.sub("shards = \"section\"", ""))
+        FileUtils.rm_rf("public")
+        run_shard_builder(false)
+        File.exists?("public/search.json").should be_true
+        Dir.exists?("public/search").should be_false
+      end
+    end
+  end
+end

--- a/spec/unit/search_shards_spec.cr
+++ b/spec/unit/search_shards_spec.cr
@@ -1,0 +1,375 @@
+require "../spec_helper"
+
+# =============================================================================
+# Sharded search index: `[search] shards`, `single_file`, `content_max_length`.
+#
+# Contract: with `shards = "none"` (default) the generator emits exactly what
+# it always did — `search.json` and no `search/` directory. Any other mode
+# adds `search/index.json` (manifest) plus one `search/<id>.json` per shard,
+# each carrying the same entry schema as `search.json`.
+# =============================================================================
+
+private def shard_config(shards : String = "section", fields = ["title", "content", "section"]) : Hwaro::Models::Config
+  config = Hwaro::Models::Config.new
+  config.search.enabled = true
+  config.search.fields = fields
+  config.search.shards = shards
+  config
+end
+
+private def shard_page(path : String, title : String, url : String, section : String, body : String = "Body text", language : String? = nil) : Hwaro::Models::Page
+  page = Hwaro::Models::Page.new(path)
+  page.title = title
+  page.url = url
+  page.section = section
+  page.draft = false
+  page.raw_content = body
+  page.language = language
+  page
+end
+
+private def sample_pages : Array(Hwaro::Models::Page)
+  [
+    shard_page("blog/second.md", "Second", "/blog/second/", "blog"),
+    shard_page("about.md", "About", "/about/", ""),
+    shard_page("blog/news/first.md", "First", "/blog/news/first/", "blog/news"),
+    shard_page("docs/intro.md", "Intro", "/docs/intro/", "docs"),
+  ]
+end
+
+private def load_search_config(toml : String) : Hwaro::Models::Config
+  Dir.mktmpdir do |dir|
+    path = File.join(dir, "config.toml")
+    File.write(path, toml)
+    return Hwaro::Models::Config.load(path)
+  end
+  raise "unreachable"
+end
+
+private def read_manifest(output_dir : String) : JSON::Any
+  JSON.parse(File.read(File.join(output_dir, "search", "index.json")))
+end
+
+private def multilingual_config(shards : String) : Hwaro::Models::Config
+  config = shard_config(shards)
+  config.default_language = "en"
+  config.languages["en"] = Hwaro::Models::LanguageConfig.new("en")
+  config.languages["ko"] = Hwaro::Models::LanguageConfig.new("ko")
+  config
+end
+
+private def multilingual_pages : Array(Hwaro::Models::Page)
+  [
+    shard_page("blog/post.md", "Post", "/blog/post/", "blog"),
+    shard_page("blog/post.ko.md", "포스트", "/ko/blog/post/", "blog", language: "ko"),
+    shard_page("index.md", "Home", "/", ""),
+    shard_page("index.ko.md", "홈", "/ko/", "", language: "ko"),
+  ]
+end
+
+describe "Hwaro::Content::Search shards" do
+  describe "shards = \"none\" (default)" do
+    it "emits only the classic search.json and no search/ directory" do
+      config = shard_config("none")
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(sample_pages, config, odir)
+        File.exists?(File.join(odir, "search.json")).should be_true
+        Dir.exists?(File.join(odir, "search")).should be_false
+      end
+    end
+
+    it "ignores single_file = false when sharding is off" do
+      config = shard_config("none")
+      config.search.single_file = false
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(sample_pages, config, odir)
+        File.exists?(File.join(odir, "search.json")).should be_true
+      end
+    end
+  end
+
+  describe "shards = \"section\"" do
+    it "writes one shard per top-level section, root pages to _root, plus a manifest" do
+      config = shard_config("section")
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(sample_pages, config, odir)
+
+        Dir.glob(File.join(odir, "search", "**", "*.json")).map { |p| p[(odir.size + 1)..] }.sort!.should eq([
+          "search/_root.json", "search/blog.json", "search/docs.json", "search/index.json",
+        ])
+
+        # Nested `blog/news` folds into the top-level `blog` shard, in the
+        # same order search.json lists the pages.
+        blog = JSON.parse(File.read(File.join(odir, "search", "blog.json"))).as_a
+        blog.map(&.["title"].as_s).should eq(["Second", "First"])
+        blog.each(&.["url"].as_s.should(start_with("/blog/")))
+        JSON.parse(File.read(File.join(odir, "search", "_root.json"))).as_a.map(&.["url"].as_s).should eq(["/about/"])
+
+        manifest = read_manifest(odir)
+        manifest["version"].as_i.should eq(1)
+        manifest["fields"].as_a.map(&.as_s).should eq(["title", "content", "section", "url", "lang"])
+        shards = manifest["shards"].as_a
+        shards.map(&.["id"].as_s).should eq(["_root", "blog", "docs"])
+        shards.map(&.["url"].as_s).should eq(["/search/_root.json", "/search/blog.json", "/search/docs.json"])
+        shards.map(&.["count"].as_i).should eq([1, 2, 1])
+        shards.map(&.["section"].as_s).should eq(["", "blog", "docs"])
+        shards.each(&.["language"].raw.should(be_nil))
+        shards.each do |s|
+          s["bytes"].as_i.should eq(File.size(File.join(odir, "search", "#{s["id"].as_s}.json")))
+        end
+      end
+    end
+
+    it "keeps the classic search.json alongside the shards by default" do
+      config = shard_config("section")
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(sample_pages, config, odir)
+        classic = JSON.parse(File.read(File.join(odir, "search.json"))).as_a
+        classic.size.should eq(4)
+        # Shard entries carry exactly the same schema as the classic file.
+        shard_entry = JSON.parse(File.read(File.join(odir, "search", "docs.json"))).as_a.first
+        classic.find! { |e| e["url"].as_s == "/docs/intro/" }.should eq(shard_entry)
+      end
+    end
+
+    it "drops search.json when single_file = false" do
+      config = shard_config("section")
+      config.search.single_file = false
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(sample_pages, config, odir)
+        File.exists?(File.join(odir, "search.json")).should be_false
+        File.exists?(File.join(odir, "search", "index.json")).should be_true
+      end
+    end
+
+    it "applies the same eligibility and exclude filters as search.json" do
+      config = shard_config("section")
+      config.search.exclude = ["/docs"]
+      pages = sample_pages
+      draft = shard_page("blog/draft.md", "Draft", "/blog/draft/", "blog")
+      draft.draft = true
+      opted_out = shard_page("blog/private.md", "Private", "/blog/private/", "blog")
+      opted_out.in_search_index = false
+      pages << draft << opted_out
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(pages, config, odir)
+        manifest = read_manifest(odir)
+        manifest["shards"].as_a.map(&.["id"].as_s).should eq(["_root", "blog"])
+        blog = File.read(File.join(odir, "search", "blog.json"))
+        blog.should_not contain("Draft")
+        blog.should_not contain("Private")
+      end
+    end
+
+    it "prefixes manifest URLs with base_path on subpath deploys" do
+      config = shard_config("section")
+      config.base_url = "https://example.com/sub"
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(sample_pages, config, odir)
+        urls = read_manifest(odir)["shards"].as_a.map(&.["url"].as_s)
+        urls.should eq(["/sub/search/_root.json", "/sub/search/blog.json", "/sub/search/docs.json"])
+        # Entry URLs inside the shards are prefixed too (same as search.json).
+        JSON.parse(File.read(File.join(odir, "search", "blog.json"))).as_a.first["url"].as_s.should eq("/sub/blog/second/")
+        # But the files stay at their un-prefixed output paths.
+        File.exists?(File.join(odir, "search", "blog.json")).should be_true
+      end
+    end
+
+    it "percent-encodes a section name in the manifest URL but not the file path" do
+      config = shard_config("section")
+      pages = [shard_page("my docs/a.md", "A", "/my-docs/a/", "my docs")]
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(pages, config, odir)
+        File.exists?(File.join(odir, "search", "my docs.json")).should be_true
+        read_manifest(odir)["shards"].as_a.first["url"].as_s.should eq("/search/my%20docs.json")
+      end
+    end
+
+    it "is deterministic across runs and page order" do
+      config = shard_config("section")
+      Dir.mktmpdir do |a|
+        Dir.mktmpdir do |b|
+          Hwaro::Content::Search.generate(sample_pages, config, a)
+          Hwaro::Content::Search.generate(sample_pages.reverse, config, b)
+          # The manifest never depends on the page order the build hands over.
+          File.read(File.join(a, "search", "index.json")).should eq(File.read(File.join(b, "search", "index.json")))
+          Hwaro::Content::Search.generate(sample_pages, config, b)
+          Dir.glob(File.join(a, "search", "**", "*.json")).each do |path|
+            File.read(path).should eq(File.read(path.sub(a, b)))
+          end
+        end
+      end
+    end
+
+    it "prunes shards listed by the previous manifest that this build did not write" do
+      config = shard_config("section")
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(sample_pages, config, odir)
+        File.exists?(File.join(odir, "search", "docs.json")).should be_true
+        # A user file under search/ that our manifest never listed survives.
+        File.write(File.join(odir, "search", "custom.json"), "{}")
+
+        Hwaro::Content::Search.generate(sample_pages.reject { |p| p.section == "docs" }, config, odir)
+        File.exists?(File.join(odir, "search", "docs.json")).should be_false
+        File.exists?(File.join(odir, "search", "custom.json")).should be_true
+        read_manifest(odir)["shards"].as_a.map(&.["id"].as_s).should eq(["_root", "blog"])
+      end
+    end
+
+    it "writes an empty manifest and prunes stale shards when no page is eligible" do
+      config = shard_config("section")
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(sample_pages, config, odir)
+        Hwaro::Content::Search.generate([] of Hwaro::Models::Page, config, odir)
+        read_manifest(odir)["shards"].as_a.should be_empty
+        Dir.glob(File.join(odir, "search", "*.json")).map { |p| File.basename(p) }.should eq(["index.json"])
+      end
+    end
+
+    it "honors skip_if_unchanged only when every expected file is present" do
+      config = shard_config("section")
+      Dir.mktmpdir do |odir|
+        # Classic file present but no manifest yet → must generate the shards.
+        File.write(File.join(odir, "search.json"), "[]")
+        Hwaro::Content::Search.generate(sample_pages, config, odir, skip_if_unchanged: true)
+        File.exists?(File.join(odir, "search", "index.json")).should be_true
+        File.read(File.join(odir, "search.json")).should_not eq("[]")
+
+        # Everything present → skipped (the sentinel survives).
+        File.write(File.join(odir, "search.json"), "[]")
+        Hwaro::Content::Search.generate(sample_pages, config, odir, skip_if_unchanged: true)
+        File.read(File.join(odir, "search.json")).should eq("[]")
+      end
+    end
+
+    it "emits plain JSON shards even for the *_javascript formats" do
+      config = shard_config("section")
+      config.search.format = "fuse_javascript"
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(sample_pages, config, odir)
+        File.read(File.join(odir, "search.json")).should start_with("var searchData = ")
+        File.read(File.join(odir, "search", "blog.json")).should start_with("[{")
+      end
+    end
+  end
+
+  describe "shards = \"language\"" do
+    it "writes one shard per language, default language pages under its code" do
+      config = multilingual_config("language")
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(multilingual_pages, config, odir)
+        shards = read_manifest(odir)["shards"].as_a
+        shards.map(&.["id"].as_s).should eq(["en", "ko"])
+        shards.map(&.["language"].as_s).should eq(["en", "ko"])
+        shards.each(&.["section"].raw.should(be_nil))
+        shards.map(&.["count"].as_i).should eq([2, 2])
+        JSON.parse(File.read(File.join(odir, "search", "ko.json"))).as_a.each(&.["lang"].as_s.should(eq("ko")))
+        JSON.parse(File.read(File.join(odir, "search", "en.json"))).as_a.each(&.["lang"].as_s.should(eq("en")))
+      end
+    end
+
+    it "excludes a language that opted odir via build_search_index = false" do
+      config = multilingual_config("language")
+      config.languages["ko"].build_search_index = false
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(multilingual_pages, config, odir)
+        read_manifest(odir)["shards"].as_a.map(&.["id"].as_s).should eq(["en"])
+        File.exists?(File.join(odir, "search", "ko.json")).should be_false
+        File.read(File.join(odir, "search.json")).should_not contain("/ko/")
+      end
+    end
+  end
+
+  describe "shards = \"section-language\"" do
+    it "nests section shards under the language code" do
+      config = multilingual_config("section-language")
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(multilingual_pages, config, odir)
+        shards = read_manifest(odir)["shards"].as_a
+        shards.map(&.["id"].as_s).should eq(["en/_root", "en/blog", "ko/_root", "ko/blog"])
+        shards.map(&.["url"].as_s).should eq(["/search/en/_root.json", "/search/en/blog.json", "/search/ko/_root.json", "/search/ko/blog.json"])
+        shards.map { |s| {s["language"].as_s, s["section"].as_s} }.should eq([{"en", ""}, {"en", "blog"}, {"ko", ""}, {"ko", "blog"}])
+        File.exists?(File.join(odir, "search", "ko", "blog.json")).should be_true
+        JSON.parse(File.read(File.join(odir, "search", "ko", "blog.json"))).as_a.map(&.["title"].as_s).should eq(["포스트"])
+      end
+    end
+
+    it "removes an emptied nested id directory when a language shard goes away" do
+      config = multilingual_config("section-language")
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(multilingual_pages, config, odir)
+        Dir.exists?(File.join(odir, "search", "ko")).should be_true
+        Hwaro::Content::Search.generate(multilingual_pages.reject { |p| p.language == "ko" }, config, odir)
+        Dir.exists?(File.join(odir, "search", "ko")).should be_false
+        read_manifest(odir)["shards"].as_a.map(&.["id"].as_s).should eq(["en/_root", "en/blog"])
+      end
+    end
+  end
+
+  describe "content_max_length" do
+    it "leaves content untouched at 0" do
+      config = shard_config("none")
+      pages = [shard_page("a.md", "A", "/a/", "", body: "one two three four five six")]
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(pages, config, odir)
+        JSON.parse(File.read(File.join(odir, "search.json"))).as_a.first["content"].as_s.should eq("one two three four five six")
+      end
+    end
+
+    it "truncates content at a word boundary in search.json and in every shard" do
+      config = shard_config("section")
+      config.search.content_max_length = 12
+      pages = [shard_page("blog/a.md", "A", "/blog/a/", "blog", body: "one two three four five six")]
+      Dir.mktmpdir do |odir|
+        Hwaro::Content::Search.generate(pages, config, odir)
+        JSON.parse(File.read(File.join(odir, "search.json"))).as_a.first["content"].as_s.should eq("one two")
+        JSON.parse(File.read(File.join(odir, "search", "blog.json"))).as_a.first["content"].as_s.should eq("one two")
+      end
+    end
+
+    it "does not truncate a content field already within the limit" do
+      Hwaro::Content::Search.truncate_words("short text", 10).should eq("short text")
+      Hwaro::Content::Search.truncate_words("short text", 100).should eq("short text")
+    end
+
+    it "cuts hard when the prefix holds no whitespace" do
+      Hwaro::Content::Search.truncate_words("abcdefghijklmnop", 5).should eq("abcde")
+      Hwaro::Content::Search.truncate_words("abcdefghij klm", 5).should eq("abcde")
+    end
+
+    it "keeps a word that ends exactly at the limit" do
+      Hwaro::Content::Search.truncate_words("hello world", 5).should eq("hello")
+      Hwaro::Content::Search.truncate_words("hello world", 6).should eq("hello")
+    end
+
+    it "counts characters, not bytes" do
+      Hwaro::Content::Search.truncate_words("한국어 검색 인덱스", 6).should eq("한국어 검색")
+    end
+  end
+
+  describe "config loading" do
+    it "defaults to shards = none, single_file = true, content_max_length = 0" do
+      config = load_search_config("title = \"T\"\nbase_url = \"http://x\"\n[search]\nenabled = true\n")
+      config.search.shards.should eq("none")
+      config.search.sharded?.should be_false
+      config.search.single_file.should be_true
+      config.search.content_max_length.should eq(0)
+    end
+
+    it "reads every shard mode plus single_file and content_max_length" do
+      %w[section language section-language].each do |mode|
+        config = load_search_config("title = \"T\"\nbase_url = \"http://x\"\n[search]\nenabled = true\nshards = \"#{mode}\"\nsingle_file = false\ncontent_max_length = 200\n")
+        config.search.shards.should eq(mode)
+        config.search.sharded?.should be_true
+        config.search.single_file.should be_false
+        config.search.content_max_length.should eq(200)
+      end
+    end
+
+    it "falls back to none on an unknown shards value and to 0 on a negative length" do
+      config = load_search_config("title = \"T\"\nbase_url = \"http://x\"\n[search]\nenabled = true\nshards = \"sections\"\ncontent_max_length = -5\n")
+      config.search.shards.should eq("none")
+      config.search.content_max_length.should eq(0)
+    end
+  end
+end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -786,7 +786,10 @@ module Hwaro
             add_route.call(config.robots.filename) if config.robots.enabled
             add_route.call(config.llms.filename) if config.llms.enabled
             add_route.call(config.llms.full_filename) if config.llms.enabled && config.llms.full_enabled
-            add_route.call(config.search.filename) if config.search.enabled
+            add_route.call(config.search.filename) if config.search.enabled && (!config.search.sharded? || config.search.single_file)
+            # Sharded index: the manifest is a fixed well-known route; the
+            # per-shard files are only discoverable through it.
+            paths << "/#{Content::Search::SHARDS_DIR}/#{Content::Search::MANIFEST_FILENAME}" if config.search.enabled && config.search.sharded?
 
             feed_filename = nil
             if config.feeds.enabled

--- a/src/content/search.cr
+++ b/src/content/search.cr
@@ -11,12 +11,42 @@ require "uri"
 module Hwaro
   module Content
     class Search
+      # Sharded output lives under `<output_dir>/search/`: one
+      # `<shard-id>.json` per shard plus this manifest. Fixed names (not
+      # derived from `filename`) so a client can discover the layout from a
+      # single well-known URL.
+      SHARDS_DIR        = "search"
+      MANIFEST_FILENAME = "index.json"
+      MANIFEST_VERSION  = 1
+
+      # Shard id for pages outside every section (`content/about.md`).
+      ROOT_SHARD_ID = "_root"
+
+      # Entry fields the generator knows how to emit; anything else in
+      # `search.fields` is silently skipped, so the manifest's `fields` list
+      # must be filtered the same way.
+      KNOWN_FIELDS = %w[title content tags url section description]
+
+      alias Entry = Hash(String, String | Array(String))
+
+      def self.manifest_path(output_dir : String) : String
+        File.join(output_dir, SHARDS_DIR, MANIFEST_FILENAME)
+      end
+
       def self.generate(pages : Array(Models::Page), config : Models::Config, output_dir : String, verbose : Bool = false, skip_if_unchanged : Bool = false)
         return unless config.search.enabled
 
+        sharded = config.search.sharded?
+        # With shards on, `single_file = false` drops the classic file; with
+        # shards off the setting is meaningless and the classic file is the
+        # only output (byte-identical to pre-shard builds).
+        single_file = !sharded || config.search.single_file
+        search_path = File.join(output_dir, File.basename(config.search.filename))
+
         if skip_if_unchanged
-          search_path = File.join(output_dir, File.basename(config.search.filename))
-          if File.exists?(search_path)
+          present = (!single_file || File.exists?(search_path)) &&
+                    (!sharded || File.exists?(manifest_path(output_dir)))
+          if present
             Logger.debug "  Search index unchanged (cache hit), skipping."
             return
           end
@@ -46,40 +76,179 @@ module Hwaro
 
         if search_pages.empty?
           Logger.info "  No pages to include in search index."
+          # An empty manifest still tells a sharded client "nothing to
+          # load" instead of a 404, and pruning drops shards a previous
+          # build wrote for pages that no longer exist.
+          write_shards(search_pages, [] of Entry, config, output_dir, verbose) if sharded
           return
         end
 
         # Build search data based on format
         search_data = build_search_data(search_pages, config)
 
-        # Both libraries use the same array for now, so Hwaro generates a common format and lets the client build the index.
-        # We've kept the names distinct to respect user intent and stay ready for library-specific optimizations later.
-        content = case config.search.format.downcase
-                  when "fuse_javascript"
-                    generate_javascript(search_data)
-                  when "fuse_json"
-                    generate_json(search_data)
-                  when "elasticlunr_json"
-                    generate_json(search_data)
-                  when "elasticlunr_javascript"
-                    generate_javascript(search_data)
-                  else
-                    Logger.warn "Unknown search format '#{config.search.format}'. Defaulting to 'fuse_json'."
-                    generate_json(search_data)
-                  end
+        if single_file
+          # Both libraries use the same array for now, so Hwaro generates a common format and lets the client build the index.
+          # We've kept the names distinct to respect user intent and stay ready for library-specific optimizations later.
+          content = case config.search.format.downcase
+                    when "fuse_javascript"
+                      generate_javascript(search_data)
+                    when "fuse_json"
+                      generate_json(search_data)
+                    when "elasticlunr_json"
+                      generate_json(search_data)
+                    when "elasticlunr_javascript"
+                      generate_javascript(search_data)
+                    else
+                      Logger.warn "Unknown search format '#{config.search.format}'. Defaulting to 'fuse_json'."
+                      generate_json(search_data)
+                    end
 
-        # Write search file
-        filename = File.basename(config.search.filename)
-        search_path = File.join(output_dir, filename)
-        Hwaro::Utils::FileSafe.atomic_write(search_path, content)
-        Logger.action :create, search_path if verbose
+          # Write search file
+          Hwaro::Utils::FileSafe.atomic_write(search_path, content)
+          Logger.action :create, search_path if verbose
+        end
+
+        write_shards(search_pages, search_data, config, output_dir, verbose) if sharded
         Logger.info "  Generated search index with #{search_pages.size} pages." if verbose
       end
 
-      private def self.build_search_data(pages : Array(Models::Page), config : Models::Config) : Array(Hash(String, String | Array(String)))
+      # The entry keys every emitted entry carries, in emission order:
+      # the configured fields (known ones only), then `url` (always
+      # present) and `lang` (always appended). Exposed for the manifest.
+      def self.entry_fields(config : Models::Config) : Array(String)
+        fields = config.search.fields.map(&.downcase).select { |f| KNOWN_FIELDS.includes?(f) }.uniq!
+        fields << "url" unless fields.includes?("url")
+        fields << "lang" unless fields.includes?("lang")
+        fields
+      end
+
+      # Truncate `text` to at most `max` characters, backing up to the last
+      # whitespace inside the cut so no word is split. A run with no
+      # whitespace at all (a long URL, untokenized CJK) is cut hard at `max`.
+      # `max <= 0` disables truncation.
+      def self.truncate_words(text : String, max : Int32) : String
+        return text if max <= 0 || text.size <= max
+        cut = text[0, max]
+        # A cut that already ends on a word boundary (the next character is
+        # whitespace) keeps its last word; otherwise back up to the last
+        # whitespace inside the cut.
+        unless text[max].whitespace?
+          if idx = cut.rindex(/\s/)
+            cut = cut[0, idx] if idx > 0
+          end
+        end
+        cut.rstrip
+      end
+
+      # Shard identity for one page under the configured `shards` mode.
+      # `section` is the page's TOP-LEVEL section (`blog` for `blog/news`)
+      # because that is the granularity a client can lazy-load by; nested
+      # sections would explode the shard count without helping.
+      private def self.shard_key(page : Models::Page, config : Models::Config) : {id: String, language: String?, section: String?}
+        lang = page.language || config.default_language
+        lang = "_default" if lang.empty?
+        top = page.section.split('/', remove_empty: true).first? || ""
+        case config.search.shards
+        when "language"
+          {id: lang, language: lang, section: nil}
+        when "section-language"
+          {id: "#{lang}/#{top.empty? ? ROOT_SHARD_ID : top}", language: lang, section: top}
+        else # "section"
+          {id: top.empty? ? ROOT_SHARD_ID : top, language: nil, section: top}
+        end
+      end
+
+      # Emit `search/<id>.json` per shard plus the `search/index.json`
+      # manifest. Shards are always plain JSON arrays whatever `format`
+      # says: the `*_javascript` wrapper only serves `<script src>` loading,
+      # and shards exist to be fetched on demand. Deterministic: shards are
+      # written in id order and the manifest lists them the same way;
+      # entries keep the order `search.json` uses.
+      private def self.write_shards(pages : Array(Models::Page), entries : Array(Entry), config : Models::Config, output_dir : String, verbose : Bool) : Nil
+        shards_dir = File.join(output_dir, SHARDS_DIR)
+        manifest_file = manifest_path(output_dir)
+        previous_ids = previous_shard_ids(manifest_file)
+
+        groups = {} of String => {language: String?, section: String?, entries: Array(Entry)}
+        pages.each_with_index do |page, i|
+          key = shard_key(page, config)
+          group = groups[key[:id]] ||= {language: key[:language], section: key[:section], entries: [] of Entry}
+          group[:entries] << entries[i]
+        end
+
+        base_path = config.base_path
+        Hwaro::Utils::FileSafe.mkdir_p(shards_dir)
+        manifest = JSON.build do |json|
+          json.object do
+            json.field "version", MANIFEST_VERSION
+            json.field "fields", entry_fields(config)
+            json.field "shards" do
+              json.array do
+                groups.keys.sort!.each do |id|
+                  group = groups[id]
+                  content = group[:entries].to_json
+                  shard_file = File.join(shards_dir, "#{id}.json")
+                  Hwaro::Utils::FileSafe.mkdir_p(File.dirname(shard_file))
+                  Hwaro::Utils::FileSafe.atomic_write(shard_file, content)
+                  Logger.action :create, shard_file if verbose
+                  json.object do
+                    json.field "id", id
+                    # Percent-encode: a section directory may carry spaces
+                    # or non-ASCII the filesystem accepts but a URL must escape.
+                    json.field "url", "#{base_path}/#{SHARDS_DIR}/#{URI.encode_path(id)}.json"
+                    json.field "language", group[:language]
+                    json.field "section", group[:section]
+                    json.field "count", group[:entries].size
+                    json.field "bytes", content.bytesize
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        # Prune shards a previous build listed that this build did not
+        # write (a removed section/language) so a warm `--cache` build or a
+        # `serve` rebuild never leaves a shard the manifest no longer knows.
+        # Only ids from OUR previous manifest are touched, never arbitrary
+        # files under `search/`.
+        (previous_ids - groups.keys).each { |id| remove_stale_shard(shards_dir, id) }
+
+        Hwaro::Utils::FileSafe.atomic_write(manifest_file, manifest)
+        Logger.action :create, manifest_file if verbose
+      end
+
+      private def self.previous_shard_ids(manifest_file : String) : Array(String)
+        return [] of String unless File.file?(manifest_file)
+        parsed = JSON.parse(File.read(manifest_file))
+        parsed["shards"].as_a.compact_map { |s| s["id"]?.try(&.as_s?) }
+      rescue JSON::ParseException | KeyError | TypeCastError | File::Error
+        [] of String
+      end
+
+      private def self.remove_stale_shard(shards_dir : String, id : String) : Nil
+        root = File.expand_path(shards_dir)
+        path = File.expand_path(File.join(shards_dir, "#{id}.json"))
+        # A hand-edited manifest could smuggle `..` into an id; never delete
+        # outside the shard directory.
+        return unless path.starts_with?(root + File::SEPARATOR)
+        File.delete?(path)
+        # Drop now-empty nested id directories (`search/ko/`) best-effort.
+        dir = File.dirname(path)
+        while dir != root && dir.starts_with?(root + File::SEPARATOR)
+          break unless Dir.empty?(dir)
+          Dir.delete(dir)
+          dir = File.dirname(dir)
+        end
+      rescue File::Error
+        # Best effort: a stale shard is harmless, a failed build is not.
+      end
+
+      private def self.build_search_data(pages : Array(Models::Page), config : Models::Config) : Array(Entry)
         # Pre-lowercase field names once instead of per-page per-field
         fields = config.search.fields.map(&.downcase)
         cjk = config.search.tokenize_cjk
+        max_content = config.search.content_max_length
 
         # Extract base path from base_url for subpath deployments. Use the
         # memoized Config helper rather than re-parsing: it also rescues a
@@ -88,7 +257,7 @@ module Hwaro
         base_path = config.base_path
 
         pages.map do |page|
-          data = {} of String => String | Array(String)
+          data = Entry.new
 
           fields.each do |field|
             case field
@@ -122,7 +291,10 @@ module Hwaro
               # escaped form (`print(&quot;hi&quot;)`). Client-side
               # search libraries match on the raw stored string.
               text_content = HTML.unescape(Utils::TextUtils.strip_html(html_content))
-              data["content"] = cjk ? Utils::TextUtils.tokenize_cjk(text_content) : text_content
+              text_content = Utils::TextUtils.tokenize_cjk(text_content) if cjk
+              # Truncate the stored value (after CJK tokenization) so the
+              # configured cap bounds what actually lands in the file.
+              data["content"] = truncate_words(text_content, max_content)
             when "tags"
               data["tags"] = page.tags
             when "url"
@@ -146,11 +318,11 @@ module Hwaro
         end
       end
 
-      private def self.generate_json(search_data : Array(Hash(String, String | Array(String)))) : String
+      private def self.generate_json(search_data : Array(Entry)) : String
         search_data.to_json
       end
 
-      private def self.generate_javascript(search_data : Array(Hash(String, String | Array(String)))) : String
+      private def self.generate_javascript(search_data : Array(Entry)) : String
         json_str = search_data.to_json
         # Avoid double-alloc: skip gsub when no </script> escape is needed (common case)
         if json_str.includes?("</")

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -77,12 +77,22 @@ module Hwaro
     end
 
     class SearchConfig
+      # `shards` partitions the index into `search/<id>.json` files plus a
+      # `search/index.json` manifest so clients lazy-load only what they
+      # need. `single_file` keeps the classic `search.json` alongside the
+      # shards; `content_max_length` (> 0) truncates each entry's `content`
+      # at a word boundary.
+      VALID_SHARDS = %w[none section language section-language]
+
       property enabled : Bool
       property format : String
       property fields : Array(String)
       property filename : String
       property exclude : Array(String)
       property tokenize_cjk : Bool
+      property shards : String
+      property single_file : Bool
+      property content_max_length : Int32
 
       def initialize
         @enabled = false
@@ -91,6 +101,13 @@ module Hwaro
         @filename = "search.json"
         @exclude = [] of String
         @tokenize_cjk = false
+        @shards = "none"
+        @single_file = true
+        @content_max_length = 0
+      end
+
+      def sharded? : Bool
+        @shards != "none"
       end
     end
 
@@ -1913,6 +1930,21 @@ module Hwaro
           config.search.exclude = exclude_arr.compact_map(&.as_s?)
         end
         config.search.tokenize_cjk = bool_value(s["tokenize_cjk"]?, config.search.tokenize_cjk)
+        if shards_any = s["shards"]?
+          shards = shards_any.as_s?
+          if shards && SearchConfig::VALID_SHARDS.includes?(shards)
+            config.search.shards = shards
+          else
+            Logger.warn "Unknown search.shards #{shards_any.raw.inspect} (expected one of: #{SearchConfig::VALID_SHARDS.join(", ")}); using \"none\""
+          end
+        end
+        config.search.single_file = bool_value(s["single_file"]?, config.search.single_file)
+        max_len = int_value(s["content_max_length"]?, config.search.content_max_length)
+        if max_len < 0
+          Logger.warn "Ignoring negative search.content_max_length #{max_len}; using 0 (no truncation)"
+          max_len = 0
+        end
+        config.search.content_max_length = max_len
       end
 
       private def self.load_plugins(config : Config)

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -758,6 +758,9 @@ module Hwaro
             filename = "search.json"
             exclude = []              # Exclude paths or patterns from search index
             tokenize_cjk = false      # Set true for Korean/Japanese/Chinese substring matching
+            # shards = "none"         # "section" | "language" | "section-language": emit search/<id>.json + search/index.json
+            # single_file = true      # With shards on, false drops the classic search.json
+            # content_max_length = 0  # > 0 truncates each entry's content (word boundary) to shrink the index
 
             TOML
         end


### PR DESCRIPTION
## What

Opt-in **sharded search index**. `search.json` is one monolithic file that grows with the site; large sites pay for the whole index before the first search. With sharding, the generator cuts the *same* entry list into `search/<id>.json` files plus a `search/index.json` manifest so clients lazy-load only the shards they need.

```toml
[search]
enabled = true
shards = "section"          # "none" (default) | "section" | "language" | "section-language"
single_file = false         # default true keeps the classic search.json alongside the shards
content_max_length = 500    # default 0 = unchanged; > 0 truncates each entry's content at a word boundary
```

- `section`: one shard per top-level content section (`blog/news` folds into `blog`), root-level pages go to `_root`.
- `language`: one shard per language; the default language shard id is its code.
- `section-language`: `ko/blog`, written as `search/ko/blog.json`.
- Manifest: `{"version":1,"fields":[...],"shards":[{"id","url","language","section","count","bytes"}]}` — shards sorted by id, no timestamp, `url` honors `base_path` and percent-encodes section names.
- Shards carry exactly the entry schema of `search.json` (same `fields`, `exclude`, `in_search_index`, drafts/`render = false`, per-language `build_search_index`, `tokenize_cjk`); they are always plain JSON regardless of `format`.
- Shards listed by the previous manifest but not written this build are pruned (only ids from our own manifest, never arbitrary files under `search/`); emptied nested dirs are removed.
- `tool check-links` registers `/search/index.json` as a generated route (and drops `/search.json` when `single_file = false`).
- New keys are read by `load_search`, so no unknown-key warning.

Docs: `features/search.md` + `.ko.md` gain a "Sharded Index" section (modes, manifest, Fuse.js lazy-load example), config table rows; `CHANGELOG` Unreleased/Added; commented hints in the config snippet. No new JS is shipped; the `docs` scaffold is untouched.

## Verification

- `crystal spec`: **8572 examples, 0 failures** (26 new unit examples in `spec/unit/search_shards_spec.cr`, 3 functional in `spec/functional/search_shards_cache_spec.cr`). Unit specs assert `search/` is absent by default, partitioning per mode, manifest content/order/`bytes`, `single_file = false`, word-boundary truncation, `base_path` URLs, multilingual scoping, pruning, `skip_if_unchanged` — all fail on `main` (no `shards`/`single_file`/`content_max_length` properties exist).
- `crystal tool format` clean, `./bin/ameba` clean on changed files.
- **Byte-identity at default (`shards = "none"`)**: built `docs/` and the `simple`, `docs`, `blog` scaffolds (`--include-multilingual en,ko`) with a `main` (v0.20.1) binary and this branch; `diff -r` of every `public/` tree is empty, no `search/` directory emitted.
- **`--cache`**: on a multilingual docs scaffold with `section-language`, cold `--cache` vs warm `--cache` vs no-cache builds are `diff -r` identical; a warm build after editing one page's title rewrites only `search/ko/guide.json` (+ manifest `bytes`). The functional spec covers cold/all-hit/partial-hit convergence with a shortcode page (no raw `{%` in shards) and shard removal when its last page is deleted.
- **`hwaro serve`**: shards are served from `.hwaro/serve/search/` (`200 application/json`), and a content edit refreshes the shard on rebuild.

## Not done / notes

- `hwaro doctor` / `hwaro tool stats` do not report search index size today, so there was nothing to extend there.
- `skills/hwaro`, `docs/content/start/config.md` and the data-model page only link to the search page / document no keys or template vars, so they are unchanged.
