### PR TITLE
fix: preserve JSON exports and reject unexpected tool arguments

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,11 +197,8 @@ docs (`.md` + `.ko.md`) when user-facing.
   `content/processors/*`; `utils/{debug_printer,sort_utils,redirect_html}`
   require models/content; `content/taxonomies.cr` constructs a `Builder`.
 - `ServeOptions` restates most `BuildOptions` fields; `to_build_options` copies them.
-- Six `X::Any → Y::Any` walkers (`frontmatter_writer`, `frontmatter_converter`,
-  hugo/eleventy importers) share a shape but differ in nil/Time/Int32 handling.
-- `exporters/base.cr` has no JSON front-matter branch (a JSON-authored page
-  exports its front matter as body text) — a bug, left as-is because fixing it
-  changes output.
+- `X::Any → Y::Any` walkers (`frontmatter_writer`, `frontmatter_converter`,
+  exporters, hugo/eleventy importers) share a shape but differ in nil/Time/Int32 handling.
 - The blog/docs/book scaffold stylesheets share byte-identical rule runs interleaved
   with formatting differences; deduplicating them needs a CSS normalisation
   pass and therefore changes emitted bytes.

--- a/changelog.d/fix-bugs.md
+++ b/changelog.d/fix-bugs.md
@@ -1,0 +1,3 @@
+### Fixed
+- Hugo and Jekyll exports now parse JSON front matter, preserving metadata and respecting draft filtering; malformed JSON headers report export errors.
+- `tool list`, `tool convert`, `tool check-links`, `tool stats`, `tool validate`, and `tool unused-assets` reject unexpected positional arguments, including arguments after `--`, instead of silently ignoring them.

--- a/docs/content/start/cli.ko.md
+++ b/docs/content/start/cli.ko.md
@@ -561,6 +561,11 @@ hwaro tool import jekyll /path --dry-run
 hwaro tool export hugo --dry-run
 ```
 
+`list`와 `convert` 명령은 사용법에 표시된 위치 인자만 받습니다.
+`check-links`, `stats`, `validate`, `unused-assets`는 위치 인자를 받지 않습니다.
+`--` 뒤의 인자를 포함한 추가 위치 인자는 사용법 오류로 거부되므로, 경로나
+다른 옵션에는 문서에 나온 플래그를 사용하세요.
+
 **서브커맨드:**
 
 | 분류 | 서브커맨드 | 설명 |

--- a/docs/content/start/cli.md
+++ b/docs/content/start/cli.md
@@ -559,6 +559,12 @@ hwaro tool import jekyll /path --dry-run
 hwaro tool export hugo --dry-run
 ```
 
+The `list` and `convert` commands accept only the positional arguments shown in
+their usage. `check-links`, `stats`, `validate`, and `unused-assets` accept no
+positional arguments. Extra positional arguments, including arguments after
+`--`, are rejected with a usage error; use the documented flags for additional
+paths and options.
+
 **Subcommands:**
 
 | Category | Subcommand | Description |

--- a/docs/content/start/tools/convert.ko.md
+++ b/docs/content/start/tools/convert.ko.md
@@ -26,6 +26,10 @@ hwaro tool convert to-yaml --dry-run
 hwaro tool convert to-yaml --json
 ```
 
+이 명령은 형식 인자(`to-yaml`, `to-toml`, `to-json`) 하나만 받습니다.
+추가 위치 인자는 오류로 거부되므로 다른 옵션은 `--content-dir` 같은 플래그를
+사용하세요.
+
 ## 옵션
 
 | 플래그 | 설명 |

--- a/docs/content/start/tools/convert.md
+++ b/docs/content/start/tools/convert.md
@@ -26,6 +26,10 @@ hwaro tool convert to-yaml --dry-run
 hwaro tool convert to-yaml --json
 ```
 
+The command accepts one format argument (`to-yaml`, `to-toml`, or `to-json`).
+Extra positional arguments are rejected; use flags such as `--content-dir` for
+additional options.
+
 ## Options
 
 | Flag | Description |

--- a/docs/content/start/tools/export.ko.md
+++ b/docs/content/start/tools/export.ko.md
@@ -6,6 +6,10 @@ weight = 10
 
 hwaro 콘텐츠를 다른 정적 사이트 생성기 형식으로 내보냅니다. `hwaro tool import`의 반대 방향 작업입니다.
 
