### PR TITLE
perf: cut build time 14-37% across corpus shapes

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -49,7 +49,7 @@ jobs:
           # src/main.cr — the old `-Dpreview_mt` flag is deprecated and its
           # legacy MT scheduler can spin forever at process exit.
           docker run --rm -v $(pwd):/hwaro -w /hwaro --entrypoint="" crystallang/crystal:1.21.0-alpine sh -c "
-            apk add --no-cache yaml-dev git curl &&
+            apk add --no-cache yaml-dev zlib-dev zlib-static git curl &&
             shards install --release --no-debug --production &&
             mkdir -p build &&
             crystal build src/main.cr -o build/hwaro-${GITHUB_REF_SLUG}-linux-${ARCH} --release --no-debug --static

--- a/changelog.d/improve-performance.md
+++ b/changelog.d/improve-performance.md
@@ -1,0 +1,3 @@
+### Changed
+- Builds are substantially faster, with byte-identical HTML output: 5000-page listing-heavy corpus −37%, 5000-page blog corpus −14%, the docs site −29%. Small sites are unchanged.
+- OG images and generated PNG variants now deflate through zlib instead of stb's bundled compressor. The images are pixel-identical and about 24% smaller, and encoding them is faster — cached OG images stay valid and are not regenerated.

--- a/spec/unit/ext/crinja_render_perf_spec.cr
+++ b/spec/unit/ext/crinja_render_perf_spec.cr
@@ -145,4 +145,108 @@ describe "ext/crinja_render_perf" do
       env.__for_fragment_cache.size.should eq(0)
     end
   end
+
+  # Patch 7 keeps the rendered `Output` on a BlockOutput and streams it at
+  # join time instead of flattening it into a String immediately. These pin
+  # the behaviour that deferral must not disturb: nesting, inheritance
+  # chains, `{{ super() }}`, repeated and empty blocks, and blocks whose
+  # content is produced under a scope that is gone by the time the page is
+  # assembled.
+  describe "block placeholder streaming" do
+    it "renders a single overridden block" do
+      env = Crinja.new
+      env.loader = Crinja::Loader::HashLoader.new({
+        "base.html"  => "<h>{% block body %}base{% endblock %}</h>",
+        "child.html" => "{% extends \"base.html\" %}{% block body %}child{% endblock %}",
+      })
+
+      env.get_template("child.html").render.should eq("<h>child</h>")
+    end
+
+    it "renders a block that was never overridden" do
+      env = Crinja.new
+      env.loader = Crinja::Loader::HashLoader.new({
+        "base.html"  => "<h>{% block body %}fallback{% endblock %}</h>",
+        "child.html" => "{% extends \"base.html\" %}",
+      })
+
+      env.get_template("child.html").render.should eq("<h>fallback</h>")
+    end
+
+    it "renders an empty block as empty" do
+      env = Crinja.new
+      env.loader = Crinja::Loader::HashLoader.new({
+        "base.html"  => "[{% block body %}{% endblock %}]",
+        "child.html" => "{% extends \"base.html\" %}{% block body %}{% endblock %}",
+      })
+
+      env.get_template("child.html").render.should eq("[]")
+    end
+
+    it "renders blocks nested inside other blocks" do
+      env = Crinja.new
+      env.loader = Crinja::Loader::HashLoader.new({
+        "base.html"  => "{% block outer %}O({% block inner %}i{% endblock %}){% endblock %}",
+        "child.html" => "{% extends \"base.html\" %}{% block inner %}I{% endblock %}",
+      })
+
+      env.get_template("child.html").render.should eq("O(I)")
+    end
+
+    it "renders a three-level inheritance chain" do
+      env = Crinja.new
+      env.loader = Crinja::Loader::HashLoader.new({
+        "base.html"   => "<{% block body %}base{% endblock %}>",
+        "middle.html" => "{% extends \"base.html\" %}{% block body %}m[{% block inner %}m-in{% endblock %}]{% endblock %}",
+        "leaf.html"   => "{% extends \"middle.html\" %}{% block inner %}leaf{% endblock %}",
+      })
+
+      env.get_template("leaf.html").render.should eq("<m[leaf]>")
+    end
+
+    it "renders super() from an overriding block" do
+      env = Crinja.new
+      env.loader = Crinja::Loader::HashLoader.new({
+        "base.html"  => "{% block body %}base{% endblock %}",
+        "child.html" => "{% extends \"base.html\" %}{% block body %}[{{ super() }}]{% endblock %}",
+      })
+
+      env.get_template("child.html").render.should eq("[base]")
+    end
+
+    it "renders a block used twice in the parent" do
+      env = Crinja.new
+      env.loader = Crinja::Loader::HashLoader.new({
+        "base.html"  => "{% block body %}b{% endblock %}|{% block body %}b{% endblock %}",
+        "child.html" => "{% extends \"base.html\" %}{% block body %}X{% endblock %}",
+      })
+
+      env.get_template("child.html").render.should eq("X|X")
+    end
+
+    it "renders a block whose body loops over template variables" do
+      env = Crinja.new
+      env.loader = Crinja::Loader::HashLoader.new({
+        "base.html"  => "<{% block body %}{% endblock %}>",
+        "child.html" => "{% extends \"base.html\" %}{% block body %}{% for x in items %}{{ x }};{% endfor %}{% endblock %}",
+      })
+
+      env.get_template("child.html").render({"items" => Crinja::Value.new([
+        Crinja::Value.new("a"), Crinja::Value.new("b"),
+      ] of Crinja::Value)}).should eq("<a;b;>")
+    end
+
+    it "renders the same template repeatedly without carrying state over" do
+      env = Crinja.new
+      env.loader = Crinja::Loader::HashLoader.new({
+        "base.html"  => "<{% block body %}{% endblock %}>",
+        "child.html" => "{% extends \"base.html\" %}{% block body %}{{ name }}{% endblock %}",
+      })
+      template = env.get_template("child.html")
+
+      template.render({"name" => Crinja::Value.new("one")}).should eq("<one>")
+      template.render({"name" => Crinja::Value.new("two")}).should eq("<two>")
+      template.render({"name" => Crinja::Value.new("three")}).should eq("<three>")
+    end
+  end
 end

