### PR TITLE
docs: collapse the site footer to one centered meta line

### DIFF
--- a/docs/i18n/en.toml
+++ b/docs/i18n/en.toml
@@ -30,17 +30,6 @@ in_this_section = "In this section"
 [toc]
 on_this_page = "On this page"
 
-[footer]
-tagline = "Fast, lightweight static site generator built with Crystal."
-docs = "Docs"
-project = "Project"
-resources = "Resources"
-releases = "Releases"
-benchmark = "Benchmark"
-sitemap = "Sitemap"
-license = "MIT License"
-skills = "Agent Skills"
-
 [error]
 not_found = "The page you are looking for doesn't exist or has been moved."
 back_home = "Back to home"

--- a/docs/i18n/ko.toml
+++ b/docs/i18n/ko.toml
@@ -30,17 +30,6 @@ in_this_section = "이 섹션의 문서"
 [toc]
 on_this_page = "목차"
 
-[footer]
-tagline = "Crystal로 만든 빠르고 가벼운 정적 사이트 생성기."
-docs = "문서"
-project = "프로젝트"
-resources = "리소스"
-releases = "릴리스"
-benchmark = "벤치마크"
-sitemap = "사이트맵"
-license = "MIT 라이선스"
-skills = "에이전트 스킬"
-
 [error]
 not_found = "찾으시는 페이지가 없거나 이동되었습니다."
 back_home = "홈으로 돌아가기"

--- a/docs/static/assets/css/05-components.css
+++ b/docs/static/assets/css/05-components.css
@@ -193,124 +193,64 @@ ul.page-list li {
    Site footer
    ============================================================================= */
 
+/* One centered tier. Inside .docs-main the prose rules (.docs-main p,
+   .docs-main p a) match at the same weight, so every override here carries
+   the extra .footer-meta class rather than relying on file order. */
 .site-footer {
     margin-top: var(--space-8);
-    padding-top: var(--space-6);
+    padding: var(--space-5) 0;
     border-top: 1px solid var(--border-subtle);
-}
-
-.site-footer-grid {
-    display: grid;
-    grid-template-columns: 1.4fr 1fr 1fr 1fr;
-    gap: var(--space-6);
-}
-
-.site-footer-logo {
-    height: 26px;
-    width: auto;
-}
-
-.site-footer .site-footer-tag {
-    margin: var(--space-3) 0 0;
-    font-size: 0.82rem;
-    line-height: 1.6;
-    color: var(--text-muted);
-    max-width: 26ch;
-}
-
-/* Beat the content h2/link rules from 04-content.css (.docs-main h2 etc.)
-   when the footer renders inside the docs column. */
-.site-footer .site-footer-col h2 {
-    font-family: var(--font-mono);
-    font-size: 0.66rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: var(--text-muted);
-    margin: 0 0 var(--space-3);
-    padding-bottom: 0;
-    border-bottom: none;
-}
-
-.site-footer-col ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-.site-footer-col li {
-    margin-bottom: var(--space-2);
-}
-
-.site-footer .site-footer-col a {
-    font-size: 0.84rem;
-    color: var(--text-secondary);
-    text-decoration: none;
-}
-
-.site-footer .site-footer-col a:hover {
-    color: var(--primary);
-}
-
-.site-footer-bottom {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-4);
-    margin-top: var(--space-6);
-    padding: var(--space-4) 0 var(--space-5);
-    border-top: 1px solid var(--border-subtle);
-    font-size: 0.78rem;
-    color: var(--text-muted);
-}
-
-.site-footer-bottom a {
-    color: var(--text-muted);
-}
-
-.site-footer-bottom a:hover {
-    color: var(--primary);
-}
-
-/* hahwul mark — Built with Love (matches dalfox docs footer) */
-.footer-mark {
     text-align: center;
-    margin-top: var(--space-5);
 }
 
-.footer-mark a {
-    display: inline-block;
-    line-height: 0;
+.site-footer .footer-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem 0.6rem;
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--text-muted);
 }
 