+원본 파일의 프론트 매터는 TOML(`+++`), YAML(`---`), JSON(`{...}`)을 지원합니다.
+세 형식 모두 동일한 필드 매핑과 초안 제외 규칙을 적용합니다. 잘못된 JSON 프론트
+매터는 본문에 복사하지 않고 내보내기 오류로 보고합니다.
+
 ```bash
 # Hugo로 내보내기
 hwaro tool export hugo
@@ -108,7 +112,7 @@ hwaro tool export hugo --verbose
 - 일반 글은 `_posts/`에 `YYYY-MM-DD-slug.md` 파일명으로 저장
 - 초안 글은 날짜 접두사 없이 `_drafts/`에 저장
 - 섹션 인덱스 파일(`_index.md`)은 `index.md` 페이지로 변환
-- 프론트 매터는 TOML(`+++`)에서 YAML(`---`)로 변환
+- 프론트 매터는 TOML, YAML, JSON에서 YAML(`---`)로 변환
 - `[taxonomies]` 테이블은 최상위 키로 승격됩니다. Hugo도 Jekyll도 중첩 테이블에서
   분류 소속을 읽지 않기 때문입니다. 같은 이름의 최상위 키가 이미 있으면 그쪽이
   우선하며, 이는 빌드가 둘을 해석하는 순서와 같습니다

--- a/docs/content/start/tools/export.md
+++ b/docs/content/start/tools/export.md
@@ -6,6 +6,10 @@ weight = 10
 
 Export hwaro content to other static site generator formats. This is the reverse of `hwaro tool import`.
 
+Source files can use TOML (`+++`), YAML (`---`), or JSON (`{...}`) front matter.
+All three formats use the same field mappings and draft filtering. Invalid JSON
+front matter is reported as an export error instead of being copied into the body.
+
 ```bash
 # Export to Hugo
 hwaro tool export hugo
@@ -108,7 +112,7 @@ Output conventions:
 - Regular posts go to `_posts/` with `YYYY-MM-DD-slug.md` filename
 - Draft posts go to `_drafts/` without date prefix
 - Section index files (`_index.md`) become `index.md` pages
-- Frontmatter is converted from TOML (`+++`) to YAML (`---`)
+- Frontmatter is converted from TOML, YAML, or JSON to YAML (`---`)
 - A `[taxonomies]` table is hoisted to top-level keys, since neither Hugo nor
   Jekyll reads taxonomy membership from a nested table. An explicit top-level
   key of the same name wins, matching how the build resolves the two

--- a/docs/content/start/tools/list.ko.md
+++ b/docs/content/start/tools/list.ko.md
@@ -30,6 +30,10 @@ hwaro tool list all --sort path --reverse
 hwaro tool list all --json
 ```
 
+이 명령은 필터 인자(`all`, `drafts`, `published`) 하나만 받습니다.
+추가 위치 인자는 오류로 거부되므로 다른 옵션은 `--content-dir` 같은 플래그를
+사용하세요.
+
 ## 옵션
 
 | 플래그 | 설명 |

--- a/docs/content/start/tools/list.md
+++ b/docs/content/start/tools/list.md
@@ -30,6 +30,10 @@ hwaro tool list all --sort path --reverse
 hwaro tool list all --json
 ```
 
+The command accepts one filter argument (`all`, `drafts`, or `published`).
+Extra positional arguments are rejected; use flags such as `--content-dir` for
+additional options.
+
 ## Options
 
 | Flag | Description |

--- a/spec/unit/cli/commands/tool/tool_commands_spec.cr
+++ b/spec/unit/cli/commands/tool/tool_commands_spec.cr
@@ -127,6 +127,32 @@ describe Hwaro::CLI::Commands::Tool::ConvertCommand do
       flag.not_nil!.value_hint.should eq("DIR")
     end
   end