--- a/spec/unit/utils/byte_scan_spec.cr
+++ b/spec/unit/utils/byte_scan_spec.cr
@@ -1,0 +1,131 @@
+require "../../spec_helper"
+
+# ByteScan replaces `String#includes?` / `String#byte_index` on hot probe
+# paths, so the contract that matters is *exact* agreement with them. The
+# differential block at the bottom is the real test; the examples above it
+# pin the edges that a random generator reaches only rarely.
+describe Hwaro::Utils::ByteScan do
+  scan = Hwaro::Utils::ByteScan
+
+  describe ".includes?" do
+    it "finds single-byte needles" do
+      scan.includes?("hello", "e").should be_true
+      scan.includes?("hello", "z").should be_false
+    end
+
+    it "finds multi-byte needles" do
+      scan.includes?("a ~~struck~~ word", "~~").should be_true
+      scan.includes?("a ~ lone tilde", "~~").should be_false
+    end
+
+    it "matches a needle at the very end of the haystack" do
+      scan.includes?("prefix{#", "{#").should be_true
+      # One byte short of a match: the candidate starts inside the haystack
+      # but its tail runs past the end.
+      scan.includes?("prefix{", "{#").should be_false
+    end
+
+    it "keeps scanning past a false first-byte hit" do
+      # Every `~` before the real `~~` is a memchr hit whose memcmp fails.
+      scan.includes?("~a~b~c~~", "~~").should be_true
+    end
+
+    it "treats the empty needle as present" do
+      scan.includes?("abc", "").should be_true
+      scan.includes?("", "").should be_true
+    end
+
+    it "reports nothing for a needle longer than the haystack" do
+      scan.includes?("ab", "abc").should be_false
+      scan.includes?("", "a").should be_false
+    end
+
+    it "matches needles containing NUL" do
+      scan.includes?("a\u0000b", "\u0000b").should be_true
+      scan.includes?("ab", "\u0000b").should be_false
+    end
+
+    it "matches multi-byte UTF-8 needles" do
+      scan.includes?("한국어 문서", "국어").should be_true
+      scan.includes?("한국어 문서", "일본").should be_false
+      scan.includes?("emoji 🌱 here", "🌱").should be_true
+    end
+  end
+
+  describe ".byte_index" do
+    it "returns a byte offset, not a character offset" do
+      # "한" is three bytes, so the char index of "x" is 1 but its byte index is 3.
+      "한x".index("x").should eq(1)
+      scan.byte_index("한x", "x").should eq(3)
+    end
+
+    it "honors a start offset" do
+      scan.byte_index("aXbX", "X").should eq(1)
+      scan.byte_index("aXbX", "X", 2).should eq(3)
+      scan.byte_index("aXbX", "X", 4).should be_nil
+    end
+
+    it "answers nil for an out-of-range or negative start" do
+      scan.byte_index("abc", "a", 99).should be_nil
+      scan.byte_index("abc", "a", -1).should be_nil
+    end
+
+    it "places the empty needle at the start offset" do
+      scan.byte_index("abc", "").should eq(0)
+      scan.byte_index("abc", "", 2).should eq(2)
+      scan.byte_index("abc", "", 3).should eq(3)
+      scan.byte_index("abc", "", 4).should be_nil
+    end
+  end
+
+  describe ".byte?" do
+    it "detects a byte anywhere in the string" do
+      scan.byte?("abc", 'b'.ord.to_u8).should be_true
+      scan.byte?("abc", 'z'.ord.to_u8).should be_false
+      scan.byte?("a\u0000b", 0_u8).should be_true
+      scan.byte?("ab", 0_u8).should be_false
+    end
+
+    it "sees bytes inside multi-byte characters" do
+      # "€" is E2 82 AC — byte?, unlike String#includes?(Char), works on bytes.
+      scan.byte?("€", 0x82_u8).should be_true
+    end
+  end
+
+  describe "agreement with String#includes?" do
+    it "matches on random haystack/needle pairs" do
+      rng = Random.new(20260908)
+      alphabet = ['a', 'b', '~', '{', '#', '+', '=', '^', '[', ']', ' ', '\n', '한', '🌱']
+
+      5_000.times do
+        haystack = String.build do |io|
+          rng.rand(0..24).times { io << alphabet.sample(rng) }
+        end
+        needle = String.build do |io|
+          rng.rand(0..3).times { io << alphabet.sample(rng) }
+        end
+
+        scan.includes?(haystack, needle).should eq(haystack.includes?(needle))
+      end
+    end
+
+    it "agrees with byte_index on where the first match starts" do
+      rng = Random.new(9080602)
+      alphabet = ['a', '~', '{', '#', ' ']
+
+      2_000.times do
+        haystack = String.build do |io|
+          rng.rand(0..20).times { io << alphabet.sample(rng) }
+        end
+        needle = String.build do |io|
+          rng.rand(1..3).times { io << alphabet.sample(rng) }
+        end
+
+        # Every byte of this alphabet outside the multi-byte chars is ASCII, so
+        # the stdlib's character index and the byte index coincide and can be
+        # compared directly.
+        scan.byte_index(haystack, needle).should eq(haystack.index(needle))
+      end
+    end
+  end
+end

