### PR TITLE
ci: cut PR wall time ~40% and stop recompiling from cold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,30 +38,70 @@ on:
         description: manual run
         required: false
         default: ""
+# A PR is superseded by its own next push far more often than a full matrix run
+# is worth. Pushes to main are never cancelled: they are the full-fidelity gate
+# and the only writer of the compiler cache the other jobs read.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
-  build-crystal:
+  # Which slice of the two heavy matrices this event needs. build-nix costs
+  # ~5 minutes per system and build-docker ~4 per arch, and running all five on
+  # every PR made packaging -- not compiling or testing -- the critical path. A
+  # PR runs one of each, which still proves the packaging compiles, links and
+  # runs; the full matrices run on every push to main, before anything can be
+  # released from it, and on the PRs that edit the packaging inputs themselves.
+  plan:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        crystal-version: [1.21.0]
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      nix: ${{ steps.matrices.outputs.nix }}
+      docker: ${{ steps.matrices.outputs.docker }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: crystal-lang/install-crystal@v1
-        with:
-          crystal: ${{ matrix.crystal-version }}
-      - name: Install dependencies
-        run: shards install
-      - name: Build
-        run: shards build
+      - id: matrices
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          nix_all='{"include":[{"system":"x86_64-linux","runner":"ubuntu-latest"},{"system":"aarch64-linux","runner":"ubuntu-24.04-arm"},{"system":"aarch64-darwin","runner":"macos-latest"}]}'
+          nix_one='{"include":[{"system":"x86_64-linux","runner":"ubuntu-latest"}]}'
+          docker_all='{"include":[{"arch":"linux/amd64","runner":"ubuntu-latest"},{"arch":"linux/arm64","runner":"ubuntu-24.04-arm"}]}'
+          docker_one='{"include":[{"arch":"linux/amd64","runner":"ubuntu-latest"}]}'
+
+          # Anything that is not a PR -- a push to main, a manual dispatch --
+          # gets everything.
+          nix="$nix_all"
+          docker="$docker_all"
+
+          if [ "$EVENT" = pull_request ]; then
+            docker="$docker_one"
+            nix="$nix_one"
+            # The three-system nix matrix exists to catch a bad release-tarball
+            # hash or a platform-specific link failure, and both of those come
+            # from the files below -- so a PR that edits one gets all three
+            # back. A `gh` failure widens too: losing coverage must never be
+            # the quiet outcome of an API hiccup.
+            if files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename'); then
+              grep -qE '^(flake\.nix|flake\.lock|shards\.nix|shard\.lock|shard\.yml|\.github/workflows/ci\.yml)$' <<<"$files" && nix="$nix_all"
+            else
+              echo "::warning::could not list the PR's files; building the full nix matrix"
+              nix="$nix_all"
+            fi
+          fi
+
+          echo "nix=$nix" >> "$GITHUB_OUTPUT"
+          echo "docker=$docker" >> "$GITHUB_OUTPUT"
   build-docker:
+    needs: plan
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - arch: linux/amd64
-            runner: ubuntu-latest
-          - arch: linux/arm64
-            runner: ubuntu-24.04-arm
+      matrix: ${{ fromJSON(needs.plan.outputs.docker) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
@@ -135,6 +175,10 @@ jobs:
       - name: Run Ameba linter
         uses: crystal-ameba/github-action@master
   tests:
+    # Also the compile gate. `shards build` here is exactly what a separate
+    # build-only job used to run twice over, and spec/functional spawns the
+    # binary it produces, so a compile break already fails this job before a
+    # single example runs.
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -144,26 +188,64 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal-version }}
+      # Crystal keys its cache by absolute source path and the runner workspace
+      # path is stable, so a restored ~/.cache/crystal gives this job both
+      # halves of a warm compile. The expensive half is the two `macro run`
+      # programs -- baked_file_system's loader (via tartrazine) and ecr's
+      # processor (via HTTP::StaticFileHandler) -- which cost ~8s of every cold
+      # compile and are cached per macro program, so `shards build` and
+      # `crystal spec` share one copy. The per-module .o/.bc files then let
+      # codegen skip everything the commit did not touch (measured: >99% reuse
+      # after a one-file edit). Only pushes to main write the cache; PRs read
+      # it, so no PR can poison what the next one restores.
+      - name: Restore Crystal cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cache/crystal
+            lib
+          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-${{ hashFiles('shard.lock') }}-${{ github.sha }}
+          restore-keys: |
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-${{ hashFiles('shard.lock') }}-
+      # ameba is a development dependency and the lint job brings its own; not
+      # cloning it here also keeps the cached lib/ to what this job compiles.
       - name: Install dependencies
-        run: shards install
+        run: shards install --without-development
       - name: Build binary
         run: shards build
       - name: Run tests
         run: crystal spec
+      # Cached object files are named after a content hash, so a changed module
+      # adds a file rather than replacing one and the directory only grows.
+      # Dropping the ones a week of pushes has not regenerated bounds it without
+      # throwing away the entries that make the next restore worth downloading.
+      - name: Trim the Crystal cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        run: |
+          find ~/.cache/crystal -type f -mtime +7 -delete
+          find ~/.cache/crystal -type d -empty -delete
+          du -sh ~/.cache/crystal
+      - name: Save Crystal cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/crystal
+            lib
+          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-${{ hashFiles('shard.lock') }}-${{ github.sha }}
   build-nix:
     # One runner per system flake.nix declares: a bad tarball hash or a
     # platform-specific link failure must not reach a user's `nix profile
-    # install` just because CI only ever built x86_64-linux.
+    # install` just because CI only ever built x86_64-linux. `plan` decides how
+    # many of them this event needs -- all three whenever one could regress
+    # (any push to main, and PRs touching the flake or the lock files), one on
+    # an ordinary source PR, where the release-mode compile and the link are
+    # what is actually at risk and x86_64-linux proves both.
+    needs: plan
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - system: x86_64-linux
-            runner: ubuntu-latest
-          - system: aarch64-linux
-            runner: ubuntu-24.04-arm
-          - system: aarch64-darwin
-            runner: macos-latest
+      matrix: ${{ fromJSON(needs.plan.outputs.nix) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -204,8 +286,20 @@ jobs:
           crystal: 1.21.0
       - name: Install build dependencies
         run: brew install openssl@3 pkg-config
+      # Same warm-compile cache as the tests job, on its own key -- macOS
+      # runners are the slowest in the matrix and this job compiles the whole
+      # program just to look at what it links.
+      - name: Restore Crystal cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cache/crystal
+            lib
+          key: crystal-${{ runner.os }}-1.21.0-${{ hashFiles('shard.lock') }}-${{ github.sha }}
+          restore-keys: |
+            crystal-${{ runner.os }}-1.21.0-${{ hashFiles('shard.lock') }}-
       - name: Install shards
-        run: shards install
+        run: shards install --without-development
       # Not --release: this job is about linkage and signatures, which are
       # identical either way, and a release build would triple the runtime.
       - name: Build binary
@@ -214,6 +308,21 @@ jobs:
           export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig"
           mkdir -p build
           crystal build src/main.cr -o build/hwaro --no-debug
+      - name: Trim the Crystal cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        run: |
+          find ~/.cache/crystal -type f -mtime +7 -delete
+          find ~/.cache/crystal -type d -empty -delete
+          du -sh ~/.cache/crystal
+      - name: Save Crystal cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/crystal
+            lib
+          key: crystal-${{ runner.os }}-1.21.0-${{ hashFiles('shard.lock') }}-${{ github.sha }}
       # The runtime half of this job only means anything on arm64: x86_64
       # happily executes a stale signature. `macos-latest` is arm64 today but
       # it is an alias GitHub has re-pointed before, and a silent move would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,18 +80,21 @@ jobs:
           docker="$docker_all"
 
           if [ "$EVENT" = pull_request ]; then
-            docker="$docker_one"
             nix="$nix_one"
-            # The three-system nix matrix exists to catch a bad release-tarball
-            # hash or a platform-specific link failure, and both of those come
-            # from the files below -- so a PR that edits one gets all three
-            # back. A `gh` failure widens too: losing coverage must never be
-            # the quiet outcome of an API hiccup.
+            docker="$docker_one"
+            # Both matrices are multi-platform to catch platform-specific
+            # breakage -- a bad release-tarball hash or a link failure for nix,
+            # an arch-specific stage package for the image -- and that risk
+            # arrives through the files each one is built from. A PR that edits
+            # any of them gets its full matrix back. A `gh` failure widens both:
+            # losing coverage must never be the quiet outcome of an API hiccup.
             if files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename'); then
               grep -qE '^(flake\.nix|flake\.lock|shards\.nix|shard\.lock|shard\.yml|\.github/workflows/ci\.yml)$' <<<"$files" && nix="$nix_all"
+              grep -qE '^(docker/Dockerfile|docker/entrypoint\.sh|action\.yml|shard\.lock|shard\.yml|\.github/workflows/ci\.yml)$' <<<"$files" && docker="$docker_all"
             else
-              echo "::warning::could not list the PR's files; building the full nix matrix"
+              echo "::warning::could not list the PR's files; building the full matrices"
               nix="$nix_all"
+              docker="$docker_all"
             fi
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,13 @@ just dev                # serve the docs site (bin/hwaro serve -i docs)
 - Anything that changes `shard.lock` must be followed by `just nix-update`.
   `flake.nix` reads the version and minimum Crystal from `shard.yml`.
 - CI (`.github/workflows/ci.yml`) sizes its two expensive matrices in the
-  `plan` job: an ordinary source PR builds one nix system and one Docker arch,
-  while every push to main — and any PR touching `flake.*`, `shards.nix`,
-  `shard.lock`, `shard.yml` or the workflow — builds all of them. Widen that
-  file list rather than the matrices when a new input can break packaging.
-  `tests` and `package-macos` restore `~/.cache/crystal`; only pushes to main
-  write it back.
+  `plan` job. An ordinary source PR builds one nix system and one Docker arch;
+  every push to main builds both matrices in full, and so does a PR touching
+  the inputs a matrix exists to protect — `flake.*`/`shards.nix` for nix,
+  `docker/`/`action.yml` for the image, `shard.lock`/`shard.yml`/the workflow
+  for both. Widen those file lists rather than the matrices when a new input
+  can break packaging. `tests` and `package-macos` restore
+  `~/.cache/crystal`; only pushes to main write it back.
 - Parallelism comes from Crystal's execution contexts: `src/main.cr` sizes the
   default `Fiber::ExecutionContext::Parallel` (honours `CRYSTAL_WORKERS`).
   **Never reintroduce `-Dpreview_mt`** — its legacy scheduler can spin forever

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,14 +25,24 @@ just dev                # serve the docs site (bin/hwaro serve -i docs)
   `crystal spec` links every run to the same fixed path under
   `~/.cache/crystal`, so two concurrent invocations clobber each other's
   binary and produce plausible-looking nonsense. `just test-file` /
-  `just test-dir` set their own `CRYSTAL_CACHE_DIR`, so they are safe to run
-  alongside `just test`.
+  `just test-dir` point `CRYSTAL_CACHE_DIR` at a **per-target** directory under
+  `$TMPDIR/hwaro-spec-cache/`, so they are safe alongside `just test` and
+  alongside each other, and a re-run of the same target reuses the last
+  compile (~2× faster). `just clean` removes them; export
+  `CRYSTAL_CACHE_DIR` yourself to override.
 - `spec/functional/**` spawns `bin/hwaro`; rebuild it (`shards build`) before
   trusting a functional run, or the specs test the old binary (the serve
   specs mark themselves pending when it is missing).
 - `bin/ameba` is built by `just ameba` (ameba 1.7 ships no executable).
 - Anything that changes `shard.lock` must be followed by `just nix-update`.
   `flake.nix` reads the version and minimum Crystal from `shard.yml`.
+- CI (`.github/workflows/ci.yml`) sizes its two expensive matrices in the
+  `plan` job: an ordinary source PR builds one nix system and one Docker arch,
+  while every push to main — and any PR touching `flake.*`, `shards.nix`,
+  `shard.lock`, `shard.yml` or the workflow — builds all of them. Widen that
+  file list rather than the matrices when a new input can break packaging.
+  `tests` and `package-macos` restore `~/.cache/crystal`; only pushes to main
+  write it back.
 - Parallelism comes from Crystal's execution contexts: `src/main.cr` sizes the
   default `Fiber::ExecutionContext::Parallel` (honours `CRYSTAL_WORKERS`).
   **Never reintroduce `-Dpreview_mt`** — its legacy scheduler can spin forever

--- a/justfile
+++ b/justfile
@@ -31,6 +31,7 @@ clean:
     rm -f src/ext/stb_impl.o
     rm -rf bin/
     rm -rf lib/
+    rm -rf "${TMPDIR:-/tmp}/hwaro-spec-cache"
 
 # Serve docs site with the built binary.
 [group('documents')]
@@ -66,6 +67,21 @@ check: ameba
 test:
     crystal spec
 
+# Per-target compiler caches for the two recipes below.
+#
+# They used to `mktemp -d` a fresh directory per invocation, which bought
+# isolation at the price of a fully cold compile every time: nothing was reused,
+# including the two `macro run` sub-compilations (baked_file_system's loader via
+# tartrazine, ecr's processor via HTTP::StaticFileHandler) that alone cost ~8s.
+# Keying the directory on the target instead keeps every bit of that isolation --
+# `crystal spec` names its binary after the spec ROOT, not the file passed to it,
+# so two targets sharing one cache dir would still clobber each other's binary --
+# while letting a re-run of the same target reuse the last one (measured: 10.9s
+# -> 5.5s on a single spec file). `just clean` removes them.
+#
+# The `:line` suffix is stripped because it selects examples at run time and
+# compiles the identical program; it must not fork a second cache.
+
 #     just test-file spec/unit/models/config_spec.cr
 #     just test-file spec/unit/models/config_spec.cr:42
 #
@@ -75,8 +91,10 @@ test-file TARGET:
     #!/usr/bin/env bash
     set -euo pipefail
     just _warn-stale-binary
-    export CRYSTAL_CACHE_DIR="${CRYSTAL_CACHE_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/hwaro-spec.XXXXXX")}"
-    crystal spec "{{ TARGET }}"
+    target="{{ TARGET }}"
+    export CRYSTAL_CACHE_DIR="${CRYSTAL_CACHE_DIR:-${TMPDIR:-/tmp}/hwaro-spec-cache/$(printf '%s' "${target%%:*}" | tr -c 'A-Za-z0-9' '-')}"
+    mkdir -p "$CRYSTAL_CACHE_DIR"
+    crystal spec "$target"
 
 #     just test-dir spec/unit/assets/sass
 #
@@ -86,8 +104,10 @@ test-dir DIR:
     #!/usr/bin/env bash
     set -euo pipefail
     just _warn-stale-binary
-    export CRYSTAL_CACHE_DIR="${CRYSTAL_CACHE_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/hwaro-spec.XXXXXX")}"
-    crystal spec "{{ DIR }}"
+    dir="{{ DIR }}"
+    export CRYSTAL_CACHE_DIR="${CRYSTAL_CACHE_DIR:-${TMPDIR:-/tmp}/hwaro-spec-cache/$(printf '%s' "$dir" | tr -c 'A-Za-z0-9' '-')}"
+    mkdir -p "$CRYSTAL_CACHE_DIR"
+    crystal spec "$dir"
 
 # Functional specs spawn bin/hwaro: a stale binary makes them test old code.
 [private]