+
+  describe "#run argument validation" do
+    it "rejects extra positional arguments" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "content"))
+        source = File.join(dir, "content", "post.md")
+        original = "+++\ntitle = \"Keep me\"\n+++\n\nBody.\n"
+        File.write(source, original)
+        cmd = Hwaro::CLI::Commands::Tool::ConvertCommand.new
+        ex = expect_raises(Hwaro::HwaroError) do
+          cmd.run(["to-yaml", "-c", File.join(dir, "content"), "--", "extra"])
+        end
+        ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+        File.read(source).should eq(original)
+
+        cmd = Hwaro::CLI::Commands::Tool::ConvertCommand.new
+        ex = expect_raises(Hwaro::HwaroError) do
+          cmd.run(["to-yaml", "extra", "-c", File.join(dir, "content")])
+        end
+        ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+        File.read(source).should eq(original)
+      end
+    end
+  end
 end
 
 describe Hwaro::CLI::Commands::Tool::ListCommand do
@@ -172,6 +198,101 @@ describe Hwaro::CLI::Commands::Tool::ListCommand do
       flag.should_not be_nil
       flag.not_nil!.takes_value.should be_true
       flag.not_nil!.value_hint.should eq("DIR")
+    end
+  end
+
+  describe "#run argument validation" do
+    it "rejects extra positional arguments" do
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "content"))
+        cmd = Hwaro::CLI::Commands::Tool::ListCommand.new
+        ex = expect_raises(Hwaro::HwaroError) do
+          cmd.run(["all", "-c", File.join(dir, "content"), "--", "extra"])
+        end
+        ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+
+        cmd = Hwaro::CLI::Commands::Tool::ListCommand.new
+        ex = expect_raises(Hwaro::HwaroError) do
+          cmd.run(["all", "extra", "-c", File.join(dir, "content")])
+        end
+        ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+        ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+      end
+    end
+  end
+end
+
+describe "tool commands positional argument validation" do
+  it "rejects positionals for check-links" do
+    Dir.mktmpdir do |dir|
+      content_dir = File.join(dir, "content")
+      FileUtils.mkdir_p(content_dir)
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["-c", content_dir, "--", "extra"]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+      cmd = Hwaro::CLI::Commands::Tool::DeadlinkCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["extra", "-c", content_dir]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+    end
+  end
+
+  it "rejects positionals for stats" do
+    Dir.mktmpdir do |dir|
+      content_dir = File.join(dir, "content")
+      FileUtils.mkdir_p(content_dir)
+      cmd = Hwaro::CLI::Commands::Tool::StatsCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["-c", content_dir, "--", "extra"]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+      cmd = Hwaro::CLI::Commands::Tool::StatsCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["extra", "-c", content_dir]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+    end
+  end
+
+  it "rejects positionals for validate" do
+    Dir.mktmpdir do |dir|
+      content_dir = File.join(dir, "content")
+      FileUtils.mkdir_p(content_dir)
+      cmd = Hwaro::CLI::Commands::Tool::ValidateCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["-c", content_dir, "--", "extra"]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+      cmd = Hwaro::CLI::Commands::Tool::ValidateCommand.new
+      ex = expect_raises(Hwaro::HwaroError) { cmd.run(["extra", "-c", content_dir]) }
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+    end
+  end
+
+  it "rejects positionals for unused-assets before scanning or deleting" do
+    Dir.mktmpdir do |dir|
+      content_dir = File.join(dir, "content")
+      static_dir = File.join(dir, "static")
+      templates_dir = File.join(dir, "templates")
+      FileUtils.mkdir_p(content_dir)
+      FileUtils.mkdir_p(static_dir)
+      FileUtils.mkdir_p(templates_dir)
+      asset = File.join(static_dir, "unused.png")
+      File.write(asset, "fixture")
+      cmd = Hwaro::CLI::Commands::Tool::UnusedAssetsCommand.new
+      ex = expect_raises(Hwaro::HwaroError) do
+        cmd.run(["-c", content_dir, "-s", static_dir, "-t", templates_dir, "--delete", "--force", "--", "extra"])
+      end
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+      File.exists?(asset).should be_true
+      cmd = Hwaro::CLI::Commands::Tool::UnusedAssetsCommand.new
+      ex = expect_raises(Hwaro::HwaroError) do
+        cmd.run(["extra", "-c", content_dir, "-s", static_dir, "-t", templates_dir, "--delete", "--force"])
+      end
+      ex.code.should eq(Hwaro::Errors::HWARO_E_USAGE)
+      ex.message.to_s.should contain("unexpected extra argument(s): 'extra'")
+      File.exists?(asset).should be_true
     end
   end
 end