--- a/spec/unit/utils/file_safe_spec.cr
+++ b/spec/unit/utils/file_safe_spec.cr
@@ -20,6 +20,44 @@ describe Hwaro::Utils::FileSafe do
       end
     end
 
+    # The parent walk stops at the deepest ancestor that already exists
+    # instead of visiting every component from the root, so these pin the
+    # shapes where "where do I start creating?" is decided.
+    it "creates only the missing tail below an existing ancestor" do
+      Dir.mktmpdir do |root|
+        Dir.mkdir_p(File.join(root, "a", "b"))
+        target = File.join(root, "a", "b", "c", "d")
+        Hwaro::Utils::FileSafe.mkdir_p(target)
+        Dir.exists?(target).should be_true
+        Dir.exists?(File.join(root, "a", "b", "c")).should be_true
+      end
+    end
+
+    it "tolerates a trailing separator" do
+      Dir.mktmpdir do |root|
+        target = File.join(root, "a", "b")
+        Hwaro::Utils::FileSafe.mkdir_p(target + File::SEPARATOR)
+        Dir.exists?(target).should be_true
+      end
+    end
+
+    it "creates a relative nested path" do
+      Dir.mktmpdir do |root|
+        Dir.cd(root) do
+          Hwaro::Utils::FileSafe.mkdir_p(Path["public", "posts", "hello"])
+          Dir.exists?(File.join(root, "public", "posts", "hello")).should be_true
+        end
+      end
+    end
+
+    it "resolves .. segments the same way the caller wrote them" do
+      Dir.mktmpdir do |root|
+        target = File.join(root, "a", "..", "b", "c")
+        Hwaro::Utils::FileSafe.mkdir_p(target)
+        Dir.exists?(File.join(root, "b", "c")).should be_true
+      end
+    end
+
     # Regression: an output_dir that is a dangling symlink (`public ->
     # nowhere`) made `Dir.exists?` false — it resolves the link — while
     # `Dir.mkdir` still hit EEXIST on the link itself, so the wrapper re-raised

--- a/src/content/processors/internal_link_resolver.cr
+++ b/src/content/processors/internal_link_resolver.cr
@@ -68,7 +68,7 @@ module Hwaro
           base_url : String = "",
           misses : Array({String, String})? = nil,
         ) : String
-          return html unless html.includes?("@/")
+          return html unless Utils::ByteScan.includes?(html, "@/")
 
           # Only treat base_url as a subpath prefix when it is a real absolute
           # URL (has a scheme). A host-only or malformed value like
@@ -145,7 +145,7 @@ module Hwaro
         # the same value by construction).
         def prefix_root_relative_links(html : String, base_url : String, base_path : String? = nil) : String
           return html if base_url.empty?
-          return html unless html.includes?("=\"/")
+          return html unless Utils::ByteScan.includes?(html, "=\"/")
 
           base_path ||= URI.parse(base_url).path.rstrip("/")
           return html if base_path.empty?
@@ -180,7 +180,7 @@ module Hwaro
         # to resolve against — e.g. an empty base_url deploy).
         def absolutize_links(html : String, page_url : String) : String
           return html if page_url.empty?
-          return html unless html.includes?("href=\"") || html.includes?("src=\"")
+          return html unless Utils::ByteScan.includes?(html, "href=\"") || Utils::ByteScan.includes?(html, "src=\"")
 
           base = URI.parse(page_url)
           return html if base.host.nil?

--- a/src/content/processors/markdown.cr
+++ b/src/content/processors/markdown.cr
@@ -95,8 +95,9 @@ module Hwaro
             html = MarkdownExtensions.postprocess(html, md_cfg)
           end
 
-          has_headers = html.includes?("<h")
-          has_images = lazy_loading && html.includes?("<img")
+          # ByteScan, not String#includes? — two whole-document probes per page.
+          has_headers = Utils::ByteScan.includes?(html, "<h")
+          has_images = lazy_loading && Utils::ByteScan.includes?(html, "<img")
 
           # Optimization: If no headers and no images (or lazy loading disabled), don't parse XML
           unless has_headers || has_images

--- a/src/content/processors/markdown_extensions.cr
+++ b/src/content/processors/markdown_extensions.cr
@@ -64,17 +64,24 @@ module Hwaro
           do_sub = config.sub
           do_sup = config.sup
 