--- a/spec/unit/assets/sass/control_flow_spec.cr
+++ b/spec/unit/assets/sass/control_flow_spec.cr
@@ -279,9 +279,14 @@ describe "Sass loop budget" do
     end
   end
 
+  # The body is a bare declaration rather than a rule on purpose. The budget is
+  # ticked once per iteration *before* the body runs, so what this asserts is
+  # unchanged -- but emitting a million rule nodes to reach the cap cost 2.9s,
+  # and the spec above already covers the budget tripping on the shape that
+  # actually allocates.
   it "errors on nested loops whose product exceeds the budget" do
     expect_raises(Hwaro::Assets::Sass::SyntaxError, /total @for\/@each\/@while iterations/) do
-      compile("@for $i from 1 through 3000 { @for $j from 1 through 3000 { .c { top: 0; } } }")
+      compile("@for $i from 1 through 3000 { @for $j from 1 through 3000 { $unused: $j; } }")
     end
   end
 

--- a/spec/unit/content/processors/inline_markdown_spec.cr
+++ b/spec/unit/content/processors/inline_markdown_spec.cr
@@ -98,9 +98,9 @@ describe Hwaro::Content::Processors::InlineMarkdown do
     # minutes here, the linear form about a millisecond.
     it "renders a long unclosed backtick run in linear time" do
       input = "`" * 100_000