--- a/spec/unit/services/exporters/json_frontmatter_spec.cr
+++ b/spec/unit/services/exporters/json_frontmatter_spec.cr
@@ -1,0 +1,92 @@
+require "../../../spec_helper"
+
+describe "JSON frontmatter export" do
+  [Hwaro::Services::Exporters::HugoExporter, Hwaro::Services::Exporters::JekyllExporter].each do |exporter_type|
+    describe exporter_type do
+      it "preserves Unicode metadata, nested values, post dates, and the body" do
+        Dir.mktmpdir do |dir|
+          content_dir = File.join(dir, "content")
+          FileUtils.mkdir_p(File.join(content_dir, "posts"))
+          header = %({"title":"한글 } 글","date":"2024-01-02","draft":false,"extra":{"rating":2.5,"id":99999999999,"enabled":true,"label":"false","items":[1,"둘"],"empty":[]}})
+          File.write(File.join(content_dir, "posts", "hello.md"), "\uFEFF#{header}\n\n본문입니다.\n")
+          output_dir = File.join(dir, "export")
+          result = exporter_type.new.run(Hwaro::Config::Options::ExportOptions.new(content_dir: content_dir, output_dir: output_dir))
+
+          result.success.should be_true
+          result.exported_count.should eq(1)
+          relative = exporter_type == Hwaro::Services::Exporters::HugoExporter ? "content/posts/hello.md" : "_posts/2024-01-02-hello.md"
+          exported = File.read(File.join(output_dir, relative))
+          dialect, header_text = Hwaro::Utils::FrontmatterScanner.detect(exported).not_nil!
+          fields = if dialect == :toml
+                     TOML.parse(header_text).transform_values { |value| Hwaro::Utils::FrontmatterWriter.toml_to_yaml_any(value) }
+                   else
+                     YAML.parse(header_text).as_h.transform_keys(&.as_s)
+                   end
+          fields["title"].as_s.should eq("한글 } 글")
+          fields["extra"]["rating"].as_f.should eq(2.5)
+          fields["extra"]["id"].as_i64.should eq(99999999999_i64)
+          fields["extra"]["enabled"].as_bool.should be_true
+          fields["extra"]["label"].as_s.should eq("false")
+          fields["extra"]["items"].as_a.map(&.to_s).should eq(["1", "둘"])
+          fields["extra"]["empty"].as_a.should be_empty
+          Hwaro::Utils::FrontmatterScanner.strip_frontmatter(exported).strip.should eq("본문입니다.")
+        end
+      end
+
+      it "skips JSON drafts by default and exports them when requested" do
+        Dir.mktmpdir do |dir|
+          content_dir = File.join(dir, "content")
+          FileUtils.mkdir_p(File.join(content_dir, "posts"))
+          File.write(File.join(content_dir, "posts", "secret.md"), %({"title":"Secret","date":"2024-01-02","draft":true}\n\nSecret body.))
+          output_dir = File.join(dir, "export")
+          options = Hwaro::Config::Options::ExportOptions.new(content_dir: content_dir, output_dir: output_dir)
+          result = exporter_type.new.run(options)
+          result.success.should be_true
+          result.exported_count.should eq(0)
+          result.skipped_count.should eq(1)
+          Dir.glob(File.join(output_dir, "**", "*.md")).should be_empty
+
+          options.drafts = true
+          result = exporter_type.new.run(options)
+          result.success.should be_true
+          result.exported_count.should eq(1)
+          relative = exporter_type == Hwaro::Services::Exporters::HugoExporter ? "content/posts/secret.md" : "_drafts/secret.md"
+          exported = File.read(File.join(output_dir, relative))
+          exported.should contain(exporter_type == Hwaro::Services::Exporters::HugoExporter ? "draft = true" : "published: false")
+        end
+      end
+
+      [%( {"title": broken}), %({"draft":true)].each do |header|
+        it "reports malformed JSON as an export error: #{header}" do
+          Dir.mktmpdir do |dir|
+            content_dir = File.join(dir, "content")
+            FileUtils.mkdir_p(content_dir)
+            File.write(File.join(content_dir, "broken.md"), "#{header.strip}\n\nBody.")
+            output_dir = File.join(dir, "export")
+            result = exporter_type.new.run(Hwaro::Config::Options::ExportOptions.new(content_dir: content_dir, output_dir: output_dir))
+            result.success.should be_false
+            result.exported_count.should eq(0)
+            result.error_count.should eq(1)
+            Dir.glob(File.join(output_dir, "**", "*.md")).should be_empty
+          end
+        end
+      end
+
+      ["{{ youtube(id=\"example\") }}\nBody.", "{:.wide}\nBody.", "{% if true %}Body.{% endif %}"].each do |body|
+        it "preserves brace-prefixed Markdown content: #{body}" do
+          Dir.mktmpdir do |dir|
+            content_dir = File.join(dir, "content")
+            FileUtils.mkdir_p(content_dir)
+            File.write(File.join(content_dir, "page.md"), body)
+            output_dir = File.join(dir, "export")
+            result = exporter_type.new.run(Hwaro::Config::Options::ExportOptions.new(content_dir: content_dir, output_dir: output_dir))
+            result.success.should be_true
+            result.exported_count.should eq(1)
+            exported = File.read(Dir.glob(File.join(output_dir, "**", "*.md")).first)
+            Hwaro::Utils::FrontmatterScanner.strip_frontmatter(exported).strip.should eq(body)
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/cli/commands/tool/convert_command.cr
+++ b/src/cli/commands/tool/convert_command.cr
@@ -54,7 +54,15 @@ module Hwaro
               CLI.register_flag(parser, DRY_RUN_FLAG) { |_| dry_run = true }
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
-              parser.unknown_args do |unknown|
+              parser.unknown_args do |before_dash, after_dash|
+                unknown = before_dash + after_dash
+                unless unknown.size <= 1
+                  raise Hwaro::HwaroError.new(
+                    code: Hwaro::Errors::HWARO_E_USAGE,
+                    message: "unexpected extra argument(s): '#{unknown[1..].join("', '")}'",
+                    hint: "hwaro tool convert takes a single <format> argument.",
+                  )
+                end
                 format = unknown.first? if unknown.present?
               end
             end

--- a/src/cli/commands/tool/deadlink_command.cr
+++ b/src/cli/commands/tool/deadlink_command.cr
@@ -155,6 +155,14 @@ module Hwaro
               end
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
+              parser.unknown_args do |before_dash, after_dash|
+                unknown = before_dash + after_dash
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "unexpected extra argument(s): '#{unknown.join("', '")}'",
+                  hint: "hwaro tool check-links accepts options only.",
+                ) unless unknown.empty?
+              end
             end
 
             Runner.enable_json_mode! if json_output