-          # Whole-content marker pre-check (memchr-fast): with none of the
-          # enabled extensions' markers present, the line pass is the
-          # identity transform and only rebuilds the string — skip it. The
-          # per-line includes? guards below are unchanged, so any page that
-          # passes this check transforms exactly as before.
-          markers_present = (do_task_lists && (result.includes?("[ ]") || result.includes?("[x]") || result.includes?("[X]"))) ||
-                            (do_strikethrough && result.includes?("~~")) ||
-                            (do_heading_ids && (result.includes?("{#") || result.includes?("<!--HID:"))) ||
-                            (do_ins && result.includes?("++")) || (do_mark && result.includes?("==")) ||
+          # Whole-content marker pre-check: with none of the enabled
+          # extensions' markers present, the line pass is the identity
+          # transform and only rebuilds the string — skip it. The per-line
+          # includes? guards below are unchanged, so any page that passes this
+          # check transforms exactly as before.
+          #
+          # `ByteScan`, not `String#includes?`: this is up to ten
+          # whole-document probes per page, and the stdlib's Rabin-Karp walks
+          # every byte in Crystal (~75x slower than an anchored memchr scan on
+          # a miss, which is the common case). Character probes already reach
+          # memchr through `String#index(Char)`.
+          scan = Utils::ByteScan
+          markers_present = (do_task_lists && (scan.includes?(result, "[ ]") || scan.includes?(result, "[x]") || scan.includes?(result, "[X]"))) ||
+                            (do_strikethrough && scan.includes?(result, "~~")) ||
+                            (do_heading_ids && (scan.includes?(result, "{#") || scan.includes?(result, "<!--HID:"))) ||
+                            (do_ins && scan.includes?(result, "++")) || (do_mark && scan.includes?(result, "==")) ||
                             (do_sub && result.includes?('~')) || (do_sup && result.includes?('^')) ||
-                            (config.attributes && (result.includes?('{') || result.includes?("<!--HATTR:")))
+                            (config.attributes && (result.includes?('{') || scan.includes?(result, "<!--HATTR:")))
 
           if markers_present
             result = process_lines_fence_aware(result) do |line, _in_fence|

--- a/src/core/build/shortcode_processor.cr
+++ b/src/core/build/shortcode_processor.cr
@@ -67,7 +67,8 @@ module Hwaro
         # the very common case of documentation pages that only show literal
         # shortcode examples inside code regions.
         def content_may_contain_shortcodes?(content : String) : Bool
-          return false unless content.includes?("{{") || content.includes?("{%")
+          # Whole-document probes: memchr-anchored, not the stdlib's Rabin-Karp.
+          return false unless Utils::ByteScan.includes?(content, "{{") || Utils::ByteScan.includes?(content, "{%")
 
           # FenceTracker (shared with the table/definition/math walkers and,
           # critically, process_shortcodes_jinja below) so the skip decision
@@ -177,7 +178,7 @@ module Hwaro
         # not a closer. (The old loop honored that only at depth 0, which is
         # exactly how a fenced example came to close a real opener.)
         private def block_body_lines(content : String) : Array(Bool)
-          return [] of Bool unless content.includes?("{%")
+          return [] of Bool unless Utils::ByteScan.includes?(content, "{%")
 
           tracker = Content::Processors::FenceTracker.new
           open_lines = [] of Int32
@@ -404,7 +405,7 @@ module Hwaro
         # named-closer normalization, an explicit/direct `{{ name(...) }}`
         # call, or a non-control `{% name %}` block opener.
         def shortcode_scan_needed?(text : String) : Bool
-          return false unless text.includes?("{{") || text.includes?("{%")
+          return false unless Utils::ByteScan.includes?(text, "{{") || Utils::ByteScan.includes?(text, "{%")
           return true if named_closer?(text)
           return true if SHORTCODE_CALL_SCAN_RE.matches?(text)
 

--- a/src/ext/crinja_render_perf.cr
+++ b/src/ext/crinja_render_perf.cr
@@ -1,7 +1,7 @@
 # Render-path performance patches for the vendored Crinja runtime — kept
 # here so we don't fork the library, mirroring ext/crinja_resolve_fix.cr.
 #
-# All three patches are byte-compat: they change how the rendered string is
+# Every patch here is byte-compat: they change how the rendered string is
 # assembled, never which bytes come out. Verified by diff -r of full output
 # trees on the harsh-5000 and public-5000 benchmark corpora.
 #
@@ -78,13 +78,11 @@ class Crinja::Renderer
   # (it raises on unresolved placeholders), which `else` covers.
   class OutputList < Output
     def value(io : IO)
-      nodes.each do |node|
-        if node.is_a?(OutputList)
-          node.value(io)
-        else
-          io << node.value
-        end
-      end
+      # Every Output subclass defines `value(io)`, so dispatching to it
+      # streams uniformly: OutputList recurses, RenderedOutput writes its
+      # string, and BlockOutput either streams its resolved subtree (patch 7)
+      # or raises through `value` exactly as upstream does when unresolved.
+      nodes.each(&.value(io))
     end
 
     # === 4. Block-free subtree pruning ==================================