-      started = Time.monotonic
+      started = Time.instant
       out = Hwaro::Content::Processors::InlineMarkdown.render(input)
-      (Time.monotonic - started).should be < 5.seconds
+      (Time.instant - started).should be < 5.seconds
       out.should eq(input)
     end
 
@@ -109,9 +109,9 @@ describe Hwaro::Content::Processors::InlineMarkdown do
     # 20k spans took ~10 s. One pass per token kind now.
     it "restores many code spans in linear time" do
       input = Array.new(20_000) { |i| "`c#{i}`" }.join(" ")
-      started = Time.monotonic
+      started = Time.instant
       out = Hwaro::Content::Processors::InlineMarkdown.render(input)
-      (Time.monotonic - started).should be < 3.seconds
+      (Time.instant - started).should be < 3.seconds
       out.should start_with("<code>c0</code> <code>c1</code>")
       out.should end_with("<code>c19999</code>")
       out.should_not contain("\x00")


### PR DESCRIPTION
CI was spending most of its wall clock re-doing work it already had, and throwing the Crystal compiler cache away on every run.

Measured on the last PR run (`34142397380`): **7m08s wall, ~30 min of runner time** across 9 jobs.

| job | before |
|---|---|
| build-nix (aarch64-darwin) | 6m58s ← critical path |
| build-nix (x86_64-linux) | 4m44s |
| build-docker ×2 | 4m25s / 4m09s |
| tests | 3m23s (60s build + 119s spec) |
| package-macos | 1m36s |
| build-crystal | 1m24s — redundant |
| lint | 11s |