--- a/src/cli/commands/tool/list_command.cr
+++ b/src/cli/commands/tool/list_command.cr
@@ -81,7 +81,15 @@ module Hwaro
               end
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
-              parser.unknown_args do |unknown|
+              parser.unknown_args do |before_dash, after_dash|
+                unknown = before_dash + after_dash
+                unless unknown.size <= 1
+                  raise Hwaro::HwaroError.new(
+                    code: Hwaro::Errors::HWARO_E_USAGE,
+                    message: "unexpected extra argument(s): '#{unknown[1..].join("', '")}'",
+                    hint: "hwaro tool list takes a single <filter> argument.",
+                  )
+                end
                 filter = unknown.first? if unknown.present?
               end
             end

--- a/src/cli/commands/tool/stats_command.cr
+++ b/src/cli/commands/tool/stats_command.cr
@@ -66,6 +66,14 @@ module Hwaro
               end
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
+              parser.unknown_args do |before_dash, after_dash|
+                unknown = before_dash + after_dash
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "unexpected extra argument(s): '#{unknown.join("', '")}'",
+                  hint: "hwaro tool stats accepts options only.",
+                ) unless unknown.empty?
+              end
             end
 
             Runner.enable_json_mode! if json_output

--- a/src/cli/commands/tool/unused_assets_command.cr
+++ b/src/cli/commands/tool/unused_assets_command.cr
@@ -72,6 +72,14 @@ module Hwaro
               parser.on("-f", "--force", "Skip confirmation prompt when deleting") { force = true }
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
+              parser.unknown_args do |before_dash, after_dash|
+                unknown = before_dash + after_dash
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "unexpected extra argument(s): '#{unknown.join("', '")}'",
+                  hint: "hwaro tool unused-assets accepts options only.",
+                ) unless unknown.empty?
+              end
             end
 
             # An explicit --templates-dir that doesn't exist must fail, not