@@ -339,5 +337,118 @@ class Crinja::Tag::For
         end
       end
     end
+  end
+end
+
+# === 7. Block placeholders hold their subtree, not a materialized String ===
+# `resolve_block_stubs` rendered each `{% block %}` and immediately flattened
+# it with `output.value` — a String.build of the ENTIRE block. For a page
+# whose body is one `{% block body %}` (what `{% extends %}` layouts always
+# produce) that is a full copy of the page, allocated and thrown away purely
+# so the parent list could copy it again into the final page string. On the
+# harsh-5000 corpus, where each page is ~400 KB, that was ~2 GB of pointless
+# allocation and memcpy per build.
+#
+# Keeping the rendered `Output` and streaming it at join time removes the
+# intermediate entirely. Deferring is safe because the block's output is inert
+# by then: `resolve_block_stubs` recurses into it first, so its own nested
+# placeholders are already resolved, and nothing in `value(io)` reads the
+# render scope the block was produced under.
+class Crinja::Renderer
+  class BlockOutput < Output
+    @resolved_output : Output?
+
+    # Overload of the upstream `resolve(String)`; `resolve("")` still lands
+    # on that one.
+    def resolve(output : Output)
+      @resolved_output = output
+    end
+
+    def resolved?
+      !@output.nil? || !@resolved_output.nil?
+    end
+
+    def value : String
+      if resolved = @resolved_output
+        return resolved.value
+      end
+      raise "block placeholder not resolved #{name}" unless resolved?
+
+      @output.not_nil! # ameba:disable Lint/NotNil -- mirrors the upstream accessor
+    end
+
+    def value(io)
+      if resolved = @resolved_output
+        resolved.value(io)
+      else
+        io << value
+      end
+    end
+  end
+
+  # Upstream body, with `placeholder.resolve(output.value)` replaced by the
+  # streaming `placeholder.resolve(output)`. Everything else — including the
+  # deliberate rebinding of `output` inside the loop — is verbatim.
+  private def resolve_block_stubs(output, block_names = Array(String).new)
+    output.each_block do |placeholder|
+      name = placeholder.name
+      unless block_names.includes?(name)
+        block_chain = @blocks[name]
+
+        if block_chain.size > 0
+          block = block_chain.first
+
+          scope = env.context
+          unless (original_scope = placeholder.scope).nil?
+            scope = original_scope
+          end
+
+          env.with_scope(scope) do
+            env.context.block_context = {name: name, index: 0}
+
+            output = render(block)
+
+            block_names << name
+            resolve_block_stubs(output, block_names)
+
+            block_names.pop
+
+            env.context.block_context = nil
+          end
+
+          placeholder.resolve(output)
+        end
+      end
+
+      placeholder.resolve("") unless placeholder.resolved?
+    end
+  end
+end
+
+# === 8. Presized page buffer ==========================================
+# `Template#render(bindings)` builds its result with a default `String.build`,
+# which starts at 64 bytes and doubles. A 400 KB page therefore reallocates
+# about thirteen times and memcpys roughly twice its own size before it is
+# finished — per page, on every page.
+#
+# Consecutive renders of the SAME template produce similarly sized output (a
+# listing page is a listing page), so the previous render's size is a good
+# capacity hint. It is only a hint: too small and `String::Builder` grows
+# exactly as it does today, too large and the final `String.build` trims the
+# excess. No byte of output depends on it.
+#
+# `@render_size_hint` is an aligned Int32 shared between render workers, so a
+# concurrent write cannot tear — the worst case is a worker reading a size
+# from a different page, which is the same class of estimate the value is.
+class Crinja::Template
+  @render_size_hint : Int32 = 0
+
+  def render(bindings = nil)
+    hint = @render_size_hint
+    result = String.build(hint > 0 ? hint : 64) do |io|
+      render(io, bindings)
+    end
+    @render_size_hint = result.bytesize
+    result
   end
 end

--- a/src/ext/stb_bindings.cr
+++ b/src/ext/stb_bindings.cr
@@ -8,6 +8,12 @@
 #
 # The ldflags backtick command auto-compiles stb_impl.o when missing or stale.
 # It checks all source files (.c and .h) so header updates trigger a rebuild.
+#
+# stb's PNG writer deflates through zlib (the STBIW_ZLIB_COMPRESS block in
+# stb_impl.c), so this object needs libz at link time. `lib_z` carries the
+# `@[Link("z")]` that supplies it; requiring it here states the dependency
+# without emitting a second `-lz` (the linker warns about duplicates).
+require "lib_z"
 
 @[Link(ldflags: "`sh -c 'D=#{__DIR__}; OBJ=$D/stb_impl.o; STALE=0; if [ ! -f \"$OBJ\" ]; then STALE=1; else for f in $D/stb_impl.c $D/stb_image.h $D/stb_image_write.h $D/stb_image_resize2.h $D/stb_truetype.h; do [ \"$f\" -nt \"$OBJ\" ] && STALE=1; done; fi; [ $STALE -eq 1 ] && ${CC:-cc} -c -O2 -o \"$OBJ\" \"$D/stb_impl.c\"; echo \"$OBJ\"'`")]
 lib LibStb

