### PR TITLE
feat(git): page.git commit metadata and lastmod fallback ([git] config)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Search: opt-in sharded index — `[search] shards = "section" | "language" | "section-language"` splits `search.json` into `search/<id>.json` files plus a `search/index.json` manifest so clients lazy-load only the shards they need; `single_file = false` drops the classic file, `content_max_length` caps each entry's `content` at a word boundary
 - Automatic summaries: pages without a `<!-- more -->` marker or `description` now get `page.summary` from the first 70 words of the rendered body (characters ×2 for CJK text), configurable via `[content] summary_length` / `summary_ellipsis`; new `page.summary_truncated` template variable
+- `[git]` config table: one `git log` per build exposes each page's commit history as `page.git` (`hash`, `short_hash`, `lastmod`, `first_commit`, `author_name`, `author_email`) and fills a missing `updated` (`use_lastmod`, default on) or `date` (`use_date`, default off) from it, so sitemap `<lastmod>`, feeds and JSON-LD `dateModified` follow the file's real history. Off by default; degrades with a single warning outside a repository, without a `git` binary, or on a shallow clone. `--cache` keys pages on their commit metadata so a new commit re-renders exactly the pages it touched.
 
 ## v0.20.1
 

--- a/docs/content/features/git-info.ko.md
+++ b/docs/content/features/git-info.ko.md
@@ -1,0 +1,95 @@
++++
+title = "Git 메타데이터"
+description = "각 페이지의 커밋 이력을 page.git으로 노출하고 lastmod를 유도"
+weight = 12
++++
+
+빌드마다 각 콘텐츠 파일의 커밋 이력을 한 번 읽어 템플릿과 SEO 출력에 노출합니다. Hugo의 `enableGitInfo`와 같은 기능입니다. `[git]`을 켜면 프론트 매터에 `updated`가 없는 페이지는 최신 커밋 시각을 받으므로 사이트맵 `<lastmod>`, 피드 `<updated>`, JSON-LD `dateModified`가 파일이 실제로 바뀐 시점을 반영합니다.
+
+## 설정
+
+`config.toml`에서 옵트인합니다.
+
+```toml
+[git]
+enabled = true
+use_lastmod = true   # 프론트 매터에 updated가 없으면 page.updated ← 최신 커밋
+use_date = false     # 프론트 매터에 date가 없으면 page.date ← 첫 커밋
+```
+
+| 키 | 타입 | 기본값 | 설명 |
+|-----|------|---------|-------------|
+| enabled | bool | false | `content/` 파일의 git 메타데이터 수집 |
+| use_lastmod | bool | true | 프론트 매터에 `updated`가 없으면 파일의 최신 커밋으로 `page.updated` 설정 |
+| use_date | bool | false | 프론트 매터에 `date`가 없으면 파일의 첫 커밋으로 `page.date` 설정 |
+
+프론트 매터가 항상 우선합니다. 폴백은 파일이 비워 둔 필드만 채웁니다.
+
+## 동작 방식
+
+1. 빌드가 `content/` 전체에 대해 `git log`를 **한 번** 실행하고(페이지마다 프로세스를 띄우지 않음) 모든 경로를 커밋에 매핑합니다. 5,200페이지 테스트 저장소에서 수집 단계 전체가 약 50ms 걸렸습니다.
+2. 소스 파일에 비병합 커밋이 하나라도 있는 페이지는 `page.git` 객체를 갖습니다.
+3. `use_lastmod` / `use_date`가 비어 있는 `updated` / `date`를 채우면 사이트맵, 피드, JSON-LD, OpenGraph, `sort_by = "date"` 등 하위 모든 곳이 템플릿 수정 없이 git에서 유도한 값을 봅니다.
+
+`hwaro serve`는 파일을 저장할 때마다가 아니라 전체 재빌드마다 한 번 이력을 수집합니다. `hwaro build --cache`는 각 페이지의 커밋 ID와 타임스탬프를 캐시 키에 포함하므로, 새 커밋 후의 웜 재빌드는 그 커밋이 건드린 페이지(와 이를 보여주는 목록)만 정확히 다시 렌더링합니다.
+
+## 템플릿 변수
+
+| 변수 | 타입 | 설명 |
+|----------|------|-------------|
+| page.git | Object? | 페이지에 이력이 없으면 `nil`(아래 참고) |
+| page.git.hash | String | 파일을 건드린 최신 비병합 커밋의 전체 커밋 ID |
+| page.git.short_hash | String | `hash`의 앞 7자 |
+| page.git.lastmod | Time | 최신 커밋의 작성자 날짜 |
+| page.git.first_commit | Time | 파일을 건드린 모든 커밋 중 가장 이른 작성자 날짜 |
+| page.git.author_name | String | 최신 커밋의 작성자 이름 |
+| page.git.author_email | String | 최신 커밋의 작성자 이메일 |
+
+`lastmod`와 `first_commit`은 실제 시간 값(작성자의 UTC 오프셋 유지)이므로 `date` 필터로 바로 포맷할 수 있습니다. 목록에서 순회하는 페이지(`section.pages`, `site.pages`, 택소노미 항목)에서도 같은 객체를 쓸 수 있습니다.
+
+```jinja
+{% if page.git %}
+<p class="meta">
+  Last updated {{ page.git.lastmod | date(format="%Y-%m-%d") }}
+  by {{ page.git.author_name }}
+  (<a href="https://github.com/you/site/commit/{{ page.git.hash }}">{{ page.git.short_hash }}</a>)
+</p>
+{% endif %}
+```
+
+다음 경우에는 `page.git`이 `nil`이고 폴백도 적용되지 않습니다.
+
+- 아직 커밋되지 않은(새로 만든 또는 추적되지 않는) 파일
+- `[[content.generate]]`로 생성된 페이지
+- 생성된 택소노미 및 목록 페이지
+- 사이트가 git 저장소 안에 있지 않은 경우의 모든 페이지
+
+## 번들, 번역, 이름 변경
+
+- 페이지 번들(`posts/hello/index.md` + 에셋)은 Markdown 파일 기준이므로 에셋만 커밋해도 `lastmod`는 움직이지 않습니다.
+- 각 번역본(`hello.md`, `hello.ko.md`)은 별도 파일이며 이력도 별도입니다.
+- 이름 변경은 **따라가지 않습니다**. 이름을 바꾼 파일의 이력은 이름 변경 커밋에서 다시 시작하므로 `first_commit`(그리고 `use_date`일 때 `page.date`)은 이름 변경 날짜가 됩니다.
+
+## 우아한 성능 저하
+
+이 기능은 빌드를 중단시키지 않습니다. 아래 상황은 각각 경고 한 번을 남기고 `page.git`을 비워 둡니다.
+
+| 상황 | 결과 |
+|-----------|--------|
+| `PATH`에 `git` 바이너리가 없음 | 경고, git 메타데이터 없음 |
+| `content/`가 저장소 안에 없음 | 경고, git 메타데이터 없음 |
+| 얕은 클론(`--depth N`) | 클론 깊이보다 오래된 파일의 `lastmod`/`first_commit`이 틀릴 수 있다는 경고, 메타데이터는 계속 사용 |
+
+대부분의 CI 체크아웃은 기본이 얕은 클론입니다. 날짜가 정확하도록 전체 이력을 가져오세요.
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+```
+
+## 함께 보기
+
+- [데이터 모델](/ko/templates/data-model/) — 전체 `page` 객체
+- [SEO](/ko/features/seo/), [구조화 데이터](/ko/features/structured-data/) — `page.updated`가 출력되는 곳
+- [증분 빌드](/ko/features/incremental-build/) — `--cache`가 재렌더링 대상을 정하는 방식

--- a/docs/content/features/git-info.md
+++ b/docs/content/features/git-info.md
@@ -1,0 +1,95 @@
++++
+title = "Git Metadata"
+description = "Expose each page's commit history as page.git and derive lastmod from it"
+weight = 12
++++
+
+Read each content file's commit history once per build and expose it to templates and SEO outputs — like Hugo's `enableGitInfo`. With `[git]` enabled, a page that has no `updated` in its front matter gets one from its latest commit, so sitemap `<lastmod>`, feed `<updated>`, and JSON-LD `dateModified` reflect when the file really changed.
+
+## Configuration
+
+Opt in via `config.toml`:
+
+```toml
+[git]
+enabled = true
+use_lastmod = true   # page.updated ← latest commit when front matter has none
+use_date = false     # page.date ← first commit when front matter has none
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| enabled | bool | false | Collect git metadata for `content/` files |
+| use_lastmod | bool | true | Set `page.updated` from the file's latest commit when front matter has no `updated` |
+| use_date | bool | false | Set `page.date` from the file's first commit when front matter has no `date` |
+
+Front matter always wins: a fallback only fills a field the file left unset.
+
+## How It Works
+
+1. The build runs **one** `git log` over `content/` (never one process per page) and maps every path to its commits. On a 5,200-page test repository the whole collection step took about 50 ms.
+2. Each page whose source file has at least one non-merge commit gets a `page.git` object.
+3. `use_lastmod` / `use_date` fill the missing `updated` / `date` fields, after which everything downstream — sitemap, feeds, JSON-LD, OpenGraph, `sort_by = "date"` — sees the git-derived value with no template changes.
+
+`hwaro serve` collects history once per full rebuild, not on every file save. `hwaro build --cache` folds each page's commit id and timestamps into its cache key, so a warm rebuild after a new commit re-renders exactly the pages that commit touched (and the listings that show them).
+
+## Template Variable
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| page.git | Object? | `nil` when the page has no history (see below) |
+| page.git.hash | String | Full commit id of the latest non-merge commit that touched the file |
+| page.git.short_hash | String | First 7 characters of `hash` |
+| page.git.lastmod | Time | Author date of that latest commit |
+| page.git.first_commit | Time | Earliest author date across every commit that touched the file |
+| page.git.author_name | String | Author name of the latest commit |
+| page.git.author_email | String | Author email of the latest commit |
+
+`lastmod` and `first_commit` are real time values (the author's UTC offset is preserved), so the `date` filter formats them directly. The same object is available on pages iterated from listings (`section.pages`, `site.pages`, taxonomy terms).
+
+```jinja
+{% if page.git %}
+<p class="meta">
+  Last updated {{ page.git.lastmod | date(format="%B %d, %Y") }}
+  by {{ page.git.author_name }}
+  (<a href="https://github.com/you/site/commit/{{ page.git.hash }}">{{ page.git.short_hash }}</a>)
+</p>
+{% endif %}
+```
+
+`page.git` is `nil` — and no fallback applies — for:
+
+- files that are not committed yet (new or untracked),
+- pages materialized from `[[content.generate]]`,
+- generated taxonomy and listing pages,
+- every page when the site is not inside a git repository.
+
+## Bundles, Translations, Renames
+
+- A page bundle (`posts/hello/index.md` + assets) is keyed by its Markdown file, so committing only an asset does not move `lastmod`.
+- Each translation (`hello.md`, `hello.ko.md`) is its own file with its own history.
+- Renames are **not** followed: a renamed file's history restarts at the rename commit, so `first_commit` (and `page.date` under `use_date`) is the rename date.
+
+## Graceful Degradation
+
+The feature never aborts a build. Each of these produces a single warning and leaves `page.git` unset:
+
+| Situation | Effect |
+|-----------|--------|
+| No `git` binary on `PATH` | Warning; no git metadata |
+| `content/` is not inside a repository | Warning; no git metadata |
+| Shallow clone (`--depth N`) | Warning that `lastmod`/`first_commit` may be wrong for files older than the clone depth; metadata is still used |
+
+Most CI checkouts are shallow by default. Fetch the full history so dates are correct:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+```
+
+## See Also
+
+- [Data Model](/templates/data-model/) — the full `page` object
+- [SEO](/features/seo/) and [Structured Data](/features/structured-data/) — where `page.updated` is emitted
+- [Incremental Build](/features/incremental-build/) — how `--cache` decides what to re-render

--- a/docs/content/start/config.ko.md
+++ b/docs/content/start/config.ko.md
@@ -314,6 +314,7 @@ Cache-Control = "no-store"
 | `[links]` | [링크](#링크) | 깨진 내부 `@/` 링크 처리 (경고 또는 빌드 실패) |
 | `[series]` | [시리즈](/ko/features/series/) | 글을 순서 있는 시리즈로 묶기 |
 | `[related]` | [관련 글](/ko/features/related-posts/) | 관련 콘텐츠 추천 |
+| `[git]` | [Git 메타데이터](/ko/features/git-info/) | `page.git` 커밋 정보와 이력 기반 `updated`/`date` 폴백 |
 | `[llms]` | [LLMs.txt](/ko/features/llms-txt/) | AI/LLM 크롤러 안내 |
 | `[pwa]` | [PWA](/ko/features/pwa/) | 프로그레시브 웹 앱 지원 |
 | `[amp]` | [AMP](/ko/features/amp/) | Accelerated Mobile Pages |
@@ -375,7 +376,7 @@ url = "/posts/"
 # 기능 섹션 — 위 기능 설정 레퍼런스 참고
 # [feeds], [sitemap], [robots], [og], [search], [highlight],
 # [pagination], [auto_includes], [assets], [sass], [image_processing],
-# [series], [related], [llms], [pwa], [amp], [deployment], etc.
+# [series], [related], [git], [llms], [pwa], [amp], [deployment], etc.
 ```
 
 ## 함께 보기

--- a/docs/content/start/config.md
+++ b/docs/content/start/config.md
@@ -314,6 +314,7 @@ Each feature has its own documentation with full configuration details. Below is
 | `[links]` | [Links](#links) | Broken internal `@/` link handling (warn or fail the build) |
 | `[series]` | [Series](/features/series/) | Group posts into ordered series |
 | `[related]` | [Related Posts](/features/related-posts/) | Related content recommendations |
+| `[git]` | [Git Metadata](/features/git-info/) | `page.git` commit info and `updated`/`date` fallbacks from history |
 | `[llms]` | [LLMs.txt](/features/llms-txt/) | AI/LLM crawler instructions |
 | `[pwa]` | [PWA](/features/pwa/) | Progressive Web App support |
 | `[amp]` | [AMP](/features/amp/) | Accelerated Mobile Pages |
@@ -375,7 +376,7 @@ url = "/posts/"
 # Feature sections — see Feature Configuration Reference above
 # [feeds], [sitemap], [robots], [og], [search], [highlight],
 # [pagination], [auto_includes], [assets], [sass], [image_processing],
-# [series], [related], [llms], [pwa], [amp], [deployment], etc.
+# [series], [related], [git], [llms], [pwa], [amp], [deployment], etc.
 ```
 
 ## See Also

--- a/docs/content/templates/data-model.ko.md
+++ b/docs/content/templates/data-model.ko.md
@@ -343,6 +343,7 @@ john-doe:
 | page.series_index | Int | 시리즈 안에서 1부터 시작하는 순번(`[series]` 활성화 필요) |
 | page.series_pages | Array<Page> | 같은 시리즈의 모든 페이지(`series_weight` 순 정렬) |
 | page.related_posts | Array<Page> | 택소노미 항목을 공유하는 페이지(`[related]` 활성화 필요) |
+| page.git | Object? | 소스 파일의 커밋 메타데이터(`[git]` 활성화 필요, 커밋되지 않았거나 생성된 페이지는 `nil`). 필드: `hash`, `short_hash`, `lastmod`(Time), `first_commit`(Time), `author_name`, `author_email` — [Git 메타데이터](/ko/features/git-info/) 참고 |
 
 ### 불리언 플래그
 

--- a/docs/content/templates/data-model.md
+++ b/docs/content/templates/data-model.md
@@ -343,6 +343,7 @@ Rendered HTML content is available as the top-level `content` variable.
 | page.series_index | Int | 1-based position within the series (requires `[series]` enabled) |
 | page.series_pages | Array<Page> | All pages in the same series, sorted by `series_weight` |
 | page.related_posts | Array<Page> | Pages sharing taxonomy terms (requires `[related]` enabled) |
+| page.git | Object? | Commit metadata for the source file (requires `[git]` enabled; `nil` for uncommitted or generated pages). Fields: `hash`, `short_hash`, `lastmod` (Time), `first_commit` (Time), `author_name`, `author_email` — see [Git Metadata](/features/git-info/) |
 
 ### Boolean Flags
 

--- a/docs/data/sidebar.yml
+++ b/docs/data/sidebar.yml
@@ -81,6 +81,8 @@
           url: /features/menus/
         - title: Output Formats
           url: /features/output-formats/
+        - title: Git Metadata
+          url: /features/git-info/
     - title: Build & Performance
       items:
         - title: Incremental Build

--- a/docs/data/sidebar_ko.yml
+++ b/docs/data/sidebar_ko.yml
@@ -79,6 +79,8 @@
           url: /ko/features/menus/
         - title: 출력 포맷
           url: /ko/features/output-formats/
+        - title: Git 메타데이터
+          url: /ko/features/git-info/
     - title: 빌드와 성능
       items:
         - title: 증분 빌드

--- a/skills/hwaro/SKILL.md
+++ b/skills/hwaro/SKILL.md
@@ -216,7 +216,8 @@ section structure; a syntax error fails the build with `HWARO_E_CONFIG` (exit
 `3`). Common sections: `[plugins]`, `[highlight]`, `[og]` / `[og.auto_image]`,
 `[search]`, `[pagination]`, `[[taxonomies]]`, `[sitemap]`, `[feeds]`,
 `[image_processing]`, `[assets]`, `[auto_includes]`, `[markdown]`, `[pwa]`,
-`[deployment]`. After editing, run `hwaro doctor`; `--fix` normalizes values
+`[deployment]`, `[git]` (opt-in `page.git` commit metadata + `updated` fallback
+from history; needs a full-depth checkout). After editing, run `hwaro doctor`; `--fix` normalizes values
 (e.g. a base_url trailing slash) and `--approve` (or `--full`) adds recommended
 sections. When unsure of a key, check the [config reference](https://hwaro.hahwul.com/start/config/).
 

--- a/spec/functional/git_info_spec.cr
+++ b/spec/functional/git_info_spec.cr
@@ -1,0 +1,234 @@
+require "./support/build_helper"
+
+# =============================================================================
+# `[git] enabled = true` end-to-end: a real repository is created in the temp
+# project, content is committed with fixed author dates, and the build must
+# expose `page.git`, fall back `updated` (and optionally `date`) to the
+# commit history, and carry that through sitemap/feeds/JSON-LD. Also pins
+# the --cache contract: a new commit to an unedited file re-renders it.
+# =============================================================================
+
+# `[git]` is the LAST table so tests can append keys to it.
+private GIT_CONFIG = <<-TOML
+  title = "Git Site"
+  base_url = "https://example.com"
+
+  [sitemap]
+  enabled = true
+
+  [feeds]
+  enabled = true
+  type = "atom"
+
+  [git]
+  enabled = true
+  TOML
+
+private PAGE_TEMPLATE = <<-HTML
+  {{ page.title }}|updated={{ page.updated }}|date={{ page.date }}|git={% if page.git %}{{ page.git.short_hash }},{{ page.git.hash }},{{ page.git.author_name }},{{ page.git.author_email }},{{ page.git.lastmod | date(format="%Y-%m-%d %H:%M") }},{{ page.git.first_commit | date(format="%Y-%m-%d") }}{% else %}none{% endif %}
+  {{ jsonld }}
+  HTML
+
+private LIST_TEMPLATE = <<-HTML
+  {% for p in section.pages %}{{ p.title }}:{{ p.updated }}:{% if p.git %}{{ p.git.short_hash }}{% else %}none{% endif %};{% endfor %}
+  HTML
+
+private def git(*args : String, env : Hash(String, String)? = nil) : String
+  stdout = IO::Memory.new
+  stderr = IO::Memory.new
+  argv = ["-c", "user.name=Spec Author", "-c", "user.email=spec@example.com", "-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null"] + args.to_a
+  status = Process.run("git", argv, env: env, output: stdout, error: stderr)
+  raise "git #{args.join(" ")} failed: #{stderr}" unless status.success?
+  stdout.to_s
+end
+
+private def commit_all(message : String, date : String, author : String = "Spec Author", email : String = "spec@example.com") : String
+  git("add", "-A")
+  git("commit", "-q", "-m", message, env: {
+    "GIT_AUTHOR_DATE"    => date,
+    "GIT_COMMITTER_DATE" => date,
+    "GIT_AUTHOR_NAME"    => author,
+    "GIT_AUTHOR_EMAIL"   => email,
+  })
+  git("rev-parse", "HEAD").strip
+end
+
+private def write_git_project(config : String = GIT_CONFIG)
+  File.write("config.toml", config)
+  FileUtils.mkdir_p("content/posts")
+  FileUtils.mkdir_p("templates")
+  File.write("templates/index.html", "HOME")
+  File.write("templates/page.html", PAGE_TEMPLATE)
+  File.write("templates/section.html", LIST_TEMPLATE)
+  File.write("content/posts/_index.md", "+++\ntitle = \"Posts\"\n+++\n")
+  File.write("content/posts/committed.md", "+++\ntitle = \"Committed\"\n+++\nbody")
+  File.write("content/posts/dated.md", "+++\ntitle = \"Dated\"\ndate = \"2020-01-01\"\nupdated = \"2021-02-03\"\n+++\nbody")
+  git("init", "-q")
+end
+
+private def run_build(cache : Bool = false) : Bool
+  builder = Hwaro::Core::Build::Builder.new
+  Hwaro::Content::Hooks.all.each { |h| builder.register(h) }
+  builder.run(Hwaro::Config::Options::BuildOptions.new(
+    output_dir: "public", parallel: false, highlight: false, cache: cache))
+end
+
+describe "[git] page metadata" do
+  it "exposes page.git and falls back updated to the latest commit" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_git_project
+        first = commit_all("first", "2024-01-10T09:00:00+00:00", "First Author", "first@example.com")
+        File.write("content/posts/committed.md", "+++\ntitle = \"Committed\"\n+++\nbody v2")
+        second = commit_all("second", "2024-03-05T14:30:00+00:00", "Second Author", "second@example.com")
+
+        run_build.should be_true
+
+        html = File.read("public/posts/committed/index.html")
+        html.should contain("updated=2024-03-05")
+        # `date` is NOT filled by default (use_date = false).
+        html.should contain("|date=|")
+        html.should contain("git=#{second[0, 7]},#{second},Second Author,second@example.com,2024-03-05 14:30,2024-01-10")
+        # JSON-LD dateModified follows page.updated.
+        html.should contain(%("dateModified":"2024-03-05T14:30:00+00:00"))
+
+        # Front matter always wins over the git fallback, but page.git is still there.
+        dated = File.read("public/posts/dated/index.html")
+        dated.should contain("updated=2021-02-03|date=2020-01-01|git=#{first[0, 7]}")
+
+        # Sitemap lastmod / feed updated pick the git-derived `updated` up.
+        sitemap = File.read("public/sitemap.xml")
+        sitemap.should match(/<loc>https:\/\/example\.com\/posts\/committed\/<\/loc>\s*<lastmod>2024-03-05<\/lastmod>/)
+        feed = File.read("public/atom.xml")
+        feed.should contain("<updated>2024-03-05T14:30:00")
+
+        # Listings (section.pages) see the same fields.
+        listing = File.read("public/posts/index.html")
+        listing.should contain("Committed:2024-03-05:#{second[0, 7]};")
+      end
+    end
+  end
+
+  it "fills date from the first commit when use_date = true" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_git_project(GIT_CONFIG + "\nuse_date = true\n")
+        commit_all("first", "2024-01-10T09:00:00+00:00")
+        File.write("content/posts/committed.md", "+++\ntitle = \"Committed\"\n+++\nbody v2")
+        commit_all("second", "2024-03-05T14:30:00+00:00")
+
+        run_build.should be_true
+        html = File.read("public/posts/committed/index.html")
+        html.should contain("updated=2024-03-05|date=2024-01-10|")
+        html.should contain(%("datePublished":"2024-01-10T09:00:00+00:00"))
+        # An explicit front-matter date still wins.
+        File.read("public/posts/dated/index.html").should contain("date=2020-01-01|")
+      end
+    end
+  end
+
+  it "leaves updated untouched when use_lastmod = false" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_git_project(GIT_CONFIG + "\nuse_lastmod = false\n")
+        sha = commit_all("first", "2024-01-10T09:00:00+00:00")
+        run_build.should be_true
+        html = File.read("public/posts/committed/index.html")
+        html.should contain("|updated=|date=|git=#{sha[0, 7]}")
+        File.read("public/sitemap.xml").should_not contain("<lastmod>2024-01-10")
+      end
+    end
+  end
+
+  it "gives uncommitted files no git info and no fallback" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_git_project
+        commit_all("first", "2024-01-10T09:00:00+00:00")
+        File.write("content/posts/new.md", "+++\ntitle = \"New\"\n+++\nnot committed")
+        run_build.should be_true
+        File.read("public/posts/new/index.html").should contain("New|updated=|date=|git=none")
+        File.read("public/posts/committed/index.html").should contain("updated=2024-01-10")
+      end
+    end
+  end
+
+  it "keys page bundles and translations by their own markdown file" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_git_project(GIT_CONFIG.sub("[git]\nenabled = true", "[languages.ko]\nname = \"Korean\"\n\n[git]\nenabled = true"))
+        FileUtils.mkdir_p("content/posts/bundle")
+        File.write("content/posts/bundle/index.md", "+++\ntitle = \"Bundle\"\n+++\nbody")
+        File.write("content/posts/bundle/photo.txt", "asset")
+        File.write("content/posts/committed.ko.md", "+++\ntitle = \"Committed KO\"\n+++\nbody")
+        commit_all("first", "2024-01-10T09:00:00+00:00")
+        File.write("content/posts/committed.ko.md", "+++\ntitle = \"Committed KO\"\n+++\nbody v2")
+        ko = commit_all("ko only", "2024-05-01T09:00:00+00:00")
+        File.write("content/posts/bundle/photo.txt", "asset v2")
+        commit_all("asset only", "2024-06-01T09:00:00+00:00")
+
+        run_build.should be_true
+        # The translation has its own history; the default-language file does not move.
+        File.read("public/ko/posts/committed/index.html").should contain("updated=2024-05-01|date=|git=#{ko[0, 7]}")
+        File.read("public/posts/committed/index.html").should contain("updated=2024-01-10")
+        # Bundle keyed by index.md: touching only an asset does not move lastmod.
+        File.read("public/posts/bundle/index.html").should contain("updated=2024-01-10")
+      end
+    end
+  end
+
+  it "warns once and builds normally when the site is not a git repository" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_git_project
+        FileUtils.rm_rf(".git")
+        log = with_captured_log { run_build.should be_true }
+        log.should contain("not inside a git repository")
+        log.scan("not inside a git repository").size.should eq(1)
+        File.read("public/posts/committed/index.html").should contain("updated=|date=|git=none")
+      end
+    end
+  end
+
+  it "keeps page.git nil when [git] is disabled" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_git_project(GIT_CONFIG.sub("[git]\nenabled = true", "[git]\nenabled = false"))
+        commit_all("first", "2024-01-10T09:00:00+00:00")
+        log = with_captured_log { run_build.should be_true }
+        log.should_not contain("[git]")
+        File.read("public/posts/committed/index.html").should contain("Committed|updated=|date=|git=none")
+        # Only the front-matter `updated` of dated.md reaches the sitemap.
+        File.read("public/sitemap.xml").should_not contain("<lastmod>2024-01-10")
+      end
+    end
+  end
+
+  it "re-renders an unedited page under --cache when a new commit moves its lastmod" do
+    Dir.mktmpdir do |dir|
+      Dir.cd(dir) do
+        write_git_project
+        commit_all("first", "2024-01-10T09:00:00+00:00")
+        run_build(cache: true).should be_true
+        File.read("public/posts/committed/index.html").should contain("updated=2024-01-10")
+        cold_listing = File.read("public/posts/index.html")
+
+        # Warm no-op rebuild: nothing moved, output is identical.
+        run_build(cache: true).should be_true
+        File.read("public/posts/committed/index.html").should contain("updated=2024-01-10")
+
+        # Rewrite history so the file's latest commit changes WITHOUT touching
+        # its bytes (amend the date) — only the git fingerprint moves.
+        git("commit", "-q", "--amend", "--no-edit", "--date", "2024-08-20T08:00:00+00:00", env: {
+          "GIT_COMMITTER_DATE" => "2024-08-20T08:00:00+00:00",
+        })
+        run_build(cache: true).should be_true
+        File.read("public/posts/committed/index.html").should contain("updated=2024-08-20")
+        # The section listing depends on the page set, which the commit moved.
+        File.read("public/posts/index.html").should_not eq(cold_listing)
+        File.read("public/posts/index.html").should contain("Committed:2024-08-20:")
+        File.read("public/sitemap.xml").should contain("<lastmod>2024-08-20</lastmod>")
+      end
+    end
+  end
+end

--- a/spec/unit/git_info_spec.cr
+++ b/spec/unit/git_info_spec.cr
@@ -1,0 +1,166 @@
+require "../spec_helper"
+
+# =============================================================================
+# `[git]` — the log parser (pure, fixture-driven) and the config table.
+#
+# The collector shells out exactly once per build with
+# `--format=%x00%H%x00%aI%x00%an%x00%ae --name-only`; these fixtures are the
+# byte shape git produces for that format so the parser is pinned to it.
+# =============================================================================
+
+private NUL = "\0"
+
+private def header(hash : String, date : String, name : String = "Alice", email : String = "alice@example.com") : String
+  "#{NUL}#{hash}#{NUL}#{date}#{NUL}#{name}#{NUL}#{email}\n\n"
+end
+
+private def load_config(toml : String) : Hwaro::Models::Config
+  Dir.mktmpdir do |dir|
+    path = File.join(dir, "config.toml")
+    File.write(path, toml)
+    return Hwaro::Models::Config.load(path)
+  end
+  raise "unreachable"
+end
+
+describe Hwaro::Core::Build::GitInfo do
+  describe ".parse_log" do
+    it "keys entries by path with hash, author and both timestamps" do
+      log = header("a" * 40, "2024-03-05T10:00:00+09:00") + "posts/a.md\nposts/b.md\n\n"
+      info = Hwaro::Core::Build::GitInfo.parse_log(log)
+
+      info.keys.sort!.should eq(["posts/a.md", "posts/b.md"])
+      a = info["posts/a.md"]
+      a.hash.should eq("a" * 40)
+      a.short_hash.should eq("aaaaaaa")
+      a.author_name.should eq("Alice")
+      a.author_email.should eq("alice@example.com")
+      a.lastmod.should eq(Time.parse_rfc3339("2024-03-05T10:00:00+09:00"))
+      a.first_commit.should eq(a.lastmod)
+      # The author's UTC offset is preserved, not normalized to UTC.
+      a.lastmod.offset.should eq(9 * 3600)
+    end
+
+    it "takes lastmod/hash/author from the newest commit and first_commit from the oldest" do
+      log = header("a" * 40, "2024-03-05T10:00:00+00:00", "Newer", "n@example.com") + "posts/a.md\n\n" +
+            header("b" * 40, "2024-02-01T10:00:00+00:00", "Middle", "m@example.com") + "posts/a.md\nposts/b.md\n\n" +
+            header("c" * 40, "2024-01-01T10:00:00+00:00", "Oldest", "o@example.com") + "posts/a.md\n\n"
+      info = Hwaro::Core::Build::GitInfo.parse_log(log)
+
+      a = info["posts/a.md"]
+      a.hash.should eq("a" * 40)
+      a.author_name.should eq("Newer")
+      a.lastmod.should eq(Time.utc(2024, 3, 5, 10, 0, 0))
+      a.first_commit.should eq(Time.utc(2024, 1, 1, 10, 0, 0))
+
+      b = info["posts/b.md"]
+      b.hash.should eq("b" * 40)
+      b.lastmod.should eq(Time.utc(2024, 2, 1, 10, 0, 0))
+      b.first_commit.should eq(b.lastmod)
+    end
+
+    it "uses the minimum author date for first_commit when history is out of walk order" do
+      # A rebased/cherry-picked commit can carry an author date OLDER than
+      # commits listed after it. first_commit must be the true minimum.
+      log = header("a" * 40, "2024-03-05T10:00:00+00:00") + "posts/a.md\n\n" +
+            header("b" * 40, "2023-06-01T10:00:00+00:00") + "posts/a.md\n\n" +
+            header("c" * 40, "2024-01-01T10:00:00+00:00") + "posts/a.md\n\n"
+      info = Hwaro::Core::Build::GitInfo.parse_log(log)
+      info["posts/a.md"].first_commit.should eq(Time.utc(2023, 6, 1, 10, 0, 0))
+      info["posts/a.md"].lastmod.should eq(Time.utc(2024, 3, 5, 10, 0, 0))
+    end
+
+    it "decodes C-quoted paths (non-ASCII forced into octal escapes, embedded quotes)" do
+      log = header("a" * 40, "2024-03-05T10:00:00+00:00") +
+            "\"posts/caf\\303\\251.md\"\n\"posts/say \\\"hi\\\".md\"\n\"posts/tab\\there.md\"\nposts/한글.md\n\n"
+      info = Hwaro::Core::Build::GitInfo.parse_log(log)
+      info.keys.sort!.should eq(["posts/café.md", "posts/say \"hi\".md", "posts/tab\there.md", "posts/한글.md"])
+    end
+
+    it "handles commits that list no files and blank lines" do
+      log = header("a" * 40, "2024-03-05T10:00:00+00:00") + "\n" +
+            header("b" * 40, "2024-01-05T10:00:00+00:00") + "posts/a.md\n\n\n"
+      info = Hwaro::Core::Build::GitInfo.parse_log(log)
+      info.size.should eq(1)
+      info["posts/a.md"].hash.should eq("b" * 40)
+    end
+
+    it "skips file lines that follow a malformed header instead of misattributing them" do
+      log = "#{NUL}#{"a" * 40}#{NUL}not-a-date#{NUL}Alice#{NUL}a@example.com\n\nposts/a.md\n\n" +
+            header("b" * 40, "2024-01-05T10:00:00+00:00") + "posts/b.md\n\n"
+      info = Hwaro::Core::Build::GitInfo.parse_log(log)
+      info.keys.should eq(["posts/b.md"])
+    end
+
+    it "returns an empty map for empty output" do
+      Hwaro::Core::Build::GitInfo.parse_log("").should be_empty
+    end
+  end
+
+  describe ".unquote_path" do
+    it "leaves unquoted paths untouched" do
+      Hwaro::Core::Build::GitInfo.unquote_path("posts/plain.md").should eq("posts/plain.md")
+    end
+
+    it "strips the quotes when nothing inside is escaped" do
+      Hwaro::Core::Build::GitInfo.unquote_path("\"posts/a b.md\"").should eq("posts/a b.md")
+    end
+
+    it "decodes backslash escapes and octal byte runs" do
+      Hwaro::Core::Build::GitInfo.unquote_path("\"a\\\\b\\n\\303\\251\"").should eq("a\\b\né")
+    end
+  end
+end
+
+describe "[git] config" do
+  it "is disabled by default with use_lastmod on and use_date off" do
+    config = load_config("title = \"x\"")
+    config.git.enabled.should be_false
+    config.git.use_lastmod.should be_true
+    config.git.use_date.should be_false
+  end
+
+  it "reads enabled / use_lastmod / use_date" do
+    config = load_config(<<-TOML)
+      [git]
+      enabled = true
+      use_lastmod = false
+      use_date = true
+      TOML
+    config.git.enabled.should be_true
+    config.git.use_lastmod.should be_false
+    config.git.use_date.should be_true
+  end
+
+  it "does not warn about [git] as an unknown top-level key" do
+    log = with_captured_log do
+      load_config("[git]\nenabled = true")
+    end
+    log.should_not contain("Unknown key 'git'")
+  end
+
+  it "warns about an unknown key inside [git]" do
+    log = with_captured_log do
+      load_config("[git]\nenabled = true\nuse_lastmodd = true")
+    end
+    log.should contain("[git]: unknown key 'use_lastmodd'")
+  end
+
+  it "ships a doctor/config snippet for the section" do
+    Hwaro::Services::ConfigSnippets::KNOWN_SECTIONS.has_key?("git").should be_true
+    Hwaro::Services::ConfigSnippets.git(commented: true).should contain("# [git]")
+    Hwaro::Services::ConfigSnippets.git(commented: false).should contain("[git]\nenabled = true")
+    Hwaro::Services::Doctor::OPTIONAL_SECTIONS.includes?("git").should be_true
+  end
+end
+
+describe Hwaro::Core::Build::CacheEntry do
+  it "round-trips git_hash and defaults it to empty for legacy entries" do
+    entry = Hwaro::Core::Build::CacheEntry.new(path: "content/a.md", mtime: 1_i64, hash: "h", output_path: "public/a/index.html", git_hash: "abc:1:2")
+    parsed = Hwaro::Core::Build::CacheEntry.from_json(entry.to_json)
+    parsed.git_hash.should eq("abc:1:2")
+
+    legacy = Hwaro::Core::Build::CacheEntry.from_json(%({"path":"content/a.md","mtime":1,"hash":"h","output_path":"p"}))
+    legacy.git_hash.should eq("")
+  end
+end

--- a/src/core/build/builder.cr
+++ b/src/core/build/builder.cr
@@ -128,6 +128,13 @@ module Hwaro
         # cached pages like an edited data/ file. "" when no remote sources
         # are configured (keeps cache keys byte-identical to pre-feature).
         @remote_data_digest : String = ""
+        # `[git]` commit metadata keyed by content-relative path, collected
+        # ONCE per full build in the Initialize phase (see GitInfo.collect)
+        # and read by parse_single_page — including the serve incremental
+        # re-parse, which deliberately reuses the last full build's map
+        # rather than shelling out to git on every keystroke. Nil when the
+        # feature is off or history is unavailable.
+        @git_info : Hash(String, Models::GitInfo)? = nil
         # Per-SERVE-SESSION memo of fetched [[data.remote]] payloads. The
         # dev server holds one Builder for the whole session, so this lives
         # exactly as long as `hwaro serve` does; `hwaro build` is one process

--- a/src/core/build/cache.cr
+++ b/src/core/build/cache.cr
@@ -45,6 +45,17 @@ module Hwaro
         @[JSON::Field(key: "assets_hash", emit_null: false)]
         property assets_hash : String
 
+        # Fingerprint of the page's git metadata (latest commit hash, lastmod,
+        # first_commit — see Render#page_git_hash) as of the build that wrote
+        # this entry. With `[git] enabled` a new commit to an unedited file
+        # changes `page.updated`/`page.git` and therefore the rendered output
+        # even though the source bytes are unchanged, so it must be part of
+        # the cache key. "" when the feature is off or the file has no
+        # history, AND for legacy entries — so a disabled site never rebuilds
+        # because of this field.
+        @[JSON::Field(key: "git_hash", emit_null: false)]
+        property git_hash : String
+
         # Secondary sibling output files this page emitted beyond
         # `output_path` (e.g. `index.json`, `index.xml` — see `[outputs]`).
         # Empty for pages with no extra formats and for every entry written
@@ -62,6 +73,7 @@ module Hwaro
           @cascade_hash : String = "",
           @output_paths : Array(String) = [] of String,
           @assets_hash : String = "",
+          @git_hash : String = "",
         )
         end
 
@@ -75,6 +87,7 @@ module Hwaro
           config_hash = ""
           cascade_hash = ""
           assets_hash = ""
+          git_hash = ""
           output_paths = [] of String
 
           pull.read_object do |key|
@@ -87,6 +100,7 @@ module Hwaro
             when "config_hash"   then config_hash = pull.read_string
             when "cascade_hash"  then cascade_hash = pull.read_string
             when "assets_hash"   then assets_hash = pull.read_string
+            when "git_hash"      then git_hash = pull.read_string
             when "output_paths"
               output_paths = [] of String
               pull.read_array { output_paths << pull.read_string }
@@ -96,7 +110,7 @@ module Hwaro
 
           new(path: path, mtime: mtime, hash: hash, output_path: output_path,
             template_hash: template_hash, config_hash: config_hash, cascade_hash: cascade_hash,
-            output_paths: output_paths, assets_hash: assets_hash)
+            output_paths: output_paths, assets_hash: assets_hash, git_hash: git_hash)
         end
       end
 
@@ -259,7 +273,7 @@ module Hwaro
         # `extra_outputs` are secondary sibling output files (see `[outputs]`)
         # that must also still exist on disk — a manually deleted `index.json`
         # forces a rebuild just like a deleted `index.html` does.
-        def changed?(file_path : String, output_path : String = "", cascade_hash : String = "", template_hash : String? = nil, extra_outputs : Array(String) = [] of String, assets_hash : String = "") : Bool
+        def changed?(file_path : String, output_path : String = "", cascade_hash : String = "", template_hash : String? = nil, extra_outputs : Array(String) = [] of String, assets_hash : String = "", git_hash : String = "") : Bool
           return true unless @enabled
           return true unless File.exists?(file_path)
 
@@ -289,6 +303,11 @@ module Hwaro
           # Legacy entries store "" here, so an asset-carrying page rebuilds
           # once after upgrading (same handling as cascade_hash).
           return true if entry.assets_hash != assets_hash
+
+          # The file's git history moved (a new commit touched it) — with
+          # `[git]` enabled the page's lastmod/commit fields render differently
+          # though the source bytes are byte-for-byte the same.
+          return true if entry.git_hash != git_hash
 
           # A template in this page's dependency closure changed.
           if template_hash && entry.template_hash != template_hash
@@ -347,7 +366,7 @@ module Hwaro
         # `output_paths` are the secondary sibling output files this page
         # emitted (see `[outputs]`); empty when the feature isn't in use.
         # Thread-safe: protected by mutex for concurrent parallel builds.
-        def update(file_path : String, output_path : String = "", cascade_hash : String = "", template_hash : String? = nil, output_paths : Array(String) = [] of String, assets_hash : String = "")
+        def update(file_path : String, output_path : String = "", cascade_hash : String = "", template_hash : String? = nil, output_paths : Array(String) = [] of String, assets_hash : String = "", git_hash : String = "")
           return unless @enabled
           return unless File.exists?(file_path)
 
@@ -361,7 +380,8 @@ module Hwaro
               existing = @entries[file_path]?
               if existing && existing.mtime == mtime && existing.output_path == output_path &&
                  existing.cascade_hash == cascade_hash && existing.template_hash == effective_template_hash &&
-                 existing.output_paths == output_paths && existing.assets_hash == assets_hash
+                 existing.output_paths == output_paths && existing.assets_hash == assets_hash &&
+                 existing.git_hash == git_hash
                 return
               end
             end
@@ -379,6 +399,7 @@ module Hwaro
               cascade_hash: cascade_hash,
               output_paths: output_paths,
               assets_hash: assets_hash,
+              git_hash: git_hash,
             )
 
             @mutex.synchronize do

--- a/src/core/build/git_info.cr
+++ b/src/core/build/git_info.cr
@@ -1,0 +1,179 @@
+# Git metadata for content pages (`[git]` in config.toml).
+#
+# ONE `git log` invocation per build walks the whole `content/` history and
+# is parsed into a `path => Models::GitInfo` map keyed by content-relative
+# path — never one process per page, which is what makes the feature usable
+# on sites with thousands of pages. Collection runs in the Initialize phase
+# (alongside data files) so the parse phase can fill `page.git` and the
+# `updated`/`date` fallbacks before URLs, sorting or SEO surfaces read them.
+#
+# Every failure mode degrades to "no git info" with a single warning and
+# never aborts the build: no `git` binary, a site outside any repository, a
+# shallow clone (history truncated, so `lastmod` may be wrong), or a file
+# that is simply not committed yet (no entry → `page.git` is nil and no
+# fallback applies).
+
+require "../../models/git_info"
+require "../../utils/logger"
+
+module Hwaro
+  module Core
+    module Build
+      module GitInfo
+        extend self
+
+        # Each commit header is a NUL-led record so it can never be confused
+        # with a pathname line: `\0<hash>\0<author date, RFC 3339>\0<name>\0<email>`.
+        # `--name-only` then lists the touched paths one per line.
+        LOG_FORMAT = "%x00%H%x00%aI%x00%an%x00%ae"
+
+        # Collect commit metadata for every file under `content_dir`, keyed
+        # by path relative to it. Returns nil (after warning) when git
+        # history is unavailable for any reason.
+        def collect(content_dir : String = "content") : Hash(String, Models::GitInfo)?
+          return unless Dir.exists?(content_dir)
+
+          output = run_git(content_dir, ["-c", "core.quotePath=false", "log", "--no-merges", "--relative",
+                                         "--format=#{LOG_FORMAT}", "--name-only", "--", "."])
+          return unless output
+
+          warn_if_shallow(content_dir)
+          parse_log(output)
+        end
+
+        # Parse `git log` output produced with LOG_FORMAT + `--name-only`.
+        # The log is newest-first, so the first header a path appears under
+        # is its latest commit (hash, author, lastmod); `first_commit` is the
+        # minimum author date over every commit listing the path (rebased or
+        # cherry-picked history can leave author dates out of walk order).
+        def parse_log(output : String) : Hash(String, Models::GitInfo)
+          result = {} of String => Models::GitInfo
+          current : Models::GitInfo? = nil
+
+          output.each_line do |line|
+            next if line.empty?
+            if line.starts_with?('\0')
+              current = parse_header(line)
+              next
+            end
+            next unless header = current
+            path = unquote_path(line)
+            next if path.empty?
+            if existing = result[path]?
+              if header.lastmod < existing.first_commit
+                result[path] = existing.copy_with(first_commit: header.lastmod)
+              end
+            else
+              result[path] = header
+            end
+          end
+
+          result
+        end
+
+        # `\0<hash>\0<date>\0<name>\0<email>` → a GitInfo whose lastmod and
+        # first_commit both hold this commit's author date. Nil for a header
+        # that does not fit (a malformed date), which also drops the file
+        # lines that follow it — better than attributing them to the
+        # previous commit.
+        private def parse_header(line : String) : Models::GitInfo?
+          fields = line.split('\0')
+          return unless fields.size >= 5
+          hash = fields[1]
+          time = Time.parse_rfc3339(fields[2]) rescue nil
+          return unless time
+          return if hash.empty?
+          Models::GitInfo.new(
+            hash: hash,
+            lastmod: time,
+            first_commit: time,
+            author_name: fields[3],
+            author_email: fields[4],
+          )
+        end
+
+        # With `core.quotePath=false` git still C-quotes a path that holds a
+        # control character, a double quote or a backslash. Undo that so the
+        # key matches the page path the ReadContent phase derived from disk.
+        def unquote_path(raw : String) : String
+          return raw unless raw.size >= 2 && raw.starts_with?('"') && raw.ends_with?('"')
+          inner = raw[1, raw.size - 2]
+          return inner unless inner.includes?('\\')
+
+          bytes = IO::Memory.new
+          i = 0
+          while i < inner.bytesize
+            byte = inner.byte_at(i)
+            if byte == '\\'.ord && i + 1 < inner.bytesize
+              nxt = inner.byte_at(i + 1)
+              case nxt
+              when 'n'.ord  then bytes.write_byte('\n'.ord.to_u8); i += 2
+              when 't'.ord  then bytes.write_byte('\t'.ord.to_u8); i += 2
+              when 'r'.ord  then bytes.write_byte('\r'.ord.to_u8); i += 2
+              when '\\'.ord then bytes.write_byte('\\'.ord.to_u8); i += 2
+              when '"'.ord  then bytes.write_byte('"'.ord.to_u8); i += 2
+              when '0'.ord..'7'.ord
+                # Up to three octal digits encode one raw byte (UTF-8 paths
+                # arrive as a run of these when quoting is forced).
+                value = 0
+                digits = 0
+                while digits < 3 && i + 1 + digits < inner.bytesize
+                  d = inner.byte_at(i + 1 + digits)
+                  break unless d >= '0'.ord && d <= '7'.ord
+                  value = value * 8 + (d - '0'.ord)
+                  digits += 1
+                end
+                bytes.write_byte(value.to_u8!)
+                i += 1 + digits
+              else
+                bytes.write_byte(byte)
+                i += 1
+              end
+            else
+              bytes.write_byte(byte)
+              i += 1
+            end
+          end
+          String.new(bytes.to_slice)
+        end
+
+        # Run `git` inside `content_dir`, returning stdout or nil after a
+        # single warning that names the reason.
+        private def run_git(content_dir : String, args : Array(String)) : String?
+          stdout = IO::Memory.new
+          stderr = IO::Memory.new
+          status = Process.run("git", args, chdir: content_dir, output: stdout, error: stderr)
+          if status.success?
+            return stdout.to_s
+          end
+
+          reason = stderr.to_s.lines.first?.try(&.strip) || "exit #{status.exit_code}"
+          if reason.includes?("not a git repository")
+            Logger.warn "[git] enabled, but #{content_dir}/ is not inside a git repository — page.git is unavailable and no lastmod fallback applies."
+          else
+            Logger.warn "[git] enabled, but `git log` failed (#{reason}) — page.git is unavailable and no lastmod fallback applies."
+          end
+          nil
+        rescue ex : IO::Error | RuntimeError
+          # `Process.run` raises when the executable cannot be spawned at all
+          # (no `git` on PATH).
+          Logger.warn "[git] enabled, but the git binary could not be run (#{ex.message}) — page.git is unavailable and no lastmod fallback applies."
+          nil
+        end
+
+        # A shallow clone (`--depth N`, the GitHub Actions checkout default)
+        # holds only the newest commits, so every older file appears to have
+        # been created — and last modified — at the truncation boundary.
+        private def warn_if_shallow(content_dir : String)
+          stdout = IO::Memory.new
+          status = Process.run("git", ["rev-parse", "--is-shallow-repository"], chdir: content_dir, output: stdout, error: Process::Redirect::Close)
+          return unless status.success? && stdout.to_s.strip == "true"
+          Logger.warn "[git] the repository is a shallow clone — page.git.lastmod/first_commit may be wrong for files older than the clone depth. Fetch full history (e.g. actions/checkout with `fetch-depth: 0`)."
+        rescue IO::Error | RuntimeError
+          # The log call above already ran git successfully; a failure here is
+          # not worth a second warning.
+        end
+      end
+    end
+  end
+end

--- a/src/core/build/phases/initialize.cr
+++ b/src/core/build/phases/initialize.cr
@@ -72,6 +72,7 @@ module Hwaro::Core::Build::Phases::Initialize
       site = Models::Site.new(config)
       @site = site
       load_data_files(site, config, ctx.options.serve_mode)
+      collect_git_info(config)
 
       # Load i18n translations
       i18n_dir = File.join("i18n")
@@ -874,6 +875,15 @@ module Hwaro::Core::Build::Phases::Initialize
     end
 
     load_remote_data(site, config, root, serve_mode)
+  end
+
+  # `[git]`: one `git log` over content/ per full build. Reset first so a
+  # serve session whose config toggled the feature off never keeps serving
+  # the previous map.
+  private def collect_git_info(config : Models::Config)
+    @git_info = nil
+    return unless config.git.enabled
+    @git_info = GitInfo.collect
   end
 
   # `[[data.remote]]` sources, fetched once per build AFTER the disk tree is

--- a/src/core/build/phases/parse_content.cr
+++ b/src/core/build/phases/parse_content.cr
@@ -426,6 +426,10 @@ module Hwaro::Core::Build::Phases::ParseContent
     # Redirect support — applies to both regular pages and sections
     page.redirect_to = data[:redirect_to]
 
+    # `[git]` metadata + date fallbacks. Must run before calculate_page_url
+    # so a `[permalinks]` date token can resolve from a git-derived `date`.
+    apply_git_info(page)
+
     # Calculate word count and reading time
     page.calculate_word_count
     page.calculate_reading_time
@@ -453,6 +457,26 @@ module Hwaro::Core::Build::Phases::ParseContent
 
     # Calculate URL
     calculate_page_url(page)
+  end
+
+  # Attach the page's commit metadata (see Builder#@git_info) and fill the
+  # `updated`/`date` gaps front matter left, per `[git] use_lastmod` /
+  # `use_date`. Always resets `page.git` first: the serve re-parse works on
+  # the live page object, and a feature toggled off mid-session must not
+  # leave the previous build's value behind. Front matter always wins — a
+  # fallback only applies to a field the file did not set. Synthesized
+  # (`[[content.generate]]`) pages have no source file and never match.
+  private def apply_git_info(page : Models::Page)
+    page.git = nil
+    return unless info_map = @git_info
+    return if page.synthesized?
+    return unless info = info_map[page.path]?
+
+    page.git = info
+    git_config = @config.try(&.git)
+    return unless git_config
+    page.updated = info.lastmod if git_config.use_lastmod && page.updated.nil?
+    page.date = info.first_commit if git_config.use_date && page.date.nil?
   end
 
   private def parse_content_sequential(pages : Array(Models::Page))

--- a/src/core/build/phases/render.cr
+++ b/src/core/build/phases/render.cr
@@ -346,7 +346,7 @@ module Hwaro::Core::Build::Phases::Render
       next true if page.synthesized?
       source_path, output_path = cache_paths_for(page, output_dir)
       fmt_paths = format_output_paths(page, output_dir, effective_output_formats(page, site.config))
-      next true if cache.changed?(source_path, output_path || "", page.cascade_fingerprint, page_template_hash(page, templates, site), extra_outputs: fmt_paths, assets_hash: page_assets_hash(page))
+      next true if cache.changed?(source_path, output_path || "", page.cascade_fingerprint, page_template_hash(page, templates, site), extra_outputs: fmt_paths, assets_hash: page_assets_hash(page), git_hash: page_git_hash(page))
       # Page's own source is unchanged: only re-render it if a set it depends on
       # changed. Skip the (cheap) marker scan entirely when nothing moved.
       next false unless page_set_changed || section_set_changed
@@ -540,6 +540,10 @@ module Hwaro::Core::Build::Phases::Render
       fp_list(digest, p.authors)
       fp_list(digest, p.tags)
       fp_list(digest, p.assets.sort)
+      # Listings can read `p.git.*` directly (not only the `updated` it feeds),
+      # so a new commit must move the set fingerprint; folded only when
+      # present so disabled sites keep their pre-feature digest.
+      fp_value(digest, page_git_hash(p)) if p.git
       fp_value(digest, "t#{p.taxonomies.size}")
       p.taxonomies.keys.sort!.each do |k|
         fp_value(digest, k)
@@ -730,7 +734,16 @@ module Hwaro::Core::Build::Phases::Render
     # up-to-date would let filter_changed_pages skip it forever.
     return unless output_path
     fmt_paths = format_output_paths(page, output_dir, effective_output_formats(page, site.config))
-    cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site), output_paths: fmt_paths, assets_hash: page_assets_hash(page))
+    cache.update(source_path, output_path, page.cascade_fingerprint, page_template_hash(page, templates, site), output_paths: fmt_paths, assets_hash: page_assets_hash(page), git_hash: page_git_hash(page))
+  end
+
+  # Fingerprint of the page's `[git]` metadata (see CacheEntry#git_hash):
+  # the commit id plus both timestamps, which is everything `page.git` and
+  # the `updated`/`date` fallbacks can render. "" when the page carries no
+  # git info so disabled sites and legacy entries compare equal.
+  private def page_git_hash(page : Models::Page) : String
+    return "" unless git = page.git
+    "#{git.hash}:#{git.lastmod.to_unix}:#{git.first_commit.to_unix}"
   end
 
   # Fingerprint of a page bundle's colocated asset names (see
@@ -2262,6 +2275,7 @@ module Hwaro::Core::Build::Phases::Render
       # cross-page value @page_crinja_value_cache cannot keep fresh on the
       # incremental `serve` path, where only the changed page is invalidated.
       "updated"         => Crinja::Value.new(p.updated.try(&.to_s("%Y-%m-%d")) || ""),
+      "git"             => git_crinja_for(p),
       "in_search_index" => Crinja::Value.new(p.in_search_index),
       "series"          => Crinja::Value.new(p.series || ""),
       "tags"            => Crinja::Value.new(p.tags.map { |t| Crinja::Value.new(t) }),
@@ -2272,6 +2286,23 @@ module Hwaro::Core::Build::Phases::Render
         p.extra.each_with_object({} of String => Crinja::Value) { |(k, v), h|
           h[k] = Utils::CrinjaUtils.from_extra(v)
         }),
+    })
+  end
+
+  # `page.git` as templates see it: a mapping of the commit fields, or nil
+  # (renders empty, `{% if page.git %}` is false) when the page has no
+  # history. `lastmod`/`first_commit` are Time values so `| date(format=…)`
+  # formats them and comparisons work; their `to_s` keeps the author's
+  # UTC offset.
+  private def git_crinja_for(page : Models::Page) : Crinja::Value
+    return Crinja::Value.new(nil) unless git = page.git
+    Crinja::Value.new({
+      "hash"         => Crinja::Value.new(git.hash),
+      "short_hash"   => Crinja::Value.new(git.short_hash),
+      "lastmod"      => Crinja::Value.new(git.lastmod),
+      "first_commit" => Crinja::Value.new(git.first_commit),
+      "author_name"  => Crinja::Value.new(git.author_name),
+      "author_email" => Crinja::Value.new(git.author_email),
     })
   end
 
@@ -3071,6 +3102,7 @@ module Hwaro::Core::Build::Phases::Render
       "reading_time"      => Crinja::Value.new(page.reading_time),
       "permalink"         => Crinja::Value.new(page.permalink || ""),
       "weight"            => Crinja::Value.new(page.weight),
+      "git"               => cached_raw["git"].as(Crinja::Value),
       "in_search_index"   => Crinja::Value.new(page.in_search_index),
       "lower"             => lower_obj || Crinja::Value.new(nil),
       "higher"            => higher_obj || Crinja::Value.new(nil),

--- a/src/hwaro.cr
+++ b/src/hwaro.cr
@@ -52,6 +52,7 @@ require "./config/options/serve_options"
 
 # Load models
 require "./models/config"
+require "./models/git_info"
 require "./models/page"
 require "./models/section"
 require "./models/site"
@@ -76,6 +77,7 @@ require "./core/lifecycle"
 
 # Load core modules
 require "./core/build/cache"
+require "./core/build/git_info"
 require "./core/build/parallel"
 require "./core/build/builder"
 

--- a/src/models/config.cr
+++ b/src/models/config.cr
@@ -168,6 +168,21 @@ module Hwaro
       end
     end
 
+    # `[git]` — per-page commit metadata (see Core::Build::GitInfo).
+    class GitConfig
+      property enabled : Bool
+      # Fill `page.updated` from the latest commit when front matter has none.
+      property use_lastmod : Bool
+      # Fill `page.date` from the first commit when front matter has none.
+      property use_date : Bool
+
+      def initialize
+        @enabled = false
+        @use_lastmod = true
+        @use_date = false
+      end
+    end
+
     # Plugin configuration for extensibility
     class PluginConfig
       property processors : Array(String)
@@ -1284,6 +1299,7 @@ module Hwaro
       property markdown : MarkdownConfig
       property series : SeriesConfig
       property related : RelatedConfig
+      property git : GitConfig
       property deployment : DeploymentConfig
       property assets : AssetsConfig
       property sass : SassConfig
@@ -1328,6 +1344,7 @@ module Hwaro
         @markdown = MarkdownConfig.new
         @series = SeriesConfig.new
         @related = RelatedConfig.new
+        @git = GitConfig.new
         @deployment = DeploymentConfig.new
         @assets = AssetsConfig.new
         @sass = SassConfig.new
@@ -1565,6 +1582,7 @@ module Hwaro
         load_markdown(config)
         load_series(config)
         load_related(config)
+        load_git(config)
         load_permalinks(config)
         load_assets(config)
         load_sass(config)
@@ -1594,7 +1612,7 @@ module Hwaro
       KNOWN_TOP_LEVEL_KEYS = %w[
         title description base_url default_language
         amp assets auto_includes build content data deployment doctor feeds
-        highlight image_processing languages links llms markdown menus og
+        git highlight image_processing languages links llms markdown menus og
         outputs pagination permalinks plugins pwa related robots sass search
         series serve sitemap static taxonomies
       ]
@@ -2423,6 +2441,18 @@ module Hwaro
         config.related.limit = int_value(s["limit"]?, config.related.limit).clamp(0, Int32::MAX)
         if taxonomies = s["taxonomies"]?.try(&.as_a?)
           config.related.taxonomies = taxonomies.compact_map(&.as_s?)
+        end
+      end
+
+      private def self.load_git(config : Config)
+        return unless s = config.raw["git"]?.try(&.as_h?)
+
+        config.git.enabled = bool_value(s["enabled"]?, config.git.enabled)
+        config.git.use_lastmod = bool_value(s["use_lastmod"]?, config.git.use_lastmod)
+        config.git.use_date = bool_value(s["use_date"]?, config.git.use_date)
+        s.each_key do |key|
+          next if key.in?("enabled", "use_lastmod", "use_date")
+          Logger.warn "[git]: unknown key '#{key}' — hwaro does not read it."
         end
       end
 

--- a/src/models/git_info.cr
+++ b/src/models/git_info.cr
@@ -1,0 +1,24 @@
+module Hwaro
+  module Models
+    # Commit metadata for one content file, collected once per build by
+    # `Core::Build::GitInfo` when `[git] enabled = true`.
+    #
+    # `hash`/`author_*`/`lastmod` describe the file's LATEST non-merge commit
+    # (the first one `git log` lists); `first_commit` is the earliest author
+    # date across every commit that touched the path. Renames are not
+    # followed, so a renamed file's history restarts at the rename commit.
+    # Times keep the author's UTC offset (`%aI`), matching how front-matter
+    # dates are treated as local wall-clock values.
+    record GitInfo,
+      hash : String,
+      lastmod : Time,
+      first_commit : Time,
+      author_name : String,
+      author_email : String do
+      # Abbreviated commit id (7 chars, git's default `--short` width).
+      def short_hash : String
+        hash[0, 7]
+      end
+    end
+  end
+end

--- a/src/models/page.cr
+++ b/src/models/page.cr
@@ -2,6 +2,7 @@ require "html"
 require "crinja"
 require "../utils/text_utils"
 require "../content/processors/fence_tracker"
+require "./git_info"
 
 module Hwaro
   module Models
@@ -211,6 +212,11 @@ module Hwaro
       # New: Redirect to - URL to redirect this page to
       property redirect_to : String?
 
+      # Commit metadata for this page's source file (`[git] enabled = true`).
+      # Nil when the feature is off, the file is uncommitted, the site is not
+      # a git checkout, or the page is synthesized/generated.
+      property git : GitInfo?
+
       def initialize(@path : String)
         @title = "Untitled"
         @draft = false
@@ -258,6 +264,7 @@ module Hwaro
         @series_pages = [] of Page
         @related_posts = [] of Page
         @redirect_to = nil
+        @git = nil
         @cascade_fingerprint = ""
         @build_warnings = [] of String
         @parse_failed = false

--- a/src/services/config_snippets.cr
+++ b/src/services/config_snippets.cr
@@ -26,6 +26,7 @@ module Hwaro
         "pagination"       => {description: "Pagination settings", snippet: -> { pagination(commented: true) }},
         "series"           => {description: "Series grouping", snippet: -> { series(commented: true) }},
         "related"          => {description: "Related posts", snippet: -> { related(commented: true) }},
+        "git"              => {description: "Git commit metadata (page.git, lastmod fallback)", snippet: -> { git(commented: true) }},
         "markdown"         => {description: "Markdown parser options", snippet: -> { markdown(commented: true) }},
         "sitemap"          => {description: "Sitemap generation", snippet: -> { sitemap(commented: true) }},
         "robots"           => {description: "Robots.txt generation", snippet: -> { robots(commented: true) }},
@@ -718,6 +719,42 @@ module Hwaro
             enabled = true
             limit = 5
             taxonomies = ["tags"]
+
+            TOML
+        end
+      end
+
+      def self.git(commented : Bool = false) : String
+        if commented
+          <<-TOML
+
+            # =============================================================================
+            # Git Metadata (Optional)
+            # =============================================================================
+            # Expose each page's commit history as page.git (hash, short_hash, lastmod,
+            # first_commit, author_name, author_email) and fill a missing `updated`
+            # from the latest commit. Needs a full-history checkout (fetch-depth: 0).
+
+            # [git]
+            # enabled = true
+            # use_lastmod = true   # page.updated ← latest commit when front matter has none
+            # use_date = false     # page.date ← first commit when front matter has none
+
+            TOML
+        else
+          <<-TOML
+
+            # =============================================================================
+            # Git Metadata
+            # =============================================================================
+            # Expose each page's commit history as page.git (hash, short_hash, lastmod,
+            # first_commit, author_name, author_email) and fill a missing `updated`
+            # from the latest commit. Needs a full-history checkout (fetch-depth: 0).
+
+            [git]
+            enabled = true
+            use_lastmod = true   # page.updated ← latest commit when front matter has none
+            use_date = false     # page.date ← first commit when front matter has none
 
             TOML
         end

--- a/src/services/defaults/config.cr
+++ b/src/services/defaults/config.cr
@@ -58,6 +58,10 @@ module Hwaro
             limit = 5
             taxonomies = ["tags"]
 
+            # Git Metadata - page.git + `updated` fallback from commit history
+            # [git]
+            # enabled = true
+
             # Plugins Configuration
             [plugins]
             processors = ["markdown"]  # List of enabled processors
@@ -152,6 +156,10 @@ module Hwaro
             enabled = true
             limit = 5
             taxonomies = ["tags"]
+
+            # Git Metadata - page.git + `updated` fallback from commit history
+            # [git]
+            # enabled = true
 
             # Plugins Configuration
             [plugins]
@@ -256,6 +264,9 @@ module Hwaro
             str << "enabled = true\n"
             str << "limit = 5\n"
             str << "taxonomies = [\"tags\"]\n\n"
+            str << "# Git Metadata - page.git + `updated` fallback from commit history\n"
+            str << "# [git]\n"
+            str << "# enabled = true\n\n"
             str << "# Plugins Configuration\n"
             str << "[plugins]\n"
             str << "processors = [\"markdown\"]  # List of enabled processors\n\n"

--- a/src/services/doctor.cr
+++ b/src/services/doctor.cr
@@ -432,6 +432,8 @@ module Hwaro
         "sass",
         # Useful but not essential to nag about
         "related", "series", "pagination",
+        # Git metadata — only meaningful inside a repository with full history
+        "git",
         # Navigation menus — many sites hardcode nav in the theme instead
         "menus",
         # Content authoring niceties


### PR DESCRIPTION
## What

Opt-in Git integration, like Hugo's `enableGitInfo`: read each content file's commit history **once per build** and expose it to templates and SEO outputs.

```toml
[git]
enabled = true
use_lastmod = true   # page.updated ← latest commit when front matter has none (default)
use_date = false     # page.date ← first commit when front matter has none
```

- One `git -c core.quotePath=false log --no-merges --relative --format='%x00%H%x00%aI%x00%an%x00%ae' --name-only -- .` run from `content/` per build, parsed into `Hash(String, Models::GitInfo)` keyed by content-relative path. Never one process per file.
- `page.git` → `hash`, `short_hash`, `lastmod`, `first_commit`, `author_name`, `author_email` (nil when no history). `lastmod`/`first_commit` are Time values (author UTC offset preserved) so `| date(format=…)` and comparisons work. Exposed on the page object and on listing entries (`section.pages`, `site.pages`, terms). No flat `page.git_lastmod` alias: the page-variable convention for objects (`lower`, `higher`, `ancestors`, `translations`) is nested, so `page.git` follows it.
- Fallbacks are applied in the parse phase before URL calculation, so `[permalinks]` date tokens, `sort_by = "date"`, sitemap `<lastmod>`, feed `<updated>`, JSON-LD `dateModified` pick the values up with no template change (each verified by the functional spec). Front matter always wins.
- `--cache`: new `CacheEntry#git_hash` (commit id + both timestamps) in the per-page key and in the page-set fingerprint; a new commit to an unedited file re-renders it and the listings showing it (spec amends a commit date without touching bytes and asserts the re-render). Legacy entries and disabled sites compare as `""`.
- `hwaro serve`: collected once per full rebuild; the incremental re-parse reuses the map.
- Graceful degradation, single warning, never aborts: no `git` binary, site not in a repo, shallow clone (`rev-parse --is-shallow-repository` → suggests `fetch-depth: 0`), uncommitted file (no info, no fallback). Synthesized (`[[content.generate]]`) and generated taxonomy pages have no info. Bundles keyed by the markdown file; translations have their own history; renames not followed (documented).
- Config plumbing: `git` in `KNOWN_TOP_LEVEL_KEYS` (no unknown-key warning), unknown keys inside `[git]` warn, doctor snippet + `OPTIONAL_SECTIONS` (no nag), commented `# [git]` block in the init config templates.
- Docs: `features/git-info.md` (+ `.ko`), sidebars, data-model + config reference (+ `.ko`), `skills/hwaro/SKILL.md`, CHANGELOG `## Unreleased`.

## Timing

5,200-page test repo (50 commits, ~13k path lines in the log): the `git log` collection step takes **~55 ms**; full build 1.2 s with `[git]` vs 1.6 s without (noise, no measurable cost).

## Verification

- `crystal spec`: 8567 examples, 0 failures (full suite). New: `spec/unit/git_info_spec.cr` (log-parser fixtures incl. C-quoted/UTF-8 paths, out-of-order author dates, malformed headers; config; cache entry round-trip) and `spec/functional/git_info_spec.cr` (real `git init` + commits with fixed author dates; 8 examples). Run against `main`: 7 of 8 functional examples fail there (the 8th asserts the disabled default).
- `crystal tool format --check` clean; `./bin/ameba` 538 inspected, 0 failures.
- **Byte-identity (feature off)**: release builds of `main` (v0.20.1) and this branch; `docs/` → `diff -r` identical; `hwaro init --scaffold docs --full-config` and `--scaffold blog --full-config` → both identical.
- **Cache**: git enabled, `build --cache` cold vs warm → `diff -r` identical; functional spec covers warm re-render after a new commit.
- **serve**: smoke-tested on the 5,200-page repo — served page shows `page.updated` + `page.git.short_hash`; editing a file mid-session re-renders the title while keeping the git fields (no git process per change).

## Left out / notes

- No `page.git_lastmod` flat alias (see above); `page.updated` already carries the value when `use_lastmod` is on.
- Renames not followed (history restarts at the rename commit) — documented.