--- a/src/cli/commands/tool/validate_command.cr
+++ b/src/cli/commands/tool/validate_command.cr
@@ -67,6 +67,14 @@ module Hwaro
               end
               CLI.register_flag(parser, JSON_FLAG) { |_| json_output = true }
               CLI.register_flag(parser, HELP_FLAG) { |_| Logger.info parser.to_s; exit }
+              parser.unknown_args do |before_dash, after_dash|
+                unknown = before_dash + after_dash
+                raise Hwaro::HwaroError.new(
+                  code: Hwaro::Errors::HWARO_E_USAGE,
+                  message: "unexpected extra argument(s): '#{unknown.join("', '")}'",
+                  hint: "hwaro tool validate accepts options only.",
+                ) unless unknown.empty?
+              end
             end
 
             Runner.enable_json_mode! if json_output

--- a/src/services/exporters/base.cr
+++ b/src/services/exporters/base.cr
@@ -1,5 +1,6 @@
 require "file_utils"
 require "yaml"
+require "json"
 require "toml"
 require "../file_action"
 require "../../config/options/export_options"
@@ -255,9 +256,35 @@ module Hwaro
               # rule, not frontmatter — keep the whole document as body.
               return {fields, content}
             end
+          elsif content.matches?(/\A\{\s*["}]/)
+            # Match the build's JSON-intent rule so shortcodes, Jinja tags,
+            # and Markdown attribute lists remain body text. The scanner's
+            # offset is in bytes, including for Unicode frontmatter.
+            end_idx = Utils::FrontmatterScanner.find_json_end(content)
+            raise ArgumentError.new("Invalid JSON frontmatter: unbalanced braces") unless end_idx
+            if json_fields = JSON.parse(content.byte_slice(0, end_idx)).as_h?
+              json_fields.each do |key, value|
+                fields[key] = json_to_yaml_any(value)
+              end
+            end
+            return {fields, content.byte_slice(end_idx).lstrip('\n')}
           end
 
           {fields, content}
+        end
+
+        private def json_to_yaml_any(value : JSON::Any, depth : Int32 = 0) : YAML::Any
+          Utils::Nesting.check!(depth)
+          case raw = value.raw
+          when Array
+            YAML::Any.new(raw.map { |item| json_to_yaml_any(item, depth + 1) })
+          when Hash
+            hash = {} of YAML::Any => YAML::Any
+            raw.each { |key, item| hash[YAML::Any.new(key)] = json_to_yaml_any(item, depth + 1) }
+            YAML::Any.new(hash)
+          else
+            YAML::Any.new(raw)
+          end
         end
 
         # Hoist a `[taxonomies]` table's entries to top-level front-matter


### PR DESCRIPTION
JSON-authored content lost its metadata during Hugo/Jekyll export, and drafts were exported without `--drafts`. Parse JSON front matter through the shared boundary scanner, preserve typed values, and report malformed headers as per-file errors.

Reject unexpected positional arguments in `list`, `convert`, `check-links`, `stats`, `validate`, and `unused-assets`, including arguments after `--`. Validation runs before conversion or deletion. Update English/Korean documentation and add a changelog fragment.

Validation:

- Regression specs demonstrated failures before the fixes.
- Clean source snapshot: `shards build` and the full `just test` suite — 8,745 examples, zero failures/errors/pending.
- `just check`, `git diff --check`, changelog validation, and file-split checks.
- All five scaffolds: init, cold/warm cached builds with identical output.
- Documentation build: 148 pages; development server HTTP and watched content updates.
- 38 CLI argument/output-mode probes; conversion and deletion reject invalid input while preserving source files.
- Hugo/Jekyll export smoke tests for Unicode, drafts, dry runs, and malformed JSON; TOML/YAML/JSON conversion round trips.
- Separate security and architecture reviews found no outstanding defects in the changes.