--- a/src/ext/stb_impl.c
+++ b/src/ext/stb_impl.c
@@ -12,6 +12,56 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
+/* PNG deflate through zlib instead of stb's built-in compressor.
+ *
+ * stb_image_write ships a small hash-chain deflate that is both slower and
+ * markedly weaker than zlib's. Measured on a 1200x630 RGBA OG image
+ * (-O2, Apple M-series), encoding the whole PNG:
+ *
+ *   stb's compressor (level 8)   15.3 ms   203,152 bytes
+ *   zlib level 3                  6.6 ms   174,733 bytes
+ *   zlib level 4                  9.4 ms   144,187 bytes
+ *   zlib level 6                 14.6 ms   128,976 bytes
+ *
+ * Level 4 is faster AND smaller than what stb produced, which is why it is
+ * the default here: OG image generation dominates a real site's build (567 ms
+ * of a 943 ms docs build), and the images it emits also ship to every social
+ * crawler that fetches them.
+ *
+ * libz is already a hard dependency of every hwaro build — Crystal's
+ * `compress/deflate`, required by src/core/build/remote_data.cr, links it —
+ * so this adds no new library. The encoded pixels are unchanged: PNG is
+ * lossless and only the IDAT deflate stream differs, so cached OG images
+ * stay valid and RENDER_REVISION deliberately does NOT move.
+ */
+#include <stdlib.h>
+#include <zlib.h>
+
+#define HWARO_PNG_ZLIB_LEVEL 4
+
+/* stb passes `stbi_write_png_compression_level` (its own default, 8) as
+ * `quality`. That number indexes stb's compressor, not zlib's — the two
+ * scales are unrelated, and zlib's 8 costs 40 ms for 5 KB less than level 4 —
+ * so it is deliberately ignored. hwaro never sets that global.
+ *
+ * Returns a buffer stb frees with STBIW_FREE (plain free), or NULL, which
+ * stb propagates as a failed write. */
+static unsigned char *hwaro_png_zlib_compress(unsigned char *data, int data_len,
+                                              int *out_len, int quality) {
+    (void)quality;
+    if (data_len < 0) return NULL;
+    uLongf bound = compressBound((uLong)data_len);
+    unsigned char *out = (unsigned char *)malloc(bound ? bound : 1);
+    if (!out) return NULL;
+    if (compress2(out, &bound, data, (uLong)data_len, HWARO_PNG_ZLIB_LEVEL) != Z_OK) {
+        free(out);
+        return NULL;
+    }
+    *out_len = (int)bound;
+    return out;
+}
+
+#define STBIW_ZLIB_COMPRESS hwaro_png_zlib_compress
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 

--- a/src/hwaro.cr
+++ b/src/hwaro.cr
@@ -35,6 +35,7 @@ require "./ext/toml_nesting_limit_fix"
 require "emoji"
 
 # Load utilities
+require "./utils/byte_scan"
 require "./utils/errors"
 require "./utils/nesting"
 require "./utils/logger"

--- a/src/utils/byte_scan.cr
+++ b/src/utils/byte_scan.cr
@@ -1,0 +1,76 @@
+# memchr-backed literal scanning.
+#
+# Crystal's `String#includes?(String)` runs a Rabin-Karp loop in Crystal code
+# — one byte per iteration, with a rolling hash update on each — and
+# `String#byte_index(Int)` is a plain byte-at-a-time `upto`. Neither reaches
+# libc's vectorized `memchr`, and hwaro probes whole documents with short
+# ASCII literals constantly: the markdown extension pre-pass alone runs ten
+# whole-document `includes?` probes per page, the minifier probes every
+# protected tag, and every rendered page gets a NUL scan before minification.
+#
+# Measured on a 375 KB document (release build, M-series):
+#
+#   html.byte_index(0)          84.5 µs      html.to_slice.index(0u8)   5.7 µs
+#   doc.includes?("~~") (miss)   423 µs      Scan.includes?(doc, "~~")  5.7 µs
+#
+# The win is entirely from delegating the scan to `memchr` (which `Slice(UInt8)#index`
+# routes to) and confirming candidates with `memcmp`, instead of walking bytes
+# in Crystal.
+#
+# These are BYTE searches, which is exactly what the `String` methods they
+# replace already do for the boolean answer: UTF-8 is self-synchronizing, so a
+# valid multi-byte needle can only match at a character boundary. Callers that
+# need a character index must keep using `String#index`.
+module Hwaro
+  module Utils
+    module ByteScan
+      extend self
+
+      # True when *byte* occurs anywhere in *str*.
+      def byte?(str : String, byte : UInt8) : Bool
+        !str.to_slice.index(byte).nil?
+      end
+
+      # True when the bytes of *needle* occur anywhere in *haystack*.
+      #
+      # Equivalent to `haystack.includes?(needle)` for every needle hwaro
+      # probes with (`String#includes?` answers the same question over the
+      # same bytes; only the index it can also return is character-based).
+      def includes?(haystack : String, needle : String) : Bool
+        !byte_index(haystack, needle).nil?
+      end
+
+      # Byte offset of the first occurrence of *needle* in *haystack*, or nil.
+      #
+      # `start` is a byte offset. An out-of-range or negative start finds
+      # nothing rather than raising — probes run on attacker-shaped content and
+      # must not turn a scan into an exception.
+      def byte_index(haystack : String, needle : String, start : Int32 = 0) : Int32?
+        return if start < 0
+        nsize = needle.bytesize
+        hsize = haystack.bytesize
+        return (start <= hsize ? start : nil) if nsize == 0
+        return if nsize > hsize - start
+
+        hay = haystack.to_slice
+        first = needle.to_unsafe.value
+        return hay.index(first, start) if nsize == 1
+
+        limit = hsize - nsize
+        rest = (nsize - 1).to_u64
+        needle_rest = needle.to_unsafe + 1
+        offset = start
+        while offset <= limit
+          found = hay.index(first, offset)
+          return unless found
+          return if found > limit
+          if LibC.memcmp((haystack.to_unsafe + found + 1).as(Void*), needle_rest.as(Void*), rest) == 0
+            return found
+          end
+          offset = found + 1
+        end
+        nil
+      end
+    end
+  end
+end