## Changes

**Delete `build-crystal`.** It ran `shards install && shards build` on the same matrix as `tests`, which does exactly that before `crystal spec`. No branch protection referenced it.

**Restore `~/.cache/crystal` (and `lib/`) in `tests` and `package-macos`.** Crystal keys that cache by absolute source path and the runner workspace path is stable, so a restore buys two things:

- the two `macro run` sub-compilations — `baked_file_system`'s loader (via tartrazine) and `ecr`'s processor (via `HTTP::StaticFileHandler`, whose directory listing we disable but still compile). Together they are **~8s of every cold compile**, and they are cached per *macro program*, so `shards build` and `crystal spec` share one copy.
- the per-module `.o`/`.bc` files — measured **3191/3192 reused** after a one-file edit.

Measured locally: binary build **17.0s → 7.6s**, spec compile **23.7s → 15.1s**. Only pushes to main write the cache, so no PR can poison what the next one restores; entries a week of pushes has not regenerated are trimmed (object files are content-hash-named, so a changed module adds a file rather than replacing one).

**Size the two heavy matrices in a new `plan` job.** An ordinary source PR builds one nix system and one Docker arch — still enough to prove the packaging compiles, links and runs, and the nix job keeps its `--release` build. Every push to main builds both in full, before anything can be released from it, and so does a PR touching the inputs a matrix exists to protect:

| matrix | widens on |
|---|---|
| build-nix (3 systems) | `flake.nix`, `flake.lock`, `shards.nix` |
| build-docker (2 arches) | `docker/Dockerfile`, `docker/entrypoint.sh`, `action.yml` |
| both | `shard.lock`, `shard.yml`, `ci.yml` |

A `gh` failure widens both rather than narrowing — losing coverage must never be the quiet outcome of an API hiccup.

**Cancel superseded PR runs.** Pushes to main are never cancelled — they are the full-fidelity gate and the only writer of the cache.

Expected: PR wall **~7-8.5 min → ~5 min**, runner time **~30 min → ~12 min**. The first run after merge populates the cache; PRs after that see the compile savings.

## Also

- `just test-file` / `just test-dir` used a fresh `mktemp -d` per invocation, so every single-file spec run paid a fully cold compile. Keyed on the target instead: **10.9s → 5.5s**. `crystal spec` names its binary after the spec *root*, not the target passed to it, so per-target directories keep exactly the isolation that made those recipes safe to run alongside `just test`. `just clean` removes them.
- The nested Sass loop-budget example emitted a million rule nodes to reach a cap that is ticked *before* the body runs (**2.9s → 0.66s**). Verified it still fails with the guard removed; the neighbouring example keeps the realistic allocate-until-OOM shape.
- Four `Time.monotonic` calls warned on every compile of the suite.

## Verification

`crystal tool format --check`, `bin/ameba` (620 files, 0 failures), `crystal spec` (8774 examples, 0 failures), `actionlint` (clean apart from a pre-existing SC2155 that is also on `main`). The `plan` script was exercised against real PRs: #796 → 1 nix system, #754 (flake fix) → 3, push → 3.

Because this PR touches `ci.yml`, its own run gets the **full** nix and Docker matrices.