-.footer-mark .hahwul-img {
-    display: inline-block;
-    width: 80px;
-    height: 80px;
+.site-footer .footer-meta a {
+    color: var(--text-muted);
+    text-decoration: none;
+    transition: color var(--transition);
+}
+
+.site-footer .footer-meta a:hover {
+    color: var(--primary);
+}
+
+/* hahwul mark — Built with Love (matches the dalfox docs footer), folded
+   into the meta line so the signature costs a glyph, not its own block. */
+.footer-sig {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.footer-sig .hahwul-img {
+    width: 22px;
+    height: 22px;
     /* Recolor the logo to the footer text tone by using its alpha as a mask
        and filling with the muted token (the raster itself is white). */
     background-color: var(--text-muted);
     -webkit-mask: url("../../images/hahwul.webp") center / contain no-repeat;
     mask: url("../../images/hahwul.webp") center / contain no-repeat;
-    transition: background-color 0.3s ease;
+    transition: background-color var(--transition);
 }
 
-.footer-mark .hahwul-img:hover {
+.site-footer .footer-meta a:hover .hahwul-img {
     background-color: var(--text);
 }
 
 .footer-love {
-    margin-top: 0.85rem;
-    color: var(--text-muted);
     font-family: "Bradley Hand", "Snell Roundhand", "Apple Chancery", cursive;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     letter-spacing: 0.02em;
-}
-
-@media (max-width: 900px) {
-    .site-footer-grid {
-        grid-template-columns: 1fr 1fr;
-    }
 }
 
 @media (max-width: 768px) {
@@ -326,13 +266,6 @@ ul.page-list li {
     .pn-next {
         grid-column: auto;
         text-align: left;
-    }
-}
-
-@media (max-width: 560px) {
-    .site-footer-grid {
-        grid-template-columns: 1fr;
-        gap: var(--space-5);
     }
 }
 

--- a/docs/templates/site-footer.html
+++ b/docs/templates/site-footer.html
@@ -1,42 +1,16 @@
+{# One centered tier: a single meta line carrying the hahwul signature, the
+   license, and the copyright. The old brand + three-column link grid only
+   restated the sidebar and the header nav, so the strip now reads as frame
+   rather than a second index. Deliberately untranslated — it is chrome, not
+   content, and the handwriting stack under "Built with Love" carries no
+   Hangul anyway. #}
 <footer class="site-footer">
-  <div class="site-footer-grid">
-    <div class="site-footer-brand">
-      <img src="/hwaro-wide.webp" alt="Hwaro" class="site-footer-logo">
-      <p class="site-footer-tag">{{ "footer.tagline" | t }}</p>
-    </div>
-    <div class="site-footer-col">
-      <h2>{{ "footer.docs" | t }}</h2>
-      <ul>
-        <li><a href="{{ base_url }}{{ lang_prefix }}/start/">{{ "nav.start" | t }}</a></li>
-        <li><a href="{{ base_url }}{{ lang_prefix }}/writing/">{{ "nav.writing" | t }}</a></li>
-        <li><a href="{{ base_url }}{{ lang_prefix }}/templates/">{{ "nav.templates" | t }}</a></li>
-        <li><a href="{{ base_url }}{{ lang_prefix }}/features/">{{ "nav.features" | t }}</a></li>
-        <li><a href="{{ base_url }}{{ lang_prefix }}/deploy/">{{ "nav.deploy" | t }}</a></li>
-      </ul>
-    </div>
-    <div class="site-footer-col">
-      <h2>{{ "footer.project" | t }}</h2>
-      <ul>
-        <li><a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener">GitHub</a></li>
-        <li><a href="https://github.com/hahwul/hwaro/releases" target="_blank" rel="noopener">{{ "footer.releases" | t }}</a></li>
-        <li><a href="https://examples.hwaro.hahwul.com" target="_blank" rel="noopener">{{ "nav.examples" | t }}</a></li>
-        <li><a href="https://hahwul.github.io/ssg-benchmark/" target="_blank" rel="noopener">{{ "footer.benchmark" | t }}</a></li>
-      </ul>
-    </div>
-    <div class="site-footer-col">
-      <h2>{{ "footer.resources" | t }}</h2>
-      <ul>
-        <li><a href="{{ base_url }}{{ lang_prefix }}/integrations/skills/">{{ "footer.skills" | t }}</a></li>
-        <li><a href="{{ base_url }}/llms.txt">llms.txt</a></li>
-        <li><a href="{{ base_url }}/sitemap.xml">{{ "footer.sitemap" | t }}</a></li>
-        <li><a href="https://github.com/hahwul/hwaro/blob/main/LICENSE" target="_blank" rel="noopener">{{ "footer.license" | t }}</a></li>
-      </ul>
-    </div>
-  </div>
-  <div class="footer-mark">
-    <a href="https://www.hahwul.com" target="_blank" rel="noopener" aria-label="hahwul">
-      <span class="hahwul-img" role="img" aria-label="hahwul"></span>
+  <p class="footer-meta">
+    <a class="footer-sig" href="https://www.hahwul.com" target="_blank" rel="noopener" aria-label="hahwul, Built with Love">
+      <span class="hahwul-img" aria-hidden="true"></span>
+      <span class="footer-love">Built with Love</span>
     </a>
-    <p class="footer-love">Built with Love</p>
-  </div>
+    <span aria-hidden="true">·</span>
+    <span>MIT · © HAHWUL</span>
+  </p>
 </footer>


### PR DESCRIPTION
Replaces the docs site footer's four-column grid with the one-line strip the [gori docs](https://github.com/hahwul/gori) use.

## Before

Brand block (`hwaro-wide.webp` + tagline) beside three link columns — Docs, Project, Resources — over a centered 80px hahwul mark and "Built with Love". Fifteen links, all but two of which the sidebar or the header nav already carried, so the block read as a second index rather than as the end of the page.

## After

```
────────────────────────────────────────
   ℋ𝒲  Built with Love  ·  MIT · © HAHWUL
```

The hahwul mark folds into the meta line at 22px, so the signature costs a glyph instead of its own block.

## Notes

- **Untranslated by design**, matching gori: the strip is chrome, not content, and the handwriting stack under "Built with Love" carries no Hangul. That retires the nine now-unused `[footer]` keys in `en.toml` and `ko.toml`.
- **CSS 119 → 39 lines.** The grid, the column rules, `.footer-mark`, the 900px/560px grid breakpoints, and the dead `.site-footer-bottom` block (no markup had ever used it) all go. The 768px block, which is about `.card-grid` and `.docs-prevnext`, is preserved verbatim.
- **Specificity.** The footer renders inside `.docs-main`, where `.docs-main p` (0,1,1) and `.docs-main p a` (0,1,2) match at the same weight, so every override carries the extra `.footer-meta` class rather than relying on stylesheet order.
- **Dropped links:** `llms.txt` and `sitemap.xml` had the footer as their only in-page entry point. Easy to add back to the meta line if they are worth a link.

## Verification

Built all 148 pages, then clipped the `.site-footer` box with headless Chrome over CDP: docs page, landing, and 390px mobile, in both dark and light themes — one line in every case, mask logo included. The `ko/` tree renders identically. No orphaned class references remain (`site-footer-grid`, `site-footer-col`, `footer-mark`, … all zero hits); braces balanced.

No changelog fragment: this changes the docs site, not hwaro's user-visible behaviour (same as 95d74b9e).