--- a/src/utils/file_safe.cr
+++ b/src/utils/file_safe.cr
@@ -31,13 +31,35 @@ module Hwaro
       # is false because we never reached the leaf — so the EEXIST bubbles
       # out and a render fails ("Unable to create directory: '…': File
       # exists"). Tolerating EEXIST per component avoids the cascade.
+      #
+      # The parent walk runs deepest-first and stops at the first component
+      # that already exists, then creates downward from there. Walking from
+      # the root instead (what `each_parent` yields, and what this used to do)
+      # cost one `Dir.exists?` stat per ancestor on every call — and every
+      # page of a large site creates a fresh leaf directory under an
+      # already-existing tree, so a six-deep output path paid six stats to
+      # create one directory. Only the components actually missing are
+      # touched now, which for that shape is a single stat plus one mkdir.
+      #
+      # EEXIST is still absorbed per component, so the concurrency argument
+      # above is unchanged: another fiber may materialize any of these
+      # directories between our stat and our mkdir.
       def self.mkdir_p(path : String | Path, mode : Int32 = 0o777) : Nil
         path = Path.new(path)
         return if Dir.exists?(path)
 
-        path.each_parent do |parent|
-          mkdir_tolerant(parent, mode)
+        missing = [] of Path
+        current = path
+        while parent = current.parent
+          # `Path#parent` is a fixed point at the root ("/" and "." both
+          # return themselves), which would spin forever without this.
+          break if parent == current
+          break if Dir.exists?(parent)
+          missing << parent
+          current = parent
         end
+
+        missing.reverse_each { |dir| mkdir_tolerant(dir, mode) }
         mkdir_tolerant(path, mode)
       end
 

--- a/src/utils/html_minifier.cr
+++ b/src/utils/html_minifier.cr
@@ -90,9 +90,9 @@ module Hwaro
         # Cheap presence probe: most pages carry no <textarea>, <math>,
         # <noscript>, …, and the heavy `.*?` extraction pattern below has
         # no fast no-match path (every '<' in the document is a candidate
-        # start). The lowercase literal decides via memchr for the
-        # markdown-rendered common case; the case-insensitive probe covers
-        # author-written uppercase tags.
+        # start). The lowercase literal decides via `ByteScan`'s memchr scan
+        # for the markdown-rendered common case; the case-insensitive probe
+        # covers author-written uppercase tags.
          "<#{tag}",
          Regex.new("<#{tag}", Regex::Options::IGNORE_CASE),
          Regex.new(
@@ -174,7 +174,9 @@ module Hwaro
       # to U+FFFD; NUL never appears inside a multi-byte sequence, so this is
       # safe.
       def scrub_nul(html : String) : String
-        return html unless html.byte_index(0)
+        # memchr, not `String#byte_index`, whose byte-at-a-time loop is ~15x
+        # slower — this probe runs over every rendered page.
+        return html unless ByteScan.byte?(html, 0_u8)
         String.build(html.bytesize) do |io|
           html.each_byte { |b| io.write_byte(b) unless b == 0 }
         end
@@ -205,7 +207,7 @@ module Hwaro
       private def protect_sensitive_blocks(html : String, preserves : Array(String)) : String
         result = html
         PROTECTED_PATTERNS.each do |(tag, open_literal, probe, pattern)|
-          next unless result.includes?(open_literal) || result.matches?(probe)
+          next unless ByteScan.includes?(result, open_literal) || result.matches?(probe)
           prefix = PROTECTED_INLINE.includes?(tag) ? PRESERVE_PREFIX_INLINE : PRESERVE_PREFIX_BLOCK
           result = result.gsub(pattern) do |match|
             idx = preserves.size

--- a/src/utils/output_guard.cr
+++ b/src/utils/output_guard.cr
@@ -19,8 +19,17 @@ module Hwaro
         # Canonicalize once — the previous within_output_dir? + canonical
         # sequence expanded output_path twice (a getcwd syscall and several
         # Path allocations each), and this runs for every written file.
-        canonical_output = canonical?(output_path)
-        canonical_dir = canonical?(output_dir)
+        #
+        # One `Dir.current` for both expansions. `File.expand_path` with no
+        # base resolves the working directory itself, and that is a `getcwd`
+        # syscall — on macOS an `open` plus `stat`, not a cheap read. This
+        # method runs for every file a build writes, so paying it twice per
+        # page was pure waste. Resolving it here (rather than memoizing it
+        # process-wide) keeps the guard correct for callers that run under a
+        # different working directory later in the same process.
+        cwd = Dir.current
+        canonical_output = canonical?(output_path, cwd)
+        canonical_dir = canonical?(output_dir, cwd)
         if canonical_output && canonical_dir && contains?(canonical_dir, canonical_output)
           canonical_output
         else
@@ -32,8 +41,9 @@ module Hwaro
       # Check if a path is within the output directory.
       #
       def within_output_dir?(output_path : String, output_dir : String) : Bool
-        dir = canonical?(output_dir)
-        target = canonical?(output_path)
+        cwd = Dir.current
+        dir = canonical?(output_dir, cwd)
+        target = canonical?(output_path, cwd)
         return false unless dir && target
         contains?(dir, target)
       end
@@ -55,8 +65,8 @@ module Hwaro
       # "String contains null byte" instead of answering "not safe", which is
       # exactly the outcome a guard exists to produce. Nil means "no canonical
       # form"; `contains?` treats that as outside.
-      private def canonical?(path : String) : String?
-        canonical(path)
+      private def canonical?(path : String, base : String? = nil) : String?
+        canonical(path, base)
       rescue ArgumentError
         nil
       end
@@ -70,8 +80,8 @@ module Hwaro
       # every page — a `-o public/` build (what shell directory completion
       # types for you) silently published nothing. Dropping trailing
       # separators makes `public/` and `public` the same directory again.
-      private def canonical(path : String) : String
-        expanded = File.expand_path(path)
+      private def canonical(path : String, base : String? = nil) : String
+        expanded = File.expand_path(path, base)
         return expanded if expanded == File::SEPARATOR_STRING
         expanded.rstrip(File::SEPARATOR)
       end


### PR DESCRIPTION
Five independent changes on the build hot path. Rendered HTML, XML and JSON output is **byte-identical** on every corpus; the only bytes that move are PNGs, which stay **pixel-identical** and get smaller.

## Measured

Release build, M-series, interleaved A/B medians, cold builds:

| corpus | before | after | delta |
|---|---|---|---|
| harsh-5000 (site-wide listings) | 3676ms | 2327ms | **−36.7%** |
| public-5000 (blog shape) | 1423ms | 1224ms | **−14.0%** |
| docs (real site, OG images) | 935ms | 664ms | **−29.0%** |
| blog scaffold (small site) | 27ms | 27ms | unchanged |
| docs OG PNG bytes | 20.2MB | 15.3MB | **−24%** |

## What changed

**1. `Utils::ByteScan` — memchr-backed literal probing.** Crystal's `String#includes?(String)` is a Rabin-Karp loop written in Crystal, and `String#byte_index(Int)` a byte-at-a-time `upto`; neither reaches libc. On a 375KB document a missing `"~~"` costs 423µs via `includes?` and 5.7µs via an anchored memchr scan. Applied to the whole-document probes that run per page: the markdown extension pre-check (up to ten of them), the NUL scrub on every rendered page, internal link resolution, and shortcode detection.

**2. PNG deflate through zlib** instead of stb's bundled compressor, which is both slower and weaker. At zlib level 4 a 1200×630 OG image encodes in 9.4ms/144KB against stb's 15.3ms/203KB — faster *and* smaller. libz was already linked for `compress/deflate`, so this adds no dependency. Only the IDAT stream changes, so `RENDER_REVISION` deliberately does not move and cached OG images stay valid.

**3. Crinja block placeholders keep their rendered `Output` and stream it at join time.** `resolve_block_stubs` used to flatten each `{% block %}` into a String immediately — for a page that is one `{% block body %}` (what every `{% extends %}` layout produces), that is a full copy of the page, allocated only so the parent list could copy it again. On harsh-5000 that was ~2GB of pointless allocation and memcpy per build.

**4. `Crinja::Template#render` presizes its `String.build`** from the previous render of the same template. A 400KB page reallocated about thirteen times from the default 64-byte buffer.

**5. Filesystem trims.** `FileSafe.mkdir_p` walks parents deepest-first and stops at the first that exists, instead of stat-ing every ancestor from the root. `OutputGuard` resolves the working directory once per call instead of twice.

## Verification

- `diff -r` of full output trees against the pre-change binary on harsh-5000, public-5000, docs and the blog scaffold — identical except docs PNGs.
- All 304 docs PNGs decoded and compared pixel-by-pixel: 304 identical, 0 mismatched. JPEGs unchanged (0 diffs), confirming only the PNG deflate path moved.
- 8774 examples green; `crystal tool format --check` and `ameba` clean.
- New specs cover `ByteScan` (including a differential fuzz against the stdlib over 7000 random pairs), the `mkdir_p` walk shapes, and block streaming (nesting, three-level inheritance, `super()`, repeated and empty blocks). The block specs were mutation-tested to confirm they fail on a broken implementation.

## Rejected after measurement

An optimistic `mkdir` (skip the `Dir.exists?` probe, tolerate EEXIST) measured within noise on both corpora and was reverted rather than kept as complexity that does not pay.